### PR TITLE
Fix/batch small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > [!IMPORTANT]
 > **STATUS: ALPHA (v3.0.0-alpha)**
 > `ytree` is in active alpha development. Expect rough edges, incomplete behaviour, and occasional regressions. Interfaces, key bindings, and configuration details may change before the first stable release.
+> Before opening an issue or suggesting a feature, check [BUGS.md](docs/BUGS.md) and [ROADMAP.md](docs/ROADMAP.md) first, so as not to create a duplicate if it is already listed.
 
 Ytree gives you a fast, keyboard-first view of logged storage: a directory tree, a file list for the current directory, and Showall for all files in the current volume (plus Global across logged volumes). You can filter and tag files, then run normal file operations (copy, move, rename, delete, archive, edit) on single files or in bulk. It also includes built-in file preview, file/directory compare tools, split-screen workflows, and archive-as-directory support with archive creation plus in-archive write operations (copy/move/rename/delete/mkdir where supported).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,6 +149,7 @@ The Split-Screen architecture treats each panel as an independent instance of a 
 *   **Transition Invariant:** A directory can only be entered (Tree to File Mode) if it contains at least one file.
 *   **Selection Memory (Breadcrumbs):** When returning from File Mode to Tree Mode and later re-entering the same directory, the panel restores the cursor to the last highlighted file.
 *   **Navigation Stability:** Moving through the Tree never automatically triggers a transition into File Mode.
+*   **Tag-View Scope Rule:** `i/I` (invert tags) and `o/O` (tagged-only file-list toggle) operate on the active pane's current file-list scope, regardless of whether focus is in tree or file window.
 *   **Root Boundary Rule:** `Left` at root is a no-op; root-content release uses `-` state-release semantics.
 
 ### 5.2 Protocol B: Archive and Volume Lifecycle

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,9 +149,12 @@ The Split-Screen architecture treats each panel as an independent instance of a 
 *   **Transition Invariant:** A directory can only be entered (Tree to File Mode) if it contains at least one file.
 *   **Selection Memory (Breadcrumbs):** When returning from File Mode to Tree Mode and later re-entering the same directory, the panel restores the cursor to the last highlighted file.
 *   **Navigation Stability:** Moving through the Tree never automatically triggers a transition into File Mode.
+*   **Root Boundary Rule:** `Left` at root is a no-op; root-content release uses `-` state-release semantics.
 
 ### 5.2 Protocol B: Archive and Volume Lifecycle
 *   **Lifecycle Management:** The active panel handles Logging new volumes, Cycling through logged volumes, and Releasing (unlogging) volumes.
+*   **Volume Menu Selection Rule:** Selecting an already-active loaded volume preserves its current in-memory expansion/collapse/tag/log state (no implicit relog).
+*   **Explicit Relog Rule:** Logging an already logged volume/path performs a fresh reload of that volume state and reanchors selection at the volume root.
 *   **Independent Rooting:** Changing the root or volume in the active panel has no impact on the inactive panel.
 
 ### 5.3 Protocol C: F7 Autoview
@@ -164,6 +167,7 @@ The Split-Screen architecture treats each panel as an independent instance of a 
 ## 6. Visual and Rendering Standards
 *   **Terminal Integrity:** UI updates are staged using `wnoutrefresh()` and committed atomically via `doupdate()` to prevent visual artifacts.
 *   **Junction Grammar:** Ncurses junctions (T-pieces, crosses) are used only for horizontal boundary lines. Vertical separators must remain clean.
+*   **Tree State Rendering Contract:** Unlogged state is rendered in the dedicated tree status-margin column; directory names do not carry a `+` suffix, while `/` may still be shown when the directory has subdirectories.
 *   **Micro-Consistency:** Mode flags must be synchronized with the layout before any redraw.
 
 ---

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -10,6 +10,18 @@ Ordering policy (for all editors, including AI editors):
 
 ## **Current Runtime Defects (Highest Priority First)**
 
+### **BUG-41: F8 Release-Volume Flow Can Blank Pane and Crash on Tab**
+*   **Description**: In `F8` split mode, after logging two volumes and releasing one, the small window can go blank, separator line can disappear, inactive pane can blank, and tabbing to the inactive pane can trigger a segmentation fault.
+*   **Impact**: Critical stability and data-safety risk (crash), plus severe UI corruption in a core split-pane workflow.
+*   **Remediation**: Harden split-pane volume-release lifecycle so panel/window ownership and active/inactive bindings are always valid after release. Add focused regression coverage for `F8` with multi-volume log/release and `Tab` switching after release.
+*   **Status**: Confirmed.
+
+### **BUG-40: Cycle-Volumes (`<`/`>`, `,`/`.`) Leaks Dir/File View State Across Volumes**
+*   **Description**: Cycling logged volumes can cause dir/file window mode/state changes in one volume to appear in the other, instead of each volume retaining its own last-used state.
+*   **Impact**: Breaks per-volume navigation predictability and increases wrong-target risk during fast volume switching workflows.
+*   **Remediation**: Preserve and restore per-volume dir/file window state independently when cycling volumes. Add regression coverage for repeated `<`/`>` transitions across volumes with different view states.
+*   **Status**: Confirmed.
+
 ### **BUG-39: `Write` Destination Ambiguity and Crash Path**
 *   **Description**: In `Write`, entering a plain filename (for example `report-2026-04-11.txt`) can be interpreted as a command execution path instead of file output, and user repro indicates this path can crash after command failure handling.
 *   **Impact**: Violates least-surprise behavior, risks data-loss/confusion for new users, and introduces a stability defect (segmentation fault).
@@ -160,7 +172,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Description**: In F8 split mode, active (inverted) versus inactive (bold and underlined) panel cursors are correct in directory view, but both are inverted in file view.
 *   **Impact**: Users can't distinguish the active panel during file navigation.
 *   **Remediation**: Make active/inactive indicator rendering consistent between directory and file views in split mode.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-19: Unlogged Tree Nodes Mislabel as `No files` and Use Misleading `dir/` Suffix**
 *   **Description**: In directory tree navigation (for example log `~`, expand `ytree/src`), an unlogged directory like `cmd` can render as `cmd/` with `No files`; expanding it then reveals files.
@@ -174,13 +186,13 @@ Ordering policy (for all editors, including AI editors):
     *   Collapse behavior (`Left` / `-`) must be idempotent for content state and must not mutate status classification.
 *   **Impact**: Misleads users about whether files exist, breaks trust in tree-state cues, and increases navigation friction in common expand/collapse workflows.
 *   **Remediation**: Enforce a strict tree-state contract (`unlogged` vs `empty` vs `has files`) with deterministic render precedence; avoid suffix/label combinations that imply false emptiness; and add regression coverage for expand/collapse (including repeated `Left`/`-`) on unlogged nodes.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-18: Tree `+` Status Marker Renders in Name Text Instead of Margin Slot**
 *   **Description**: When a directory is Unlogged/released, the `+` state marker can appear appended to the directory name text rather than in the dedicated tree status/margin position.
 *   **Impact**: Blurs directory identity with state signaling and makes tree-state scanning less reliable in navigation-heavy flows.
 *   **Remediation**: Render `+` only in the tree status/margin slot for Unlogged entries and keep directory name text unchanged.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-17: Single-Empty-Directory Archive Can Collapse Tree Rendering**
 *   **Description**: In archive mode, when the archive contains only one empty directory, ytree can skip normal tree-node rendering and show that directory identity as appended archive-name/path text instead.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -215,7 +215,7 @@ Ordering policy (for all editors, including AI editors):
 *   If the scope has no files, the action is a silent no-op (no beep/modal).
 *   Add focused regression tests for dir-mode invert behavior (filesystem + archive coverage).
 *   Update `etc/ytree.1.md` and regenerate `docs/USAGE.md` (`make docs`) when behavior lands.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Completed.
 
 ### **Task 57: F7 Top Path Line Must Preserve Full `filename.ext`**
 *   **Goal:** In F7 preview mode, the top line above the directory window must display file context as `path + filename.ext` for the selected file.
@@ -850,7 +850,7 @@ Ordering policy (for all editors, including AI editors):
     *   Leaving the mode restores the normal file/filter view; tags remain unchanged.
     *   This should compose cleanly with existing filters, grep-on-tagged workflows, and compare/tag workflows.
 *   **Rationale:** After tagging, compare, or grep operations, users often want a focused "show me only the files I marked" result view instead of manually navigating through the full list.
-*   - [ ] **Status:** Not Started.
+*   - [ ] **Status:** In Progress (tagged-only toggle shipped on `o/O`; broader workflow/key-shape refinements remain).
 
 ### **Idea FE-8: Investigate Recursive Tagging vs Existing Showall/Global Workflow**
 *   **Goal:** Determine whether recursive tagging provides enough real workflow benefit over the current `log dir -> Showall/Global -> tag` path to justify added complexity.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -50,7 +50,7 @@ The screen is divided into non-overlapping zones. Geometry is calculated dynamic
 The first character column of the Tree View serves as the Memory State Indicator:
 *   `+` : **Unlogged.** The directory entry is visible in the tree, but its file list is not in memory. The File View must display `**Unlogged**`.
 *   ` ` (Blank): **Logged.** The file list for this directory is resident in memory.
-*   Trailing `/`: Visual indicator that the directory contains subdirectories on the disk.
+*   Directory-name suffix contract: `+` is a status-margin marker (not a name suffix). A trailing `/` may still be shown on a directory name to indicate subdirectory presence.
 
 ---
 
@@ -59,11 +59,12 @@ The first character column of the Tree View serves as the Memory State Indicator
 ### 3.1 Focus Flow (`SMALLWINDOWSKIP`)
 The behavior of the `Enter` key on a directory node is governed by the configuration:
 
+*   **State gate (all configs):** If the selected directory is unlogged/not-yet-scanned, `Enter` performs one-level log/reveal (same as `+`) and keeps focus in Tree View.
 *   **Bypass Mode (`SMALLWINDOWSKIP=1`):**
-    *   `Enter` on Tree -> **Instant Zoom**. File Window expands to full height.
+    *   `Enter` on a logged directory in Tree -> **Instant Zoom**. File Window expands to full height.
     *   `Enter` or `Esc` on Zoomed Window -> Returns focus to the **Tree View**.
 *   **Staged Navigation (`SMALLWINDOWSKIP=0`):**
-    *   `Enter` on Tree -> **Focus Shift**. Focus moves to the File View (Small Window). Tree remains visible.
+    *   `Enter` on a logged directory in Tree -> **Focus Shift**. Focus moves to the File View (Small Window). Tree remains visible.
     *   `Enter` on Small Window -> **Zoom**. File Window expands to full height.
 *   **Navigation Stability:** Moving the cursor through the Tree must **never** automatically trigger a transition into File Mode or Zoom.
 
@@ -74,12 +75,12 @@ The behavior of the `Enter` key on a directory node is governed by the configura
 ### 3.3 Directory Memory Commands (Structural Controls)
 *   **`+` or `=` (Expand):** Shallow Log. Scans the files of the current directory and the names of immediate subdirectories. `=` is a convenience alias (unshifted `+` on most keyboard layouts).
 *   **`*` (Asterisk):** Deep Log. Recursively scans the entire branch.
-*   **`-` (Minus / Collapse):** State-based memory release. First press collapses an expanded node. Second press on a collapsed (but logged) node evicts the file list, sets the status indicator to `+`, and marks the directory as Unlogged.
+*   **`-` (Minus / Collapse):** State-based memory release. First press collapses an expanded node. Second press on a collapsed (but logged) node evicts the file list, sets the status indicator to `+`, and marks the directory as Unlogged. At root, use `-` to release logged contents.
 
 ### 3.4 Arrow Key Navigation (Spatial Controls)
 Arrow keys provide spatial, cursor-oriented navigation through the tree. They are distinct from the structural `+`/`-`/`*` controls:
 *   **`→` (Right Arrow / Drill Down):** Progressive depth navigation. If the node is collapsed: expand one level. If already expanded: move cursor to the first child.
-*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. At the filesystem root, collapse the root subtree; if already collapsed, this is a no-op.
+*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. At the filesystem root, `Left` is a no-op.
 
 ### 3.5 Preview Mode (`F7`) Contract
 `F7` is the primary inspect mode for viewing file contents while retaining list-oriented navigation.
@@ -117,7 +118,11 @@ The `ytree` input system follows a layered model designed for high-speed interac
 ### 4.3 Key Behavioral Rules
 *   **The Minus Rule (`-`):** State-based memory release. First press collapses an expanded node; second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged.
 *   **The Right Arrow Rule (`→`):** Progressive drill-down. Expand collapsed → move to child. Always takes the user one step deeper into the tree.
+*   **The Root-Left Rule (`←` at root):** No-op. Root content release is handled by `-`, not by `Left`.
 *   **The Plus/Equals Rule (`+`/`=`):** Explicit one-level expand only. No cursor movement. `=` is the unshifted alias for `+`.
+*   **The Tree Marker Rule (`+` status):** Unlogged state is rendered only in the dedicated tree status margin column; directory names do not carry a `+` suffix.
+*   **The Volume Menu Rule (`K` menu):** Selecting the already-active volume preserves its current in-memory state (no implicit relog/reload).
+*   **The Explicit Relog Rule (`L` on current path):** Logging an already logged volume/path performs a fresh relog/reload of that volume state and reanchors selection at volume root.
 *   **The Archive/Global Jump (`\`):** In Archive Mode, jumps to the archive root. in Global/Showall views, jumps to the highlighted file's directory.
 *   **Numeric FileInfo Band (`1..9`, `0`):** Number keys are the canonical file-display controls in normal list contexts (not active in `F7` preview). These controls apply to file-display rendering for the active pane whether focus is currently in the tree/dir window or file window.
 *   **Vi-Key Collision Policy:** When `VI_KEYS=1`, lowercase `h/j/k/l` are reserved for navigation. Uppercase `H/K/L/J` are used for commands (Hex, Volume, Log, Compare).

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -123,6 +123,8 @@ The `ytree` input system follows a layered model designed for high-speed interac
 *   **The Tree Marker Rule (`+` status):** Unlogged state is rendered only in the dedicated tree status margin column; directory names do not carry a `+` suffix.
 *   **The Volume Menu Rule (`K` menu):** Selecting the already-active volume preserves its current in-memory state (no implicit relog/reload).
 *   **The Explicit Relog Rule (`L` on current path):** Logging an already logged volume/path performs a fresh relog/reload of that volume state and reanchors selection at volume root.
+*   **The Invert Rule (`i`/`I`):** In both tree and file windows, invert tags applies to the active pane's current file-list scope (filesystem and archive contexts).
+*   **The Only-Tagged Rule (`o`/`O`):** In both tree and file windows, toggle tagged-only file-list view for the active pane's current scope; toggling never changes tag state.
 *   **The Archive/Global Jump (`\`):** In Archive Mode, jumps to the archive root. in Global/Showall views, jumps to the highlighted file's directory.
 *   **Numeric FileInfo Band (`1..9`, `0`):** Number keys are the canonical file-display controls in normal list contexts (not active in `F7` preview). These controls apply to file-display rendering for the active pane whether focus is currently in the tree/dir window or file window.
 *   **Vi-Key Collision Policy:** When `VI_KEYS=1`, lowercase `h/j/k/l` are reserved for navigation. Uppercase `H/K/L/J` are used for commands (Hex, Volume, Log, Compare).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -83,13 +83,13 @@ available commands.
 **Directory Mode** Focus is on the directory hierarchy tree. Navigation
 keys allow moving between folders. Typing alphanumeric characters
 triggers a directory mode command (key bindings). \* **Action:** Press
-**Return** to switch focus to the **File Mode** (file list) for the
+**Enter** to switch focus to the **File Mode** (file list) for the
 selected directory.
 
 **File Mode** Focus is on the file list of the selected directory.
 Operations here affect specific files. Typing alphanumeric characters
 triggers a file mode command (key bindings). \* **Action:** Press
-**Return** to toggle the file window to full-screen. Press **Return**
+**Enter** to toggle the file window to full-screen. Press **Enter**
 again to restore the split view or switch back to **Directory Mode**.
 
 **Showall Mode** Toggle file-list mode for all files in the currently
@@ -195,6 +195,8 @@ Active when browsing the directory tree window.
   (`>2023-01-01`), and sizes (`>1M`).
 - **G** (Global): Show all files across all logged volumes in one global
   list.
+- **I** (Invert Tags): Toggle tag state for files in the
+  selected/current directory scope.
 - **J** (Compare): Open the compare submenu (directory, logged tree, or
   external viewer). With `VI_KEYS=1`, use uppercase `J` for this action.
 - **L** (Log): Log a new directory or archive file. Logging an already
@@ -202,6 +204,8 @@ Active when browsing the directory tree window.
   the volume root.
 - **M** (Makedir): Create a new directory.
 - **N** (New File): Create a new empty file.
+- **O** (Only tagged): Toggle tagged-only file-list view for the current
+  directory scope.
 - **P** (Pipe, or **\|**): Pipe the selected directory to a command
   (stdin).
 - **R** (Rename): Rename selected directory.
@@ -224,7 +228,7 @@ Active when browsing the directory tree window.
   directories.
 - **^F** (Dir Mode): Cycle directory display modes (Filenames only -\>
   Attributes -\> Inode/Owner -\> Times).
-- **Return**: On logged directories, switch to File Mode (focus the file
+- **Enter**: On logged directories, switch to File Mode (focus the file
   window). On unlogged/not-yet-scanned directories, perform one-level
   log/reveal (same behavior as `+`) and stay in Directory Mode.
 - **-**: State-based collapse/release. First press collapses an expanded
@@ -267,6 +271,8 @@ Active when the file window is focused.
 - **M** (Move): Move the selected file.
 - **^N**: Move all tagged files.
 - **N** (New File): Create a new empty file.
+- **O** (Only tagged): Toggle tagged-only file-list view (show tagged
+  files only).
 - **P** (Pipe, or **\|**): Pipe content of file to a command (stdin).
 - **R** (Rename): Rename the selected file.
 - **S** (Sort): Sort filelist (Access time, Change time, Extension,
@@ -292,7 +298,7 @@ Active when the file window is focused.
   selected file/directory when nothing is tagged. Directory sources are
   archived recursively.
 - **^F** (File Mode): Cycle file display modes.
-- **Return**: Switch to Full Screen File Mode / Directory Mode.
+- **Enter**: Switch to Full Screen File Mode / Directory Mode.
 - **Left Arrow**: Move to the previous visible file column; in
   one-column layouts this performs page-up navigation.
 - **Right Arrow**: Move to the next visible file column; in one-column
@@ -314,16 +320,20 @@ root/non-root navigation rules.
 - **F** (Filter): Set file filter.
 - **G** (Global): Show all files across all logged volumes in one global
   list.
+- **I** (Invert Tags): Toggle tag state for files in the
+  selected/current archive directory scope.
 - **L** (Log): Log a new directory or archive. Logging an already logged
   volume/path performs a fresh reload and reanchors selection at the
   volume root.
 - **M** (Makedir): Create directory in archive context where supported.
+- **O** (Only tagged): Toggle tagged-only file-list view for the current
+  archive directory scope.
 - **R** (Rename): Rename selected archive directory entry.
 - **S** (Showall): Show all files in the archive.
 - **T** (Tag): Tag all files in current virtual directory.
 - **U** (Untag): Untag all files in current virtual directory.
 - **^F** (Dir Mode): Cycle display modes.
-- **Return**: Switch to Archive-File Mode.
+- **Enter**: Switch to Archive-File Mode.
 - **-**: State-based collapse/release. Expanded nodes collapse;
   collapsed logged nodes (or logged leaves) unlog/release.
 - **Left Arrow**: Collapse the current archive directory when expanded;
@@ -344,6 +354,8 @@ root/non-root navigation rules.
 - **H** (Hex): View file in hex mode.
 - **I** (Invert Tags): Toggle the tag state of all visible files.
 - **M** (Move): Move selected file using archive-aware semantics.
+- **O** (Only tagged): Toggle tagged-only file-list view (show tagged
+  files only).
 - **P** (Pipe, or **\|**): Pipe content to command.
 - **R** (Rename): Rename selected archive file entry.
 - **S** (Sort): Sort file list.
@@ -360,7 +372,7 @@ root/non-root navigation rules.
 - **W** (Write): Export file content to a command or file.
 - **Y** (Pathcopy): Copy selected file with relative path preservation.
 - **^F** (File Mode): Cycle display modes.
-- **Return**: Switch to Archive-Dir Mode.
+- **Enter**: Switch to Archive-Dir Mode.
 - **\\**: No-op.
 
 Archive file-window status text:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -159,9 +159,11 @@ These commands work in most modes:
 - **^L**: **Reload**. Re-read the contents of the current directory from
   disk and refresh the view.
 - **K**: **Volume Menu**. Show a list of all currently logged volumes
-  (drives/paths). Select a volume to switch context instantly. Press
-  `Delete` (or `D`) in the menu to release (unlog) a volume. *(With
-  `VI_KEYS=1`, use uppercase `K`; lowercase `k` is navigation.)*
+  (drives/paths). Select a volume to switch context instantly. Selecting
+  the already-active volume preserves its current in-memory state (no
+  implicit relog). Press `Delete` (or `D`) in the menu to release
+  (unlog) a volume. *(With `VI_KEYS=1`, use uppercase `K`; lowercase `k`
+  is navigation.)*
 - **\<** / **\>** (or **,** / **.**): **Cycle Volumes**. Switch to the
   previous or next logged volume instantly.
 - **^Q**: **Quit to Directory**. If you exit ytree with ^Q, the last
@@ -195,15 +197,11 @@ Active when browsing the directory tree window.
   list.
 - **J** (Compare): Open the compare submenu (directory, logged tree, or
   external viewer). With `VI_KEYS=1`, use uppercase `J` for this action.
-- **L** (Log): Log a new directory or archive file.
+- **L** (Log): Log a new directory or archive file. Logging an already
+  logged volume/path performs a fresh reload and reanchors selection at
+  the volume root.
 - **M** (Makedir): Create a new directory.
 - **N** (New File): Create a new empty file.
-- **O** (Compress): Create an archive from the current selection. If one
-  or more files are tagged, ytree archives the tagged files. If nothing
-  is tagged, ytree archives the selected file or selected directory.
-  Directory sources are archived recursively. Supported destination
-  suffixes: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`,
-  `.tar.xz`/`.txz`, `.zip`.
 - **P** (Pipe, or **\|**): Pipe the selected directory to a command
   (stdin).
 - **R** (Rename): Rename selected directory.
@@ -216,22 +214,35 @@ Active when browsing the directory tree window.
   file using a formatting dialog (Raw, Framed, Page Break).
 - **X** (eXecute): Execute a shell command. The `{}` placeholder is
   replaced by the current directory path.
+- **Z** (archive): Create an archive from the current selection. If one
+  or more files are tagged, ytree archives the tagged files. If nothing
+  is tagged, ytree archives the selected file or selected directory.
+  Directory sources are archived recursively. Supported destination
+  suffixes: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`,
+  `.tar.xz`/`.txz`, `.zip`.
 - **\`** (Backtick): Toggle visibility of hidden dot-files and
   directories.
 - **^F** (Dir Mode): Cycle directory display modes (Filenames only -\>
   Attributes -\> Inode/Owner -\> Times).
-- **Return**: Switch to File Mode (focus the file window).
+- **Return**: On logged directories, switch to File Mode (focus the file
+  window). On unlogged/not-yet-scanned directories, perform one-level
+  log/reveal (same behavior as `+`) and stay in Directory Mode.
 - **-**: State-based collapse/release. First press collapses an expanded
   node. Second press on a collapsed logged node evicts the file list
-  (sets `+` status) and marks the directory as Unlogged.
+  (sets `+` status) and marks the directory as Unlogged. At root, use
+  `-` to release logged contents.
+- **Tree status marker**: Unlogged directories use `+` in the left
+  status margin column. Directory names do not carry a `+` suffix; an
+  unlogged directory may still show `/` when it has subdirectories.
 - **Left Arrow**: If the selected directory is expanded, collapse it.
-  Otherwise move selection to its parent directory. At filesystem root,
-  collapse the root subtree; if already collapsed, this is a no-op.
+  Otherwise move selection to its parent directory. Repeated `Left`
+  keeps ascending (and collapsing where needed). At filesystem root,
+  `Left` is a no-op.
 - **Right Arrow** (Drill Down): Progressive depth navigation. If
   collapsed: expand one level. If already expanded: move cursor to the
-  first child.
-- **+** (or **=**): Expand the selected directory by one level. `=` is a
-  convenience alias (unshifted `+` on most keyboards).
+  first child. It does not jump to siblings.
+- **+** (or **=**): One-level log/reveal only (no cursor movement). `=`
+  is a convenience alias (unshifted `+` on most keyboards).
 - **\*** (Asterisk): Recursively expand the current directory and all
   its subdirectories.
 
@@ -250,13 +261,12 @@ Active when the file window is focused.
 - **H** (Hex): View selected file in hex mode.
 - **I** (Invert Tags): Toggle the tag state of all visible files.
 - **J** (Compare): Compare the selected file with a target file.
-- **L** (Log): Log a new directory or archive file.
+- **L** (Log): Log a new directory or archive file. Logging an already
+  logged volume/path performs a fresh reload and reanchors selection at
+  the volume root.
 - **M** (Move): Move the selected file.
 - **^N**: Move all tagged files.
 - **N** (New File): Create a new empty file.
-- **O** (Archive): Create an archive from tagged files, or from the
-  selected file/directory when nothing is tagged. Directory sources are
-  archived recursively.
 - **P** (Pipe, or **\|**): Pipe content of file to a command (stdin).
 - **R** (Rename): Rename the selected file.
 - **S** (Sort): Sort filelist (Access time, Change time, Extension,
@@ -278,6 +288,9 @@ Active when the file window is focused.
   filename.
 - **Y**: (Pathcopy): Copy selected file, replicating its directory
   structure relative to the current volume root.
+- **Z** (archive): Create an archive from tagged files, or from the
+  selected file/directory when nothing is tagged. Directory sources are
+  archived recursively.
 - **^F** (File Mode): Cycle file display modes.
 - **Return**: Switch to Full Screen File Mode / Directory Mode.
 - **Left Arrow**: Move to the previous visible file column; in
@@ -301,7 +314,9 @@ root/non-root navigation rules.
 - **F** (Filter): Set file filter.
 - **G** (Global): Show all files across all logged volumes in one global
   list.
-- **L** (Log): Log a new directory or archive.
+- **L** (Log): Log a new directory or archive. Logging an already logged
+  volume/path performs a fresh reload and reanchors selection at the
+  volume root.
 - **M** (Makedir): Create directory in archive context where supported.
 - **R** (Rename): Rename selected archive directory entry.
 - **S** (Showall): Show all files in the archive.

--- a/etc/ytree.1.md
+++ b/etc/ytree.1.md
@@ -97,7 +97,7 @@ These commands work in most modes:
 *   **\\**: In **Showall**/**Global** file lists, exit that mode and jump to the selected file in its owner directory. In Archive-Dir mode, `\\` jumps to archive root when used below root, and exits to the parent physical directory when used at archive root. In normal filesystem dir/file windows and Archive-File mode, `\\` is a no-op.
 *   **B**: Toggle Brief (Compact) filename view in the File Window.
 *   **^L**: **Reload**. Re-read the contents of the current directory from disk and refresh the view.
-*   **K**: **Volume Menu**. Show a list of all currently logged volumes (drives/paths). Select a volume to switch context instantly. Press `Delete` (or `D`) in the menu to release (unlog) a volume. *(With `VI_KEYS=1`, use uppercase `K`; lowercase `k` is navigation.)*
+*   **K**: **Volume Menu**. Show a list of all currently logged volumes (drives/paths). Select a volume to switch context instantly. Selecting the already-active volume preserves its current in-memory state (no implicit relog). Press `Delete` (or `D`) in the menu to release (unlog) a volume. *(With `VI_KEYS=1`, use uppercase `K`; lowercase `k` is navigation.)*
 *   **<** / **>** (or **,** / **.**): **Cycle Volumes**. Switch to the previous or next logged volume instantly.
 *   **^Q**: **Quit to Directory**. If you exit ytree with ^Q, the last selected directory becomes your current working directory. See shell wrapper function below.
 *   **Q**: **Quit**. Exit ytree.
@@ -122,7 +122,7 @@ Active when browsing the directory tree window.
 *   **F** (Filter): Set file filter. Supports regex patterns (e.g., `*.c`), exclusions (`-*.o`), attributes (`:r`, `:x`), dates (`>2023-01-01`), and sizes (`>1M`).
 *   **G** (Global): Show all files across all logged volumes in one global list.
 *   **J** (Compare): Open the compare submenu (directory, logged tree, or external viewer). With `VI_KEYS=1`, use uppercase `J` for this action.
-*   **L** (Log): Log a new directory or archive file.
+*   **L** (Log): Log a new directory or archive file. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
 *   **M** (Makedir): Create a new directory.
 *   **N** (New File): Create a new empty file.
 *   **P** (Pipe, or **|**): Pipe the selected directory to a command (stdin).
@@ -136,11 +136,12 @@ Active when browsing the directory tree window.
 *   **Z** (archive): Create an archive from the current selection. If one or more files are tagged, ytree archives the tagged files. If nothing is tagged, ytree archives the selected file or selected directory. Directory sources are archived recursively. Supported destination suffixes: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`, `.tar.xz`/`.txz`, `.zip`.
 *   **`** (Backtick): Toggle visibility of hidden dot-files and directories.
 *   **^F** (Dir Mode): Cycle directory display modes (Filenames only -> Attributes -> Inode/Owner -> Times).
-*   **Return**: Switch to File Mode (focus the file window).
-*   **-**: State-based collapse/release. First press collapses an expanded node. Second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged.
-*   **Left Arrow**: If the selected directory is expanded, collapse it. Otherwise move selection to its parent directory. At filesystem root, collapse the root subtree; if already collapsed, this is a no-op.
-*   **Right Arrow** (Drill Down): Progressive depth navigation. If collapsed: expand one level. If already expanded: move cursor to the first child.
-*   **+** (or **=**): Expand the selected directory by one level. `=` is a convenience alias (unshifted `+` on most keyboards).
+*   **Return**: On logged directories, switch to File Mode (focus the file window). On unlogged/not-yet-scanned directories, perform one-level log/reveal (same behavior as `+`) and stay in Directory Mode.
+*   **-**: State-based collapse/release. First press collapses an expanded node. Second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged. At root, use `-` to release logged contents.
+*   **Tree status marker**: Unlogged directories use `+` in the left status margin column. Directory names do not carry a `+` suffix; an unlogged directory may still show `/` when it has subdirectories.
+*   **Left Arrow**: If the selected directory is expanded, collapse it. Otherwise move selection to its parent directory. Repeated `Left` keeps ascending (and collapsing where needed). At filesystem root, `Left` is a no-op.
+*   **Right Arrow** (Drill Down): Progressive depth navigation. If collapsed: expand one level. If already expanded: move cursor to the first child. It does not jump to siblings.
+*   **+** (or **=**): One-level log/reveal only (no cursor movement). `=` is a convenience alias (unshifted `+` on most keyboards).
 *   **\*** (Asterisk): Recursively expand the current directory and all its subdirectories.
 
 ### File Mode
@@ -157,7 +158,7 @@ Active when the file window is focused.
 *   **H** (Hex): View selected file in hex mode.
 *   **I** (Invert Tags): Toggle the tag state of all visible files.
 *   **J** (Compare): Compare the selected file with a target file.
-*   **L** (Log): Log a new directory or archive file.
+*   **L** (Log): Log a new directory or archive file. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
 *   **M** (Move): Move the selected file.
 *   **^N**: Move all tagged files.
 *   **N** (New File): Create a new empty file.
@@ -194,7 +195,7 @@ When browsing an archive (ZIP, TAR, ISO, etc.), ytree behaves like a virtual fil
 *   **D** (Delete): Delete selected archive directory entry.
 *   **F** (Filter): Set file filter.
 *   **G** (Global): Show all files across all logged volumes in one global list.
-*   **L** (Log): Log a new directory or archive.
+*   **L** (Log): Log a new directory or archive. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
 *   **M** (Makedir): Create directory in archive context where supported.
 *   **R** (Rename): Rename selected archive directory entry.
 *   **S** (Showall): Show all files in the archive.

--- a/etc/ytree.1.md
+++ b/etc/ytree.1.md
@@ -51,11 +51,11 @@ ytree monitors the **currently selected directory** for changes (created/deleted
 
 **Directory Mode**
 Focus is on the directory hierarchy tree. Navigation keys allow moving between folders. Typing alphanumeric characters triggers a directory mode command (key bindings).
-*   **Action:** Press **Return** to switch focus to the **File Mode** (file list) for the selected directory.
+*   **Action:** Press **Enter** to switch focus to the **File Mode** (file list) for the selected directory.
 
 **File Mode**
 Focus is on the file list of the selected directory. Operations here affect specific files. Typing alphanumeric characters triggers a file mode command (key bindings).
-*   **Action:** Press **Return** to toggle the file window to full-screen. Press **Return** again to restore the split view or switch back to **Directory Mode**.
+*   **Action:** Press **Enter** to toggle the file window to full-screen. Press **Enter** again to restore the split view or switch back to **Directory Mode**.
 
 **Showall Mode**
 Toggle file-list mode for all files in the currently logged volume.
@@ -121,10 +121,12 @@ Active when browsing the directory tree window.
 *   **D** (Delete): Delete selected directory.
 *   **F** (Filter): Set file filter. Supports regex patterns (e.g., `*.c`), exclusions (`-*.o`), attributes (`:r`, `:x`), dates (`>2023-01-01`), and sizes (`>1M`).
 *   **G** (Global): Show all files across all logged volumes in one global list.
+*   **I** (Invert Tags): Toggle tag state for files in the selected/current directory scope.
 *   **J** (Compare): Open the compare submenu (directory, logged tree, or external viewer). With `VI_KEYS=1`, use uppercase `J` for this action.
 *   **L** (Log): Log a new directory or archive file. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
 *   **M** (Makedir): Create a new directory.
 *   **N** (New File): Create a new empty file.
+*   **O** (Only tagged): Toggle tagged-only file-list view for the current directory scope.
 *   **P** (Pipe, or **|**): Pipe the selected directory to a command (stdin).
 *   **R** (Rename): Rename selected directory.
 *   **S** (Showall): Show all files in all directories of the current volume.
@@ -136,7 +138,7 @@ Active when browsing the directory tree window.
 *   **Z** (archive): Create an archive from the current selection. If one or more files are tagged, ytree archives the tagged files. If nothing is tagged, ytree archives the selected file or selected directory. Directory sources are archived recursively. Supported destination suffixes: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`, `.tar.xz`/`.txz`, `.zip`.
 *   **`** (Backtick): Toggle visibility of hidden dot-files and directories.
 *   **^F** (Dir Mode): Cycle directory display modes (Filenames only -> Attributes -> Inode/Owner -> Times).
-*   **Return**: On logged directories, switch to File Mode (focus the file window). On unlogged/not-yet-scanned directories, perform one-level log/reveal (same behavior as `+`) and stay in Directory Mode.
+*   **Enter**: On logged directories, switch to File Mode (focus the file window). On unlogged/not-yet-scanned directories, perform one-level log/reveal (same behavior as `+`) and stay in Directory Mode.
 *   **-**: State-based collapse/release. First press collapses an expanded node. Second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged. At root, use `-` to release logged contents.
 *   **Tree status marker**: Unlogged directories use `+` in the left status margin column. Directory names do not carry a `+` suffix; an unlogged directory may still show `/` when it has subdirectories.
 *   **Left Arrow**: If the selected directory is expanded, collapse it. Otherwise move selection to its parent directory. Repeated `Left` keeps ascending (and collapsing where needed). At filesystem root, `Left` is a no-op.
@@ -162,6 +164,7 @@ Active when the file window is focused.
 *   **M** (Move): Move the selected file.
 *   **^N**: Move all tagged files.
 *   **N** (New File): Create a new empty file.
+*   **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only).
 *   **P** (Pipe, or **|**): Pipe content of file to a command (stdin).
 *   **R** (Rename): Rename the selected file.
 *   **S** (Sort): Sort filelist (Access time, Change time, Extension, Group, Modification time, Name, Owner, Size).
@@ -179,7 +182,7 @@ Active when the file window is focused.
 *   **Y**: (Pathcopy): Copy selected file, replicating its directory structure relative to the current volume root.
 *   **Z** (archive): Create an archive from tagged files, or from the selected file/directory when nothing is tagged. Directory sources are archived recursively.
 *   **^F** (File Mode): Cycle file display modes.
-*   **Return**: Switch to Full Screen File Mode / Directory Mode.
+*   **Enter**: Switch to Full Screen File Mode / Directory Mode.
 *   **Left Arrow**: Move to the previous visible file column; in one-column
     layouts this performs page-up navigation.
 *   **Right Arrow**: Move to the next visible file column; in one-column
@@ -195,14 +198,16 @@ When browsing an archive (ZIP, TAR, ISO, etc.), ytree behaves like a virtual fil
 *   **D** (Delete): Delete selected archive directory entry.
 *   **F** (Filter): Set file filter.
 *   **G** (Global): Show all files across all logged volumes in one global list.
+*   **I** (Invert Tags): Toggle tag state for files in the selected/current archive directory scope.
 *   **L** (Log): Log a new directory or archive. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
 *   **M** (Makedir): Create directory in archive context where supported.
+*   **O** (Only tagged): Toggle tagged-only file-list view for the current archive directory scope.
 *   **R** (Rename): Rename selected archive directory entry.
 *   **S** (Showall): Show all files in the archive.
 *   **T** (Tag): Tag all files in current virtual directory.
 *   **U** (Untag): Untag all files in current virtual directory.
 *   **^F** (Dir Mode): Cycle display modes.
-*   **Return**: Switch to Archive-File Mode.
+*   **Enter**: Switch to Archive-File Mode.
 *   **-**: State-based collapse/release. Expanded nodes collapse; collapsed logged nodes (or logged leaves) unlog/release.
 *   **Left Arrow**: Collapse the current archive directory when expanded; otherwise move selection to its parent directory.
 *   **Right Arrow** (Drill Down): Progressive depth navigation. If collapsed: expand one level. If already expanded: move cursor to the first child.
@@ -218,6 +223,7 @@ When browsing an archive (ZIP, TAR, ISO, etc.), ytree behaves like a virtual fil
 *   **H** (Hex): View file in hex mode.
 *   **I** (Invert Tags): Toggle the tag state of all visible files.
 *   **M** (Move): Move selected file using archive-aware semantics.
+*   **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only).
 *   **P** (Pipe, or **|**): Pipe content to command.
 *   **R** (Rename): Rename selected archive file entry.
 *   **S** (Sort): Sort file list.
@@ -233,7 +239,7 @@ When browsing an archive (ZIP, TAR, ISO, etc.), ytree behaves like a virtual fil
 *   **W** (Write): Export file content to a command or file.
 *   **Y** (Pathcopy): Copy selected file with relative path preservation.
 *   **^F** (File Mode): Cycle display modes.
-*   **Return**: Switch to Archive-Dir Mode.
+*   **Enter**: Switch to Archive-Dir Mode.
 *   **\\**: No-op.
 
 Archive file-window status text:

--- a/etc/ytree.1.md
+++ b/etc/ytree.1.md
@@ -125,7 +125,6 @@ Active when browsing the directory tree window.
 *   **L** (Log): Log a new directory or archive file.
 *   **M** (Makedir): Create a new directory.
 *   **N** (New File): Create a new empty file.
-*   **O** (Compress): Create an archive from the current selection. If one or more files are tagged, ytree archives the tagged files. If nothing is tagged, ytree archives the selected file or selected directory. Directory sources are archived recursively. Supported destination suffixes: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`, `.tar.xz`/`.txz`, `.zip`.
 *   **P** (Pipe, or **|**): Pipe the selected directory to a command (stdin).
 *   **R** (Rename): Rename selected directory.
 *   **S** (Showall): Show all files in all directories of the current volume.
@@ -134,6 +133,7 @@ Active when browsing the directory tree window.
 *   **V** (MoveDir): Move the selected directory branch.
 *   **W** (Write): Export files in the selected directory to a command or file using a formatting dialog (Raw, Framed, Page Break).
 *   **X** (eXecute): Execute a shell command. The `{}` placeholder is replaced by the current directory path.
+*   **Z** (archive): Create an archive from the current selection. If one or more files are tagged, ytree archives the tagged files. If nothing is tagged, ytree archives the selected file or selected directory. Directory sources are archived recursively. Supported destination suffixes: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`, `.tar.xz`/`.txz`, `.zip`.
 *   **`** (Backtick): Toggle visibility of hidden dot-files and directories.
 *   **^F** (Dir Mode): Cycle directory display modes (Filenames only -> Attributes -> Inode/Owner -> Times).
 *   **Return**: Switch to File Mode (focus the file window).
@@ -161,7 +161,6 @@ Active when the file window is focused.
 *   **M** (Move): Move the selected file.
 *   **^N**: Move all tagged files.
 *   **N** (New File): Create a new empty file.
-*   **O** (Archive): Create an archive from tagged files, or from the selected file/directory when nothing is tagged. Directory sources are archived recursively.
 *   **P** (Pipe, or **|**): Pipe content of file to a command (stdin).
 *   **R** (Rename): Rename the selected file.
 *   **S** (Sort): Sort filelist (Access time, Change time, Extension, Group, Modification time, Name, Owner, Size).
@@ -177,6 +176,7 @@ Active when the file window is focused.
 *   **W** (Write): Export the selected file to a command or file using a formatting dialog (Raw, Framed, Page Break).
 *   **X** (eXecute): Execute a shell command. `{}` is replaced by the filename.
 *   **Y**: (Pathcopy): Copy selected file, replicating its directory structure relative to the current volume root.
+*   **Z** (archive): Create an archive from tagged files, or from the selected file/directory when nothing is tagged. Directory sources are archived recursively.
 *   **^F** (File Mode): Cycle file display modes.
 *   **Return**: Switch to Full Screen File Mode / Directory Mode.
 *   **Left Arrow**: Move to the previous visible file column; in one-column

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -107,6 +107,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
   struct Volume *loaded_vol = NULL;
   struct Volume *old_vol = NULL;
   struct Volume *reuse_vol = NULL;
+  BOOL reload_requested = FALSE;
   Statistic *s;
   struct stat st_check;
 
@@ -170,34 +171,39 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
     }
 
     if (access_ok) {
-      panel->vol = found_vol;
-      s = &panel->vol->vol_stats;
-      ctx->global_search_term[0] = '\0';
-      ctx->view_mode = panel->vol->vol_stats.log_mode;
+      if (found_vol == panel->vol &&
+          strcmp(found_vol->vol_stats.log_path, resolved_path) == 0) {
+        reload_requested = TRUE;
+      } else {
+        panel->vol = found_vol;
+        s = &panel->vol->vol_stats;
+        ctx->global_search_term[0] = '\0';
+        ctx->view_mode = panel->vol->vol_stats.log_mode;
 
-      /* Re-apply the volume's own filter */
-      (void)SetFilter(s->file_spec, s);
-      if (ctx->hook_recalculate_sys_stats)
-        ctx->hook_recalculate_sys_stats(ctx, s);
+        /* Re-apply the volume's own filter */
+        (void)SetFilter(s->file_spec, s);
+        if (ctx->hook_recalculate_sys_stats)
+          ctx->hook_recalculate_sys_stats(ctx, s);
 
-      /* Refresh display */
-      if (ctx->hook_display_menu)
-        ctx->hook_display_menu(ctx);
-      if (ctx->hook_build_dir_entry_list)
-        ctx->hook_build_dir_entry_list(ctx, panel->vol, &(int){0});
-      RestorePanelTreeSelection(ctx, panel);
+        /* Refresh display */
+        if (ctx->hook_display_menu)
+          ctx->hook_display_menu(ctx);
+        if (ctx->hook_build_dir_entry_list)
+          ctx->hook_build_dir_entry_list(ctx, panel->vol, &(int){0});
+        RestorePanelTreeSelection(ctx, panel);
 
-      if (ctx->hook_display_tree)
-        ctx->hook_display_tree(ctx, panel->vol, ctx->ctx_dir_window,
-                               panel->disp_begin_pos,
-                               panel->disp_begin_pos + panel->cursor_pos, TRUE);
-      if (ctx->hook_display_disk_statistic)
-        ctx->hook_display_disk_statistic(ctx, s);
-      if (ctx->hook_display_avail_bytes)
-        ctx->hook_display_avail_bytes(ctx, s);
-      if (ctx->hook_init_clock)
-        ctx->hook_init_clock(ctx);
-      return 0;
+        if (ctx->hook_display_tree)
+          ctx->hook_display_tree(
+              ctx, panel->vol, ctx->ctx_dir_window, panel->disp_begin_pos,
+              panel->disp_begin_pos + panel->cursor_pos, TRUE);
+        if (ctx->hook_display_disk_statistic)
+          ctx->hook_display_disk_statistic(ctx, s);
+        if (ctx->hook_display_avail_bytes)
+          ctx->hook_display_avail_bytes(ctx, s);
+        if (ctx->hook_init_clock)
+          ctx->hook_init_clock(ctx);
+        return 0;
+      }
     } else {
       /* Volume exists but is inaccessible */
       if (ctx->hook_ui_message)
@@ -220,7 +226,8 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
   old_vol = panel->vol;
 
   /* Determine if we can reuse the "virgin" volume */
-  if (old_vol != NULL && old_vol->vol_stats.log_path[0] == '\0') {
+  if (old_vol != NULL &&
+      (old_vol->vol_stats.log_path[0] == '\0' || reload_requested)) {
     reuse_vol = old_vol;
   }
 
@@ -332,7 +339,13 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
   /* Final Refresh */
   if (ctx->hook_build_dir_entry_list)
     ctx->hook_build_dir_entry_list(ctx, panel->vol, &(int){0});
-  RestorePanelTreeSelection(ctx, panel);
+  if (reload_requested) {
+    panel->disp_begin_pos = 0;
+    panel->cursor_pos = 0;
+    panel->vol->saved_tree_index = 0;
+  } else {
+    RestorePanelTreeSelection(ctx, panel);
+  }
   if (ctx->hook_display_tree)
     ctx->hook_display_tree(ctx, panel->vol, ctx->ctx_dir_window,
                            panel->disp_begin_pos,

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -724,6 +724,17 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       DirNav_MoveEnd(ctx, &dir_entry, ctx->active);
       break;
     case ACTION_MOVE_RIGHT:
+      if (dir_entry->up_tree == NULL && dir_entry->unlogged_flag) {
+        (void)snprintf(new_log_path, sizeof(new_log_path), "%s",
+                       s->log_path);
+        if (LogDisk(ctx, ctx->active, new_log_path) == 0) {
+          s = &ctx->active->vol->vol_stats;
+          dir_entry = ResolveActiveDirEntry(ctx, s);
+          need_dsp_help = TRUE;
+        }
+        break;
+      }
+
       if (!dir_entry->not_scanned && dir_entry->sub_tree != NULL) {
         if (DirOps_SelectVisibleDirAndRefresh(ctx, ctx->active,
                                               dir_entry->sub_tree,
@@ -747,13 +758,13 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       HandleReadSubTree(ctx, dir_entry, &need_dsp_help, ctx->active);
       break;
     case ACTION_MOVE_LEFT:
-      if (!dir_entry->not_scanned && dir_entry->sub_tree != NULL) {
-        HandleCollapseSubTree(ctx, dir_entry, &need_dsp_help, ctx->active);
+      if (dir_entry->up_tree == NULL) {
+        /* Root boundary: left is a no-op. Use '-' to release root contents. */
         break;
       }
 
-      if (dir_entry->up_tree == NULL) {
-        /* FS root boundary no-op. */
+      if (!dir_entry->not_scanned && dir_entry->sub_tree != NULL) {
+        HandleCollapseSubTree(ctx, dir_entry, &need_dsp_help, ctx->active);
         break;
       }
 

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -849,6 +849,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     case ACTION_UNTAG:
     case ACTION_TAG_ALL:
     case ACTION_UNTAG_ALL:
+    case ACTION_INVERT:
+    case ACTION_TOGGLE_TAGGED_MODE:
     case ACTION_CMD_TAGGED_S:
       if (HandleDirTagActions(ctx, action, &dir_entry, &need_dsp_help, &ch)) {
         break;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1371,6 +1371,7 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
                            BOOL *need_dsp_help_ptr, int *ch_ptr,
                            int *unput_char_ptr, YtreeAction *action_ptr) {
   const YtreePanel *saved_panel;
+  char new_log_path[PATH_LENGTH + 1];
 
   if (!ctx || !ctx->active || !dir_entry_ptr || !*dir_entry_ptr || !s_ptr ||
       !*s_ptr || !start_vol_ptr || !*start_vol_ptr || !need_dsp_help_ptr ||
@@ -1388,6 +1389,29 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
             *dir_entry_ptr ? (*dir_entry_ptr)->name : "NULL",
             *dir_entry_ptr ? (unsigned int)(*dir_entry_ptr)->matching_files
                            : 0U);
+
+  if (*dir_entry_ptr &&
+      ((*dir_entry_ptr)->unlogged_flag ||
+       ((*dir_entry_ptr)->not_scanned && (*dir_entry_ptr)->total_files == 0))) {
+    DirEntry *child;
+
+    new_log_path[0] = '\0';
+    HandlePlus(ctx, *dir_entry_ptr, NULL, new_log_path, need_dsp_help_ptr,
+               ctx->active);
+    *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
+
+    if (*dir_entry_ptr) {
+      for (child = (*dir_entry_ptr)->sub_tree; child; child = child->next) {
+        child->not_scanned = TRUE;
+        child->unlogged_flag = TRUE;
+      }
+      BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
+      RefreshView(ctx, *dir_entry_ptr);
+    }
+
+    ctx->focused_window = FOCUS_TREE;
+    return DIR_WINDOW_DISPATCH_HANDLED;
+  }
 
   if (*dir_entry_ptr == NULL || (*dir_entry_ptr)->total_files == 0) {
     UI_Beep(ctx, FALSE);

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1371,7 +1371,6 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
                            BOOL *need_dsp_help_ptr, int *ch_ptr,
                            int *unput_char_ptr, YtreeAction *action_ptr) {
   const YtreePanel *saved_panel;
-  char new_log_path[PATH_LENGTH + 1];
 
   if (!ctx || !ctx->active || !dir_entry_ptr || !*dir_entry_ptr || !s_ptr ||
       !*s_ptr || !start_vol_ptr || !*start_vol_ptr || !need_dsp_help_ptr ||
@@ -1394,6 +1393,7 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
       ((*dir_entry_ptr)->unlogged_flag ||
        ((*dir_entry_ptr)->not_scanned && (*dir_entry_ptr)->total_files == 0))) {
     DirEntry *child;
+    char new_log_path[PATH_LENGTH + 1];
 
     new_log_path[0] = '\0';
     HandlePlus(ctx, *dir_entry_ptr, NULL, new_log_path, need_dsp_help_ptr,

--- a/src/ui/dir_tags.c
+++ b/src/ui/dir_tags.c
@@ -81,6 +81,55 @@ void HandleTagAllDirs(ViewContext *ctx, struct Volume *vol, DirEntry *dir_entry,
   return;
 }
 
+static void HandleInvertDirTags(ViewContext *ctx, DirEntry *dir_entry,
+                                YtreePanel *p) {
+  Statistic *s = &p->vol->vol_stats;
+  FileEntry *fe_ptr;
+
+  for (fe_ptr = dir_entry->file; fe_ptr; fe_ptr = fe_ptr->next) {
+    if (ctx->hide_dot_files && fe_ptr->name[0] == '.')
+      continue;
+
+    if (!fe_ptr->matching)
+      continue;
+
+    fe_ptr->tagged = !fe_ptr->tagged;
+    if (fe_ptr->tagged) {
+      dir_entry->tagged_files++;
+      dir_entry->tagged_bytes += fe_ptr->stat_struct.st_size;
+      s->disk_tagged_files++;
+      s->disk_tagged_bytes += fe_ptr->stat_struct.st_size;
+    } else {
+      dir_entry->tagged_files--;
+      dir_entry->tagged_bytes -= fe_ptr->stat_struct.st_size;
+      s->disk_tagged_files--;
+      s->disk_tagged_bytes -= fe_ptr->stat_struct.st_size;
+    }
+    PanelTags_RecordFileState(p, fe_ptr, fe_ptr->tagged);
+  }
+
+  dir_entry->start_file = 0;
+  dir_entry->cursor_pos = -1;
+  DisplayFileWindow(ctx, p, dir_entry);
+  RefreshWindow(p->pan_file_window);
+  DisplayDiskStatistic(ctx, s);
+  UpdateStatsPanel(ctx, dir_entry, s);
+}
+
+static void HandleDirTaggedOnlyToggle(ViewContext *ctx, DirEntry *dir_entry,
+                                      YtreePanel *p) {
+  if (dir_entry->tagged_files)
+    dir_entry->tagged_flag = !dir_entry->tagged_flag;
+  else
+    dir_entry->tagged_flag = FALSE;
+
+  BuildFileEntryList(ctx, p);
+  dir_entry->start_file = 0;
+  dir_entry->cursor_pos = 0;
+  DisplayFileWindow(ctx, p, dir_entry);
+  RefreshWindow(p->pan_file_window);
+}
+
 BOOL HandleDirTagActions(ViewContext *ctx, int action,
                          DirEntry **dir_entry_ptr, BOOL *need_dsp_help,
                          int *ch) {
@@ -99,6 +148,16 @@ BOOL HandleDirTagActions(ViewContext *ctx, int action,
     return TRUE;
   case ACTION_UNTAG_ALL:
     HandleTagAllDirs(ctx, ctx->active->vol, dir_entry, FALSE, ctx->active);
+    return TRUE;
+  case ACTION_INVERT:
+    HandleInvertDirTags(ctx, dir_entry, ctx->active);
+    if (need_dsp_help)
+      *need_dsp_help = TRUE;
+    return TRUE;
+  case ACTION_TOGGLE_TAGGED_MODE:
+    HandleDirTaggedOnlyToggle(ctx, dir_entry, ctx->active);
+    if (need_dsp_help)
+      *need_dsp_help = TRUE;
     return TRUE;
   case ACTION_CMD_TAGGED_S:
     HandleShowAll(ctx, TRUE, FALSE, dir_entry, need_dsp_help, ch, ctx->active);

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -38,10 +38,10 @@ static void PrintNavLine(WINDOW *win, int y, const char *str);
  * Updated: (F)ilespec -> (F)ilter, spacing adjustments.
  */
 static char dir_help_disk_mode_0[] = "DIR      (A)ttributes (B)rief (C)opy "
-                                     "(D)elete (F)ilter (G)lobal (J) compare "
-                                     "(L)og (M)akedir (N)ewfile";
+                                     "(D)elete (F)ilter (G)lobal (I)nvert "
+                                     "(J) compare (L)og (M)akedir (N)ewfile";
 static char dir_help_disk_mode_1[] =
-    "COMMANDS (P)ipe (Q)uit (R)ename (S)howall (T)ag (U)ntag mo(V)edir "
+    "COMMANDS (O)nly tagged (P)ipe (Q)uit (R)ename (S)howall (T)ag (U)ntag mo(V)edir "
     "(W)rite e(X)ecute "
     "(Z) archive (/) jump (`) dotfiles";
 static char dir_help_nav[] =
@@ -73,7 +73,7 @@ static char file_help_disk_mode_0[] =
     "FILE     (A)ttributes (B)rief (C)opy/(^K) (D)elete (E)dit (F)ilter "
     "(^F)ilemode (H)ex (I)nvert (J) compare (L)og";
 static char file_help_disk_mode_1[] =
-    "COMMANDS (M)ove/(^N) (N)ewfile "
+    "COMMANDS (M)ove/(^N) (N)ewfile (O)nly tagged "
     "(P)ipe (Q)uit (R)ename (S)ort (W)rite e(X)ecute pathcop(Y) "
     "(Z) archive "
     "(/) jump (`) dotfiles";

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -41,9 +41,9 @@ static char dir_help_disk_mode_0[] = "DIR      (A)ttributes (B)rief (C)opy "
                                      "(D)elete (F)ilter (G)lobal (J) compare "
                                      "(L)og (M)akedir (N)ewfile";
 static char dir_help_disk_mode_1[] =
-    "COMMANDS c(O)mpress (P)ipe (Q)uit (R)ename (S)howall (T)ag (U)ntag "
-    "mo(V)edir "
-    "(W)rite e(X)ecute (/) jump (`) dotfiles";
+    "COMMANDS (P)ipe (Q)uit (R)ename (S)howall (T)ag (U)ntag mo(V)edir "
+    "(W)rite e(X)ecute "
+    "(Z) archive (/) jump (`) dotfiles";
 static char dir_help_nav[] =
     "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
     "(F8) split  (F10) config  (Esc) cancel";
@@ -74,7 +74,8 @@ static char file_help_disk_mode_0[] =
     "(^F)ilemode (H)ex (I)nvert (J) compare (L)og";
 static char file_help_disk_mode_1[] =
     "COMMANDS (M)ove/(^N) (N)ewfile "
-    "c(O)mpress (P)ipe (Q)uit (R)ename (S)ort (W)rite e(X)ecute pathcop(Y) "
+    "(P)ipe (Q)uit (R)ename (S)ort (W)rite e(X)ecute pathcop(Y) "
+    "(Z) archive "
     "(/) jump (`) dotfiles";
 static char file_help_nav[] =
     "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "

--- a/src/ui/file_list.c
+++ b/src/ui/file_list.c
@@ -282,7 +282,7 @@ void BuildFileEntryList(ViewContext *ctx, YtreePanel *panel) {
                          panel->vol->vol_stats.tree);
     }
   } else {
-    ReadFileList(ctx, panel, FALSE, dir_entry);
+    ReadFileList(ctx, panel, dir_entry->tagged_flag, dir_entry);
   }
   Panel_Sort(panel, panel->vol->vol_stats.kind_of_sort);
 

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -540,6 +540,9 @@ YtreeAction GetKeyAction(const ViewContext *ctx, int ch) {
   case 'n':
   case 'N':
     return ACTION_CMD_MKFILE;
+  case 'o':
+  case 'O':
+    return ACTION_TOGGLE_TAGGED_MODE;
   case 'p':
   case 'P':
     return ACTION_CMD_P;

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -534,9 +534,6 @@ YtreeAction GetKeyAction(const ViewContext *ctx, int ch) {
   case 'h':
   case 'H':
     return ACTION_CMD_H;
-  case 'o':
-  case 'O':
-    return ACTION_CMD_I;
   case 'm':
   case 'M':
     return ACTION_CMD_M;
@@ -564,6 +561,9 @@ YtreeAction GetKeyAction(const ViewContext *ctx, int ch) {
   case 'y':
   case 'Y':
     return ACTION_CMD_Y;
+  case 'z':
+  case 'Z':
+    return ACTION_CMD_I;
   case '`':
     return ACTION_TOGGLE_HIDDEN;
 

--- a/src/ui/render_dir.c
+++ b/src/ui/render_dir.c
@@ -138,6 +138,8 @@ void PrintDirEntry(ViewContext *ctx, struct Volume *vol, WINDOW *win,
 
   /* --- Redesigned Drawing Logic --- */
 
+  const int status_col = 0;
+  const int graph_col = 3;
   int attr_start_col = 38; /* Column where attributes begin */
   int graph_len = strlen(graph_buffer);
   chtype line_attr;
@@ -161,8 +163,10 @@ void PrintDirEntry(ViewContext *ctx, struct Volume *vol, WINDOW *win,
       wattron(win, A_BOLD | A_UNDERLINE);
   }
 
-  /* Part 1: Draw the tree graph characters manually */
-  wmove(win, y, 0);
+  /* Part 1: Draw status marker and tree graph characters manually */
+  mvwaddch(win, y, status_col,
+           (de_ptr->unlogged_flag || de_ptr->not_scanned) ? '+' : ' ');
+  wmove(win, y, graph_col);
   wattron(win, A_ALTCHARSET);
   for (j = 0; j < (unsigned int)graph_len; ++j) {
     int ch;
@@ -193,10 +197,17 @@ void PrintDirEntry(ViewContext *ctx, struct Volume *vol, WINDOW *win,
   (void)snprintf(name_buffer, sizeof(name_buffer), "%s",
                  (*dir_name) ? dir_name : ".");
   if (de_ptr->not_scanned) {
-    size_t name_len = strlen(name_buffer);
-    if (name_len < sizeof(name_buffer) - 1) {
-      name_buffer[name_len] = de_ptr->unlogged_flag ? '+' : '/';
-      name_buffer[name_len + 1] = '\0';
+    BOOL has_subdirs = (de_ptr->sub_tree != NULL);
+    if (!has_subdirs && S_ISDIR(de_ptr->stat_struct.st_mode) &&
+        de_ptr->stat_struct.st_nlink > 2) {
+      has_subdirs = TRUE;
+    }
+    if (has_subdirs) {
+      size_t name_len = strlen(name_buffer);
+      if (name_len < sizeof(name_buffer) - 1) {
+        name_buffer[name_len] = '/';
+        name_buffer[name_len + 1] = '\0';
+      }
     }
   }
 
@@ -204,10 +215,10 @@ void PrintDirEntry(ViewContext *ctx, struct Volume *vol, WINDOW *win,
   int max_name_len;
   if (ctx->dir_mode == MODE_3) {
     /* In MODE_3 (name-only), truncate based on full window width */
-    max_name_len = ctx->layout.dir_win_width - graph_len - 1;
+    max_name_len = ctx->layout.dir_win_width - graph_col - graph_len - 1;
   } else {
     /* In other modes, truncate to prevent overlap with attributes */
-    max_name_len = attr_start_col - graph_len - 1;
+    max_name_len = attr_start_col - graph_col - graph_len - 1;
   }
   /* Safety: Ensure max_name_len is at least 1 to avoid issues with CutName */
   if (max_name_len < 1) {
@@ -228,7 +239,7 @@ void PrintDirEntry(ViewContext *ctx, struct Volume *vol, WINDOW *win,
     else
       wattron(win, A_BOLD | A_UNDERLINE);
   }
-  mvwaddstr(win, y, graph_len, name_buffer);
+  mvwaddstr(win, y, graph_col + graph_len, name_buffer);
   if (hilight && !ctx->highlight_full_line) {
     if (is_active)
       wattroff(win, A_REVERSE);

--- a/src/ui/render_file.c
+++ b/src/ui/render_file.c
@@ -633,7 +633,7 @@ void DisplayFiles(ViewContext *ctx, YtreePanel *panel, const DirEntry *de_ptr,
     const char *empty_label = "No files";
     if (de_ptr->access_denied) {
       empty_label = "Permission Denied!";
-    } else if (de_ptr->unlogged_flag) {
+    } else if (de_ptr->unlogged_flag || de_ptr->not_scanned) {
       empty_label = "Unlogged";
     }
     mvwaddstr(win, 0, first_filename_col, empty_label);

--- a/src/ui/render_file.c
+++ b/src/ui/render_file.c
@@ -207,6 +207,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
   int base_color_pair;
   int width;
   BOOL is_tagged;
+  int highlight_attr;
 
   if (!panel->file_entry_list)
     return;
@@ -217,6 +218,9 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
   if (fe_ptr == NULL)
     return;
   is_tagged = PanelTags_FileIsTagged(panel, fe_ptr);
+  highlight_attr = (ctx->is_split_screen && panel != ctx->active)
+                       ? (A_BOLD | A_UNDERLINE)
+                       : A_REVERSE;
 
   if (ctx->fixed_col_width > 0) {
     pos_x = x * (ctx->fixed_col_width + 1);
@@ -233,7 +237,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
     if (is_tagged)
       wattron(win, A_BOLD);
     if (hilight)
-      wattron(win, A_REVERSE);
+      wattron(win, highlight_attr);
 
     /* Draw */
     wprintw(win, "%c%c%s", (is_tagged) ? TAGGED_SYMBOL : ' ',
@@ -248,7 +252,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
 
     /* Cleanup */
     if (hilight)
-      wattroff(win, A_REVERSE);
+      wattroff(win, highlight_attr);
     if (is_tagged)
       wattroff(win, A_BOLD);
     wattroff(win, COLOR_PAIR(color));
@@ -340,7 +344,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
     if (is_tagged)
       wattron(win, A_BOLD);
     if (hilight)
-      wattron(win, A_REVERSE);
+      wattron(win, highlight_attr);
 
     /* Build the full line string */
     switch (panel->file_mode) {
@@ -452,7 +456,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
     waddstr(win, line_ptr);
 
     if (hilight)
-      wattroff(win, A_REVERSE);
+      wattroff(win, highlight_attr);
     if (is_tagged)
       wattroff(win, A_BOLD);
 
@@ -514,10 +518,10 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
 
     /* Highlight only the name */
     if (hilight)
-      wattron(win, A_REVERSE);
+      wattron(win, highlight_attr);
     AddClippedAtCursor(win, display_name, width);
     if (hilight)
-      wattroff(win, A_REVERSE);
+      wattroff(win, highlight_attr);
 
     /* Print attributes for modes other than MODE_3 */
     if (panel->file_mode != MODE_3) {

--- a/src/ui/volume_menu.c
+++ b/src/ui/volume_menu.c
@@ -385,20 +385,20 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
         selected_index = 0;
 
       struct Volume *target_vol = vol_array[selected_index];
-
       if (target_vol != ctx->active->vol) {
         int login_result =
             LogDisk(ctx, ctx->active, target_vol->vol_stats.log_path);
         free(vol_array);
         return login_result;
       }
+
       free(vol_array);
-      /* If we are already on the selected volume, just ensure list is synced */
+      /* Already on selected volume: preserve existing in-memory state. */
       {
         int dummy;
         BuildDirEntryList(ctx, ctx->active->vol, &dummy);
       }
-      return 0; /* Already on selected volume */
+      return 0;
     }
   }
 

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -28,6 +28,39 @@ def _create_archive(root, archive_name="sample.tar"):
     return archive_path
 
 
+def _assert_margin_plus_marker(screen_rows, dir_name, expect_slash=False):
+    candidates = [
+        line
+        for line in screen_rows
+        if dir_name in line and "Path:" not in line and "CURRENT DIR" not in line
+        and "ATTRIBUTES" not in line
+    ]
+    row = next((line for line in candidates if "tq" in line or "mq" in line), "")
+    if not row and candidates:
+        row = candidates[0]
+    assert row, f"Expected a tree row for {dir_name!r}.\n" + "\n".join(screen_rows)
+    name_col = row.find(dir_name)
+    plus_col = row.find("+")
+    assert plus_col >= 0 and plus_col < name_col, (
+        "Unlogged marker must render in tree status margin, not in name text.\n"
+        f"row={row!r}"
+    )
+    assert f"{dir_name}+" not in row, (
+        "Tree row must not append '+' suffixes to directory names.\n"
+        f"row={row!r}"
+    )
+    if expect_slash:
+        assert f"{dir_name}/" in row, (
+            "Unlogged directory with subdirs should show '/' suffix.\n"
+            f"row={row!r}"
+        )
+    else:
+        assert f"{dir_name}/" not in row, (
+            "Unlogged directory without subdirs should not show '/' suffix.\n"
+            f"row={row!r}"
+        )
+
+
 def test_archive_left_at_root_does_not_exit_archive(tmp_path, ytree_binary):
     """LEFT is collapse-only and must not exit archive mode at archive root."""
     root = tmp_path / "archive_exit_root"
@@ -82,8 +115,8 @@ def test_minus_on_leaf_unlogs_directory_state(tmp_path, ytree_binary):
         "Leaf directory should be unlogged after '-' and not enter file mode.\n"
         f"Footer:\n{footer}\n\nScreen:\n{screen}"
     )
-    assert "leaf_file.txt" not in screen, (
-        "Leaf file remained visible after '-' unlog contract.\n"
+    assert "leaf_file.txt" in screen, (
+        "Enter on unlogged leaf should relog/reveal one level while staying in tree mode.\n"
         f"Screen:\n{screen}"
     )
 
@@ -274,12 +307,8 @@ def test_unlogged_tree_shows_plus_marker_and_plus_relogs(tmp_path, ytree_binary)
     tui.send_keystroke(Keys.DOWN, wait=0.3)
     tui.send_keystroke("-", wait=0.4)
     screen_after_unlog = _screen_text(tui)
-    node_lines = [line for line in tui.get_screen_dump() if "node" in line]
-    assert node_lines, f"Expected node row after unlog.\n{screen_after_unlog}"
-    assert any("+" in line for line in node_lines), (
-        "Unlogged directory should display '+' marker in tree row.\n"
-        f"{screen_after_unlog}"
-    )
+    rows_after_unlog = tui.get_screen_dump()
+    _assert_margin_plus_marker(rows_after_unlog, "node")
 
     tui.send_keystroke("+", wait=0.5)
     tui.send_keystroke(Keys.ENTER, wait=0.4)
@@ -290,6 +319,299 @@ def test_unlogged_tree_shows_plus_marker_and_plus_relogs(tmp_path, ytree_binary)
     )
 
     tui.quit()
+
+
+def test_enter_on_unlogged_dir_relogs_and_reveals_first_level_only(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "unlogged_enter_relogs_first_level"
+    root.mkdir()
+    node = root / "node"
+    node.mkdir()
+    (node / "child_a").mkdir()
+    (node / "child_b").mkdir()
+    (node / "child_a" / "nested.txt").write_text("payload", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke("-", wait=0.4)
+        before = _screen_text(tui)
+        assert "child_a" not in before, (
+            "Precondition failed: collapsed unlogged directory should hide "
+            "first-level children before Enter.\n"
+            f"{before}"
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.6)
+        after = _screen_text(tui)
+        footer = _footer_text(tui).lower()
+
+        assert "child_a" in after and "child_b" in after, (
+            "Enter on unlogged dir should relog and reveal immediate "
+            "subdirectories.\n"
+            f"{after}"
+        )
+        rows = tui.get_screen_dump()
+        _assert_margin_plus_marker(rows, "child_a")
+        _assert_margin_plus_marker(rows, "child_b")
+        assert "hex invert j compare" not in footer, (
+            "Enter on unlogged dir should stay in directory window, not switch "
+            "to file window.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{after}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_unlogged_directory_with_subdirs_shows_slash_suffix(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "unlogged_slash_suffix"
+    root.mkdir()
+    top = root / "top"
+    top.mkdir()
+    (top / "child").mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke("+", wait=0.5)
+        tui.send_keystroke("-", wait=0.4)
+        tui.send_keystroke("-", wait=0.4)
+        _assert_margin_plus_marker(tui.get_screen_dump(), "top", expect_slash=True)
+    finally:
+        tui.quit()
+
+
+def test_unlogged_placeholder_with_subdirs_shows_slash_suffix(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "unlogged_placeholder_slash_suffix"
+    root.mkdir()
+    (root / ".ytree").write_text("TREEDEPTH=0\n", encoding="utf-8")
+    top = root / "top"
+    top.mkdir()
+    (top / "child").mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.4)
+        _assert_margin_plus_marker(tui.get_screen_dump(), "top", expect_slash=True)
+    finally:
+        tui.quit()
+
+
+def test_enter_on_placeholder_dir_logs_and_reveals_first_level_only(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "placeholder_enter_reveals_first_level"
+    root.mkdir()
+    src = root / "src"
+    src.mkdir()
+    (src / "cmd").mkdir()
+    (src / "ui").mkdir()
+    (src / "cmd" / "main.c").write_text("int main(void){return 0;}\n",
+                                         encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        before = _screen_text(tui)
+        assert "cmd+" not in before and "ui+" not in before, (
+            "Precondition failed: placeholder directory should hide first-level "
+            "children before Enter.\n"
+            f"{before}"
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.6)
+        after = _screen_text(tui)
+        footer = _footer_text(tui).lower()
+
+        assert "cmd" in after and "ui" in after, (
+            "Enter on placeholder dir should reveal immediate subdirectories.\n"
+            f"{after}"
+        )
+        rows = tui.get_screen_dump()
+        _assert_margin_plus_marker(rows, "cmd")
+        _assert_margin_plus_marker(rows, "ui")
+        assert "hex invert j compare" not in footer, (
+            "Enter on placeholder dir should stay in directory window, not "
+            "switch to file window.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{after}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_root_minus_resets_tree_and_right_relogs_to_profile_depth(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "root_minus_right_profile_depth"
+    root.mkdir()
+    (root / ".ytree").write_text("TREEDEPTH=1\n", encoding="utf-8")
+    src = root / "src"
+    src.mkdir()
+    cmd = src / "cmd"
+    cmd.mkdir()
+    deep = cmd / "deeper"
+    deep.mkdir()
+    (deep / "leaf.txt").write_text("payload", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke("*", wait=0.7)
+        expanded = _screen_text(tui)
+        assert "deeper" in expanded, (
+            "Precondition failed: expected deep expansion before root reset.\n"
+            f"{expanded}"
+        )
+
+        tui.send_keystroke(Keys.HOME, wait=0.3)
+        for _ in range(8):
+            header = tui.get_screen_dump()[0]
+            if str(root) in header:
+                break
+            tui.send_keystroke(Keys.LEFT, wait=0.3)
+
+        before_rows = tui.get_screen_dump()
+        at_root_before = "\n".join(before_rows)
+        assert str(root) in tui.get_screen_dump()[0], (
+            "Precondition failed: expected selection at root before root-left "
+            "no-op assertion.\n"
+            f"{at_root_before}"
+        )
+
+        tui.send_keystroke(Keys.LEFT, wait=0.5)
+        after_rows = tui.get_screen_dump()
+        at_root_after = "\n".join(after_rows)
+        assert "\n".join(after_rows[1:]) == "\n".join(before_rows[1:]), (
+            "Left at root should be a no-op; use '-' to release root contents.\n"
+            f"Before:\n{at_root_before}\n\nAfter:\n{at_root_after}"
+        )
+
+        tui.send_keystroke("-", wait=0.7)
+        tui.send_keystroke("-", wait=0.7)
+        after_minus = _screen_text(tui)
+        assert "deeper" not in after_minus, (
+            "Root '-' release should clear expanded descendant state.\n"
+            f"{after_minus}"
+        )
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.9)
+        after_right = _screen_text(tui)
+        assert "src/" in after_right, (
+            "Right on reset root should relog to configured depth and show "
+            "first-level directory placeholders.\n"
+            f"{after_right}"
+        )
+        assert "deeper" not in after_right, (
+            "Right after root reset must not restore previous deep expansion state.\n"
+            f"{after_right}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_enter_on_placeholder_dir_is_consistent_with_smallwindowskip_one(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "placeholder_enter_smallwindowskip_one"
+    root.mkdir()
+    (root / ".ytree").write_text("SMALLWINDOWSKIP=1\n", encoding="utf-8")
+
+    src = root / "src"
+    src.mkdir()
+    (src / "cmd").mkdir()
+    (src / "ui").mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        before = _screen_text(tui)
+        assert "cmd+" not in before and "ui+" not in before, (
+            "Precondition failed: placeholder directory should hide first-level "
+            "children before Enter (SMALLWINDOWSKIP=1).\n"
+            f"{before}"
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.6)
+        after = _screen_text(tui)
+        footer = _footer_text(tui).lower()
+
+        assert "cmd" in after and "ui" in after, (
+            "Enter behavior should match standard mode for placeholder dirs "
+            "when SMALLWINDOWSKIP=1.\n"
+            f"{after}"
+        )
+        rows = tui.get_screen_dump()
+        _assert_margin_plus_marker(rows, "cmd")
+        _assert_margin_plus_marker(rows, "ui")
+        assert "hex invert j compare" not in footer, (
+            "Enter on placeholder dir should remain in directory view when "
+            "SMALLWINDOWSKIP=1.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{after}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_enter_on_placeholder_dir_is_consistent_with_smallwindowskip_zero(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "placeholder_enter_smallwindowskip_zero"
+    root.mkdir()
+    (root / ".ytree").write_text("SMALLWINDOWSKIP=0\n", encoding="utf-8")
+
+    src = root / "src"
+    src.mkdir()
+    (src / "cmd").mkdir()
+    (src / "ui").mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        before = _screen_text(tui)
+        assert "cmd+" not in before and "ui+" not in before, (
+            "Precondition failed: placeholder directory should hide first-level "
+            "children before Enter (SMALLWINDOWSKIP=0).\n"
+            f"{before}"
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.6)
+        after = _screen_text(tui)
+        footer = _footer_text(tui).lower()
+
+        assert "cmd" in after and "ui" in after, (
+            "Enter behavior should match standard mode for placeholder dirs "
+            "when SMALLWINDOWSKIP=0.\n"
+            f"{after}"
+        )
+        rows = tui.get_screen_dump()
+        _assert_margin_plus_marker(rows, "cmd")
+        _assert_margin_plus_marker(rows, "ui")
+        assert "hex invert j compare" not in footer, (
+            "Enter on placeholder dir should remain in directory view when "
+            "SMALLWINDOWSKIP=0.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{after}"
+        )
+    finally:
+        tui.quit()
 
 
 def test_logged_empty_vs_unlogged_labels(tmp_path, ytree_binary):
@@ -337,6 +659,134 @@ def test_logged_empty_vs_unlogged_labels(tmp_path, ytree_binary):
     )
 
     tui.quit()
+
+
+def test_placeholder_dir_shows_unlogged_not_no_files(tmp_path, ytree_binary):
+    root = tmp_path / "placeholder_shows_unlogged"
+    root.mkdir()
+    src = root / "src"
+    src.mkdir()
+    (src / "cmd").mkdir()
+    (src / "cmd" / "main.c").write_text("int main(void){return 0;}\n",
+                                         encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.4)
+        screen = _screen_text(tui)
+        assert "Unlogged" in screen, (
+            "Unscanned placeholder directory should display Unlogged in file view.\n"
+            f"{screen}"
+        )
+        assert "No files" not in screen, (
+            "Placeholder/unlogged directory must not display No files.\n"
+            f"{screen}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_volume_menu_enter_on_current_volume_preserves_existing_state(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "volume_menu_preserve_current_state"
+    root.mkdir()
+    active_dir = root / "active_dir"
+    stale_dir = root / "vol_old_name_dir"
+    active_dir.mkdir()
+    stale_dir.mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        before_rename = _screen_text(tui)
+        assert "vol_old_name_dir" in before_rename, (
+            "Precondition failed: expected original tree entry before rename.\n"
+            f"{before_rename}"
+        )
+
+        stale_dir.rename(root / "vol_new_name_dir")
+        time.sleep(0.4)
+
+        before_relog = _screen_text(tui)
+        assert "vol_old_name_dir" in before_relog, (
+            "Tree should remain stale before explicit relog when focused on sibling.\n"
+            f"{before_relog}"
+        )
+
+        tui.send_keystroke("K", wait=0.3)
+        tui.send_keystroke(Keys.ENTER, wait=0.9)
+
+        after_select = _screen_text(tui)
+        assert "vol_old_name_dir" in after_select, (
+            "Selecting the current volume in Volume Menu should preserve its "
+            "existing in-memory state (no relog).\n"
+            f"{after_select}"
+        )
+        assert "vol_new_name_dir" not in after_select, (
+            "Volume Menu selection must not implicitly refresh/reload current "
+            "volume state.\n"
+            f"{after_select}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_log_command_on_current_volume_reloads_tree_state(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "log_current_volume_refresh"
+    root.mkdir()
+    active_dir = root / "active_dir"
+    stale_dir = root / "vol_old_name_dir"
+    active_dir.mkdir()
+    stale_dir.mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        before_rename = _screen_text(tui)
+        assert "vol_old_name_dir" in before_rename, (
+            "Precondition failed: expected original tree entry before rename.\n"
+            f"{before_rename}"
+        )
+
+        stale_dir.rename(root / "vol_new_name_dir")
+        time.sleep(0.4)
+
+        before_log = _screen_text(tui)
+        assert "vol_old_name_dir" in before_log, (
+            "Tree should remain stale before explicit relog command.\n"
+            f"{before_log}"
+        )
+
+        tui.send_keystroke(Keys.LOG, wait=0.3)
+        tui.send_keystroke(Keys.CTRL_U, wait=0.1)
+        tui.send_keystroke(str(root), wait=0.1)
+        tui.send_keystroke(Keys.ENTER, wait=0.9)
+
+        after_log = _screen_text(tui)
+        assert "vol_new_name_dir" in after_log, (
+            "Logging the current volume should refresh the tree from disk.\n"
+            f"{after_log}"
+        )
+        assert "vol_old_name_dir" not in after_log, (
+            "Relog should replace stale directory entries with current disk state.\n"
+            f"{after_log}"
+        )
+        header = tui.get_screen_dump()[0]
+        assert str(root) in header and str(root / "active_dir") not in header, (
+            "Explicit relog should reanchor selection at volume root.\n"
+            f"Header: {header!r}\n\nScreen:\n{after_log}"
+        )
+    finally:
+        tui.quit()
 
 
 def test_depth_limited_placeholder_plus_loads_leaf_files(tmp_path, ytree_binary):

--- a/tests/test_archive_ui.py
+++ b/tests/test_archive_ui.py
@@ -264,7 +264,7 @@ def test_archive_create_overwrite_prompt_respects_no_then_yes(ytree_binary, tmp_
         tui.send_keystroke(Keys.ENTER, wait=0.4)
         assert tui.wait_for_content("0_source.txt", timeout=3.0)
 
-        tui.send_keystroke("O", wait=0.2)
+        tui.send_keystroke("Z", wait=0.2)
         assert tui.wait_for_content("Create archive:", timeout=3.0)
         tui.send_keystroke(f"{archive_path}\r", wait=0.3)
         assert tui.wait_for_content("Overwrite z_existing.zip? (y/n)", timeout=3.0)
@@ -273,7 +273,7 @@ def test_archive_create_overwrite_prompt_respects_no_then_yes(ytree_binary, tmp_
         assert _zip_names(archive_path) == ["existing.txt"]
         assert _zip_read_text(archive_path, "existing.txt") == "old payload"
 
-        tui.send_keystroke("O", wait=0.2)
+        tui.send_keystroke("Z", wait=0.2)
         assert tui.wait_for_content("Create archive:", timeout=3.0)
         tui.send_keystroke(f"{archive_path}\r", wait=0.3)
         assert tui.wait_for_content("Overwrite z_existing.zip? (y/n)", timeout=3.0)
@@ -318,7 +318,7 @@ def test_archive_create_inside_source_directory_is_allowed(ytree_binary, tmp_pat
 
     tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
     try:
-        tui.send_keystroke("O", wait=0.2)
+        tui.send_keystroke("Z", wait=0.2)
         assert tui.wait_for_content("Recursive? (Y/n)", timeout=3.0)
         tui.send_keystroke("y", wait=0.2)
         assert tui.wait_for_content("Create archive:", timeout=3.0)
@@ -345,7 +345,7 @@ def test_archive_create_overwrite_excludes_destination_from_payload(
 
     tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
     try:
-        tui.send_keystroke("O", wait=0.2)
+        tui.send_keystroke("Z", wait=0.2)
         assert tui.wait_for_content("Recursive? (Y/n)", timeout=3.0)
         tui.send_keystroke("y", wait=0.2)
         assert tui.wait_for_content("Create archive:", timeout=3.0)
@@ -375,7 +375,7 @@ def test_archive_create_exclusion_empty_payload_shows_status_and_aborts(
         tui.send_keystroke(Keys.ENTER, wait=0.4)
         assert tui.wait_for_content("only.zip", timeout=3.0)
 
-        tui.send_keystroke("O", wait=0.2)
+        tui.send_keystroke("Z", wait=0.2)
         assert tui.wait_for_content("Create archive:", timeout=3.0)
         tui.send_keystroke(f"{destination}\r", wait=0.3)
         assert tui.wait_for_content("Overwrite only.zip? (y/n)", timeout=3.0)
@@ -406,7 +406,7 @@ def test_archive_create_inside_source_round_trip_integrity(ytree_binary, tmp_pat
 
     tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
     try:
-        tui.send_keystroke("O", wait=0.2)
+        tui.send_keystroke("Z", wait=0.2)
         assert tui.wait_for_content("Recursive? (Y/n)", timeout=3.0)
         tui.send_keystroke("y", wait=0.2)
         assert tui.wait_for_content("Create archive:", timeout=3.0)
@@ -446,7 +446,7 @@ def test_archive_create_unsupported_format_shows_and_clears_status_error(
         tui.send_keystroke(Keys.ENTER, wait=0.4)
         assert tui.wait_for_content("source.txt", timeout=3.0)
 
-        tui.send_keystroke("O", wait=0.2)
+        tui.send_keystroke("Z", wait=0.2)
         assert tui.wait_for_content("Create archive:", timeout=3.0)
         tui.send_keystroke(f"{destination}\r", wait=0.4)
         assert tui.wait_for_content("Unsupported archive format: .7z", timeout=3.0)

--- a/tests/test_file_window_dispatch_regressions.py
+++ b/tests/test_file_window_dispatch_regressions.py
@@ -103,3 +103,18 @@ def test_HandleFileWindow_delegates_misc_dispatch_hotspot():
     assert "GetNewLogPath(ctx, ctx->active" not in handle_block, (
         "Log branch body should be handled in extracted misc helper."
     )
+
+
+def test_PrintFileEntry_uses_inactive_split_highlight_style():
+    render_source = _read_source("src/ui/render_file.c")
+    print_file_entry_block = _extract_function_block(
+        render_source, "void PrintFileEntry("
+    )
+
+    assert "ctx->is_split_screen && panel != ctx->active" in print_file_entry_block, (
+        "PrintFileEntry must detect inactive split-panel rows instead of treating "
+        "all highlighted rows as active."
+    )
+    assert "A_BOLD | A_UNDERLINE" in print_file_entry_block, (
+        "Inactive split-panel file-row highlight must use underline+bold styling."
+    )

--- a/tests/test_tagged_action_regressions.py
+++ b/tests/test_tagged_action_regressions.py
@@ -1,8 +1,11 @@
 import time
+import zipfile
 
 from helpers_source import extract_function_block as _extract_function_block
 from helpers_source import read_repo_source
 from helpers_ui import assert_file_tag_state as _assert_file_tag_state
+from helpers_ui import footer_text as _footer_text
+from helpers_ui import screen_text as _screen_text
 from tui_harness import YtreeTUI
 from ytree_keys import Keys
 
@@ -42,6 +45,99 @@ def test_invert_tags_i_and_upper_i_on_mixed_set(ytree_binary, tmp_path):
         _assert_file_tag_state(tui, "alpha.txt", True)
         _assert_file_tag_state(tui, "beta.txt", False)
         _assert_file_tag_state(tui, "gamma.txt", True)
+    finally:
+        tui.quit()
+
+
+def test_invert_tags_i_and_upper_i_in_directory_window(ytree_binary, tmp_path):
+    work_dir = tmp_path / "dir_window_invert_tags"
+    work_dir.mkdir()
+    (work_dir / "alpha.txt").write_text("alpha", encoding="utf-8")
+    (work_dir / "beta.txt").write_text("beta", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(work_dir))
+    time.sleep(0.5)
+
+    try:
+        footer = _footer_text(tui)
+        assert "j tree" in footer, f"Expected dir-window footer before invert.\n{footer}"
+
+        tui.send_keystroke("t", wait=0.25)
+        _assert_file_tag_state(tui, "alpha.txt", True)
+        _assert_file_tag_state(tui, "beta.txt", True)
+
+        tui.send_keystroke("i", wait=0.25)
+        _assert_file_tag_state(tui, "alpha.txt", False)
+        _assert_file_tag_state(tui, "beta.txt", False)
+
+        tui.send_keystroke("I", wait=0.25)
+        _assert_file_tag_state(tui, "alpha.txt", True)
+        _assert_file_tag_state(tui, "beta.txt", True)
+    finally:
+        tui.quit()
+
+
+def test_invert_tags_i_and_upper_i_in_archive_directory_window(
+    ytree_binary, tmp_path
+):
+    archive_path = tmp_path / "invert_archive.zip"
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr("alpha.txt", "alpha")
+        zf.writestr("beta.txt", "beta")
+
+    tui = YtreeTUI(
+        executable=ytree_binary, cwd=str(tmp_path), args=[str(archive_path)]
+    )
+    time.sleep(0.6)
+
+    try:
+        tui.send_keystroke("t", wait=0.25)
+        _assert_file_tag_state(tui, "alpha.txt", True)
+        _assert_file_tag_state(tui, "beta.txt", True)
+
+        tui.send_keystroke("i", wait=0.25)
+        _assert_file_tag_state(tui, "alpha.txt", False)
+        _assert_file_tag_state(tui, "beta.txt", False)
+
+        tui.send_keystroke("I", wait=0.25)
+        _assert_file_tag_state(tui, "alpha.txt", True)
+        _assert_file_tag_state(tui, "beta.txt", True)
+    finally:
+        tui.quit()
+
+
+def test_only_tagged_toggle_o_from_directory_window(ytree_binary, tmp_path):
+    work_dir = tmp_path / "dir_window_only_tagged"
+    work_dir.mkdir()
+    (work_dir / "alpha.txt").write_text("alpha", encoding="utf-8")
+    (work_dir / "beta.txt").write_text("beta", encoding="utf-8")
+    (work_dir / "gamma.txt").write_text("gamma", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(work_dir))
+    time.sleep(0.5)
+
+    try:
+        tui.send_keystroke(Keys.ENTER, wait=0.35)
+        tui.send_keystroke("t", wait=0.2)  # alpha
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.2)  # gamma
+        tui.send_keystroke(Keys.ESC, wait=0.35)
+
+        footer = _footer_text(tui)
+        assert "j tree" in footer, f"Expected directory footer before tagged-only toggle.\n{footer}"
+
+        tui.send_keystroke("o", wait=0.35)
+        tagged_only_screen = _screen_text(tui)
+        assert "alpha.txt" in tagged_only_screen, tagged_only_screen
+        assert "gamma.txt" in tagged_only_screen, tagged_only_screen
+        assert "beta.txt" not in tagged_only_screen, tagged_only_screen
+
+        tui.send_keystroke("O", wait=0.35)
+        full_screen = _screen_text(tui)
+        assert "alpha.txt" in full_screen, full_screen
+        assert "beta.txt" in full_screen, full_screen
+        assert "gamma.txt" in full_screen, full_screen
     finally:
         tui.quit()
 


### PR DESCRIPTION
## Type
- [x] Typo/docs
- [ ] i18n
- [ ] Refactor (no behavior change)
- [x] Bug fix
- [x] Feature/enhancement
- [ ] Other (describe):

## What changed
- Remapped archive action keybinding to `z/Z`.
- Added `i/I` invert-tags support in both directory and file workflows.
- Added `o/O` tagged-only file-list toggle.
- Fixed split-mode inactive file-window visual state so inactive selection is underline+bold (not inverted).
- Unified tree unlogged/relog navigation behavior, including relog/reset handling and unlogged-state rendering behavior.
- Updated user-facing README guidance in alpha warning section to direct bug/feature checks through project tracking docs.

## Why this change
- Improve keybinding clarity and discoverability.
- Make tag workflows consistent across contexts.
- Improve split-pane visual clarity for active vs inactive focus.
- Make tree/logging behavior more predictable.
- Improve contributor/user guidance during alpha.

## What you did to verify changes and results
- Ran targeted regression tests for keybindings, tagged behavior, split-view behavior, and tree/logging behavior.
- Regenerated usage docs from man source and verified command/help text alignment.
- Ran full QA gate locally:
  - `source .venv/bin/activate`
  - `make qa-all`
  - Result: completed successfully locally.

- Why this PR is large:
  - It combines multiple related UX and navigation correctness updates with matching regression coverage.

- Why it is not split right now (include links to related PRs, if any):
  - The changes are interrelated in behavior and were validated together as a single integration batch.

- What could break:
  - Existing user muscle memory for previous keybindings.
  - Edge-case interactions in split mode and tree navigation.
  - Help/footer text fit on small terminal sizes.