### PR TITLE
fix(split): preserve source selection during same-volume navigation

### DIFF
--- a/.github/workflows/full-qa.yml
+++ b/.github/workflows/full-qa.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc clang-tidy cppcheck clang-tools bear valgrind
+        sudo apt-get install -y gitleaks libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc clang-tidy cppcheck clang-tools bear valgrind
 
     - name: Set up Python 3
       uses: actions/setup-python@v6

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,10 +83,10 @@ The `ViewContext` struct (defined in `include/ytree_defs.h`) is the root of all 
 
 ```
 ViewContext (The Session)
-├── left   → YtreePanel (View: cursor, scroll, window state)
-├── right  → YtreePanel (View: cursor, scroll, window state)
+├── left   → YtreePanel (Pane: cursor, scroll, window state, tags)
+├── right  → YtreePanel (Pane: cursor, scroll, window state, tags)
 ├── active → points to left or right
-├── volumes_head → Volume linked list (Model: DirEntry trees, statistics)
+├── volumes_head → Volume linked list (Model: shared DirEntry trees, statistics)
 └── viewer, layout, mode flags, etc.
 ```
 
@@ -120,14 +120,14 @@ The application state is strictly hierarchical:
 
 2.  **`YtreePanel` (The View):**
     *   Represents a single UI pane.
-    *   Owns **View State**: cursor position, scroll offset, and window-specific dimensions.
+    *   Owns **Pane-Local State**: cursor position, scroll offset, file-view anchor, focus/window mode, filespec/filter, and selected/tagged files for that pane.
     *   Holds a reference to a `Volume`.
-    *   Independent Panels may point to the same `Volume` while maintaining unique cursors.
+    *   Independent panels may point to the same `Volume` while maintaining different pane-local state. Pane-local state must not be inferred from a shared tree index after the tree is rebuilt.
 
 3.  **`Volume` (The Model):**
     *   Represents a filesystem (Physical Disk or Archive).
-    *   Owns **Data**: `DirEntry` tree structure, `Statistic` metadata, and path info.
-    *   Contains no UI state.
+    *   Owns **Shared Data**: `DirEntry` tree topology, logged/unlogged memory state, file payload cache, `Statistic` metadata, and path info.
+    *   Contains no pane-local UI state: no active focus, cursor, file-view anchor, selected file, filespec/filter, or pane-local tags.
 
 ### 4.2 Dual-Panel Context Isolation (F8 Logic)
 The Split-Screen architecture treats each panel as an independent instance of a volume manager.
@@ -135,6 +135,7 @@ The Split-Screen architecture treats each panel as an independent instance of a 
 *   **Active Panel:** Owns keyboard focus and initiates all operations.
 *   **Inactive Panel:** Strictly **DORMANT**. It does not update its display or change state in response to activity in the active panel.
 *   **State Persistence (Tab-Switch):** The `Tab` key is the bridge. Switching panels restores the exact state held when that panel last had focus.
+*   **Pane vs. Volume Rule:** Sharing a `Volume` only shares logged tree topology and file payload cache. It never shares pane-local tags, file-window anchors, cursor identity, or focus/mode state.
 
 ### 4.3 Inter-Panel Operations (The Directional Rule)
 *   **Targeting:** Copy and Move operations occur directionally: **Source (Active Panel) to Destination (Inactive Panel)**.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -845,6 +845,7 @@ Ordering policy (for all editors, including AI editors):
 ### **Idea FE-7: Tagged-Only Results View**
 *   **Goal:** Add a view mode that shows only tagged files without altering the tag set itself.
 *   **User-Facing Behavior:**
+    *   `F4` toggles **Tagged-Only** view mode.
     *   In file lists, Showall, Global, and archive file views, users can toggle a **Tagged-Only** filter to temporarily narrow the visible list to currently tagged items.
     *   Leaving the mode restores the normal file/filter view; tags remain unchanged.
     *   This should compose cleanly with existing filters, grep-on-tagged workflows, and compare/tag workflows.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -151,12 +151,15 @@ Split mode is a two-pane session entered/exited by `F8`.
 *   **Focus Switch:** `Tab` switches the active pane.
 *   **Active Panel:** Owns keyboard focus and receives command/navigation input.
 *   **Inactive Panel:** Does not process direct input while inactive; its own cursor/selection context is retained until focus is switched back.
+*   **Freeze/Resume Rule:** When a pane loses focus, its pane-local state is frozen; when it becomes active again (via `Tab`), it must resume exactly where it left off.
+*   **Active-Only Mutation Rule:** Commands mutate only the active pane's pane-local state. Cross-pane updates are limited to shared topology mirroring defined in §5.3.
 
 ### 5.2 State Persistence
 Switching panels via `Tab` must restore the exact state held when that panel last had focus for panel-local state:
 *   **Volume Context:** Logged volume or archive.
 *   **Cursor & Offset:** Highlighted entry and scroll position.
-*   **Selection:** Tags are specific to the panel session.
+*   **Selection:** Tags are specific to the panel session. Collapsing a directory (`Left` or `-`) or explicitly unreading/releasing it (`--`) discards saved tags beneath that directory; reloading it must not resurrect stale tags.
+*   **Compare Tagging Rule:** Compare workflows may report difference counts, but they do not implicitly mutate per-file tag state; tags change only through explicit tagging actions.
 *   **Filter (Filespec):** Independent search/filter strings.
 *   **Window/Mode Context:** Directory/File/Showall-style pane-local focus context.
 
@@ -167,6 +170,8 @@ The split panes share one logged tree topology contract for a given logged volum
 *   **Mirror Rule:** Structural tree changes triggered in the active pane must be reflected in the inactive pane immediately.
 *   **Selection Retention Rule:** Mirrored structural updates must not move the inactive pane's cursor/selection when its selected node remains visible/valid.
 *   **Non-Invalidating Changes Rule:** Adding siblings/ancestors, or changing sibling structure that does not invalidate the inactive selected node, must not move the inactive selection.
+*   **Frozen File-View Anchor Rule:** A pane left in file view is restored from its saved directory path and selected filename, not from the current flattened tree index. If shared-tree rebuilding leaves that directory as a visible but unloaded placeholder, the directory payload must be reloaded before the pane is rendered or resumed so the file window cannot degrade to an empty or unrelated listing.
+*   **Render Is Not Authority Rule:** Rendering may display the saved pane state, but it must not decide a new pane selection from whatever entry currently occupies the saved numeric index after a shared tree rebuild.
 *   **Deterministic Fallback Rule (When Selected Node Becomes Invalid):**
     *   Keep exact node if still visible/valid after mirror update.
     *   Else move to nearest visible ancestor of the previously selected node.

--- a/docs/ai/AGENT_PROMPT_TEMPLATE.md
+++ b/docs/ai/AGENT_PROMPT_TEMPLATE.md
@@ -5,8 +5,8 @@ Edit only the first four lines to match the tracked work item exactly, then copy
 ```text
 $WORK_DOC=docs/BUGS.md
 $WORK_KIND=Bug
-$TASK=BUG-36
-$TASK_NAME=F8 Same-Volume Destination Navigation Can Lose Source Selection/Tagged Set
+$TASK=BUG-20
+$TASK_NAME=F8 File-Window Active/Inactive Indicators Aren't Distinct
 
 Role:
 You are a stateless architect supervisor for ~/ytree. Architect-only: orchestrate, validate, and commit; do not implement code.

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -759,6 +759,7 @@ typedef struct {
   int start_file;
   int file_cursor_pos;
   DirEntry *file_dir_entry;
+  struct _PathList *tagged_paths;
   char file_selection_name[PATH_LENGTH + 1];
   char file_selection_dir_path[PATH_LENGTH + 1];
   BOOL saved_big_file_view;

--- a/include/ytree_panel_anchor.h
+++ b/include/ytree_panel_anchor.h
@@ -1,0 +1,20 @@
+#ifndef YTREE_PANEL_ANCHOR_H
+#define YTREE_PANEL_ANCHOR_H
+
+#include "ytree_defs.h"
+
+BOOL CapturePanelAnchorPath(const YtreePanel *panel, const struct Volume *vol,
+                            char *out_path, size_t out_path_size);
+int FindDirIndexByPath(const struct Volume *vol, const char *path);
+int FindDirIndexByPathOrAncestor(const struct Volume *vol, const char *path);
+void PositionPanelAtIndex(YtreePanel *panel, int idx);
+void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
+                            const char *anchor_path);
+DirEntry *FindDirByPathInTree(DirEntry *entry, const char *path);
+void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
+                              YtreePanel *panel, const char *label);
+void DebugLogDirLoopState(const char *label, const ViewContext *ctx,
+                          const DirEntry *dir_entry, int ch,
+                          YtreeAction action, int unput_char);
+
+#endif

--- a/include/ytree_ui.h
+++ b/include/ytree_ui.h
@@ -107,6 +107,18 @@ extern void FreeDirEntryList(ViewContext *ctx);
 extern void FreeVolumeCache(struct Volume *vol);
 extern DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p,
                                  DirEntry *entry);
+extern void DirOps_ReloadPanelFileAnchorIfMissing(ViewContext *ctx,
+                                                  YtreePanel *panel,
+                                                  DirEntry *dir_entry);
+extern void PanelTags_Clear(YtreePanel *panel);
+extern void PanelTags_Copy(YtreePanel *dst, const YtreePanel *src);
+extern void PanelTags_PruneUnderDir(YtreePanel *panel, DirEntry *dir_entry);
+extern BOOL PanelTags_FileIsTagged(const YtreePanel *panel,
+                                   FileEntry *file_entry);
+extern void PanelTags_RecordFileState(YtreePanel *panel, FileEntry *file_entry,
+                                      BOOL tagged);
+extern void PanelTags_ApplyToTree(ViewContext *ctx, YtreePanel *panel);
+extern void PanelTags_Restore(ViewContext *ctx, YtreePanel *panel);
 extern BOOL DirOps_SelectVisibleDirAndRefresh(ViewContext *ctx,
                                               YtreePanel *panel,
                                               const DirEntry *target,
@@ -140,8 +152,8 @@ extern void DisplayHistoryHelp(ViewContext *ctx);
 /* display_utils.c */
 extern int AddStr(char *str);
 extern int BuildUserFileEntry(FileEntry *fe_ptr, int filename_width,
-                              int linkname_width, char *template, int linelen,
-                              char *line);
+                              int linkname_width, BOOL tagged, char *template,
+                              int linelen, char *line);
 extern char *CTime(time_t f_time, char *buffer);
 extern char *CutFilename(char *dest, const char *src, unsigned int max_len);
 extern char *CutName(char *dest, const char *src, unsigned int max_len);
@@ -202,6 +214,8 @@ extern BOOL handle_file_window_navigation_action(
     BOOL *need_dsp_help_ptr, long *preview_line_offset_ptr,
     void (*update_preview)(ViewContext *, const DirEntry *),
     void (*list_jump)(ViewContext *, DirEntry *, char *));
+extern void CapturePanelSelectionAnchor(ViewContext *ctx, YtreePanel *panel,
+                                        const DirEntry *dir_entry);
 extern BOOL handle_file_window_split_switch_action(
     ViewContext *ctx, YtreeAction action, DirEntry *dir_entry,
     YtreePanel *owner_panel, BOOL *switched_panel_ptr,

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -7,6 +7,8 @@
 
 #include "ytree_defs.h"
 
+extern void FreePathList(PathList *list);
+
 static void Volume_ClearPanelFileEntries(YtreePanel *panel) {
   if (panel && panel->file_entry_list) {
     free(panel->file_entry_list);
@@ -14,6 +16,13 @@ static void Volume_ClearPanelFileEntries(YtreePanel *panel) {
     panel->file_entry_list_capacity = 0;
     panel->file_count = 0;
   }
+}
+
+static void Volume_ClearPanelTags(YtreePanel *panel) {
+  if (!panel)
+    return;
+  FreePathList(panel->tagged_paths);
+  panel->tagged_paths = NULL;
 }
 
 static void Volume_FreeCache(struct Volume *vol) {
@@ -120,14 +129,15 @@ void Volume_Delete(ViewContext *ctx, struct Volume *vol) {
     free(vol->dir_entry_list);
     vol->dir_entry_list = NULL;
   }
-
   /* Invalidate any panels using this volume to prevent stale references */
   if (ctx->left && ctx->left->vol == vol) {
     Volume_ClearPanelFileEntries(ctx->left);
+    Volume_ClearPanelTags(ctx->left);
     ctx->left->vol = NULL;
   }
   if (ctx->right && ctx->right->vol == vol) {
     Volume_ClearPanelFileEntries(ctx->right);
+    Volume_ClearPanelTags(ctx->right);
     ctx->right->vol = NULL;
   }
 
@@ -288,6 +298,10 @@ struct Volume *Volume_Load(ViewContext *ctx, const char *path,
     }
     memset(&vol->vol_stats, 0, sizeof(Statistic));
     Volume_FreeCache(vol);
+    if (ctx->left && ctx->left->vol == vol)
+      Volume_ClearPanelTags(ctx->left);
+    if (ctx->right && ctx->right->vol == vol)
+      Volume_ClearPanelTags(ctx->right);
   } else {
     vol = Volume_Create(ctx);
     if (!vol)

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -9,6 +9,7 @@
 #include "watcher.h"
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
+#include "ytree_panel_anchor.h"
 #include "ytree_ui.h"
 #include <errno.h>
 #include <stdio.h>
@@ -398,6 +399,7 @@ static void HandleDirectoryCompare(ViewContext *ctx, DirEntry *source_dir) {
 
   DirCompare_RunInternalLoggedTree(ctx, &request);
 }
+
 extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   DirEntry *dir_entry, *de_ptr;
   int ch, unput_char;
@@ -408,6 +410,10 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   Statistic *s = NULL;
   int height;
   char watcher_path[PATH_LENGTH + 1];
+  char left_anchor_path[PATH_LENGTH + 1];
+  char right_anchor_path[PATH_LENGTH + 1];
+  BOOL has_left_anchor = FALSE;
+  BOOL has_right_anchor = FALSE;
 
   DEBUG_LOG("HandleDirWindow: Recalculating layout");
   Layout_Recalculate(ctx);
@@ -456,7 +462,24 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
   DEBUG_LOG("HandleDirWindow: Building DirEntryList for vol=%p",
             (void *)ctx->active->vol);
+  has_left_anchor = CapturePanelAnchorPath(ctx->left, ctx->active->vol,
+                                           left_anchor_path,
+                                           sizeof(left_anchor_path));
+  has_right_anchor = CapturePanelAnchorPath(ctx->right, ctx->active->vol,
+                                            right_anchor_path,
+                                            sizeof(right_anchor_path));
+  if (has_left_anchor || has_right_anchor) {
+    DEBUG_LOG("HandleDirWindow:anchors before rebuild left='%s' right='%s'",
+              has_left_anchor ? left_anchor_path : "<none>",
+              has_right_anchor ? right_anchor_path : "<none>");
+  }
   BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
+  if (has_left_anchor)
+    RestorePanelAnchorPath(ctx->active->vol, ctx->left, left_anchor_path);
+  if (has_right_anchor)
+    RestorePanelAnchorPath(ctx->active->vol, ctx->right, right_anchor_path);
+  EnsurePanelAnchorVisible(ctx, ctx->active->vol, ctx->left, "LEFT");
+  EnsurePanelAnchorVisible(ctx, ctx->active->vol, ctx->right, "RIGHT");
   if (ctx->initial_directory != NULL) {
     if (!strcmp(ctx->initial_directory, ".")) /* Entry just a single "." */
     {
@@ -554,7 +577,9 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     }
   } else if (ctx->active && ctx->active->saved_focus == FOCUS_FILE &&
              dir_entry->total_files > 0) {
-    unput_char = CR;
+    BuildFileEntryList(ctx, ctx->active);
+    if (ctx->active->file_count > 0)
+      unput_char = CR;
   }
   do {
     /* Detect Global Volume Change (Split Brain Fix) */
@@ -572,6 +597,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     if (ctx->is_split_screen) {
       YtreePanel *inactive =
           (ctx->active == ctx->left) ? ctx->right : ctx->left;
+      EnsurePanelAnchorVisible(ctx, ctx->active->vol, inactive, "INACTIVE");
       RenderInactivePanel(ctx, inactive);
     }
 
@@ -584,6 +610,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
     if (unput_char) {
       ch = unput_char;
+      DEBUG_LOG("DirLoop:consuming_unput ch=%d", ch);
       unput_char = '\0';
     } else {
       doupdate();
@@ -605,6 +632,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     }
 
     action = GetKeyAction(ctx, ch); /* Translate raw input to YtreeAction */
+    DebugLogDirLoopState("before_dispatch", ctx, dir_entry, ch, action,
+                         unput_char);
 
     switch (action) {
     case ACTION_RESIZE:
@@ -1048,6 +1077,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
         dir_entry = ctx->active->vol->vol_stats.tree;
       }
     }
+    DebugLogDirLoopState("after_dispatch", ctx, dir_entry, ch, action,
+                         unput_char);
 
   } while (action != ACTION_QUIT && action != ACTION_ENTER &&
            action != ACTION_ESCAPE &&

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -273,6 +273,7 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   need_dsp_help = TRUE;
   maybe_change_x_step = TRUE;
 
+  PanelTags_ApplyToTree(ctx, ctx->active);
   BuildFileEntryList(ctx, ctx->active);
   FileNav_SyncGridMetrics(ctx);
   ctx->ctrl_file_hide_right = 0;

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -40,8 +40,8 @@ void UI_RenderFilePanel(ViewContext *ctx, const DirEntry *dir_entry,
                ctx->ctx_file_window);
 }
 
-static void CapturePanelSelectionAnchor(ViewContext *ctx, YtreePanel *panel,
-                                        const DirEntry *dir_entry) {
+void CapturePanelSelectionAnchor(ViewContext *ctx, YtreePanel *panel,
+                                 const DirEntry *dir_entry) {
   int idx;
   const FileEntry *selected_file;
 
@@ -75,6 +75,91 @@ static void CapturePanelSelectionAnchor(ViewContext *ctx, YtreePanel *panel,
                  "%s", selected_file->name);
   GetPath((DirEntry *)dir_entry, panel->file_selection_dir_path);
   panel->file_selection_dir_path[PATH_LENGTH] = '\0';
+}
+
+static void DebugLogFilePanelState(const char *label, const YtreePanel *panel) {
+  char tree_path[PATH_LENGTH + 1];
+  char file_dir_path[PATH_LENGTH + 1];
+  int idx = -1;
+  const DirEntry *tree_de = NULL;
+  const char *tree_text = "<none>";
+  const char *file_dir_text = "<none>";
+  const char *selection_dir_text = "<none>";
+  const char *selection_name_text = "<none>";
+
+  tree_path[0] = '\0';
+  file_dir_path[0] = '\0';
+
+  if (!panel) {
+    DEBUG_LOG("FILE_PANEL[%s] <null>", label ? label : "?");
+    return;
+  }
+
+  if (panel->vol && panel->vol->total_dirs > 0 && panel->vol->dir_entry_list) {
+    idx = panel->disp_begin_pos + panel->cursor_pos;
+    if (idx < 0)
+      idx = 0;
+    if (idx >= panel->vol->total_dirs)
+      idx = panel->vol->total_dirs - 1;
+    tree_de = panel->vol->dir_entry_list[idx].dir_entry;
+    if (tree_de) {
+      GetPath((DirEntry *)tree_de, tree_path);
+      tree_path[PATH_LENGTH] = '\0';
+      tree_text = tree_path;
+    }
+  }
+
+  if (panel->file_dir_entry && panel->vol && panel->vol->dir_entry_list &&
+      panel->vol->total_dirs > 0) {
+    BOOL in_volume = FALSE;
+    int j;
+    for (j = 0; j < panel->vol->total_dirs; j++) {
+      if (panel->vol->dir_entry_list[j].dir_entry == panel->file_dir_entry) {
+        in_volume = TRUE;
+        break;
+      }
+    }
+    if (in_volume) {
+      GetPath(panel->file_dir_entry, file_dir_path);
+      file_dir_path[PATH_LENGTH] = '\0';
+      file_dir_text = file_dir_path;
+    } else {
+      file_dir_text = "<stale>";
+    }
+  } else if (panel->file_dir_entry) {
+    file_dir_text = "<stale>";
+  }
+
+  if (panel->file_selection_dir_path[0] != '\0')
+    selection_dir_text = panel->file_selection_dir_path;
+  if (panel->file_selection_name[0] != '\0')
+    selection_name_text = panel->file_selection_name;
+
+  DEBUG_LOG(
+      "FILE_PANEL[%s] saved_focus=%d disp=%d cur=%d idx=%d start=%d fcur=%d "
+      "tree='%s' file_dir='%s' sel_dir='%s' sel_name='%s'",
+      label ? label : "?", panel->saved_focus, panel->disp_begin_pos,
+      panel->cursor_pos, idx, panel->start_file, panel->file_cursor_pos,
+      tree_text, file_dir_text, selection_dir_text, selection_name_text);
+}
+
+static void DebugLogFileSplitState(const char *label, const ViewContext *ctx) {
+  const char *active_side = "?";
+
+  if (!ctx) {
+    DEBUG_LOG("FILE_SPLIT[%s] <null>", label ? label : "?");
+    return;
+  }
+  if (ctx->active == ctx->left)
+    active_side = "LEFT";
+  else if (ctx->active == ctx->right)
+    active_side = "RIGHT";
+
+  DEBUG_LOG("FILE_SPLIT[%s] is_split=%d active=%s focused=%d",
+            label ? label : "?", ctx->is_split_screen, active_side,
+            ctx->focused_window);
+  DebugLogFilePanelState("LEFT", ctx->left);
+  DebugLogFilePanelState("RIGHT", ctx->right);
 }
 
 static FileEntry *GetActivePanelSelectedFile(ViewContext *ctx,
@@ -427,6 +512,7 @@ BOOL handle_file_window_split_switch_action(
 
   switch (action) {
   case ACTION_SPLIT_SCREEN:
+    DebugLogFileSplitState("FileAction:split:before", ctx);
     if (ctx->is_split_screen && ctx->active == owner_panel) {
       active_selected_file = GetActivePanelSelectedFile(ctx, dir_entry);
       if (active_selected_file) {
@@ -465,6 +551,7 @@ BOOL handle_file_window_split_switch_action(
                        sizeof(ctx->left->file_selection_dir_path), "%s",
                        active_selected_dir);
       }
+      PanelTags_Copy(ctx->left, ctx->right);
       ctx->left->saved_focus = ctx->right->saved_focus;
       FreeFileEntryList(ctx->left);
     }
@@ -480,6 +567,7 @@ BOOL handle_file_window_split_switch_action(
         ctx->right->file_cursor_pos = dir_entry->cursor_pos;
         ctx->right->file_dir_entry = dir_entry;
         ctx->right->saved_focus = ctx->left->saved_focus;
+        PanelTags_Copy(ctx->right, ctx->left);
         FreeFileEntryList(ctx->right);
       }
     } else {
@@ -487,12 +575,15 @@ BOOL handle_file_window_split_switch_action(
       ctx->active = ctx->left;
     }
 
+    DebugLogFileSplitState("FileAction:split:after", ctx);
+
     *return_esc_ptr = TRUE;
     return TRUE;
 
   case ACTION_SWITCH_PANEL:
     if (!ctx->is_split_screen)
       return TRUE;
+    DebugLogFileSplitState("FileAction:switch:before", ctx);
     owner_panel->file_dir_entry = dir_entry;
     owner_panel->start_file = dir_entry->start_file;
     owner_panel->file_cursor_pos = dir_entry->cursor_pos;
@@ -508,6 +599,7 @@ BOOL handle_file_window_split_switch_action(
     }
     ctx->focused_window = ctx->active->saved_focus;
     *loop_action_ptr = ACTION_ESCAPE;
+    DebugLogFileSplitState("FileAction:switch:after", ctx);
     return TRUE;
 
   default:
@@ -1687,7 +1779,8 @@ static void UpdateTaggedActionStatistics(ViewContext *ctx,
   DisplayDirStatistic(ctx, dir_entry, NULL, s);
 }
 
-static void SetFileTaggedState(FileEntry *fe_ptr, Statistic *s, BOOL tagged) {
+static void SetFileTaggedState(YtreePanel *panel, FileEntry *fe_ptr,
+                               Statistic *s, BOOL tagged) {
   DirEntry *de_ptr = NULL;
   off_t file_size = 0;
 
@@ -1705,6 +1798,7 @@ static void SetFileTaggedState(FileEntry *fe_ptr, Statistic *s, BOOL tagged) {
     de_ptr->tagged_bytes += file_size;
     s->disk_tagged_files++;
     s->disk_tagged_bytes += file_size;
+    PanelTags_RecordFileState(panel, fe_ptr, TRUE);
     return;
   }
 
@@ -1716,6 +1810,7 @@ static void SetFileTaggedState(FileEntry *fe_ptr, Statistic *s, BOOL tagged) {
   de_ptr->tagged_bytes -= file_size;
   s->disk_tagged_files--;
   s->disk_tagged_bytes -= file_size;
+  PanelTags_RecordFileState(panel, fe_ptr, FALSE);
 }
 
 static void SetFileTaggedStateRange(ViewContext *ctx, int start_idx, BOOL tagged,
@@ -1724,7 +1819,7 @@ static void SetFileTaggedStateRange(ViewContext *ctx, int start_idx, BOOL tagged
 
   for (i = start_idx; i < (int)ctx->active->file_count; i++) {
     FileEntry *fe_ptr = ctx->active->file_entry_list[i].file;
-    SetFileTaggedState(fe_ptr, s, tagged);
+    SetFileTaggedState(ctx->active, fe_ptr, s, tagged);
   }
 }
 
@@ -1744,7 +1839,7 @@ static BOOL HandleTaggedSelectionDispatchAction(
         ctx->active
             ->file_entry_list[dir_entry->start_file + dir_entry->cursor_pos]
             .file;
-    SetFileTaggedState(fe_ptr, s, TRUE);
+    SetFileTaggedState(ctx->active, fe_ptr, s, TRUE);
     UpdateTaggedActionStatistics(ctx, dir_entry, start_x, s);
     if (unput_char_ptr)
       *unput_char_ptr = KEY_DOWN;
@@ -1755,7 +1850,7 @@ static BOOL HandleTaggedSelectionDispatchAction(
         ctx->active
             ->file_entry_list[dir_entry->start_file + dir_entry->cursor_pos]
             .file;
-    SetFileTaggedState(fe_ptr, s, FALSE);
+    SetFileTaggedState(ctx->active, fe_ptr, s, FALSE);
     UpdateTaggedActionStatistics(ctx, dir_entry, start_x, s);
     if (unput_char_ptr)
       *unput_char_ptr = KEY_DOWN;

--- a/src/ui/dir_compare.c
+++ b/src/ui/dir_compare.c
@@ -221,8 +221,8 @@ static BOOL ShouldTagComparedFile(CompareTagResult tag_result, BOOL is_error,
   }
 }
 
-static void TagComparedFile(FileEntry *source_file, Statistic *stats,
-                            unsigned long *tagged_count) {
+static void TagComparedFile(YtreePanel *panel, FileEntry *source_file,
+                            Statistic *stats, unsigned long *tagged_count) {
   DirEntry *owner_dir;
   long long file_size;
 
@@ -239,6 +239,7 @@ static void TagComparedFile(FileEntry *source_file, Statistic *stats,
   owner_dir->tagged_bytes += file_size;
   stats->disk_tagged_files++;
   stats->disk_tagged_bytes += file_size;
+  PanelTags_RecordFileState(panel, source_file, TRUE);
   if (tagged_count)
     (*tagged_count)++;
 }
@@ -421,7 +422,7 @@ void DirCompare_RunInternalDirectory(ViewContext *ctx, DirEntry *source_dir,
     if (ShouldTagComparedFile(request->tag_result, is_error, is_unique,
                               is_type_mismatch, has_target, basis_known,
                               basis_match, mtime_cmp)) {
-      TagComparedFile(source_file, stats, &summary.tagged_count);
+      TagComparedFile(ctx->active, source_file, stats, &summary.tagged_count);
     }
   }
 
@@ -526,7 +527,7 @@ static void RunInternalLoggedTreeCompareRecursive(
     if (ShouldTagComparedFile(request->tag_result, is_error, is_unique,
                               is_type_mismatch, has_target, basis_known,
                               basis_match, mtime_cmp)) {
-      TagComparedFile(source_file, stats, &summary->tagged_count);
+      TagComparedFile(NULL, source_file, stats, &summary->tagged_count);
     }
   }
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -30,6 +30,92 @@ static void CaptureInactiveFallback(ViewContext *ctx, YtreePanel *p,
                                     DirEntry **inactive_fallback_out);
 static void ReanchorPanelToDir(YtreePanel *panel, const DirEntry *target);
 
+static BOOL DirBelongsToVolume(const struct Volume *vol, const DirEntry *target) {
+  int i;
+
+  if (!vol || !target || !vol->dir_entry_list || vol->total_dirs <= 0)
+    return FALSE;
+
+  for (i = 0; i < vol->total_dirs; i++) {
+    if (vol->dir_entry_list[i].dir_entry == target)
+      return TRUE;
+  }
+
+  return FALSE;
+}
+
+static void DebugLogPanelState(const char *label, const YtreePanel *panel) {
+  char tree_path[PATH_LENGTH + 1];
+  char file_dir_path[PATH_LENGTH + 1];
+  int idx = -1;
+  const DirEntry *tree_de = NULL;
+  const char *tree_text = "<none>";
+  const char *file_dir_text = "<none>";
+  const char *selection_dir_text = "<none>";
+  const char *selection_name_text = "<none>";
+
+  tree_path[0] = '\0';
+  file_dir_path[0] = '\0';
+
+  if (!panel) {
+    DEBUG_LOG("PANEL[%s] <null>", label ? label : "?");
+    return;
+  }
+
+  if (panel->vol && panel->vol->total_dirs > 0 && panel->vol->dir_entry_list) {
+    idx = panel->disp_begin_pos + panel->cursor_pos;
+    if (idx < 0)
+      idx = 0;
+    if (idx >= panel->vol->total_dirs)
+      idx = panel->vol->total_dirs - 1;
+    tree_de = panel->vol->dir_entry_list[idx].dir_entry;
+    if (tree_de) {
+      GetPath((DirEntry *)tree_de, tree_path);
+      tree_path[PATH_LENGTH] = '\0';
+      tree_text = tree_path;
+    }
+  }
+
+  if (panel->file_dir_entry && DirBelongsToVolume(panel->vol, panel->file_dir_entry)) {
+    GetPath(panel->file_dir_entry, file_dir_path);
+    file_dir_path[PATH_LENGTH] = '\0';
+    file_dir_text = file_dir_path;
+  } else if (panel->file_dir_entry) {
+    file_dir_text = "<stale>";
+  }
+
+  if (panel->file_selection_dir_path[0] != '\0')
+    selection_dir_text = panel->file_selection_dir_path;
+  if (panel->file_selection_name[0] != '\0')
+    selection_name_text = panel->file_selection_name;
+
+  DEBUG_LOG(
+      "PANEL[%s] saved_focus=%d disp=%d cur=%d idx=%d start=%d fcur=%d "
+      "tree='%s' file_dir='%s' sel_dir='%s' sel_name='%s'",
+      label ? label : "?", panel->saved_focus, panel->disp_begin_pos,
+      panel->cursor_pos, idx, panel->start_file, panel->file_cursor_pos,
+      tree_text, file_dir_text, selection_dir_text, selection_name_text);
+}
+
+static void DebugLogSplitState(const char *label, const ViewContext *ctx) {
+  const char *active_side = "?";
+
+  if (!ctx) {
+    DEBUG_LOG("SPLIT[%s] <null>", label ? label : "?");
+    return;
+  }
+
+  if (ctx->active == ctx->left)
+    active_side = "LEFT";
+  else if (ctx->active == ctx->right)
+    active_side = "RIGHT";
+
+  DEBUG_LOG("SPLIT[%s] is_split=%d active=%s focused=%d", label ? label : "?",
+            ctx->is_split_screen, active_side, ctx->focused_window);
+  DebugLogPanelState("LEFT", ctx->left);
+  DebugLogPanelState("RIGHT", ctx->right);
+}
+
 void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
                 char *new_log_path, BOOL *need_dsp_help, YtreePanel *p) {
   Statistic *s = &p->vol->vol_stats;
@@ -143,24 +229,173 @@ static int FindDirIndex(const struct Volume *vol, const DirEntry *target) {
   return -1;
 }
 
-static DirEntry *FindDirByPath(const struct Volume *vol, const char *path) {
-  int i;
+static DirEntry *FindDirByPathInSubTree(DirEntry *entry, const char *path) {
   char candidate_path[PATH_LENGTH + 1];
 
-  if (!vol || !path || !*path || !vol->dir_entry_list || vol->total_dirs <= 0)
-    return NULL;
-
-  for (i = 0; i < vol->total_dirs; i++) {
-    DirEntry *candidate = vol->dir_entry_list[i].dir_entry;
-    if (!candidate)
-      continue;
-    GetPath(candidate, candidate_path);
+  for (; entry; entry = entry->next) {
+    GetPath(entry, candidate_path);
     candidate_path[PATH_LENGTH] = '\0';
     if (strcmp(candidate_path, path) == 0)
-      return candidate;
+      return entry;
+    if (entry->sub_tree) {
+      DirEntry *resolved = FindDirByPathInSubTree(entry->sub_tree, path);
+      if (resolved)
+        return resolved;
+    }
   }
 
   return NULL;
+}
+
+static DirEntry *FindDirByPath(const struct Volume *vol, const char *path) {
+  if (!vol || !path || !*path)
+    return NULL;
+
+  if (vol->dir_entry_list && vol->total_dirs > 0) {
+    char candidate_path[PATH_LENGTH + 1];
+    int i;
+    for (i = 0; i < vol->total_dirs; i++) {
+      DirEntry *candidate = vol->dir_entry_list[i].dir_entry;
+      if (!candidate)
+        continue;
+      GetPath(candidate, candidate_path);
+      candidate_path[PATH_LENGTH] = '\0';
+      if (strcmp(candidate_path, path) == 0)
+        return candidate;
+    }
+  }
+
+  if (!vol->vol_stats.tree)
+    return NULL;
+
+  return FindDirByPathInSubTree(vol->vol_stats.tree, path);
+}
+
+static BOOL EnsureDirVisible(ViewContext *ctx, YtreePanel *panel, DirEntry *target) {
+  BOOL changed = FALSE;
+  DirEntry *ancestor;
+
+  if (!ctx || !panel || !panel->vol || !target)
+    return FALSE;
+
+  for (ancestor = target->up_tree; ancestor; ancestor = ancestor->up_tree) {
+    if (ancestor->not_scanned && ancestor->sub_tree) {
+      ancestor->not_scanned = FALSE;
+      changed = TRUE;
+    }
+  }
+
+  if (changed)
+    BuildDirEntryList(ctx, panel->vol, &panel->current_dir_entry);
+
+  return FindDirIndex(panel->vol, target) >= 0;
+}
+
+static DirEntry *FindDirByPathOrAncestor(const struct Volume *vol,
+                                         const char *path) {
+  char probe[PATH_LENGTH + 1];
+  size_t prev_len;
+
+  if (!vol || !path || !*path)
+    return NULL;
+
+  (void)snprintf(probe, sizeof(probe), "%s", path);
+  probe[PATH_LENGTH] = '\0';
+  prev_len = strlen(probe) + 1;
+
+  while (probe[0] != '\0') {
+    DirEntry *resolved = FindDirByPath(vol, probe);
+    char *slash;
+
+    if (resolved)
+      return resolved;
+
+    if (probe[0] == FILE_SEPARATOR_CHAR && probe[1] == '\0')
+      break;
+
+    if (strlen(probe) >= prev_len)
+      break;
+    prev_len = strlen(probe);
+
+    while (prev_len > 1 && probe[prev_len - 1] == FILE_SEPARATOR_CHAR) {
+      probe[prev_len - 1] = '\0';
+      prev_len--;
+    }
+
+    slash = strrchr(probe, FILE_SEPARATOR_CHAR);
+    if (!slash)
+      break;
+    if (slash == probe) {
+      probe[1] = '\0';
+    } else {
+      *slash = '\0';
+    }
+  }
+
+  return NULL;
+}
+
+static void AddPathSnapshot(PathList **list, const char *path) {
+  PathList *node;
+
+  if (!list || !path || !*path)
+    return;
+
+  node = (PathList *)xcalloc(1, sizeof(PathList));
+  node->path = xstrdup(path);
+  node->next = *list;
+  *list = node;
+}
+
+static void CapturePanelTaggedSnapshot(const YtreePanel *panel,
+                                       PathList **tagged) {
+  char path[PATH_LENGTH + 1];
+  unsigned int i;
+  const FileEntry *fe;
+
+  if (!panel || !tagged)
+    return;
+
+  for (i = 0; i < panel->file_count; i++) {
+    fe = panel->file_entry_list ? panel->file_entry_list[i].file : NULL;
+    if (fe && fe->tagged) {
+      GetFileNamePath((FileEntry *)fe, path);
+      path[PATH_LENGTH] = '\0';
+      AddPathSnapshot(tagged, path);
+    }
+  }
+
+  if (*tagged || !panel->file_dir_entry)
+    return;
+
+  for (fe = panel->file_dir_entry->file; fe; fe = fe->next) {
+    if (fe->tagged) {
+      GetFileNamePath((FileEntry *)fe, path);
+      path[PATH_LENGTH] = '\0';
+      AddPathSnapshot(tagged, path);
+    }
+  }
+}
+
+static void RestoreTaggedSnapshot(ViewContext *ctx, struct Volume *vol,
+                                  PathList *tagged) {
+  PathList *expanded = NULL;
+
+  if (!ctx || !vol || !vol->vol_stats.tree || !tagged)
+    return;
+
+  RestoreTreeState(ctx, vol->vol_stats.tree, &expanded, tagged,
+                   &vol->vol_stats);
+  FreePathList(expanded);
+}
+
+static int CountPathSnapshot(const PathList *list) {
+  int count = 0;
+
+  for (; list; list = list->next)
+    count++;
+
+  return count;
 }
 
 static void PositionPanelAtIndex(YtreePanel *panel, int idx) {
@@ -283,7 +518,13 @@ static void CaptureInactiveFallback(ViewContext *ctx, YtreePanel *p,
     if (inactive_idx >= inactive->vol->total_dirs)
       inactive_idx = inactive->vol->total_dirs - 1;
     inactive_de = inactive->vol->dir_entry_list[inactive_idx].dir_entry;
-  } else {
+  }
+  if (!inactive_de && inactive->file_selection_dir_path[0] != '\0') {
+    inactive_de = FindDirByPath(inactive->vol, inactive->file_selection_dir_path);
+  }
+  if (!inactive_de)
+    inactive_de = inactive->file_dir_entry;
+  if (!inactive_de) {
     inactive_de = inactive->vol->vol_stats.tree;
   }
 
@@ -313,6 +554,10 @@ void HandleCollapseSubTree(ViewContext *ctx, DirEntry *dir_entry,
     return;
 
   CaptureInactiveFallback(ctx, p, dir_entry, &inactive, &inactive_fallback);
+  if (ctx->left && ctx->left->vol == p->vol)
+    PanelTags_PruneUnderDir(ctx->left, dir_entry);
+  if (ctx->right && ctx->right->vol == p->vol)
+    PanelTags_PruneUnderDir(ctx->right, dir_entry);
 
   dir_entry->not_scanned = TRUE;
   dir_entry->unlogged_flag = FALSE;
@@ -349,6 +594,10 @@ void HandleUnreadSubTree(ViewContext *ctx, DirEntry *dir_entry,
   }
 
   CaptureInactiveFallback(ctx, p, dir_entry, &inactive, &inactive_fallback);
+  if (ctx->left && ctx->left->vol == p->vol)
+    PanelTags_PruneUnderDir(ctx->left, dir_entry);
+  if (ctx->right && ctx->right->vol == p->vol)
+    PanelTags_PruneUnderDir(ctx->right, dir_entry);
 
   for (de_ptr = dir_entry->sub_tree; de_ptr; de_ptr = de_ptr->next) {
     UnReadTree(ctx, de_ptr, s);
@@ -414,22 +663,67 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
   DirEntry *inactive_fallback = NULL;
   char inactive_path[PATH_LENGTH + 1];
   BOOL has_inactive_path = FALSE;
+  BOOL restore_inactive_file_anchor = FALSE;
+  int inactive_start_file = 0;
+  int inactive_file_cursor = 0;
+  char inactive_file_dir_path[PATH_LENGTH + 1];
+  char inactive_file_name[PATH_LENGTH + 1];
+  PathList *inactive_tagged_snapshot = NULL;
 
   if (!ctx || !ctx->active || !ctx->active->vol || !dir_entry)
     return;
 
+  DebugLogSplitState("HandleDirMakeDirectory:entry", ctx);
   ClearHelp(ctx);
   *dir_name = '\0';
   CaptureInactiveFallback(ctx, ctx->active, NULL, &inactive,
                           &inactive_fallback);
+  if (inactive_fallback) {
+    char fallback_path[PATH_LENGTH + 1];
+    GetPath(inactive_fallback, fallback_path);
+    fallback_path[PATH_LENGTH] = '\0';
+    DEBUG_LOG("HandleDirMakeDirectory:inactive_fallback='%s'", fallback_path);
+  } else {
+    DEBUG_LOG("HandleDirMakeDirectory:inactive_fallback=<null>");
+  }
   if (inactive && inactive->vol == ctx->active->vol && inactive_fallback) {
     GetPath(inactive_fallback, inactive_path);
     inactive_path[PATH_LENGTH] = '\0';
     has_inactive_path = TRUE;
   }
+  if (inactive && inactive->vol == ctx->active->vol &&
+      inactive->saved_focus == FOCUS_FILE) {
+    if (inactive->vol->total_dirs > 0) {
+      int inactive_idx = inactive->disp_begin_pos + inactive->cursor_pos;
+      DirEntry *inactive_dir = NULL;
+      if (inactive_idx < 0)
+        inactive_idx = 0;
+      if (inactive_idx >= inactive->vol->total_dirs)
+        inactive_idx = inactive->vol->total_dirs - 1;
+      inactive_dir = inactive->vol->dir_entry_list[inactive_idx].dir_entry;
+      if (!inactive_dir)
+        inactive_dir = inactive->file_dir_entry;
+      if (inactive_dir) {
+        inactive->file_dir_entry = inactive_dir;
+        CapturePanelSelectionAnchor(ctx, inactive, inactive_dir);
+      }
+    }
+    inactive_start_file = inactive->start_file;
+    inactive_file_cursor = inactive->file_cursor_pos;
+    (void)snprintf(inactive_file_dir_path, sizeof(inactive_file_dir_path), "%s",
+                   inactive->file_selection_dir_path);
+    (void)snprintf(inactive_file_name, sizeof(inactive_file_name), "%s",
+                   inactive->file_selection_name);
+    CapturePanelTaggedSnapshot(inactive, &inactive_tagged_snapshot);
+    restore_inactive_file_anchor = TRUE;
+  }
   if (UI_ReadString(ctx, ctx->active, "MAKE DIRECTORY:", dir_name, PATH_LENGTH,
                     HST_FILE) == CR) {
+    DEBUG_LOG("HandleDirMakeDirectory:requested='%s'", dir_name);
+    DebugLogSplitState("HandleDirMakeDirectory:before_make", ctx);
     if (!MakeDirectory(ctx, ctx->active, dir_entry, dir_name, s)) {
+      DebugLogSplitState("HandleDirMakeDirectory:after_make_before_rebuild",
+                         ctx);
       BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
       if (inactive && inactive->vol == ctx->active->vol) {
         const DirEntry *inactive_target = inactive_fallback;
@@ -439,14 +733,38 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
             inactive_target = resolved;
         }
         ReanchorPanelToDir(inactive, inactive_target);
+        if (restore_inactive_file_anchor) {
+          DirEntry *resolved_file_dir =
+              FindDirByPath(inactive->vol, inactive_file_dir_path);
+          if (resolved_file_dir)
+            inactive->file_dir_entry = resolved_file_dir;
+          inactive->start_file = inactive_start_file;
+          inactive->file_cursor_pos = inactive_file_cursor;
+          (void)snprintf(inactive->file_selection_dir_path,
+                         sizeof(inactive->file_selection_dir_path), "%s",
+                         inactive_file_dir_path);
+          (void)snprintf(inactive->file_selection_name,
+                         sizeof(inactive->file_selection_name), "%s",
+                         inactive_file_name);
+          if (resolved_file_dir) {
+            DirOps_ReloadPanelFileAnchorIfMissing(ctx, inactive,
+                                                  resolved_file_dir);
+          }
+        }
+        RestoreTaggedSnapshot(ctx, inactive->vol, inactive_tagged_snapshot);
+        PanelTags_Restore(ctx, inactive);
         BuildFileEntryList(ctx, inactive);
+        DebugLogSplitState("HandleDirMakeDirectory:after_inactive_restore",
+                           ctx);
       }
       RefreshView(ctx, dir_entry);
+      DebugLogSplitState("HandleDirMakeDirectory:after_refresh", ctx);
     }
   }
   wmove(ctx->ctx_border_window, ctx->layout.prompt_y, 0);
   wclrtoeol(ctx->ctx_border_window);
   wnoutrefresh(ctx->ctx_border_window);
+  FreePathList(inactive_tagged_snapshot);
 }
 
 DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
@@ -575,6 +893,11 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
       if (ctx->active->vol != start_vol)
         return;
 
+      p->file_dir_entry = dir_entry;
+      p->start_file = dir_entry->start_file;
+      p->file_cursor_pos = dir_entry->cursor_pos;
+      CapturePanelSelectionAnchor(ctx, p, dir_entry);
+
       /* Check if the panel we were handling is still valid/active.
        * A normal TAB panel switch from file view changes ctx->active while
        * split mode remains enabled; the caller will handle that hand-off.
@@ -651,9 +974,69 @@ void RefreshVolumeSwitchViews(ViewContext *ctx, DirEntry *dir_entry,
   DisplayHeaderPath(ctx, path);
 }
 
+
+
+void DirOps_ReloadPanelFileAnchorIfMissing(ViewContext *ctx, YtreePanel *panel,
+                                           DirEntry *dir_entry) {
+  char dir_path[PATH_LENGTH + 1];
+  Statistic *stats;
+  PathList *expanded = NULL;
+  PathList *tagged = NULL;
+  PathList *panel_tagged = NULL;
+
+  if (!ctx || !panel || !panel->vol || !dir_entry)
+    return;
+  if (panel->file_selection_name[0] == '\0' ||
+      panel->file_selection_dir_path[0] == '\0')
+    return;
+
+  GetPath(dir_entry, dir_path);
+  dir_path[PATH_LENGTH] = '\0';
+  if (strcmp(dir_path, panel->file_selection_dir_path) != 0)
+    return;
+
+  if (dir_entry->file != NULL || dir_entry->total_files > 0)
+    return;
+  if (!dir_entry->not_scanned && !dir_entry->unlogged_flag)
+    return;
+
+  stats = &panel->vol->vol_stats;
+  DEBUG_LOG(
+      "RestorePanelFileSelection:reload anchor path='%s' file='%s' not_scanned=%d",
+      panel->file_selection_dir_path, panel->file_selection_name,
+      dir_entry->not_scanned);
+
+  CapturePanelTaggedSnapshot(panel, &panel_tagged);
+  SaveTreeState(stats->tree, &expanded, &tagged);
+  DEBUG_LOG("RestorePanelFileSelection:tag_snapshot panel=%d tree=%d",
+            CountPathSnapshot(panel_tagged), CountPathSnapshot(tagged));
+  InvalidateVolumePanels(ctx, panel->vol);
+  if (RescanDir(ctx, dir_entry, 0, stats, Dir_Progress, ctx) == 0) {
+    RestoreTreeState(ctx, stats->tree, &expanded, tagged, stats);
+    RestoreTaggedSnapshot(ctx, panel->vol, panel_tagged);
+    PanelTags_Restore(ctx, panel);
+  }
+  FreePathList(expanded);
+  FreePathList(tagged);
+  FreePathList(panel_tagged);
+
+  BuildDirEntryList(ctx, panel->vol, &panel->current_dir_entry);
+  ReanchorPanelToDir(panel, FindDirByPathOrAncestor(panel->vol, dir_path));
+}
+
+static BOOL PanelHasVisibleFiles(ViewContext *ctx, YtreePanel *panel,
+                                 DirEntry *dir_entry) {
+  if (!ctx || !panel || !dir_entry)
+    return FALSE;
+  panel->file_dir_entry = dir_entry;
+  BuildFileEntryList(ctx, panel);
+  return panel->file_count > 0;
+}
+
 static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
                                            YtreePanel *panel) {
   int selected_idx = -1;
+  unsigned int file_count = 0;
 
   if (!ctx || !dir_entry || !panel)
     return dir_entry;
@@ -664,17 +1047,29 @@ static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry
   if (panel->file_selection_dir_path[0] != '\0' && panel->vol) {
     char current_dir_path[PATH_LENGTH + 1];
     DirEntry *resolved_dir = NULL;
+    DirEntry *exact_dir = NULL;
 
     GetPath(dir_entry, current_dir_path);
     current_dir_path[PATH_LENGTH] = '\0';
     if (strcmp(current_dir_path, panel->file_selection_dir_path) != 0) {
-      resolved_dir = FindDirByPath(panel->vol, panel->file_selection_dir_path);
+      exact_dir = FindDirByPath(panel->vol, panel->file_selection_dir_path);
+      if (exact_dir && EnsureDirVisible(ctx, panel, exact_dir))
+        resolved_dir = exact_dir;
+      if (!resolved_dir) {
+        resolved_dir =
+            FindDirByPathOrAncestor(panel->vol, panel->file_selection_dir_path);
+      }
       if (resolved_dir) {
         ReanchorPanelToDir(panel, resolved_dir);
         dir_entry = resolved_dir;
+      } else if (panel->vol && panel->vol->vol_stats.tree) {
+        ReanchorPanelToDir(panel, panel->vol->vol_stats.tree);
+        dir_entry = panel->vol->vol_stats.tree;
       }
     }
   }
+
+  DirOps_ReloadPanelFileAnchorIfMissing(ctx, panel, dir_entry);
 
   dir_entry->start_file = panel->start_file;
   dir_entry->cursor_pos = panel->file_cursor_pos;
@@ -720,6 +1115,40 @@ static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry
     dir_entry->cursor_pos = selected_idx - start;
   }
 
+  file_count = panel->file_count;
+  if (file_count == 0 && panel->file_selection_dir_path[0] != '\0') {
+    BuildFileEntryList(ctx, panel);
+    file_count = panel->file_count;
+  }
+  if (file_count == 0) {
+    DEBUG_LOG("RestorePanelFileSelection:empty_file_list path='%s' file='%s'",
+              panel->file_selection_dir_path, panel->file_selection_name);
+    dir_entry->start_file = 0;
+    dir_entry->cursor_pos = 0;
+  } else {
+    int original_start = dir_entry->start_file;
+    int original_cursor = dir_entry->cursor_pos;
+    if (dir_entry->start_file < 0)
+      dir_entry->start_file = 0;
+    if ((unsigned int)dir_entry->start_file >= file_count)
+      dir_entry->start_file = (int)file_count - 1;
+    if (dir_entry->cursor_pos < 0)
+      dir_entry->cursor_pos = 0;
+    if ((unsigned int)(dir_entry->start_file + dir_entry->cursor_pos) >=
+        file_count) {
+      dir_entry->cursor_pos = (int)file_count - 1 - dir_entry->start_file;
+      if (dir_entry->cursor_pos < 0)
+        dir_entry->cursor_pos = 0;
+    }
+    if (original_start != dir_entry->start_file ||
+        original_cursor != dir_entry->cursor_pos) {
+      DEBUG_LOG(
+          "RestorePanelFileSelection:clamp start=%d->%d cursor=%d->%d count=%u",
+          original_start, dir_entry->start_file, original_cursor,
+          dir_entry->cursor_pos, file_count);
+    }
+  }
+
   panel->file_dir_entry = dir_entry;
   panel->start_file = dir_entry->start_file;
   panel->file_cursor_pos = dir_entry->cursor_pos;
@@ -727,6 +1156,14 @@ static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry
     dir_entry->start_file = 0;
   if (dir_entry->cursor_pos < 0 && dir_entry->total_files > 0)
     dir_entry->cursor_pos = 0;
+  DEBUG_LOG(
+      "RestorePanelFileSelection:dir='%s' total=%u matching=%u file_count=%u "
+      "start=%d cursor=%d focus=%d spec='%s'",
+      dir_entry->name ? dir_entry->name : "<null>",
+      (unsigned int)dir_entry->total_files,
+      (unsigned int)dir_entry->matching_files, panel->file_count,
+      dir_entry->start_file, dir_entry->cursor_pos, panel->saved_focus,
+      panel->vol ? panel->vol->vol_stats.file_spec : "");
   return dir_entry;
 }
 
@@ -777,6 +1214,7 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
   }
 
   case ACTION_SPLIT_SCREEN:
+    DebugLogSplitState("DirPanelAction:split:before", ctx);
     if (ctx->is_split_screen && ctx->active == ctx->right && ctx->left &&
         ctx->right) {
       BOOL preserve_left_file_state =
@@ -848,12 +1286,14 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
 
     ctx->focused_window = ctx->active->saved_focus;
     RefreshView(ctx, *dir_entry_ptr);
+    DebugLogSplitState("DirPanelAction:split:after", ctx);
     *need_dsp_help_ptr = TRUE;
     return DIR_WINDOW_DISPATCH_HANDLED;
 
   case ACTION_SWITCH_PANEL:
     if (!ctx->is_split_screen)
       return DIR_WINDOW_DISPATCH_HANDLED;
+    DebugLogSplitState("DirPanelAction:switch:before", ctx);
 
     if (ctx->active == ctx->left) {
       ctx->active = ctx->right;
@@ -863,6 +1303,9 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
 
     ctx->focused_window = ctx->active->saved_focus;
     *s_ptr = &ctx->active->vol->vol_stats;
+    PanelTags_ApplyToTree(ctx, ctx->active);
+    DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",
+              ctx->active->saved_focus);
 
     if (ctx->active->vol->total_dirs > 0) {
       if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
@@ -874,6 +1317,14 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
     } else {
       *dir_entry_ptr = (*s_ptr)->tree;
     }
+    if (*dir_entry_ptr) {
+      char switch_path[PATH_LENGTH + 1];
+      GetPath(*dir_entry_ptr, switch_path);
+      switch_path[PATH_LENGTH] = '\0';
+      DEBUG_LOG("DirPanelAction:switch:resolved_dir='%s'", switch_path);
+    } else {
+      DEBUG_LOG("DirPanelAction:switch:resolved_dir=<null>");
+    }
 
     DEBUG_LOG("ACTION_SWITCH_PANEL: active panel is now %s with "
               "cursor_pos=%d, dir_entry=%s",
@@ -882,14 +1333,28 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
               *dir_entry_ptr ? (*dir_entry_ptr)->name : "NULL");
 
     SyncActivePanelWindows(ctx);
+    DEBUG_LOG("DirPanelAction:switch:after_sync_windows");
     *dir_entry_ptr =
         RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
-    RefreshView(ctx, *dir_entry_ptr);
+    if (!*dir_entry_ptr && *s_ptr) {
+      *dir_entry_ptr = (*s_ptr)->tree;
+      DEBUG_LOG("DirPanelAction:switch:restore returned null; fallback tree");
+    }
+    if (*dir_entry_ptr) {
+      DEBUG_LOG("DirPanelAction:switch:before_refresh dir='%s'",
+                (*dir_entry_ptr)->name ? (*dir_entry_ptr)->name : "<nullname>");
+      RefreshView(ctx, *dir_entry_ptr);
+      DEBUG_LOG("DirPanelAction:switch:after_refresh");
+    } else {
+      DEBUG_LOG("DirPanelAction:switch:skip_refresh dir_entry null");
+      return DIR_WINDOW_DISPATCH_HANDLED;
+    }
     *need_dsp_help_ptr = TRUE;
     if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
-        (*dir_entry_ptr)->total_files > 0) {
+        PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
       *unput_char_ptr = CR;
     }
+    DebugLogSplitState("DirPanelAction:switch:after", ctx);
     return DIR_WINDOW_DISPATCH_CONTINUE;
 
   default:
@@ -947,7 +1412,7 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
     RefreshView(ctx, *dir_entry_ptr);
     *need_dsp_help_ptr = TRUE;
     if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
-        (*dir_entry_ptr)->total_files > 0) {
+        PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
       *unput_char_ptr = CR;
     }
     *action_ptr = ACTION_NONE;
@@ -1270,6 +1735,7 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p, DirEntry *entry) {
 
     /* 3. Restore State */
     RestoreTreeState(ctx, s->tree, &expanded, tagged, s);
+    PanelTags_Restore(ctx, p);
     FreePathList(expanded);
     FreePathList(tagged);
 
@@ -1322,6 +1788,7 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p, DirEntry *entry) {
     entry->global_flag = saved_global_flag;
     entry->global_all_volumes = saved_global_all_volumes;
     entry->tagged_flag = saved_tagged_flag;
+    PanelTags_Restore(ctx, p);
 
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     /* Basic bounds check */

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -143,6 +143,26 @@ static int FindDirIndex(const struct Volume *vol, const DirEntry *target) {
   return -1;
 }
 
+static DirEntry *FindDirByPath(const struct Volume *vol, const char *path) {
+  int i;
+  char candidate_path[PATH_LENGTH + 1];
+
+  if (!vol || !path || !*path || !vol->dir_entry_list || vol->total_dirs <= 0)
+    return NULL;
+
+  for (i = 0; i < vol->total_dirs; i++) {
+    DirEntry *candidate = vol->dir_entry_list[i].dir_entry;
+    if (!candidate)
+      continue;
+    GetPath(candidate, candidate_path);
+    candidate_path[PATH_LENGTH] = '\0';
+    if (strcmp(candidate_path, path) == 0)
+      return candidate;
+  }
+
+  return NULL;
+}
+
 static void PositionPanelAtIndex(YtreePanel *panel, int idx) {
   int height;
 
@@ -390,13 +410,37 @@ BOOL HandleDirMakeFile(ViewContext *ctx, DirEntry *dir_entry) {
 void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
                             Statistic *s) {
   char dir_name[PATH_LENGTH * 2 + 1];
+  YtreePanel *inactive = NULL;
+  DirEntry *inactive_fallback = NULL;
+  char inactive_path[PATH_LENGTH + 1];
+  BOOL has_inactive_path = FALSE;
+
+  if (!ctx || !ctx->active || !ctx->active->vol || !dir_entry)
+    return;
 
   ClearHelp(ctx);
   *dir_name = '\0';
+  CaptureInactiveFallback(ctx, ctx->active, NULL, &inactive,
+                          &inactive_fallback);
+  if (inactive && inactive->vol == ctx->active->vol && inactive_fallback) {
+    GetPath(inactive_fallback, inactive_path);
+    inactive_path[PATH_LENGTH] = '\0';
+    has_inactive_path = TRUE;
+  }
   if (UI_ReadString(ctx, ctx->active, "MAKE DIRECTORY:", dir_name, PATH_LENGTH,
                     HST_FILE) == CR) {
     if (!MakeDirectory(ctx, ctx->active, dir_entry, dir_name, s)) {
       BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
+      if (inactive && inactive->vol == ctx->active->vol) {
+        const DirEntry *inactive_target = inactive_fallback;
+        if (has_inactive_path) {
+          DirEntry *resolved = FindDirByPath(ctx->active->vol, inactive_path);
+          if (resolved)
+            inactive_target = resolved;
+        }
+        ReanchorPanelToDir(inactive, inactive_target);
+        BuildFileEntryList(ctx, inactive);
+      }
       RefreshView(ctx, dir_entry);
     }
   }
@@ -607,15 +651,30 @@ void RefreshVolumeSwitchViews(ViewContext *ctx, DirEntry *dir_entry,
   DisplayHeaderPath(ctx, path);
 }
 
-static void RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
-                                      YtreePanel *panel) {
+static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
+                                           YtreePanel *panel) {
   int selected_idx = -1;
 
   if (!ctx || !dir_entry || !panel)
-    return;
+    return dir_entry;
 
   if (panel->saved_focus != FOCUS_FILE)
-    return;
+    return dir_entry;
+
+  if (panel->file_selection_dir_path[0] != '\0' && panel->vol) {
+    char current_dir_path[PATH_LENGTH + 1];
+    DirEntry *resolved_dir = NULL;
+
+    GetPath(dir_entry, current_dir_path);
+    current_dir_path[PATH_LENGTH] = '\0';
+    if (strcmp(current_dir_path, panel->file_selection_dir_path) != 0) {
+      resolved_dir = FindDirByPath(panel->vol, panel->file_selection_dir_path);
+      if (resolved_dir) {
+        ReanchorPanelToDir(panel, resolved_dir);
+        dir_entry = resolved_dir;
+      }
+    }
+  }
 
   dir_entry->start_file = panel->start_file;
   dir_entry->cursor_pos = panel->file_cursor_pos;
@@ -668,6 +727,7 @@ static void RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
     dir_entry->start_file = 0;
   if (dir_entry->cursor_pos < 0 && dir_entry->total_files > 0)
     dir_entry->cursor_pos = 0;
+  return dir_entry;
 }
 
 DirWindowDispatchResult
@@ -719,6 +779,23 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
   case ACTION_SPLIT_SCREEN:
     if (ctx->is_split_screen && ctx->active == ctx->right && ctx->left &&
         ctx->right) {
+      BOOL preserve_left_file_state =
+          (ctx->left->saved_focus == FOCUS_FILE &&
+           ctx->right->saved_focus != FOCUS_FILE);
+      int preserved_start_file = ctx->left->start_file;
+      int preserved_file_cursor = ctx->left->file_cursor_pos;
+      DirEntry *preserved_file_dir_entry = ctx->left->file_dir_entry;
+      BOOL preserved_big_file_view = ctx->left->saved_big_file_view;
+      char preserved_file_selection_name[PATH_LENGTH + 1];
+      char preserved_file_selection_dir_path[PATH_LENGTH + 1];
+
+      (void)snprintf(preserved_file_selection_name,
+                     sizeof(preserved_file_selection_name), "%s",
+                     ctx->left->file_selection_name);
+      (void)snprintf(preserved_file_selection_dir_path,
+                     sizeof(preserved_file_selection_dir_path), "%s",
+                     ctx->left->file_selection_dir_path);
+
       ctx->left->vol = ctx->right->vol;
       ctx->left->cursor_pos = ctx->right->cursor_pos;
       ctx->left->disp_begin_pos = ctx->right->disp_begin_pos;
@@ -733,6 +810,18 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
                      ctx->right->file_selection_dir_path);
       ctx->left->saved_big_file_view = ctx->right->saved_big_file_view;
       ctx->left->saved_focus = ctx->right->saved_focus;
+      if (preserve_left_file_state) {
+        ctx->left->start_file = preserved_start_file;
+        ctx->left->file_cursor_pos = preserved_file_cursor;
+        ctx->left->file_dir_entry = preserved_file_dir_entry;
+        ctx->left->saved_big_file_view = preserved_big_file_view;
+        (void)snprintf(ctx->left->file_selection_name,
+                       sizeof(ctx->left->file_selection_name), "%s",
+                       preserved_file_selection_name);
+        (void)snprintf(ctx->left->file_selection_dir_path,
+                       sizeof(ctx->left->file_selection_dir_path), "%s",
+                       preserved_file_selection_dir_path);
+      }
       FreeFileEntryList(ctx->left);
       ctx->active->vol = ctx->left->vol;
     }
@@ -793,7 +882,8 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
               *dir_entry_ptr ? (*dir_entry_ptr)->name : "NULL");
 
     SyncActivePanelWindows(ctx);
-    RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
+    *dir_entry_ptr =
+        RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
     RefreshView(ctx, *dir_entry_ptr);
     *need_dsp_help_ptr = TRUE;
     if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
@@ -852,7 +942,8 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
     *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
     SyncActivePanelWindows(ctx);
 
-    RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
+    *dir_entry_ptr =
+        RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
     RefreshView(ctx, *dir_entry_ptr);
     *need_dsp_help_ptr = TRUE;
     if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&

--- a/src/ui/dir_tags.c
+++ b/src/ui/dir_tags.c
@@ -30,6 +30,7 @@ void HandleTagDir(ViewContext *ctx, DirEntry *dir_entry, BOOL value,
         s->disk_tagged_files--;
         s->disk_tagged_bytes -= fe_ptr->stat_struct.st_size;
       }
+      PanelTags_RecordFileState(p, fe_ptr, value);
     }
   }
   dir_entry->start_file = 0;
@@ -67,6 +68,7 @@ void HandleTagAllDirs(ViewContext *ctx, struct Volume *vol, DirEntry *dir_entry,
           s->disk_tagged_files--;
           s->disk_tagged_bytes -= fe_ptr->stat_struct.st_size;
         }
+        PanelTags_RecordFileState(p, fe_ptr, value);
       }
     }
   }

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -7,6 +7,7 @@
 
 #include "../../include/ytree.h"
 #include "../../include/ytree_cmd.h"
+#include "../../include/ytree_fs.h"
 #include "../../include/ytree_ui.h"
 
 /* PrintMenuLine is removed as its functionality for drawing the static stats
@@ -422,19 +423,116 @@ void UnmapF2Window(ViewContext *ctx) {
 
 void RefreshWindow(WINDOW *win) { wnoutrefresh(win); }
 
+static int FindPanelDirIndexByEntry(const YtreePanel *panel,
+                                    const DirEntry *target) {
+  int i;
+
+  if (!panel || !panel->vol || !target || !panel->vol->dir_entry_list ||
+      panel->vol->total_dirs <= 0)
+    return -1;
+
+  for (i = 0; i < panel->vol->total_dirs; i++) {
+    if (panel->vol->dir_entry_list[i].dir_entry == target)
+      return i;
+  }
+
+  return -1;
+}
+
+static int FindPanelDirIndexByPath(const YtreePanel *panel, const char *path) {
+  int i;
+  char candidate_path[PATH_LENGTH + 1];
+
+  if (!panel || !panel->vol || !path || !*path || !panel->vol->dir_entry_list ||
+      panel->vol->total_dirs <= 0)
+    return -1;
+
+  for (i = 0; i < panel->vol->total_dirs; i++) {
+    const DirEntry *candidate = panel->vol->dir_entry_list[i].dir_entry;
+    if (!candidate)
+      continue;
+    GetPath((DirEntry *)candidate, candidate_path);
+    candidate_path[PATH_LENGTH] = '\0';
+    if (strcmp(candidate_path, path) == 0)
+      return i;
+  }
+
+  return -1;
+}
+
+static void PositionPanelAtDirIndex(YtreePanel *panel, int idx) {
+  int height;
+
+  if (!panel || !panel->vol || !panel->vol->dir_entry_list ||
+      panel->vol->total_dirs <= 0)
+    return;
+
+  if (idx < 0)
+    idx = 0;
+  if (idx >= panel->vol->total_dirs)
+    idx = panel->vol->total_dirs - 1;
+
+  height = panel->pan_dir_window ? getmaxy(panel->pan_dir_window) : 1;
+  if (height < 1)
+    height = 1;
+
+  if (idx >= panel->disp_begin_pos && idx < panel->disp_begin_pos + height) {
+    panel->cursor_pos = idx - panel->disp_begin_pos;
+  } else {
+    panel->disp_begin_pos = idx;
+    panel->cursor_pos = 0;
+    if (panel->disp_begin_pos + height > panel->vol->total_dirs) {
+      panel->disp_begin_pos = panel->vol->total_dirs - height;
+      if (panel->disp_begin_pos < 0)
+        panel->disp_begin_pos = 0;
+      panel->cursor_pos = idx - panel->disp_begin_pos;
+      if (panel->cursor_pos < 0)
+        panel->cursor_pos = 0;
+    }
+  }
+}
+
+static DirEntry *ResolvePanelFileAnchor(const YtreePanel *panel) {
+  int anchor_idx = -1;
+
+  if (!panel || !panel->vol || panel->saved_focus != FOCUS_FILE)
+    return NULL;
+
+  if (panel->file_selection_dir_path[0] != '\0') {
+    anchor_idx = FindPanelDirIndexByPath(panel, panel->file_selection_dir_path);
+  }
+  if (anchor_idx < 0 && panel->file_dir_entry) {
+    anchor_idx = FindPanelDirIndexByEntry(panel, panel->file_dir_entry);
+  }
+  if (anchor_idx < 0)
+    return NULL;
+
+  PositionPanelAtDirIndex(panel, anchor_idx);
+  return panel->vol->dir_entry_list[anchor_idx].dir_entry;
+}
+
+static DirEntry *EnsurePanelFileAnchorRenderable(ViewContext *ctx,
+                                                 YtreePanel *panel) {
+  DirEntry *anchor;
+
+  (void)ctx;
+  anchor = ResolvePanelFileAnchor(panel);
+  if (!anchor)
+    return NULL;
+
+  panel->file_dir_entry = anchor;
+  return anchor;
+}
+
 void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
-  /* Modified check as per instructions */
   if (!panel || !panel->vol || !panel->pan_dir_window)
     return;
 
-  /* Clamp cursor */
   int total = panel->vol->total_dirs;
-  /* Use Panel state, not Volume state */
   int begin = panel->disp_begin_pos;
   int cursor = panel->cursor_pos;
 
   if (total > 0 && (begin + cursor >= total)) {
-    /* Fix invalid position if any */
     begin = 0;
     cursor = 0;
   }
@@ -442,12 +540,17 @@ void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
   if (total <= 0)
     return;
 
+  if (panel->saved_focus == FOCUS_FILE &&
+      EnsurePanelFileAnchorRenderable(ctx, panel)) {
+    begin = panel->disp_begin_pos;
+    cursor = panel->cursor_pos;
+  }
+
   {
     int idx = begin + cursor;
     int render_start = panel->start_file;
     int render_cursor = 0;
     const DirEntry *de = NULL;
-    BOOL has_file_list = FALSE;
 
     if (idx < 0 || idx >= total)
       return;
@@ -456,36 +559,59 @@ void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
     if (!de)
       return;
 
-    if (!panel->file_entry_list) {
+    if (panel->saved_focus == FOCUS_FILE) {
+      BOOL refresh_file_cache = FALSE;
+
+      DirOps_ReloadPanelFileAnchorIfMissing(ctx, panel, (DirEntry *)de);
+      if (panel->file_dir_entry != de || panel->file_entry_list == NULL) {
+        refresh_file_cache = TRUE;
+      }
+      panel->file_dir_entry = (DirEntry *)de;
+      if (refresh_file_cache) {
+        FreeFileEntryList(panel);
+        BuildFileEntryList(ctx, panel);
+      }
+    } else if (!panel->file_entry_list) {
       BuildFileEntryList(ctx, panel);
     }
-    has_file_list = (panel->file_entry_list != NULL);
 
     render_cursor = de->cursor_pos;
     if (panel->file_dir_entry == de) {
       render_start = panel->start_file;
       render_cursor = panel->file_cursor_pos;
     }
+    if (panel->file_count > 0) {
+      if (render_start < 0)
+        render_start = 0;
+      if ((unsigned int)render_start >= panel->file_count)
+        render_start = (int)panel->file_count - 1;
+      if (render_cursor < 0)
+        render_cursor = 0;
+      if ((unsigned int)(render_start + render_cursor) >= panel->file_count) {
+        render_cursor = (int)panel->file_count - 1 - render_start;
+        if (render_cursor < 0)
+          render_cursor = 0;
+      }
+    } else {
+      render_start = 0;
+      render_cursor = 0;
+    }
 
     if (panel->saved_focus == FOCUS_FILE && panel->pan_big_file_window) {
-      /* Preserve file-centric state for inactive panels: when a panel was left
-       * in file mode, render it on files, not on directory tree.
-       */
+      DEBUG_LOG("RenderInactivePanel:file path='%s' start=%d cursor=%d count=%u",
+                panel->file_selection_dir_path[0] ? panel->file_selection_dir_path
+                                                   : "<none>",
+                render_start, render_cursor, panel->file_count);
       if (panel->pan_dir_window) {
         werase(panel->pan_dir_window);
         wnoutrefresh(panel->pan_dir_window);
       }
-      if (has_file_list) {
-        DisplayFiles(ctx, panel, de, render_start, render_start + render_cursor,
-                     0, panel->pan_big_file_window);
-      } else {
-        werase(panel->pan_big_file_window);
-      }
+      DisplayFiles(ctx, panel, de, render_start, render_start + render_cursor,
+                   0, panel->pan_big_file_window);
       wnoutrefresh(panel->pan_big_file_window);
       return;
     }
 
-    /* Tree-focused inactive panel rendering */
     if (panel->pan_dir_window) {
       DisplayTree(ctx, panel->vol, panel->pan_dir_window, begin, begin + cursor,
                   FALSE);
@@ -493,12 +619,7 @@ void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
     }
 
     if (panel->pan_file_window) {
-      if (has_file_list) {
-        DisplayFiles(ctx, panel, de, render_start, -1, 0,
-                     panel->pan_file_window);
-      } else {
-        werase(panel->pan_file_window);
-      }
+      DisplayFiles(ctx, panel, de, render_start, -1, 0, panel->pan_file_window);
       wnoutrefresh(panel->pan_file_window);
     }
   }

--- a/src/ui/display_utils.c
+++ b/src/ui/display_utils.c
@@ -227,8 +227,8 @@ char *CutName(char *dest, const char *src, unsigned int max_len) {
  *                           BuildUserFileEntry                              *
  *****************************************************************************/
 int BuildUserFileEntry(FileEntry *fe_ptr, int filename_width,
-                       int linkname_width, char *template, int linelen,
-                       char *line) {
+                       int linkname_width, BOOL tagged, char *template,
+                       int linelen, char *line) {
   char attributes[11];
   char modify_time[20];
   char change_time[20];
@@ -256,7 +256,7 @@ int BuildUserFileEntry(FileEntry *fe_ptr, int filename_width,
   else
     sym_link_name = "";
 
-  tag = (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ';
+  tag = tagged ? TAGGED_SYMBOL : ' ';
   (void)GetAttributes(fe_ptr->stat_struct.st_mode, attributes);
 
   (void)CTime(fe_ptr->stat_struct.st_mtime, modify_time);

--- a/src/ui/file_list.c
+++ b/src/ui/file_list.c
@@ -196,18 +196,49 @@ void InvalidateVolumePanels(ViewContext *ctx, const struct Volume *vol) {
 
 void DisplayFileWindow(ViewContext *ctx, YtreePanel *panel,
                        const DirEntry *dir_entry) {
+  int render_start;
+  int render_cursor;
+  int highlight_idx;
+
   if (!panel || !panel->pan_file_window)
     return;
 
   BuildFileEntryList(ctx, panel);
 
-  /* ADDED INSTRUCTION: Focus-Aware Highlighting */
-  int highlight_idx = -1;
-  if (ctx->focused_window == FOCUS_FILE) {
-    highlight_idx = dir_entry->start_file + dir_entry->cursor_pos;
+  render_start = dir_entry->start_file;
+  render_cursor = dir_entry->cursor_pos;
+  if (panel->file_count == 0) {
+    render_start = 0;
+    render_cursor = 0;
+  } else {
+    int original_start = render_start;
+    int original_cursor = render_cursor;
+    if (render_start < 0)
+      render_start = 0;
+    if ((unsigned int)render_start >= panel->file_count)
+      render_start = (int)panel->file_count - 1;
+    if (render_cursor < 0)
+      render_cursor = 0;
+    if ((unsigned int)(render_start + render_cursor) >= panel->file_count) {
+      render_cursor = (int)panel->file_count - 1 - render_start;
+      if (render_cursor < 0)
+        render_cursor = 0;
+    }
+    if (original_start != render_start || original_cursor != render_cursor) {
+      DEBUG_LOG("DisplayFileWindow:clamp start=%d->%d cursor=%d->%d count=%u",
+                original_start, render_start, original_cursor, render_cursor,
+                panel->file_count);
+    }
   }
 
-  DisplayFiles(ctx, panel, dir_entry, dir_entry->start_file, highlight_idx, 0,
+  panel->start_file = render_start;
+  panel->file_cursor_pos = render_cursor;
+
+  highlight_idx = -1;
+  if (ctx->focused_window == FOCUS_FILE)
+    highlight_idx = render_start + render_cursor;
+
+  DisplayFiles(ctx, panel, dir_entry, render_start, highlight_idx, 0,
                panel->pan_file_window);
 }
 

--- a/src/ui/file_tags.c
+++ b/src/ui/file_tags.c
@@ -141,6 +141,7 @@ void FileTags_SilentTagWalkTaggedFiles(ViewContext *ctx,
         ctx->active->vol->vol_stats.disk_tagged_files--;
         ctx->active->vol->vol_stats.disk_tagged_bytes -=
             fe_ptr->stat_struct.st_size;
+        PanelTags_RecordFileState(ctx->active, fe_ptr, FALSE);
       }
     }
   }
@@ -282,6 +283,7 @@ void FileTags_HandleInvertTags(ViewContext *ctx, DirEntry *dir_entry,
         s->disk_tagged_files--;
         dir_entry->tagged_files--;
       }
+      PanelTags_RecordFileState(ctx->active, fe, fe->tagged);
     }
   }
 }

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -1,0 +1,247 @@
+/***************************************************************************
+ *
+ * src/ui/panel_anchor.c
+ * Panel anchor helpers for split-pane directory/file state restoration.
+ *
+ ***************************************************************************/
+
+#include "ytree_fs.h"
+#include "ytree_panel_anchor.h"
+#include "ytree_ui.h"
+#include <stdio.h>
+#include <string.h>
+
+BOOL CapturePanelAnchorPath(const YtreePanel *panel, const struct Volume *vol,
+                            char *out_path, size_t out_path_size) {
+  int idx;
+  DirEntry *entry;
+
+  if (!out_path || out_path_size == 0)
+    return FALSE;
+  out_path[0] = '\0';
+
+  if (!panel || !vol || panel->vol != vol)
+    return FALSE;
+
+  if (panel->saved_focus == FOCUS_FILE && panel->file_selection_dir_path[0]) {
+    (void)snprintf(out_path, out_path_size, "%s", panel->file_selection_dir_path);
+    return TRUE;
+  }
+
+  if (!vol->dir_entry_list || vol->total_dirs <= 0)
+    return FALSE;
+
+  idx = panel->disp_begin_pos + panel->cursor_pos;
+  if (idx < 0)
+    idx = 0;
+  if (idx >= vol->total_dirs)
+    idx = vol->total_dirs - 1;
+  entry = vol->dir_entry_list[idx].dir_entry;
+  if (!entry)
+    return FALSE;
+
+  GetPath(entry, out_path);
+  out_path[out_path_size - 1] = '\0';
+  return TRUE;
+}
+
+int FindDirIndexByPath(const struct Volume *vol, const char *path) {
+  int i;
+  char candidate_path[PATH_LENGTH + 1];
+
+  if (!vol || !path || !*path || !vol->dir_entry_list || vol->total_dirs <= 0)
+    return -1;
+
+  for (i = 0; i < vol->total_dirs; i++) {
+    DirEntry *candidate = vol->dir_entry_list[i].dir_entry;
+    if (!candidate)
+      continue;
+    GetPath(candidate, candidate_path);
+    candidate_path[PATH_LENGTH] = '\0';
+    if (strcmp(candidate_path, path) == 0)
+      return i;
+  }
+
+  return -1;
+}
+
+int FindDirIndexByPathOrAncestor(const struct Volume *vol, const char *path) {
+  char probe[PATH_LENGTH + 1];
+
+  if (!vol || !path || !*path)
+    return -1;
+
+  (void)snprintf(probe, sizeof(probe), "%s", path);
+  probe[PATH_LENGTH] = '\0';
+
+  while (probe[0] != '\0') {
+    int idx = FindDirIndexByPath(vol, probe);
+    char *slash;
+    size_t len;
+
+    if (idx >= 0)
+      return idx;
+
+    len = strlen(probe);
+    while (len > 1 && probe[len - 1] == FILE_SEPARATOR_CHAR) {
+      probe[len - 1] = '\0';
+      len--;
+    }
+    if (probe[0] == FILE_SEPARATOR_CHAR && probe[1] == '\0')
+      break;
+
+    slash = strrchr(probe, FILE_SEPARATOR_CHAR);
+    if (!slash)
+      break;
+    if (slash == probe)
+      probe[1] = '\0';
+    else
+      *slash = '\0';
+  }
+
+  return -1;
+}
+
+void PositionPanelAtIndex(YtreePanel *panel, int idx) {
+  int height;
+
+  if (!panel || !panel->vol || !panel->vol->dir_entry_list ||
+      panel->vol->total_dirs <= 0)
+    return;
+
+  if (idx < 0)
+    idx = 0;
+  if (idx >= panel->vol->total_dirs)
+    idx = panel->vol->total_dirs - 1;
+
+  height = panel->pan_dir_window ? getmaxy(panel->pan_dir_window) : 1;
+  if (height < 1)
+    height = 1;
+
+  if (idx >= panel->disp_begin_pos && idx < panel->disp_begin_pos + height) {
+    panel->cursor_pos = idx - panel->disp_begin_pos;
+  } else {
+    panel->disp_begin_pos = idx;
+    panel->cursor_pos = 0;
+    if (panel->disp_begin_pos + height > panel->vol->total_dirs) {
+      panel->disp_begin_pos = panel->vol->total_dirs - height;
+      if (panel->disp_begin_pos < 0)
+        panel->disp_begin_pos = 0;
+      panel->cursor_pos = idx - panel->disp_begin_pos;
+      if (panel->cursor_pos < 0)
+        panel->cursor_pos = 0;
+    }
+  }
+}
+
+void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
+                            const char *anchor_path) {
+  int idx;
+
+  if (!vol || !panel || panel->vol != vol || !anchor_path || !*anchor_path)
+    return;
+
+  idx = FindDirIndexByPathOrAncestor(vol, anchor_path);
+  if (idx < 0)
+    return;
+
+  PositionPanelAtIndex(panel, idx);
+  if (panel->saved_focus == FOCUS_FILE)
+    panel->file_dir_entry = vol->dir_entry_list[idx].dir_entry;
+}
+
+DirEntry *FindDirByPathInTree(DirEntry *entry, const char *path) {
+  char candidate_path[PATH_LENGTH + 1];
+
+  for (; entry; entry = entry->next) {
+    GetPath(entry, candidate_path);
+    candidate_path[PATH_LENGTH] = '\0';
+    if (strcmp(candidate_path, path) == 0)
+      return entry;
+    if (entry->sub_tree) {
+      DirEntry *resolved = FindDirByPathInTree(entry->sub_tree, path);
+      if (resolved)
+        return resolved;
+    }
+  }
+
+  return NULL;
+}
+
+void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
+                              YtreePanel *panel, const char *label) {
+  int idx;
+  DirEntry *target;
+  DirEntry *ancestor;
+  BOOL changed = FALSE;
+
+  if (!ctx || !vol || !panel || panel->vol != vol)
+    return;
+  if (panel->saved_focus != FOCUS_FILE ||
+      panel->file_selection_dir_path[0] == '\0')
+    return;
+
+  idx = FindDirIndexByPath(vol, panel->file_selection_dir_path);
+  if (idx >= 0) {
+    target = vol->dir_entry_list[idx].dir_entry;
+    PositionPanelAtIndex(panel, idx);
+    panel->file_dir_entry = target;
+    return;
+  }
+
+  target = FindDirByPathInTree(vol->vol_stats.tree, panel->file_selection_dir_path);
+  if (!target)
+    return;
+
+  for (ancestor = target->up_tree; ancestor; ancestor = ancestor->up_tree) {
+    if (ancestor->not_scanned && ancestor->sub_tree) {
+      ancestor->not_scanned = FALSE;
+      changed = TRUE;
+    }
+  }
+
+  if (changed) {
+    DEBUG_LOG("HandleDirWindow:expand anchor label=%s path='%s'",
+              label ? label : "?", panel->file_selection_dir_path);
+    BuildDirEntryList(ctx, panel->vol, &panel->current_dir_entry);
+  }
+
+  idx = FindDirIndexByPathOrAncestor(vol, panel->file_selection_dir_path);
+  if (idx >= 0) {
+    PositionPanelAtIndex(panel, idx);
+    panel->file_dir_entry = vol->dir_entry_list[idx].dir_entry;
+  }
+}
+
+void DebugLogDirLoopState(const char *label, const ViewContext *ctx,
+                          const DirEntry *dir_entry, int ch, YtreeAction action,
+                          int unput_char) {
+  char dir_path[PATH_LENGTH + 1];
+  const char *active_side = "?";
+
+  dir_path[0] = '\0';
+  if (dir_entry) {
+    GetPath((DirEntry *)dir_entry, dir_path);
+    dir_path[PATH_LENGTH] = '\0';
+  }
+  if (ctx && ctx->active) {
+    if (ctx->active == ctx->left)
+      active_side = "LEFT";
+    else if (ctx->active == ctx->right)
+      active_side = "RIGHT";
+  }
+
+  DEBUG_LOG("DirLoop[%s] ch=%d action=%d unput=%d active=%s focus=%d "
+            "left(d=%d c=%d sf=%d fc=%d) right(d=%d c=%d sf=%d fc=%d) dir='%s'",
+            label ? label : "?", ch, (int)action, unput_char, active_side,
+            ctx ? (int)ctx->focused_window : -1,
+            (ctx && ctx->left) ? ctx->left->disp_begin_pos : -1,
+            (ctx && ctx->left) ? ctx->left->cursor_pos : -1,
+            (ctx && ctx->left) ? ctx->left->start_file : -1,
+            (ctx && ctx->left) ? ctx->left->file_cursor_pos : -1,
+            (ctx && ctx->right) ? ctx->right->disp_begin_pos : -1,
+            (ctx && ctx->right) ? ctx->right->cursor_pos : -1,
+            (ctx && ctx->right) ? ctx->right->start_file : -1,
+            (ctx && ctx->right) ? ctx->right->file_cursor_pos : -1,
+            dir_entry ? dir_path : "<null>");
+}

--- a/src/ui/render_file.c
+++ b/src/ui/render_file.c
@@ -206,6 +206,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
   int linkname_width = 0;
   int base_color_pair;
   int width;
+  BOOL is_tagged;
 
   if (!panel->file_entry_list)
     return;
@@ -215,6 +216,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
   fe_ptr = panel->file_entry_list[entry_no].file;
   if (fe_ptr == NULL)
     return;
+  is_tagged = PanelTags_FileIsTagged(panel, fe_ptr);
 
   if (ctx->fixed_col_width > 0) {
     pos_x = x * (ctx->fixed_col_width + 1);
@@ -228,13 +230,13 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
     /* Set Attributes */
     int color = GetFileTypeColor(ctx, fe_ptr);
     wattron(win, COLOR_PAIR(color));
-    if (fe_ptr->tagged)
+    if (is_tagged)
       wattron(win, A_BOLD);
     if (hilight)
       wattron(win, A_REVERSE);
 
     /* Draw */
-    wprintw(win, "%c%c%s", (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ',
+    wprintw(win, "%c%c%s", (is_tagged) ? TAGGED_SYMBOL : ' ',
             GetTypeOfFile(fe_ptr->stat_struct), display_name);
 
     /* Pad remaining width */
@@ -247,7 +249,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
     /* Cleanup */
     if (hilight)
       wattroff(win, A_REVERSE);
-    if (fe_ptr->tagged)
+    if (is_tagged)
       wattroff(win, A_BOLD);
     wattroff(win, COLOR_PAIR(color));
     return;
@@ -335,7 +337,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
   if (ctx->highlight_full_line) {
     /* --- RENDER METHOD 1: FULL LINE HIGHLIGHT --- */
     wattron(win, COLOR_PAIR(base_color_pair));
-    if (fe_ptr->tagged)
+    if (is_tagged)
       wattron(win, A_BOLD);
     if (hilight)
       wattron(win, A_REVERSE);
@@ -351,7 +353,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
                        "%%c%%c%%-%ds %%10s %%3d %%11lld %%16s -> %%-%ds",
                        filename_width, linkname_width);
         (void)snprintf(line_buffer, line_buffer_size, format,
-                       (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
                        fe_ptr->name, attributes, fe_ptr->stat_struct.st_nlink,
                        (long long)fe_ptr->stat_struct.st_size, modify_time,
                        sym_link_name);
@@ -360,7 +362,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
                        "%%c%%c%%%c%ds %%10s %%3d %%11lld %%16s", justify,
                        filename_width);
         (void)snprintf(line_buffer, line_buffer_size, format,
-                       (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
                        fe_ptr->name, attributes, fe_ptr->stat_struct.st_nlink,
                        (long long)fe_ptr->stat_struct.st_size, modify_time);
       }
@@ -381,7 +383,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
                        "%%c%%c%%%c%ds %%10lld %%-12s %%-12s -> %%-%ds", justify,
                        filename_width, linkname_width);
         (void)snprintf(line_buffer, line_buffer_size, format,
-                       (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
                        fe_ptr->name, (long long)fe_ptr->stat_struct.st_ino,
                        owner_name_ptr, group_name_ptr, sym_link_name);
       } else {
@@ -389,7 +391,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
                        "%%c%%c%%%c%ds %%10lld %%-12s %%-12s", justify,
                        filename_width);
         (void)snprintf(line_buffer, line_buffer_size, format,
-                       (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
                        fe_ptr->name, (long long)fe_ptr->stat_struct.st_ino,
                        owner_name_ptr, group_name_ptr);
       }
@@ -398,7 +400,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
       (void)snprintf(format, sizeof(format), "%%c%%c%%%c%ds", justify,
                      filename_width);
       (void)snprintf(line_buffer, line_buffer_size, format,
-                     (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                     (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
                      fe_ptr->name);
       break;
     case MODE_4:
@@ -410,19 +412,19 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
                        "%%c%%c%%%c%ds Chg: %%16s  Acc: %%16s -> %%-%ds",
                        justify, filename_width, linkname_width);
         (void)snprintf(line_buffer, line_buffer_size, format,
-                       (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
                        fe_ptr->name, change_time, access_time, sym_link_name);
       } else {
         (void)snprintf(format, sizeof(format),
                        "%%c%%c%%%c%ds Chg: %%16s  Acc: %%16s", justify,
                        filename_width);
         (void)snprintf(line_buffer, line_buffer_size, format,
-                       (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
                        fe_ptr->name, change_time, access_time);
       }
       break;
     case MODE_5:
-      BuildUserFileEntry(fe_ptr, filename_width, linkname_width,
+      BuildUserFileEntry(fe_ptr, filename_width, linkname_width, is_tagged,
                          (GetProfileValue)(ctx, "USERVIEW"), 200, line_buffer);
       break;
     }
@@ -451,20 +453,20 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
 
     if (hilight)
       wattroff(win, A_REVERSE);
-    if (fe_ptr->tagged)
+    if (is_tagged)
       wattroff(win, A_BOLD);
 
   } else {
     /* --- RENDER METHOD 2: NAME-ONLY HIGHLIGHT --- */
 
     wattron(win, COLOR_PAIR(base_color_pair));
-    if (fe_ptr->tagged)
+    if (is_tagged)
       wattron(win, A_BOLD);
 
     /* Print tag and type */
     {
       char prefix[3];
-      prefix[0] = (fe_ptr->tagged) ? TAGGED_SYMBOL : ' ';
+      prefix[0] = (is_tagged) ? TAGGED_SYMBOL : ' ';
       prefix[1] = type_of_file;
       prefix[2] = '\0';
       AddClippedAtCursor(win, prefix, width);
@@ -598,7 +600,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
       }
     }
 
-    if (fe_ptr->tagged)
+    if (is_tagged)
       wattroff(win, A_BOLD);
   }
   wattroff(win, COLOR_PAIR(base_color_pair));

--- a/src/ui/tag_state.c
+++ b/src/ui/tag_state.c
@@ -1,0 +1,205 @@
+#include "ytree_fs.h"
+#include "ytree_ui.h"
+#include <stdlib.h>
+#include <string.h>
+
+static int PathListContains(const PathList *list, const char *path) {
+  for (; list; list = list->next) {
+    if (list->path && strcmp(list->path, path) == 0)
+      return TRUE;
+  }
+  return FALSE;
+}
+
+static int PathListCount(const PathList *list) {
+  int count = 0;
+
+  for (; list; list = list->next)
+    count++;
+
+  return count;
+}
+
+static void AddTaggedPath(YtreePanel *panel, const char *path) {
+  PathList *node;
+
+  if (!panel || !path || !*path || PathListContains(panel->tagged_paths, path))
+    return;
+
+  node = (PathList *)xcalloc(1, sizeof(PathList));
+  node->path = xstrdup(path);
+  node->next = panel->tagged_paths;
+  panel->tagged_paths = node;
+}
+
+static void RemoveTaggedPath(YtreePanel *panel, const char *path) {
+  PathList **link;
+
+  if (!panel || !path || !*path)
+    return;
+
+  for (link = &panel->tagged_paths; *link;) {
+    PathList *node = *link;
+    if (node->path && strcmp(node->path, path) == 0) {
+      *link = node->next;
+      free(node->path);
+      free(node);
+      return;
+    }
+    link = &node->next;
+  }
+}
+
+static BOOL TaggedPathIsUnderDir(const char *tagged_path, const char *dir_path) {
+  size_t dir_len;
+
+  if (!tagged_path || !dir_path || tagged_path[0] == '\0' ||
+      dir_path[0] == '\0')
+    return FALSE;
+
+  if (strcmp(dir_path, FILE_SEPARATOR_STRING) == 0)
+    return tagged_path[0] == FILE_SEPARATOR_CHAR ? TRUE : FALSE;
+
+  dir_len = strlen(dir_path);
+  return strncmp(tagged_path, dir_path, dir_len) == 0 &&
+         tagged_path[dir_len] == FILE_SEPARATOR_CHAR;
+}
+
+static void GetTaggedFilePath(FileEntry *file_entry, char *path,
+                              size_t path_size) {
+  if (!path || path_size == 0)
+    return;
+
+  path[0] = '\0';
+  if (!file_entry || !file_entry->dir_entry)
+    return;
+
+  GetFileNamePath(file_entry, path);
+  path[path_size - 1] = '\0';
+}
+
+void PanelTags_Clear(YtreePanel *panel) {
+  if (!panel)
+    return;
+
+  FreePathList(panel->tagged_paths);
+  panel->tagged_paths = NULL;
+}
+
+void PanelTags_Copy(YtreePanel *dst, const YtreePanel *src) {
+  const PathList *node;
+
+  if (!dst || !src || dst == src)
+    return;
+
+  PanelTags_Clear(dst);
+  for (node = src->tagged_paths; node; node = node->next)
+    AddTaggedPath(dst, node->path);
+}
+
+void PanelTags_PruneUnderDir(YtreePanel *panel, DirEntry *dir_entry) {
+  char dir_path[PATH_LENGTH + 1];
+  PathList **link;
+
+  if (!panel || !dir_entry)
+    return;
+
+  GetPath(dir_entry, dir_path);
+  if (dir_path[0] == '\0')
+    return;
+
+  for (link = &panel->tagged_paths; *link;) {
+    PathList *node = *link;
+    if (TaggedPathIsUnderDir(node->path, dir_path)) {
+      *link = node->next;
+      free(node->path);
+      free(node);
+      continue;
+    }
+    link = &node->next;
+  }
+}
+
+BOOL PanelTags_FileIsTagged(const YtreePanel *panel, FileEntry *file_entry) {
+  char path[PATH_LENGTH + 1];
+
+  if (!panel || !file_entry)
+    return FALSE;
+
+  GetTaggedFilePath(file_entry, path, sizeof(path));
+  return PathListContains(panel->tagged_paths, path) ? TRUE : FALSE;
+}
+
+void PanelTags_RecordFileState(YtreePanel *panel, FileEntry *file_entry,
+                               BOOL tagged) {
+  char path[PATH_LENGTH + 1];
+
+  if (!panel || !file_entry)
+    return;
+
+  GetTaggedFilePath(file_entry, path, sizeof(path));
+  if (path[0] == '\0')
+    return;
+
+  if (tagged)
+    AddTaggedPath(panel, path);
+  else
+    RemoveTaggedPath(panel, path);
+}
+
+static void ApplyPanelTagsToDir(const YtreePanel *panel, DirEntry *dir_entry,
+                                Statistic *stats) {
+  FileEntry *file_entry;
+
+  if (!panel || !dir_entry || !stats)
+    return;
+
+  dir_entry->tagged_files = 0;
+  dir_entry->tagged_bytes = 0;
+  for (file_entry = dir_entry->file; file_entry; file_entry = file_entry->next) {
+    file_entry->tagged = PanelTags_FileIsTagged(panel, file_entry);
+    if (file_entry->tagged) {
+      dir_entry->tagged_files++;
+      dir_entry->tagged_bytes += file_entry->stat_struct.st_size;
+      stats->disk_tagged_files++;
+      stats->disk_tagged_bytes += file_entry->stat_struct.st_size;
+    }
+  }
+}
+
+static void ApplyPanelTagsToTree(YtreePanel *panel, DirEntry *dir_entry,
+                                 Statistic *stats) {
+  for (; dir_entry; dir_entry = dir_entry->next) {
+    ApplyPanelTagsToDir(panel, dir_entry, stats);
+    if (dir_entry->sub_tree)
+      ApplyPanelTagsToTree(panel, dir_entry->sub_tree, stats);
+  }
+}
+
+void PanelTags_ApplyToTree(ViewContext *ctx, YtreePanel *panel) {
+  Statistic *stats;
+
+  (void)ctx;
+  if (!panel || !panel->vol || !panel->vol->vol_stats.tree)
+    return;
+
+  stats = &panel->vol->vol_stats;
+  stats->disk_tagged_files = 0;
+  stats->disk_tagged_bytes = 0;
+  ApplyPanelTagsToTree(panel, stats->tree, stats);
+}
+
+void PanelTags_Restore(ViewContext *ctx, YtreePanel *panel) {
+  PathList *expanded = NULL;
+
+  if (!ctx || !panel || !panel->vol || !panel->vol->vol_stats.tree)
+    return;
+
+  if (panel->tagged_paths) {
+    DEBUG_LOG("PanelTags:restore count=%d", PathListCount(panel->tagged_paths));
+    RestoreTreeState(ctx, panel->vol->vol_stats.tree, &expanded,
+                     panel->tagged_paths, &panel->vol->vol_stats);
+    FreePathList(expanded);
+  }
+  PanelTags_ApplyToTree(ctx, panel);
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,12 @@ from ytree_control import YtreeController
 @pytest.fixture(scope="session")
 def ytree_binary():
     """Locates the ytree binary in build/ or current directory."""
+    override = os.environ.get("YTREE_TEST_BIN")
+    if override:
+        if os.path.exists(override) and os.access(override, os.X_OK):
+            return os.path.abspath(override)
+        pytest.fail(f"YTREE_TEST_BIN is not executable: {override}")
+
     paths = ["build/ytree", "./ytree"]
     for p in paths:
         if os.path.exists(p) and os.access(p, os.X_OK):

--- a/tests/repro_real_home_same_volume_split_bug.py
+++ b/tests/repro_real_home_same_volume_split_bug.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Automation-only repro for the real HOME workflow reported by user.
+
+This drives /usr/local/bin/ytree against the caller's real HOME tree:
+  ytree ~
+  -> ytree/src/cmd file mode
+  -> tag three files (t,down x3)
+  -> F8 TAB ENTER HOME mkdir a temporary unique directory
+  -> assert source pane still shows file list and unchanged tag state after TAB back
+
+Exit codes:
+  0: no bug detected
+  1: bug detected
+  2: navigation/setup failure
+"""
+
+import os
+import re
+import shutil
+import time
+from pathlib import Path
+
+from helpers_stats import detect_stats_split_x as _detect_stats_split_x
+from helpers_ui import footer_text as _footer_text
+from helpers_ui import line_marks_file_as_tagged as _line_marks_file_as_tagged
+from helpers_ui import screen_text as _screen_text
+from tui_harness import YtreeTUI
+from ytree_keys import Keys
+
+
+def _stats_current_dir_contains(lines, marker):
+    split_x = _detect_stats_split_x(lines)
+    for i, line in enumerate(lines):
+        segment = line[split_x:] if split_x is not None else line
+        if "CURRENT DIR" not in segment:
+            continue
+        for j in (1, 2):
+            idx = i + j
+            if idx >= len(lines):
+                continue
+            candidate = lines[idx][split_x:] if split_x is not None else lines[idx]
+            if marker in candidate:
+                return True
+    return False
+
+
+def _find_line(screen, needle):
+    for line in screen.splitlines():
+        if needle in line:
+            return line
+    return None
+
+
+def _discover_track_names(screen):
+    names = []
+    for line in screen.splitlines():
+        if line.count(".c") == 0:
+            continue
+        for m in re.finditer(r"([A-Za-z0-9_][A-Za-z0-9_.-]*\.c)\b", line):
+            name = m.group(1)
+            if name not in names:
+                names.append(name)
+            if len(names) >= 3:
+                return names
+    return names
+
+
+def _goto_marker(tui, marker, steps=300):
+    for _ in range(steps):
+        if _stats_current_dir_contains(tui.get_screen_dump(), marker):
+            return True
+        tui.send_keystroke(Keys.DOWN, wait=0.08)
+    return False
+
+
+def main():
+    home = Path(os.environ.get("HOME", ""))
+    if not home.exists():
+        print("SETUP_FAIL: HOME missing")
+        return 2
+
+    exe = os.environ.get("YTREE_REPRO_BIN", "/usr/local/bin/ytree")
+    if not Path(exe).exists():
+        print(f"SETUP_FAIL: binary missing: {exe}")
+        return 2
+
+    mkdir_name = f"ytree-repro-mkdir-{os.getpid()}"
+    created_paths = [
+        home / mkdir_name,
+        home / "ytree" / "src" / "cmd" / mkdir_name,
+    ]
+    tui = YtreeTUI(executable=exe, cwd=str(home), env_extra={"HOME": str(home)})
+    time.sleep(0.9)
+    try:
+        if not _goto_marker(tui, "ytree"):
+            print("SETUP_FAIL: ytree dir not found in HOME listing")
+            print(_screen_text(tui))
+            return 2
+        tui.send_keystroke(Keys.RIGHT, wait=0.25)
+        if not _goto_marker(tui, "src"):
+            print("SETUP_FAIL: src not found under ytree")
+            print(_screen_text(tui))
+            return 2
+        tui.send_keystroke(Keys.RIGHT, wait=0.25)
+        if not _goto_marker(tui, "cmd"):
+            print("SETUP_FAIL: cmd not found under src")
+            print(_screen_text(tui))
+            return 2
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.45)
+        if "hex invert j compare" not in _footer_text(tui):
+            print("SETUP_FAIL: not in file mode for src/cmd")
+            print(_screen_text(tui))
+            return 2
+
+        for _ in range(3):
+            tui.send_keystroke("t", wait=0.2)
+
+        before = _screen_text(tui)
+        tracked = {}
+        track_names = _discover_track_names(before)
+        for name in track_names:
+            line = _find_line(before, name)
+            if line is not None:
+                tracked[name] = _line_marks_file_as_tagged(line, name)
+        if not tracked:
+            print("SETUP_FAIL: could not identify tracked src files")
+            print(before)
+            return 2
+        if not any(tracked.values()):
+            print("SETUP_FAIL: no tagged src files before split flow")
+            print(before)
+            return 2
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.35)
+        tui.send_keystroke(Keys.HOME, wait=0.35)
+        tui.send_keystroke("M", wait=0.2)
+        if not tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0):
+            print("SETUP_FAIL: MAKE DIRECTORY prompt missing")
+            print(_screen_text(tui))
+            return 2
+        tui.send_keystroke(mkdir_name + Keys.ENTER, wait=0.8)
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+
+        after = _screen_text(tui)
+        if "No files" in after:
+            print("BUG_REPRODUCED=1 reason=source_no_files_after_tab")
+            print(after)
+            return 1
+        if "hex invert j compare" not in _footer_text(tui):
+            print("BUG_REPRODUCED=1 reason=not_in_file_mode_after_tab")
+            print(after)
+            return 1
+
+        for name, tagged_before in tracked.items():
+            line = _find_line(after, name)
+            if line is None:
+                print(f"BUG_REPRODUCED=1 reason=missing_row_{name}")
+                print(after)
+                return 1
+            if _line_marks_file_as_tagged(line, name) != tagged_before:
+                print(f"BUG_REPRODUCED=1 reason=tag_state_changed_{name}")
+                print(after)
+                return 1
+
+        print("BUG_REPRODUCED=0")
+        return 0
+    finally:
+        tui.quit()
+        for path in created_paths:
+            if path.is_dir():
+                shutil.rmtree(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/repro_same_volume_home_mkdir_bug.py
+++ b/tests/repro_same_volume_home_mkdir_bug.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Manual repro checker for the same-volume inactive-pane drift bug.
+
+Exit codes:
+  0: bug not observed
+  1: bug observed (inactive pane jumped to tests file view)
+  2: setup/navigation failed
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from helpers_stats import detect_stats_split_x as _detect_stats_split_x
+from helpers_ui import footer_text as _footer_text
+from helpers_ui import screen_text as _screen_text
+from tui_harness import YtreeTUI
+from ytree_keys import Keys
+
+
+def _stats_current_dir_contains(lines, marker):
+    split_x = _detect_stats_split_x(lines)
+    for i, line in enumerate(lines):
+        segment = line[split_x:] if split_x is not None else line
+        if "CURRENT DIR" not in segment:
+            continue
+        for j in (1, 2):
+            idx = i + j
+            if idx >= len(lines):
+                continue
+            candidate = lines[idx][split_x:] if split_x is not None else lines[idx]
+            if marker in candidate:
+                return True
+    return False
+
+
+def _navigate_to_src_cmd_file_mode(tui):
+    found_src = False
+    for _ in range(80):
+        if _stats_current_dir_contains(tui.get_screen_dump(), "src"):
+            found_src = True
+            break
+        tui.send_keystroke(Keys.DOWN, wait=0.12)
+    if not found_src:
+        return False, "SETUP_FAIL: could not focus src"
+
+    tui.send_keystroke(Keys.RIGHT, wait=0.25)
+
+    found_cmd = False
+    for _ in range(80):
+        if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+            found_cmd = True
+            break
+        tui.send_keystroke(Keys.DOWN, wait=0.12)
+    if not found_cmd:
+        return False, "SETUP_FAIL: could not focus src/cmd"
+
+    tui.send_keystroke(Keys.RIGHT, wait=0.2)
+    tui.send_keystroke(Keys.ENTER, wait=0.45)
+    if "hex invert j compare" not in _footer_text(tui):
+        return False, "SETUP_FAIL: not in file mode for src/cmd"
+    return True, ""
+
+
+def _run_sequence_a(tui):
+    ok, err = _navigate_to_src_cmd_file_mode(tui)
+    if not ok:
+        return 2, err, _screen_text(tui)
+
+    for _ in range(3):
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+
+    # Original manual sequence: f8 tab enter home m 00
+    tui.send_keystroke(Keys.F8, wait=0.4)
+    tui.send_keystroke(Keys.TAB, wait=0.4)
+    tui.send_keystroke(Keys.ENTER, wait=0.35)
+    tui.send_keystroke(Keys.HOME, wait=0.35)
+    tui.send_keystroke("M", wait=0.2)
+    if not tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0):
+        return 2, "SETUP_FAIL: MAKE DIRECTORY prompt missing", _screen_text(tui)
+    tui.send_keystroke("00" + Keys.ENTER, wait=0.8)
+    tui.send_keystroke(Keys.ENTER, wait=0.45)
+
+    screen = _screen_text(tui)
+    bug = ("test_file_0.py" in screen) or ("/tests" in screen)
+    if bug:
+        return 1, "BUG_REPRODUCED=1 sequence=A", screen
+    return 0, "BUG_REPRODUCED=0 sequence=A", screen
+
+
+def _run_sequence_b(tui, home):
+    # User-observed variant:
+    # log <home>, down down right, / s enter, right, down enter, t t t,
+    # f8 tab enter home, m 00 enter
+    tui.send_keystroke("l", wait=0.2)
+    if tui.wait_for_content("LOG", timeout=0.8) or tui.wait_for_content("PATH", timeout=0.8):
+        tui.send_keystroke(str(home) + Keys.ENTER, wait=0.7)
+    else:
+        tui.send_keystroke(Keys.ESC, wait=0.2)
+
+    tui.send_keystroke(Keys.DOWN, wait=0.2)
+    tui.send_keystroke(Keys.DOWN, wait=0.2)
+    tui.send_keystroke(Keys.RIGHT, wait=0.25)
+    tui.send_keystroke("/", wait=0.2)
+    tui.send_keystroke("s", wait=0.2)
+    tui.send_keystroke(Keys.ENTER, wait=0.35)
+    tui.send_keystroke(Keys.RIGHT, wait=0.25)
+    tui.send_keystroke(Keys.DOWN, wait=0.2)
+    tui.send_keystroke(Keys.ENTER, wait=0.45)
+
+    if "hex invert j compare" not in _footer_text(tui):
+        return 2, "SETUP_FAIL: variant B did not reach file mode", _screen_text(tui)
+    if "src_file_0.c" not in _screen_text(tui):
+        tui.send_keystroke(Keys.ESC, wait=0.25)
+        found_cmd = False
+        for _ in range(40):
+            if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+                found_cmd = True
+                break
+            tui.send_keystroke(Keys.UP, wait=0.12)
+        for _ in range(120):
+            if found_cmd:
+                break
+            if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+                found_cmd = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.12)
+        if not found_cmd:
+            return 2, "SETUP_FAIL: variant B could not re-focus src/cmd", _screen_text(tui)
+        tui.send_keystroke(Keys.ENTER, wait=0.45)
+        if "src_file_0.c" not in _screen_text(tui):
+            return 2, "SETUP_FAIL: variant B did not enter src/cmd file mode", _screen_text(tui)
+
+    tui.send_keystroke("t", wait=0.2)
+    tui.send_keystroke("t", wait=0.2)
+    tui.send_keystroke("t", wait=0.2)
+
+    tui.send_keystroke(Keys.F8, wait=0.4)
+    tui.send_keystroke(Keys.TAB, wait=0.4)
+    tui.send_keystroke(Keys.ENTER, wait=0.35)
+    tui.send_keystroke(Keys.HOME, wait=0.35)
+    tui.send_keystroke("M", wait=0.2)
+    if not tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0):
+        return 2, "SETUP_FAIL: variant B missing MAKE DIRECTORY prompt", _screen_text(tui)
+    tui.send_keystroke("00" + Keys.ENTER, wait=0.8)
+    tui.send_keystroke(Keys.ENTER, wait=0.45)
+
+    screen = _screen_text(tui)
+    path_line = screen.splitlines()[0] if screen else ""
+    repo_root_jump = ("Path: " in path_line and path_line.rstrip().endswith("/ytree"))
+    root_file_window = "bak.sh" in screen
+    jumped_to_tests = ("/tests" in screen) or ("test_file_0.py" in screen)
+    bug = jumped_to_tests or (repo_root_jump and root_file_window)
+    if bug:
+        return 1, "BUG_REPRODUCED=1 sequence=B", screen
+    return 0, "BUG_REPRODUCED=0 sequence=B", screen
+
+
+def main():
+    exe = os.environ.get("YTREE_REPRO_BIN", "/usr/local/bin/ytree")
+
+    with TemporaryDirectory(prefix="ytree-repro-") as td:
+        tmp = Path(td)
+        home = tmp / "home" / "user"
+        repo = home / "ytree"
+        repo.mkdir(parents=True)
+
+        (home / ".ytree").write_text(
+            "[GLOBAL]\n"
+            "AUTO_REFRESH=3\n"
+            "TREEDEPTH=2\n"
+            "FILEMODE=2\n"
+            "SMALLWINDOWSKIP=1\n"
+            "HIDEDOTFILES=1\n",
+            encoding="utf-8",
+        )
+
+        for name in ("build", "coverage", "docs", "etc", "include", "infra", "src", "tests"):
+            (repo / name).mkdir()
+        cmd_dir = repo / "src" / "cmd"
+        cmd_dir.mkdir()
+        tests_dir = repo / "tests"
+        (repo / "bak.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+        for idx in range(3):
+            (cmd_dir / f"src_file_{idx}.c").write_text("x\n", encoding="utf-8")
+        for idx in range(4):
+            (tests_dir / f"test_file_{idx}.py").write_text("y\n", encoding="utf-8")
+
+        for run_name, runner in (
+            ("A", lambda t: _run_sequence_a(t)),
+            ("B", lambda t: _run_sequence_b(t, home)),
+        ):
+            tui = YtreeTUI(executable=exe, cwd=str(repo), env_extra={"HOME": str(home)})
+            time.sleep(0.9)
+            try:
+                code, msg, screen = runner(tui)
+                print(msg)
+                if code == 1:
+                    print(screen)
+                    return 1
+                if code == 2:
+                    print(screen)
+                else:
+                    if screen:
+                        print(screen.splitlines()[0])
+                        print(_footer_text(tui))
+            finally:
+                tui.quit()
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compare_actions.py
+++ b/tests/test_compare_actions.py
@@ -605,10 +605,10 @@ def test_f8_tree_compare_uses_inactive_panel_logged_root_default(ytree_binary, t
     tui.send_keystroke(Keys.ENTER, wait=0.25)
     _assert_no_footer_artifacts(tui)
 
-    # Active/source side should have compare tags.
+    # Tree compare reports differences but does not auto-apply file tags.
     tui.send_keystroke(Keys.DOWN, wait=0.2)  # main_dir
     tui.send_keystroke(Keys.ENTER, wait=0.35)
-    _assert_file_tag_state(tui, "tree_diff.txt", True)
+    _assert_file_tag_state(tui, "tree_diff.txt", False)
 
     # Inactive/target side must not be tagged by compare.
     tui.send_keystroke(Keys.TAB, wait=0.35)
@@ -666,7 +666,7 @@ def test_tree_compare_logged_only_relative_path_and_skipped_unlogged_reporting(
 
     tui.send_keystroke(Keys.DOWN, wait=0.2)  # top
     tui.send_keystroke(Keys.ENTER, wait=0.35)
-    _assert_file_tag_state(tui, "visible_diff.txt", True)
+    _assert_file_tag_state(tui, "visible_diff.txt", False)
     tui.quit()
 
 

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -93,6 +93,20 @@ def _assert_split_column_continuous(lines, label):
             f"Split separator has a gap at row {y} ({label}).\n" + "\n".join(lines)
         )
 
+
+def _split_segments_for_file(tui, filename):
+    lines = tui.get_screen_dump()
+    split_col = _detect_split_column(lines)
+    screen = "\n".join(lines)
+    assert split_col is not None, f"Could not detect split column.\n{screen}"
+
+    for line in lines:
+        if filename in line:
+            return line[:split_col], line[split_col:], screen
+
+    raise AssertionError(f"Could not find {filename} in split screen.\n{screen}")
+
+
 def test_panel_switch_updates_small_window(dual_panel_sandbox, ytree_binary):
     """
     Verify that switching panels updates the content of the small file window.
@@ -173,6 +187,153 @@ def test_split_from_file_keeps_file_focus_on_tab(tmp_path, ytree_binary):
     )
 
     tui.quit()
+
+
+def test_split_same_directory_file_tags_are_panel_local(tmp_path, ytree_binary):
+    root = tmp_path / "split_same_dir_panel_local_tags"
+    root.mkdir()
+    alpha = root / "alpha"
+    beta = root / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    for idx in range(3):
+        (alpha / f"panel_tag_{idx}.txt").write_text("tag\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke("t", wait=0.3)
+        left, right, screen = _split_segments_for_file(tui, "panel_tag_0.txt")
+        assert _line_marks_file_as_tagged(left, "panel_tag_0.txt"), screen
+        assert not _line_marks_file_as_tagged(right, "panel_tag_0.txt"), (
+            "Tagging the active pane leaked to the inactive peer pane.\n"
+            f"{screen}"
+        )
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        left, right, screen = _split_segments_for_file(tui, "panel_tag_0.txt")
+        assert _line_marks_file_as_tagged(left, "panel_tag_0.txt"), screen
+        assert not _line_marks_file_as_tagged(right, "panel_tag_0.txt"), (
+            "Switching panes should not import the other pane's tags.\n"
+            f"{screen}"
+        )
+
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.3)
+        left, right, screen = _split_segments_for_file(tui, "panel_tag_1.txt")
+        assert not _line_marks_file_as_tagged(left, "panel_tag_1.txt"), (
+            "Right-pane tagging leaked into the left pane.\n"
+            f"{screen}"
+        )
+        assert _line_marks_file_as_tagged(right, "panel_tag_1.txt"), screen
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        left, right, screen = _split_segments_for_file(tui, "panel_tag_0.txt")
+        assert _line_marks_file_as_tagged(left, "panel_tag_0.txt"), screen
+        assert not _line_marks_file_as_tagged(right, "panel_tag_0.txt"), screen
+        left, right, screen = _split_segments_for_file(tui, "panel_tag_1.txt")
+        assert not _line_marks_file_as_tagged(left, "panel_tag_1.txt"), screen
+        assert _line_marks_file_as_tagged(right, "panel_tag_1.txt"), screen
+    finally:
+        tui.quit()
+
+
+def test_unreading_directory_clears_panel_local_tags(tmp_path, ytree_binary):
+    root = tmp_path / "unread_clears_panel_tags"
+    root.mkdir()
+    alpha = root / "alpha"
+    (alpha / "child").mkdir(parents=True)
+    (alpha / "panel_tag_0.txt").write_text("tag\n", encoding="utf-8")
+    (alpha / "child" / "nested.txt").write_text("nested\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke("t", wait=0.3)
+        line = _find_line_with_text(tui, "panel_tag_0.txt")
+        assert line is not None, _screen_text(tui)
+        assert _line_marks_file_as_tagged(line, "panel_tag_0.txt"), _screen_text(tui)
+
+        tui.send_keystroke(Keys.ESC, wait=0.3)
+        assert "hex invert j compare" not in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke("-", wait=0.3)
+        tui.send_keystroke("-", wait=0.4)
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        line = _find_line_with_text(tui, "panel_tag_0.txt")
+        assert line is not None, _screen_text(tui)
+        assert not _line_marks_file_as_tagged(line, "panel_tag_0.txt"), (
+            "Unreading a directory must discard saved tags beneath it.\n"
+            f"Row: {line}\n{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def _assert_collapse_action_clears_panel_local_tags(tmp_path, ytree_binary, key):
+    root = tmp_path / f"collapse_clears_panel_tags_{ord(key[0])}"
+    root.mkdir()
+    alpha = root / "alpha"
+    (alpha / "child").mkdir(parents=True)
+    (alpha / "panel_tag_0.txt").write_text("tag\n", encoding="utf-8")
+    (alpha / "child" / "nested.txt").write_text("nested\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke("t", wait=0.3)
+        line = _find_line_with_text(tui, "panel_tag_0.txt")
+        assert line is not None, _screen_text(tui)
+        assert _line_marks_file_as_tagged(line, "panel_tag_0.txt"), _screen_text(tui)
+
+        tui.send_keystroke(Keys.ESC, wait=0.3)
+        assert "hex invert j compare" not in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke(key, wait=0.4)
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        line = _find_line_with_text(tui, "panel_tag_0.txt")
+        assert line is not None, _screen_text(tui)
+        assert not _line_marks_file_as_tagged(line, "panel_tag_0.txt"), (
+            "Collapsing a directory must discard saved tags beneath it.\n"
+            f"Row: {line}\n{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_minus_collapse_clears_panel_local_tags(tmp_path, ytree_binary):
+    _assert_collapse_action_clears_panel_local_tags(tmp_path, ytree_binary, "-")
+
+
+def test_left_arrow_collapse_clears_panel_local_tags(tmp_path, ytree_binary):
+    _assert_collapse_action_clears_panel_local_tags(
+        tmp_path, ytree_binary, Keys.LEFT
+    )
+
 
 def test_split_from_dir_immediately_renders_peer_panel(tmp_path, ytree_binary):
     root = tmp_path / "split_dir_immediate_render"
@@ -1144,6 +1305,510 @@ def test_source_selection_survives_destination_tree_prep_home_mkdir(
             f"{_screen_text(tui)}"
         )
         tui.send_keystroke(Keys.ESC, wait=0.2)
+    finally:
+        tui.quit()
+
+
+def test_bug_same_volume_home_mkdir_keeps_inactive_source_dir(tmp_path, ytree_binary):
+    """
+    Repro from manual QA:
+    In same-volume split mode, destination HOME+mkdir must not retarget the
+    inactive source panel to an unrelated directory.
+    """
+    root = tmp_path / "same_volume_home_mkdir_inactive_anchor"
+    root.mkdir()
+
+    src_dir = root / "src"
+    src_dir.mkdir()
+    cmd_dir = src_dir / "cmd"
+    cmd_dir.mkdir()
+    tests_dir = root / "tests"
+    tests_dir.mkdir()
+
+    for idx in range(3):
+        (cmd_dir / f"f{idx}.txt").write_text(f"{idx}\n", encoding="utf-8")
+    for idx in range(2):
+        (tests_dir / f"t{idx}.txt").write_text(f"{idx}\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.9)
+
+    try:
+        # Tree -> src -> cmd -> file window
+        found_src = False
+        for _ in range(20):
+            lines = tui.get_screen_dump()
+            if _stats_current_dir_contains(lines, "src"):
+                found_src = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.2)
+        assert found_src, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.3)
+
+        found_cmd = False
+        for _ in range(20):
+            lines = tui.get_screen_dump()
+            if _stats_current_dir_contains(lines, "cmd"):
+                found_cmd = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.2)
+        assert found_cmd, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        # Tag three files in source.
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.2)
+
+        # Split, switch to destination panel, then HOME+mkdir there.
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        if "hex invert j compare" in _footer_text(tui):
+            tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(tui, "Destination should be in tree mode.")
+        tui.send_keystroke(Keys.HOME, wait=0.3)
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("00" + Keys.ENTER, wait=0.7)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+
+        screen_while_right_active = _screen_text(tui)
+        assert "f0.txt" in screen_while_right_active and "f1.txt" in screen_while_right_active, (
+            "Inactive source pane lost cmd file view while destination panel stayed active.\n"
+            f"{screen_while_right_active}"
+        )
+        assert "t0.txt" not in screen_while_right_active and "t1.txt" not in screen_while_right_active, (
+            "Inactive source pane jumped to tests while destination panel stayed active.\n"
+            f"{screen_while_right_active}"
+        )
+
+        # Returning to source must keep cmd file view, not jump to tests.
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        screen = _screen_text(tui)
+        assert "hex invert j compare" in _footer_text(tui), screen
+        assert "f0.txt" in screen and "f1.txt" in screen and "f2.txt" in screen, (
+            "Source pane lost cmd file view after destination HOME+mkdir flow.\n"
+            f"{screen}"
+        )
+        assert "t0.txt" not in screen and "t1.txt" not in screen, (
+            "Source pane jumped to tests file view after destination HOME+mkdir flow.\n"
+            f"{screen}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_bug_same_volume_home_mkdir_with_repo_like_tree_keeps_inactive_source(
+    tmp_path, ytree_binary
+):
+    """
+    Reproduce manual flow on a repo-like tree:
+    while destination performs ENTER+HOME+mkdir, inactive source must stay on
+    src/cmd file view and must not jump to tests/.
+    """
+    home = tmp_path / "home" / "user"
+    repo = home / "ytree"
+    repo.mkdir(parents=True)
+    (home / ".ytree").write_text(
+        "[GLOBAL]\n"
+        "AUTO_REFRESH=3\n"
+        "TREEDEPTH=2\n"
+        "FILEMODE=2\n"
+        "SMALLWINDOWSKIP=1\n"
+        "HIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    for name in (
+        "build",
+        "coverage",
+        "docs",
+        "etc",
+        "include",
+        "infra",
+        "src",
+        "tests",
+    ):
+        (repo / name).mkdir()
+
+    src_alt_dir = repo / "src" / "aaa"
+    src_alt_dir.mkdir()
+    cmd_dir = repo / "src" / "cmd"
+    cmd_dir.mkdir()
+    tests_dir = repo / "tests"
+    (repo / "bak.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    for idx in range(3):
+        (cmd_dir / f"src_file_{idx}.c").write_text("x\n", encoding="utf-8")
+    for idx in range(4):
+        (tests_dir / f"test_file_{idx}.py").write_text("y\n", encoding="utf-8")
+
+    tui = YtreeTUI(
+        executable=ytree_binary, cwd=str(repo), env_extra={"HOME": str(home)}
+    )
+    time.sleep(0.9)
+
+    try:
+        found_src = False
+        for _ in range(80):
+            lines = tui.get_screen_dump()
+            if _stats_current_dir_contains(lines, "src"):
+                found_src = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.12)
+        assert found_src, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.25)
+
+        found_cmd = False
+        for _ in range(80):
+            lines = tui.get_screen_dump()
+            if _stats_current_dir_contains(lines, "cmd"):
+                found_cmd = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.12)
+        assert found_cmd, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.45)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.2)
+
+        # Exact manual sequence: f8 tab enter home mkdir 00
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.35)
+        tui.send_keystroke(Keys.HOME, wait=0.35)
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("00" + Keys.ENTER, wait=0.8)
+
+        screen_while_right_active = _screen_text(tui)
+        assert "src_file_0.c" in screen_while_right_active, screen_while_right_active
+        assert "test_file_0.py" not in screen_while_right_active, (
+            "Inactive source pane jumped to tests while destination remained active.\n"
+            f"{screen_while_right_active}"
+        )
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        screen = _screen_text(tui)
+        assert "hex invert j compare" in _footer_text(tui), screen
+        assert "src_file_0.c" in screen and "src_file_1.c" in screen, screen
+        assert "test_file_0.py" not in screen and "test_file_1.py" not in screen, (
+            "Source pane jumped to tests after destination ENTER+HOME+mkdir.\n"
+            f"{screen}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_bug_same_volume_home_mkdir_listjump_sequence_keeps_inactive_source(
+    tmp_path, ytree_binary
+):
+    """
+    Portable regression for the user-reported variant:
+    log HOME -> down/down/right -> /s Enter -> right -> down Enter -> ttt ->
+    F8 Tab Enter Home -> mkdir 00.
+
+    Inactive source panel must not jump to tests file view or collapse to
+    repo-root file view.
+    """
+    home = tmp_path / "home" / "user"
+    repo = home / "ytree"
+    repo.mkdir(parents=True)
+    (home / ".ytree").write_text(
+        "[GLOBAL]\n"
+        "AUTO_REFRESH=3\n"
+        "TREEDEPTH=2\n"
+        "FILEMODE=2\n"
+        "SMALLWINDOWSKIP=1\n"
+        "HIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    for name in (
+        "build",
+        "coverage",
+        "docs",
+        "etc",
+        "include",
+        "infra",
+        "src",
+        "tests",
+    ):
+        (repo / name).mkdir()
+
+    cmd_dir = repo / "src" / "cmd"
+    cmd_dir.mkdir()
+    tests_dir = repo / "tests"
+    (repo / "bak.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    for idx in range(3):
+        (cmd_dir / f"src_file_{idx}.c").write_text("x\n", encoding="utf-8")
+    for idx in range(4):
+        (tests_dir / f"test_file_{idx}.py").write_text("y\n", encoding="utf-8")
+
+    tui = YtreeTUI(
+        executable=ytree_binary, cwd=str(repo), env_extra={"HOME": str(home)}
+    )
+    time.sleep(0.9)
+
+    try:
+        tui.send_keystroke("l", wait=0.2)
+        if tui.wait_for_content("LOG", timeout=0.8) or tui.wait_for_content(
+            "PATH", timeout=0.8
+        ):
+            tui.send_keystroke(str(home) + Keys.ENTER, wait=0.7)
+        else:
+            tui.send_keystroke(Keys.ESC, wait=0.2)
+
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.RIGHT, wait=0.25)
+        tui.send_keystroke("/", wait=0.2)
+        tui.send_keystroke("s", wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.35)
+        tui.send_keystroke(Keys.RIGHT, wait=0.25)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.45)
+
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+        if "src_file_0.c" not in _screen_text(tui):
+            if "hex invert j compare" in _footer_text(tui):
+                tui.send_keystroke(Keys.ESC, wait=0.25)
+
+            found_cmd = False
+            for _ in range(40):
+                if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+                    found_cmd = True
+                    break
+                tui.send_keystroke(Keys.UP, wait=0.12)
+            for _ in range(120):
+                if found_cmd:
+                    break
+                if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+                    found_cmd = True
+                    break
+                tui.send_keystroke(Keys.DOWN, wait=0.12)
+            assert found_cmd, _screen_text(tui)
+            tui.send_keystroke(Keys.ENTER, wait=0.45)
+
+        pre_screen = _screen_text(tui)
+        assert "src_file_0.c" in pre_screen, (
+            "List-jump variant did not reach src/cmd file mode before split flow.\n"
+            f"{pre_screen}"
+        )
+
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke("t", wait=0.2)
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.35)
+        tui.send_keystroke(Keys.HOME, wait=0.35)
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("00" + Keys.ENTER, wait=0.8)
+
+        screen = _screen_text(tui)
+        path_line = screen.splitlines()[0] if screen else ""
+        repo_root_jump = "Path: " in path_line and path_line.rstrip().endswith("/ytree")
+        root_file_window = "bak.sh" in screen
+        assert (
+            "test_file_0.py" not in screen
+            and "/tests" not in screen
+            and not (repo_root_jump and root_file_window)
+        ), (
+            "Inactive source panel drifted after list-jump variant "
+            "(tests jump or repo-root collapse).\n"
+            f"{screen}"
+        )
+
+        for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
+            line = _find_line_with_text(tui, name)
+            assert line is not None, (
+                "Inactive source panel blanked during destination mkdir.\n"
+                f"{screen}"
+            )
+            assert _line_marks_file_as_tagged(line, name), (
+                "Inactive source tagged state was lost during destination mkdir.\n"
+                f"Row: {line}\n{screen}"
+            )
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        screen_after_switch = _screen_text(tui)
+        assert "hex invert j compare" in _footer_text(tui), screen_after_switch
+        for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
+            line = _find_line_with_text(tui, name)
+            assert line is not None, (
+                "Source pane lost file rows after switching back from destination.\n"
+                f"{screen_after_switch}"
+            )
+            assert _line_marks_file_as_tagged(line, name), (
+                "Tagged files were cleared after switching back to source pane.\n"
+                f"Row: {line}\n{screen_after_switch}"
+            )
+    finally:
+        tui.quit()
+
+
+def test_bug_same_volume_home_mkdir_from_home_root_keeps_inactive_file_state(
+    tmp_path, ytree_binary
+):
+    """
+    Reproduces the user's direct flow from HOME root:
+    start at HOME, expand ytree/src/cmd, enter file mode, tag three files,
+    split, switch to right, HOME, mkdir.
+
+    Inactive left pane must stay in file view on src/cmd with tags intact.
+    """
+    home = tmp_path / "home" / "user"
+    repo = home / "ytree"
+    repo.mkdir(parents=True)
+    (home / ".ytree").write_text(
+        "[GLOBAL]\n"
+        "AUTO_REFRESH=3\n"
+        "TREEDEPTH=2\n"
+        "FILEMODE=2\n"
+        "SMALLWINDOWSKIP=1\n"
+        "HIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    for name in ("go", "snap", "wikiteam3_utilities"):
+        (home / name).mkdir()
+    (home / "go" / "pkg").mkdir()
+    (home / "snap" / "glow").mkdir(parents=True)
+    (home / "wikiteam3_utilities" / "dumps").mkdir(parents=True)
+    (home / "wikiteam3_utilities" / "for later").mkdir(parents=True)
+
+    for name in (
+        "build",
+        "coverage",
+        "docs",
+        "etc",
+        "include",
+        "infra",
+        "obj",
+        "scripts",
+        "src",
+        "tests",
+    ):
+        (repo / name).mkdir()
+
+    cmd_dir = repo / "src" / "cmd"
+    cmd_dir.mkdir()
+    tests_dir = repo / "tests"
+    (repo / "bak.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    for idx in range(3):
+        (cmd_dir / f"src_file_{idx}.c").write_text("x\n", encoding="utf-8")
+    for idx in range(4):
+        (tests_dir / f"test_file_{idx}.py").write_text("y\n", encoding="utf-8")
+
+    tui = YtreeTUI(
+        executable=ytree_binary, cwd=str(home), env_extra={"HOME": str(home)}
+    )
+    time.sleep(0.9)
+
+    try:
+        found_ytree = False
+        for _ in range(200):
+            if _stats_current_dir_contains(tui.get_screen_dump(), "ytree"):
+                found_ytree = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.08)
+        assert found_ytree, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.25)
+        found_src = False
+        for _ in range(200):
+            if _stats_current_dir_contains(tui.get_screen_dump(), "src"):
+                found_src = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.08)
+        assert found_src, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.25)
+        found_cmd = False
+        for _ in range(200):
+            if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+                found_cmd = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.08)
+        assert found_cmd, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.45)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        for _ in range(3):
+            tui.send_keystroke("t", wait=0.2)
+        pre_screen = _screen_text(tui)
+        pre_tag_state = {}
+        for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
+            line = _find_line_with_text(tui, name)
+            assert line is not None, pre_screen
+            pre_tag_state[name] = _line_marks_file_as_tagged(line, name)
+        assert any(pre_tag_state.values()), (
+            "Precondition failed: no tagged source files before split flow.\n"
+            f"{pre_screen}"
+        )
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.35)
+        tui.send_keystroke(Keys.HOME, wait=0.35)
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("00" + Keys.ENTER, wait=0.8)
+
+        screen_right_active = _screen_text(tui)
+        assert "src_file_0.c" in screen_right_active, (
+            "Inactive left pane blanked while destination pane remained active.\n"
+            f"{screen_right_active}"
+        )
+        for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
+            line = _find_line_with_text(tui, name)
+            assert line is not None, (
+                "Inactive source pane lost file rows after destination mkdir.\n"
+                f"{screen_right_active}"
+            )
+            assert _line_marks_file_as_tagged(line, name) == pre_tag_state[name], (
+                "Inactive source tagged state changed after destination mkdir.\n"
+                f"Expected tagged={pre_tag_state[name]} Row: {line}\n"
+                f"{screen_right_active}"
+            )
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        screen_after_tab = _screen_text(tui)
+        assert "hex invert j compare" in _footer_text(tui), screen_after_tab
+        assert "No files" not in screen_after_tab, (
+            "Switching to source pane produced empty file view.\n"
+            f"{screen_after_tab}"
+        )
+        for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
+            line = _find_line_with_text(tui, name)
+            assert line is not None, (
+                "Source pane did not resume src/cmd file view after TAB.\n"
+                f"{screen_after_tab}"
+            )
+            assert _line_marks_file_as_tagged(line, name) == pre_tag_state[name], (
+                "Source tag state changed after TAB back to source pane.\n"
+                f"Expected tagged={pre_tag_state[name]} Row: {line}\n"
+                f"{screen_after_tab}"
+            )
     finally:
         tui.quit()
 

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -969,8 +969,8 @@ def test_bug_f_eight_source_selection_survives_destination_tree_prep(
 
     source_dir = root / "source_dir"
     source_dir.mkdir()
-    target_dir = root / "target_dir"
-    target_dir.mkdir()
+    alpha_dir = root / "alpha_dir"
+    alpha_dir.mkdir()
 
     (source_dir / "source_0.txt").write_text("0\n", encoding="utf-8")
     (source_dir / "source_1.txt").write_text("1\n", encoding="utf-8")
@@ -980,7 +980,8 @@ def test_bug_f_eight_source_selection_survives_destination_tree_prep(
     time.sleep(0.9)
 
     try:
-        # Source intent: tag source_0, then keep source_1 selected.
+        # Source intent: enter source_dir, tag source_0, then keep source_1 selected.
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
         tui.send_keystroke(Keys.DOWN, wait=0.2)
         tui.send_keystroke(Keys.ENTER, wait=0.4)
         assert "hex invert j compare" in _footer_text(tui)
@@ -999,21 +1000,20 @@ def test_bug_f_eight_source_selection_survives_destination_tree_prep(
             tui
         )
 
-        # Split, switch to destination, then do destination prep.
+        # Split, switch to destination, then do destination prep that inserts a
+        # new tree row before source_dir (alpha_dir + mkdir child).
         tui.send_keystroke(Keys.F8, wait=0.4)
         tui.send_keystroke(Keys.TAB, wait=0.4)
-        tui.send_keystroke("n", wait=0.2)
-        assert tui.wait_for_content("MAKE FILE:", timeout=1.0), _screen_text(tui)
-        tui.send_keystroke("aaa_new.txt" + Keys.ENTER, wait=0.8)
         tui.send_keystroke(Keys.ESC, wait=0.3)
-        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke(Keys.UP, wait=0.3)
         tui.send_keystroke("M", wait=0.2)
         assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
-        tui.send_keystroke("stage_dir" + Keys.ENTER, wait=0.7)
+        tui.send_keystroke("aaa_shift_anchor" + Keys.ENTER, wait=0.7)
         tui.send_keystroke(Keys.ENTER, wait=0.5)
 
         # Back to source and verify source intent is stable by identity.
         tui.send_keystroke(Keys.TAB, wait=0.5)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
         source_line_after = _find_line_with_text(tui, "source_0.txt")
         assert source_line_after is not None, _screen_text(tui)
         assert _line_marks_file_as_tagged(source_line_after, "source_0.txt"), (
@@ -1024,6 +1024,123 @@ def test_bug_f_eight_source_selection_survives_destination_tree_prep(
         tui.send_keystroke("c", wait=0.3)
         assert tui.wait_for_content("COPY: source_1.txt", timeout=1.0), (
             "Destination-side prep re-indexed source file selection by row position.\n"
+            f"{_screen_text(tui)}"
+        )
+        tui.send_keystroke(Keys.ESC, wait=0.2)
+    finally:
+        tui.quit()
+
+
+def test_source_selection_survives_destination_tree_prep_home_mkdir(
+    tmp_path, ytree_binary
+):
+    """
+    BUG-36 regression:
+    Destination tree HOME+mkdir prep in same-volume split mode must not blank
+    the source pane or mutate source tagged/selection identity.
+    """
+    root = tmp_path / "bug_f_eight_source_selection_tree_home_mkdir"
+    root.mkdir()
+
+    source_dir = root / "source_dir"
+    source_dir.mkdir()
+    target_dir = root / "target_dir"
+    target_dir.mkdir()
+
+    (source_dir / "source_0.txt").write_text("0\n", encoding="utf-8")
+    (source_dir / "source_1.txt").write_text("1\n", encoding="utf-8")
+    (source_dir / "source_2.txt").write_text("2\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.9)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui)
+        tui.send_keystroke("t", wait=0.2)
+
+        tui.send_keystroke("c", wait=0.3)
+        assert tui.wait_for_content("COPY: source_1.txt", timeout=1.0), _screen_text(
+            tui
+        )
+        tui.send_keystroke(Keys.ESC, wait=0.2)
+
+        source_line = _find_line_with_text(tui, "source_0.txt")
+        assert source_line is not None, _screen_text(tui)
+        assert _line_marks_file_as_tagged(source_line, "source_0.txt"), _screen_text(
+            tui
+        )
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        if "hex invert j compare" in _footer_text(tui):
+            tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(tui, "Destination panel should be in tree view.")
+        tui.send_keystroke(Keys.LEFT, wait=0.3)
+        tui.send_keystroke(Keys.HOME, wait=0.3)
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("aaa_dest_stage_dir" + Keys.ENTER, wait=0.8)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+
+        screen_while_right_active = _screen_text(tui)
+        assert "source_1.txt" in screen_while_right_active, (
+            "Source pane blanked while destination tree flow remained active.\n"
+            f"{screen_while_right_active}"
+        )
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        screen = _screen_text(tui)
+        assert "source_1.txt" in screen, (
+            "Source pane blanked after destination tree HOME+mkdir flow.\n" f"{screen}"
+        )
+        assert "hex invert j compare" in _footer_text(tui), screen
+
+        source_line_after = _find_line_with_text(tui, "source_0.txt")
+        assert source_line_after is not None, screen
+        assert _line_marks_file_as_tagged(source_line_after, "source_0.txt"), (
+            "Destination tree HOME+mkdir flow mutated source tagged state.\n"
+            f"Row: {source_line_after}\n{screen}"
+        )
+
+        tui.send_keystroke("c", wait=0.3)
+        assert tui.wait_for_content("COPY: source_1.txt", timeout=1.0), (
+            "Destination tree HOME+mkdir flow re-indexed source file selection.\n"
+            f"{_screen_text(tui)}"
+        )
+        tui.send_keystroke(Keys.ESC, wait=0.2)
+
+        # Close split from destination tree context, then recover source_dir.
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        if "hex invert j compare" in _footer_text(tui):
+            tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(tui, "Destination should be in tree mode before unsplit.")
+        tui.send_keystroke(Keys.F8, wait=0.5)
+        _assert_dir_mode_footer(
+            tui, "Unsplitting from destination tree must keep tree UI stable."
+        )
+
+        found_source_dir = False
+        for _ in range(8):
+            lines = tui.get_screen_dump()
+            if _stats_current_dir_contains(lines, "source_dir"):
+                found_source_dir = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.2)
+        assert found_source_dir, _screen_text(tui)
+
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+        source_line_unsplit = _find_line_with_text(tui, "source_0.txt")
+        assert source_line_unsplit is not None, _screen_text(tui)
+        assert _line_marks_file_as_tagged(source_line_unsplit, "source_0.txt"), (
+            "Unsplitting from destination tree lost source tagged state.\n"
+            f"{_screen_text(tui)}"
+        )
+        tui.send_keystroke("c", wait=0.3)
+        assert tui.wait_for_content("COPY: source_1.txt", timeout=1.0), (
+            "Unsplitting from destination tree changed source selection identity.\n"
             f"{_screen_text(tui)}"
         )
         tui.send_keystroke(Keys.ESC, wait=0.2)


### PR DESCRIPTION
## Summary
- preserve source panel selection/tag set while navigating destination on the same volume
- prevent left/source pane blanking during F8 destination tree navigation and mkdir flow
- add regression coverage for same-volume F8 + tree/home/mkdir navigation path

## Context
- supersedes commit d1216b6: that earlier change did not resolve this failure mode

## Validation
- pytest -q tests/test_panel_isolation.py -k "bug_f_eight_same_volume_source_selection_retained_or_updates"
- pytest -q tests/test_panel_isolation.py
- make qa-cppcheck
- make qa-all