### PR TITLE
docs(pr): clarify large-warning instructions

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,17 @@ cd "$REPO_ROOT"
 ZERO_SHA="0000000000000000000000000000000000000000"
 delete_only=1
 updates_main=0
+codebase_changed=0
+
+is_codebase_path() {
+  local path="$1"
+  case "$path" in
+    src/*|include/*|tests/*|scripts/*|.githooks/*|Makefile)
+      return 0
+      ;;
+  esac
+  return 1
+}
 
 while read -r local_ref local_sha remote_ref remote_sha; do
   if [[ "$local_sha" != "$ZERO_SHA" && "$local_ref" != "(delete)" ]]; then
@@ -15,6 +26,26 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   if [[ "$remote_ref" == "refs/heads/main" && "$local_sha" != "$ZERO_SHA" &&
         "$local_ref" != "(delete)" ]]; then
     updates_main=1
+    if [[ "${YTREE_PRE_PUSH_FORCE:-0}" == "1" ]]; then
+      codebase_changed=1
+      continue
+    fi
+
+    if [[ "$remote_sha" == "$ZERO_SHA" ]]; then
+      diff_range="$local_sha"
+    else
+      diff_range="$remote_sha..$local_sha"
+    fi
+
+    while IFS= read -r changed_path; do
+      if [[ -z "$changed_path" ]]; then
+        continue
+      fi
+      if is_codebase_path "$changed_path"; then
+        codebase_changed=1
+        break
+      fi
+    done < <(git diff --name-only --diff-filter=ACMRTUXB "$diff_range")
   fi
 done
 
@@ -25,6 +56,12 @@ fi
 
 if [[ "$updates_main" != "1" ]]; then
   echo "[pre-push] Push does not update main: skipping CI gate."
+  exit 0
+fi
+
+if [[ "$codebase_changed" != "1" ]]; then
+  echo "[pre-push] Updating main without codebase changes: skipping CI gate."
+  echo "[pre-push] Set YTREE_PRE_PUSH_FORCE=1 to force make ci-baseline."
   exit 0
 fi
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,9 @@
-> Before opening this PR, update your branch from the latest `main` and commit on top of that latest `main`.
-> This helps avoid merge conflicts and stale reviews.
-
-## Type
-- [ ] Typo/docs
-- [ ] i18n
-- [ ] Refactor (no behavior change)
-- [ ] Bug fix
-- [ ] Feature/enhancement
-- [ ] Other (describe):
-
-## What changed
--
-
-## Why this change
--
-
-## What you did to verify changes and results
-<!-- In plain language, say what you checked and what happened.
-If you did not run checks/tests, write: none + why. -->
+> Thank you for your contribution.
+> A brief plain-language summary of this PR is appreciated.
 
 <!--
-If CI posts a "Large PR Warning", edit the PR description and answer this section.
-If you opened the PR with a custom body and this section is missing, add it manually.
+For size/L and size/XL PRs, if CI posts a "Large PR Warning", also add:
+- Why it is not split right now (include links to related PRs, if any)
+- What could break
+If the bot asks again, paste the same answers into the latest bot warning comment too.
 -->
-- Why this PR is large:
-- Why it is not split right now (include links to related PRs, if any):
-- What could break:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -98,21 +98,25 @@ jobs:
                 marker,
                 "### Large PR Warning",
                 "",
-                `This PR is labeled **${labelName}** (${changedLines} changed lines).`,
+                "Thank you for your contribution.",
+                `This PR is labeled **${labelName}**.`,
                 "",
-                "Please fill the **For large PRs only** section in the PR template:",
-                "- Why this PR is large",
+                "Please add the following in the PR description:",
+                "If this warning appears again, paste the same answers in the latest warning comment as well.",
+                "A brief plain-language summary of the PR is also helpful.",
                 "- Why it is not split right now (and links to related PRs, if any)",
                 "- What could break",
               ].join("\n");
 
               if (existingComment) {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: existingComment.id,
-                  body,
-                });
+                if ((existingComment.body || "").trim() !== body.trim()) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existingComment.id,
+                    body,
+                  });
+                }
               } else {
                 await github.rest.issues.createComment({
                   owner,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -96,7 +96,9 @@ make hooks-install
 
 This installs a tracked pre-push gate:
 - Pushes that do not update `main`: skip local pre-push CI gate.
-- Pushes that update `main`: run `make ci-baseline` (unsafe C API guard + pytest coverage via gcov/lcov).
+- Pushes that update `main` with codebase changes (`src/`, `include/`, `tests/`, `scripts/`, `.githooks/`, `Makefile`): run `make ci-baseline` (unsafe C API guard + pytest coverage via gcov/lcov).
+- Pushes that update `main` without codebase changes (for example docs-only updates): skip the local pre-push CI gate.
+- Set `YTREE_PRE_PUSH_FORCE=1` to force the baseline gate on any `main` update.
 
 `make hooks-install` also installs repo-local git aliases so fast push is available as native git subcommands in this clone:
 - `git push-fast-up` -> fast push with `-u origin <current-branch>` for first push of a new branch.

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -1,0 +1,50 @@
+You are acting as my implementation agent in ~/ytree.
+
+Task:
+
+Process requirements:
+1) Sync local main with GitHub main:
+   - git checkout main
+   - git fetch origin
+   - git pull --ff-only
+
+2) Create and use branch:
+   - git checkout -b <type>/<short-task-name>
+   - use a suitable type (e.g. fix, feat, chore, docs)
+
+3) Before implementing:
+   - discuss the task with me first
+   - confirm exact scope, intended behavior, and acceptance criteria
+   - only implement after I explicitly approve
+
+4) Implementation:
+   - implement the approved task only
+   - keep scope tight and avoid unrelated edits
+
+5) Validation:
+   - run targeted tests as needed
+   - after task completion, run full gate:
+     source .venv/bin/activate
+     make qa-all
+   - DO NOT run full gate before task completion
+
+6) Commits:
+   - use Conventional Commits
+   - for follow-up corrections to the same intent, prefer amend:
+     git commit --amend --no-edit
+   - keep branch history workable; final merge will be rebase/ff-friendly
+
+7) Push + PR-ready summary:
+   - what changed (by file)
+   - test evidence (commands + outcomes)
+   - risks/regressions to watch
+
+8) Stay through completion:
+   - if checks fail, fix root cause and re-run gates
+   - continue until branch is green and PR-ready
+
+Important guardrails:
+- Do not rewrite or drop prior merged work from main.
+- Do not broaden scope beyond the approved task.
+- If uncertain, ask before choosing behavior-changing options.
+- If anything is ambiguous, ask me to clarify instead of guessing.

--- a/docs/ai/RELAY_PROMPT_TEMPLATE.md
+++ b/docs/ai/RELAY_PROMPT_TEMPLATE.md
@@ -1,4 +1,4 @@
-# AGENT Prompt Template
+# Relay Prompt Template
 
 Edit only the first four lines to match the tracked work item exactly, then copy/paste the full prompt as-is.
 


### PR DESCRIPTION
- Simplifies PR guidance so small PRs stay low-friction, with a short plain-language summary request by default.
- Keeps detailed risk/split explanation requests only for Large/XL PR warnings, reducing noise on trivial docs changes.
