### PR TITLE
fix(relay): harden watchdog stall visibility

### DIFF
--- a/scripts/relay_runtime.py
+++ b/scripts/relay_runtime.py
@@ -52,6 +52,18 @@ _NOOP_PLACEHOLDER_COMMANDS: set[tuple[str, ...]] = {
 }
 
 _REPORT_HANDLE_PATTERN = re.compile(r"(?:^|\s)report_handle=(\S+)")
+DEFAULT_MAINTAINER_HEARTBEAT_SECONDS = max(
+    30, int(os.environ.get("RELAY_MAINTAINER_HEARTBEAT_SECONDS", "300"))
+)
+DEFAULT_NO_PROGRESS_STALL_SECONDS = max(
+    DEFAULT_MAINTAINER_HEARTBEAT_SECONDS + 30,
+    int(
+        os.environ.get(
+            "RELAY_NO_PROGRESS_STALL_SECONDS",
+            str(DEFAULT_MAINTAINER_HEARTBEAT_SECONDS * 3),
+        )
+    ),
+)
 
 
 def _utc_iso(ts: float | None = None) -> str:
@@ -823,8 +835,16 @@ class TemporalRelayStore:
         self._emit_events(events)
         return final_status
 
-    def watchdog_scan(self, *, now: float | None = None) -> dict[str, int]:
+    def watchdog_scan(
+        self,
+        *,
+        now: float | None = None,
+        maintainer_heartbeat_seconds: int = DEFAULT_MAINTAINER_HEARTBEAT_SECONDS,
+        no_progress_stall_seconds: int = DEFAULT_NO_PROGRESS_STALL_SECONDS,
+    ) -> dict[str, int]:
         stamp = now if now is not None else time.time()
+        maintainer_interval = max(30, int(maintainer_heartbeat_seconds))
+        progress_stall_interval = max(maintainer_interval + 30, int(no_progress_stall_seconds))
         stalled = 0
         requeued = 0
         failed = 0
@@ -837,36 +857,109 @@ class TemporalRelayStore:
                 FROM units u
                 INNER JOIN runs r ON r.run_id = u.run_id
                 WHERE u.status = ?
-                  AND (
-                        (u.lease_expires_at IS NOT NULL AND u.lease_expires_at <= ?)
-                        OR
-                        (u.heartbeat_at IS NOT NULL AND u.heartbeat_at <= (? - r.heartbeat_stale_seconds))
-                  )
+                  AND r.status = ?
                 """,
-                (UNIT_STATUS_RUNNING, stamp, stamp),
+                (UNIT_STATUS_RUNNING, RUN_STATUS_RUNNING),
             ).fetchall()
 
             for row in candidates:
-                stale_reason = "lease_expired"
-                if row["heartbeat_at"] is not None and float(row["heartbeat_at"]) <= stamp - int(
+                run_id = str(row["run_id"])
+                unit_id = str(row["unit_id"])
+                role = str(row["role"])
+                heartbeat_at = float(row["heartbeat_at"]) if row["heartbeat_at"] is not None else None
+                lease_expired = row["lease_expires_at"] is not None and float(row["lease_expires_at"]) <= stamp
+                heartbeat_stale = heartbeat_at is not None and heartbeat_at <= stamp - int(
                     row["heartbeat_stale_seconds"]
-                ):
+                )
+
+                progress_row = conn.execute(
+                    """
+                    SELECT MAX(ts_epoch) AS ts_epoch
+                    FROM temporal_history
+                    WHERE run_id = ?
+                      AND unit_id = ?
+                      AND event_type != ?
+                    """,
+                    (run_id, unit_id, "heartbeat"),
+                ).fetchone()
+                last_progress_epoch = (
+                    float(progress_row["ts_epoch"])
+                    if progress_row and progress_row["ts_epoch"] is not None
+                    else stamp
+                )
+                progress_age = max(0.0, stamp - last_progress_epoch)
+                no_progress_stall = progress_age >= float(progress_stall_interval)
+
+                stale_reason = None
+                stall_event_type = "stall_detected"
+                stall_message = "watchdog detected stale lease"
+                if heartbeat_stale:
                     stale_reason = "heartbeat_stale"
+                elif lease_expired:
+                    stale_reason = "lease_expired"
+                elif no_progress_stall:
+                    stale_reason = "no_progress"
+                    stall_event_type = "stall_detected_no_progress"
+                    stall_message = "watchdog detected no-progress stall"
+
+                if stale_reason is None:
+                    if progress_age >= float(maintainer_interval):
+                        reminder_row = conn.execute(
+                            """
+                            SELECT MAX(ts_epoch) AS ts_epoch
+                            FROM temporal_history
+                            WHERE run_id = ?
+                              AND unit_id = ?
+                              AND event_type = ?
+                            """,
+                            (run_id, unit_id, "maintainer_update_required"),
+                        ).fetchone()
+                        last_reminder_epoch = (
+                            float(reminder_row["ts_epoch"])
+                            if reminder_row and reminder_row["ts_epoch"] is not None
+                            else None
+                        )
+                        reminder_due = (
+                            last_reminder_epoch is None
+                            or (stamp - last_reminder_epoch) >= float(maintainer_interval)
+                        )
+                        if reminder_due:
+                            events.append(
+                                {
+                                    "run_id": run_id,
+                                    "unit_id": unit_id,
+                                    "role": role,
+                                    "event_type": "maintainer_update_required",
+                                    "status": UNIT_STATUS_RUNNING,
+                                    "message": "unit still running; maintainer update required",
+                                    "metadata": {
+                                        "progress_age_s": round(progress_age, 1),
+                                        "heartbeat_age_s": round(stamp - heartbeat_at, 1)
+                                        if heartbeat_at is not None
+                                        else None,
+                                        "maintainer_heartbeat_seconds": maintainer_interval,
+                                    },
+                                    "ts": stamp,
+                                }
+                            )
+                    continue
+
                 stalled += 1
 
                 attempts = int(row["attempt"])
                 max_attempts = int(row["max_attempts"])
                 base_event = {
-                    "run_id": str(row["run_id"]),
-                    "unit_id": str(row["unit_id"]),
-                    "role": str(row["role"]),
-                    "event_type": "stall_detected",
+                    "run_id": run_id,
+                    "unit_id": unit_id,
+                    "role": role,
+                    "event_type": stall_event_type,
                     "status": "stalled",
-                    "message": "watchdog detected stale lease",
+                    "message": stall_message,
                     "metadata": {
                         "stale_reason": stale_reason,
                         "lease_owner": row["lease_owner"],
                         "lease_token": row["lease_token"],
+                        "progress_age_s": round(progress_age, 1),
                     },
                     "ts": stamp,
                 }
@@ -905,9 +998,9 @@ class TemporalRelayStore:
                         events.append(base_event)
                         events.append(
                             {
-                                "run_id": str(row["run_id"]),
-                                "unit_id": str(row["unit_id"]),
-                                "role": str(row["role"]),
+                                "run_id": run_id,
+                                "unit_id": unit_id,
+                                "role": role,
                                 "event_type": "retry_scheduled",
                                 "status": UNIT_STATUS_RETRYABLE,
                                 "message": "watchdog requeued stalled unit",
@@ -959,7 +1052,7 @@ class TemporalRelayStore:
                         events.append(base_event)
                         events.append(
                             {
-                                "run_id": str(row["run_id"]),
+                                "run_id": run_id,
                                 "unit_id": "-",
                                 "role": ROLE_SYSTEM,
                                 "event_type": "workflow_failed",
@@ -1391,6 +1484,24 @@ def _build_parser() -> argparse.ArgumentParser:
     watchdog = sub.add_parser("watchdog", help="Detect stale leases and requeue/fail units")
     watchdog.add_argument("--once", action="store_true")
     watchdog.add_argument("--poll-seconds", type=int, default=5)
+    watchdog.add_argument(
+        "--maintainer-heartbeat-seconds",
+        type=int,
+        default=DEFAULT_MAINTAINER_HEARTBEAT_SECONDS,
+        help=(
+            "Emit maintainer_update_required when unit progress is silent for this interval "
+            "(minimum 30s)"
+        ),
+    )
+    watchdog.add_argument(
+        "--no-progress-stall-seconds",
+        type=int,
+        default=DEFAULT_NO_PROGRESS_STALL_SECONDS,
+        help=(
+            "Treat a running unit as stalled when no non-heartbeat progress arrives for this interval "
+            "(minimum maintainer heartbeat + 30s)"
+        ),
+    )
 
     dash = sub.add_parser("dashboard", help="Render low-noise dashboard view")
     dash.add_argument("--verbose", action="store_true")
@@ -1450,7 +1561,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "watchdog":
         while True:
-            result = store.watchdog_scan()
+            result = store.watchdog_scan(
+                maintainer_heartbeat_seconds=args.maintainer_heartbeat_seconds,
+                no_progress_stall_seconds=args.no_progress_stall_seconds,
+            )
             print(
                 f"watchdog stalled={result['stalled']} requeued={result['requeued']} failed={result['failed']}"
             )

--- a/tests/test_relay_runtime.py
+++ b/tests/test_relay_runtime.py
@@ -35,6 +35,29 @@ def _start_run(store: relay.TemporalRelayStore, run_id: str, now: float = 1000.0
     )
 
 
+def _start_run_custom_lease(
+    store: relay.TemporalRelayStore,
+    run_id: str,
+    *,
+    now: float,
+    lease_ttl_seconds: int,
+    heartbeat_late_seconds: int,
+    heartbeat_stale_seconds: int,
+) -> None:
+    store.start_or_resume_run(
+        run_id=run_id,
+        idempotency_key=f"idem-{run_id}",
+        retry_policy=relay.RetryPolicy(max_attempts=3, backoff_seconds=0),
+        lease_policy=relay.LeasePolicy(
+            lease_ttl_seconds=lease_ttl_seconds,
+            heartbeat_late_seconds=heartbeat_late_seconds,
+            heartbeat_stale_seconds=heartbeat_stale_seconds,
+        ),
+        activity_timeout_seconds=30,
+        now=now,
+    )
+
+
 def _write_executable_script(path: Path, body: str) -> Path:
     path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
@@ -92,6 +115,84 @@ def test_watchdog_marks_stale_and_requeues(tmp_path: Path) -> None:
 
     event_types = [event["event_type"] for event in event_log.read_events()]
     assert "stall_detected" in event_types
+    assert "retry_scheduled" in event_types
+
+
+def test_watchdog_emits_maintainer_update_required_for_long_running_unit(tmp_path: Path) -> None:
+    store, event_log, _db_path, _log_path = _new_store(tmp_path)
+    _start_run_custom_lease(
+        store,
+        "run-maintainer-update",
+        now=1000.0,
+        lease_ttl_seconds=600,
+        heartbeat_late_seconds=900,
+        heartbeat_stale_seconds=1200,
+    )
+
+    developer = relay.RelayWorker(store, role=relay.ROLE_DEVELOPER, worker_id="developer-maintainer")
+    lease = developer.claim_next(now=1000.0)
+    assert lease is not None
+
+    first = store.watchdog_scan(
+        now=1031.0,
+        maintainer_heartbeat_seconds=30,
+        no_progress_stall_seconds=120,
+    )
+    assert first == {"stalled": 0, "requeued": 0, "failed": 0}
+
+    second = store.watchdog_scan(
+        now=1040.0,
+        maintainer_heartbeat_seconds=30,
+        no_progress_stall_seconds=120,
+    )
+    assert second == {"stalled": 0, "requeued": 0, "failed": 0}
+
+    third = store.watchdog_scan(
+        now=1062.0,
+        maintainer_heartbeat_seconds=30,
+        no_progress_stall_seconds=120,
+    )
+    assert third == {"stalled": 0, "requeued": 0, "failed": 0}
+
+    reminder_events = [
+        event for event in event_log.read_events() if event["event_type"] == "maintainer_update_required"
+    ]
+    assert len(reminder_events) == 2
+    assert reminder_events[0]["metadata"]["maintainer_heartbeat_seconds"] == 30
+
+    unit = [row for row in store.list_units(run_id="run-maintainer-update") if row["unit_id"] == "developer_run"][0]
+    assert unit["status"] == relay.UNIT_STATUS_RUNNING
+
+
+def test_watchdog_no_progress_stall_requeues_when_heartbeats_continue(tmp_path: Path) -> None:
+    store, event_log, _db_path, _log_path = _new_store(tmp_path)
+    _start_run_custom_lease(
+        store,
+        "run-no-progress",
+        now=2000.0,
+        lease_ttl_seconds=600,
+        heartbeat_late_seconds=900,
+        heartbeat_stale_seconds=1200,
+    )
+
+    developer = relay.RelayWorker(store, role=relay.ROLE_DEVELOPER, worker_id="developer-no-progress")
+    lease = developer.claim_next(now=2000.0)
+    assert lease is not None
+    assert developer.heartbeat(lease, now=2090.0)
+
+    result = store.watchdog_scan(
+        now=2100.0,
+        maintainer_heartbeat_seconds=30,
+        no_progress_stall_seconds=60,
+    )
+    assert result == {"stalled": 1, "requeued": 1, "failed": 0}
+
+    unit = [row for row in store.list_units(run_id="run-no-progress") if row["unit_id"] == "developer_run"][0]
+    assert unit["status"] == relay.UNIT_STATUS_RETRYABLE
+    assert unit["last_error"] == "watchdog: no_progress"
+
+    event_types = [event["event_type"] for event in event_log.read_events()]
+    assert "stall_detected_no_progress" in event_types
     assert "retry_scheduled" in event_types
 
 


### PR DESCRIPTION
## Summary
- add configurable maintainer heartbeat and no-progress stall thresholds for watchdog scans
- emit `maintainer_update_required` events while units run without non-heartbeat progress
- detect `no_progress` stalls and route them through existing retry/terminal failure paths
- expose new watchdog CLI flags for these thresholds
- add regression coverage for maintainer reminders and no-progress stall requeue behavior

## Validation
- pytest -q tests/test_relay_runtime.py