### PR TITLE
ci(workflows): speed gates with parallel jobs and caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-test:
-    name: Baseline local-equivalent gate
+  guard-fuzz-sync:
+    name: Guard fuzz harness sync
     runs-on: ubuntu-latest
 
     steps:
@@ -16,20 +19,12 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install System Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang llvm libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc lcov
-
     - name: Set up Python 3
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"
-
-    - name: Install Python Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r scripts/requirements.txt
+        cache: pip
+        cache-dependency-path: scripts/requirements.txt
 
     - name: Guard fuzz harness sync
       env:
@@ -49,8 +44,105 @@ jobs:
         fi
         python3 scripts/check_fuzz_harness_sync.py --base "$BASE_SHA" --head "$HEAD_SHA"
 
-    - name: Run baseline gate (local-equivalent, includes qa-fileops-integrity)
-      run: make ci-baseline
+  qa-fileops-integrity:
+    name: File mutation integrity gate
+    runs-on: ubuntu-latest
+    needs: guard-fuzz-sync
+    env:
+      CC: ccache cc
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install System Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ccache libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc
+
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ github.workflow }}-baseline-${{ hashFiles('Makefile', '.github/workflows/ci.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.workflow }}-baseline-
+          ${{ runner.os }}-ccache-${{ github.workflow }}-
+
+    - name: Set up Python 3
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: scripts/requirements.txt
+
+    - name: Install Python Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r scripts/requirements.txt
+
+    - name: Configure compiler cache
+      run: |
+        ccache --set-config=max_size=700M
+        ccache --set-config=sloppiness=time_macros
+        ccache --zero-stats
+
+    - name: Run unsafe API and file mutation gate
+      run: |
+        make qa-unsafe-apis
+        make qa-fileops-integrity
+
+    - name: Report ccache stats
+      if: always()
+      run: ccache --show-stats
+
+  qa-pytest-coverage:
+    name: Full coverage baseline gate
+    runs-on: ubuntu-latest
+    needs: guard-fuzz-sync
+    env:
+      CC: ccache cc
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install System Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ccache clang llvm libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc lcov
+
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ github.workflow }}-coverage-${{ hashFiles('Makefile', '.github/workflows/ci.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.workflow }}-coverage-
+          ${{ runner.os }}-ccache-${{ github.workflow }}-
+
+    - name: Set up Python 3
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: scripts/requirements.txt
+
+    - name: Install Python Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r scripts/requirements.txt
+
+    - name: Configure compiler cache
+      run: |
+        ccache --set-config=max_size=700M
+        ccache --set-config=sloppiness=time_macros
+        ccache --zero-stats
+
+    - name: Run coverage baseline gate
+      run: make qa-pytest-coverage
 
     - name: Publish coverage summary
       if: always() && hashFiles('coverage/summary.txt') != ''
@@ -66,6 +158,49 @@ jobs:
       with:
         name: lcov-info
         path: coverage/lcov.info
+
+    - name: Report ccache stats
+      if: always()
+      run: ccache --show-stats
+
+  qa-fuzz:
+    name: Fuzz baseline gate
+    runs-on: ubuntu-latest
+    needs: guard-fuzz-sync
+    env:
+      FUZZ_CC: ccache clang
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install System Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ccache clang
+
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ github.workflow }}-fuzz-${{ hashFiles('Makefile', '.github/workflows/ci.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.workflow }}-fuzz-
+          ${{ runner.os }}-ccache-${{ github.workflow }}-
+
+    - name: Configure compiler cache
+      run: |
+        ccache --set-config=max_size=700M
+        ccache --set-config=sloppiness=time_macros
+        ccache --zero-stats
+
+    - name: Run fuzz baseline gate
+      run: make qa-fuzz FUZZ_CC="$FUZZ_CC"
+
+    - name: Report ccache stats
+      if: always()
+      run: ccache --show-stats
 
     - name: Upload fuzz artifacts
       if: always() && hashFiles('build/fuzz/artifacts/*') != ''

--- a/.github/workflows/full-qa.yml
+++ b/.github/workflows/full-qa.yml
@@ -5,15 +5,22 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: full-qa-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   qa-all:
     name: Full local-equivalent QA gate (qa-all)
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    env:
+      CC: ccache cc
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
 
     steps:
     - uses: actions/checkout@v6
@@ -23,17 +30,34 @@ jobs:
     - name: Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y gitleaks libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc clang-tidy cppcheck clang-tools bear valgrind
+        sudo apt-get install -y ccache gitleaks libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc clang-tidy cppcheck clang-tools bear valgrind
+
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ github.workflow }}-qa-all-${{ hashFiles('Makefile', '.github/workflows/full-qa.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.workflow }}-qa-all-
+          ${{ runner.os }}-ccache-${{ github.workflow }}-
 
     - name: Set up Python 3
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"
+        cache: pip
+        cache-dependency-path: scripts/requirements.txt
 
     - name: Install Python Dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r scripts/requirements.txt
+
+    - name: Configure compiler cache
+      run: |
+        ccache --set-config=max_size=900M
+        ccache --set-config=sloppiness=time_macros
+        ccache --zero-stats
 
     - name: Guard fuzz harness sync
       env:
@@ -70,10 +94,18 @@ jobs:
         name: qa-all-valgrind-log
         path: valgrind.log
 
+    - name: Report ccache stats
+      if: always()
+      run: ccache --show-stats
+
   qa-sanitize:
     name: Sanitizer gate (qa-sanitize)
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      CC: ccache cc
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
 
     steps:
     - uses: actions/checkout@v6
@@ -81,17 +113,34 @@ jobs:
     - name: Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc clang
+        sudo apt-get install -y ccache libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc clang
+
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ github.workflow }}-qa-sanitize-${{ hashFiles('Makefile', '.github/workflows/full-qa.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.workflow }}-qa-sanitize-
+          ${{ runner.os }}-ccache-${{ github.workflow }}-
 
     - name: Set up Python 3
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"
+        cache: pip
+        cache-dependency-path: scripts/requirements.txt
 
     - name: Install Python Dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r scripts/requirements.txt
+
+    - name: Configure compiler cache
+      run: |
+        ccache --set-config=max_size=900M
+        ccache --set-config=sloppiness=time_macros
+        ccache --zero-stats
 
     - name: Run sanitizer QA gate
       run: make qa-sanitize 2>&1 | tee qa-sanitize.log
@@ -102,3 +151,7 @@ jobs:
       with:
         name: qa-sanitize-log
         path: qa-sanitize.log
+
+    - name: Report ccache stats
+      if: always()
+      run: ccache --show-stats


### PR DESCRIPTION
## Type
- [ ] Typo/docs
- [ ] i18n
- [ ] Refactor (no behavior change)
- [ ] Bug fix
- [x] Feature/enhancement
- [ ] Other (describe):

## What changed
- split baseline CI into parallel required jobs: guard fuzz sync, file mutation integrity, full coverage baseline, and fuzz baseline
- add ccache restore/save and pip caching to baseline and full QA workflows
- set full-qa workflow concurrency to `cancel-in-progress: false` to preserve complete run history per commit

## Why this change
- reduce wall-clock time by running independent QA gates concurrently
- keep every required QA signal in place (no check removal)
- reduce redundant rebuild/setup work while preserving failure provenance on full QA runs

## What you did to verify changes and results
- validated workflow YAML parses cleanly with `python3 -c "import yaml; yaml.safe_load(...)"` for both changed workflow files
- reviewed resulting workflow graph and job commands to confirm all existing baseline/full signals are still present

- Why this PR is large:
  Workflow jobs were restructured to parallelize baseline gating and add cache plumbing in two CI workflows.
- Why it is not split right now (include links to related PRs, if any):
  The speed-up is the composition of both changes together (baseline fan-out plus shared cache/provenance behavior). Splitting would make the intermediate state harder to evaluate and revert.
- What could break:
  Cache key or cache-directory misconfiguration could produce lower-than-expected cache hit rates; workflow required-check names may need branch protection updates if exact job-name matching is configured.