### PR TITLE
docs(terminology): standardize panel and pane usage

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,8 +83,8 @@ The `ViewContext` struct (defined in `include/ytree_defs.h`) is the root of all 
 
 ```
 ViewContext (The Session)
-├── left   → YtreePanel (Pane: cursor, scroll, window state, tags)
-├── right  → YtreePanel (Pane: cursor, scroll, window state, tags)
+├── left   → YtreePanel (Panel: cursor, scroll, window state, tags)
+├── right  → YtreePanel (Panel: cursor, scroll, window state, tags)
 ├── active → points to left or right
 ├── volumes_head → Volume linked list (Model: shared DirEntry trees, statistics)
 └── viewer, layout, mode flags, etc.
@@ -119,15 +119,15 @@ The application state is strictly hierarchical:
     *   Owns the `volumes_head` registry of all loaded volumes.
 
 2.  **`YtreePanel` (The View):**
-    *   Represents a single UI pane.
-    *   Owns **Pane-Local State**: cursor position, scroll offset, file-view anchor, focus/window mode, filespec/filter, and selected/tagged files for that pane.
+    *   Represents a single UI panel.
+    *   Owns **Panel-Local State**: cursor position, scroll offset, file-view anchor, focus/window mode, filespec/filter, and selected/tagged files for that panel.
     *   Holds a reference to a `Volume`.
-    *   Independent panels may point to the same `Volume` while maintaining different pane-local state. Pane-local state must not be inferred from a shared tree index after the tree is rebuilt.
+    *   Independent panels may point to the same `Volume` while maintaining different panel-local state. Panel-local state must not be inferred from a shared tree index after the tree is rebuilt.
 
 3.  **`Volume` (The Model):**
     *   Represents a filesystem (Physical Disk or Archive).
     *   Owns **Shared Data**: `DirEntry` tree topology, logged/unlogged memory state, file payload cache, `Statistic` metadata, and path info.
-    *   Contains no pane-local UI state: no active focus, cursor, file-view anchor, selected file, filespec/filter, or pane-local tags.
+    *   Contains no panel-local UI state: no active focus, cursor, file-view anchor, selected file, filespec/filter, or panel-local tags.
 
 ### 4.2 Dual-Panel Context Isolation (F8 Logic)
 The Split-Screen architecture treats each panel as an independent instance of a volume manager.
@@ -135,7 +135,7 @@ The Split-Screen architecture treats each panel as an independent instance of a 
 *   **Active Panel:** Owns keyboard focus and initiates all operations.
 *   **Inactive Panel:** Strictly **DORMANT**. It does not update its display or change state in response to activity in the active panel.
 *   **State Persistence (Tab-Switch):** The `Tab` key is the bridge. Switching panels restores the exact state held when that panel last had focus.
-*   **Pane vs. Volume Rule:** Sharing a `Volume` only shares logged tree topology and file payload cache. It never shares pane-local tags, file-window anchors, cursor identity, or focus/mode state.
+*   **Panel vs. Volume Rule:** Sharing a `Volume` only shares logged tree topology and file payload cache. It never shares panel-local tags, file-window anchors, cursor identity, or focus/mode state.
 
 ### 4.3 Inter-Panel Operations (The Directional Rule)
 *   **Targeting:** Copy and Move operations occur directionally: **Source (Active Panel) to Destination (Inactive Panel)**.
@@ -149,7 +149,7 @@ The Split-Screen architecture treats each panel as an independent instance of a 
 *   **Transition Invariant:** A directory can only be entered (Tree to File Mode) if it contains at least one file.
 *   **Selection Memory (Breadcrumbs):** When returning from File Mode to Tree Mode and later re-entering the same directory, the panel restores the cursor to the last highlighted file.
 *   **Navigation Stability:** Moving through the Tree never automatically triggers a transition into File Mode.
-*   **Tag-View Scope Rule:** `i/I` (invert tags) and `o/O` (tagged-only file-list toggle) operate on the active pane's current file-list scope, regardless of whether focus is in tree or file window.
+*   **Tag-View Scope Rule:** `i/I` (invert tags) and `o/O` (tagged-only file-list toggle) operate on the active panel's current file-list scope, regardless of whether focus is in tree or file window.
 *   **Root Boundary Rule:** `Left` at root is a no-op; root-content release uses `-` state-release semantics.
 
 ### 5.2 Protocol B: Archive and Volume Lifecycle

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -10,10 +10,10 @@ Ordering policy (for all editors, including AI editors):
 
 ## **Current Runtime Defects (Highest Priority First)**
 
-### **BUG-41: F8 Release-Volume Flow Can Blank Pane and Crash on Tab**
-*   **Description**: In `F8` split mode, after logging two volumes and releasing one, the small window can go blank, separator line can disappear, inactive pane can blank, and tabbing to the inactive pane can trigger a segmentation fault.
-*   **Impact**: Critical stability and data-safety risk (crash), plus severe UI corruption in a core split-pane workflow.
-*   **Remediation**: Harden split-pane volume-release lifecycle so panel/window ownership and active/inactive bindings are always valid after release. Add focused regression coverage for `F8` with multi-volume log/release and `Tab` switching after release.
+### **BUG-41: F8 Release-Volume Flow Can Blank Panel and Crash on Tab**
+*   **Description**: In `F8` split mode, after logging two volumes and releasing one, the small window can go blank, separator line can disappear, inactive panel can blank, and tabbing to the inactive panel can trigger a segmentation fault.
+*   **Impact**: Critical stability and data-safety risk (crash), plus severe UI corruption in a core split-panel workflow.
+*   **Remediation**: Harden split-panel volume-release lifecycle so panel/window ownership and active/inactive bindings are always valid after release. Add focused regression coverage for `F8` with multi-volume log/release and `Tab` switching after release.
 *   **Status**: Confirmed.
 
 ### **BUG-40: Cycle-Volumes (`<`/`>`, `,`/`.`) Leaks Dir/File View State Across Volumes**
@@ -42,7 +42,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Status**: Fixed.
 
 ### **BUG-37: F8 Mirrored Tree Changes Can Move Inactive Selection to Wrong Node**
-*   **Description**: In `F8` split mode, mirrored expand/collapse changes can move the inactive pane selection unexpectedly to another sibling/ancestor even when the original inactive selection should remain valid.
+*   **Description**: In `F8` split mode, mirrored expand/collapse changes can move the inactive panel selection unexpectedly to another sibling/ancestor even when the original inactive selection should remain valid.
 *   **Repro (Confirmed)**:
 *   Select `~/ytree/obj/cmd`, then enter split mode (`F8`).
     *   Collapse `obj`: inactive cursor moves to `obj`; expand `obj`: inactive remains on `obj`.
@@ -51,7 +51,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Expected Behavior**:
     *   Inactive selection remains stable under mirrored tree-shape updates while its selected node is still visible/valid.
     *   If invalidated, fallback target must follow a deterministic rule.
-*   **Impact**: Breaks split-pane predictability and makes inactive-pane targeting unreliable for copy/move/compare workflows.
+*   **Impact**: Breaks split-panel predictability and makes inactive-panel targeting unreliable for copy/move/compare workflows.
 *   **Remediation**: Preserve inactive selection by stable node identity (not row/index), and apply deterministic fallback only when the selected node becomes invalid.
 *   **Related**: `ROADMAP` Task 45 (inactive split-panel selection semantics + regression coverage).
 *   **Status**: Fixed.
@@ -115,7 +115,7 @@ Ordering policy (for all editors, including AI editors):
 ### **BUG-28: Viewer Return (`v` -> `q`) Can Corrupt UI and Input State**
 *   **Description**: In WSL repro, running ytree, opening `View` on a file (`v`), then quitting viewer (`q`) can leave the main UI mostly vanished/artifacted (for example stray clock digits only). Follow-on input/state is also corrupted: `^L` has negligible/no effect, `Enter` no longer toggles to dir window, and a subsequent `q` exits ytree.
 *   **Impact**: Breaks core post-view workflow and can leave the session in a partially unusable state until restart.
-*   **Remediation**: Harden viewer-return restore path to reestablish full ncurses paint + mode/input state atomically (window ownership, active pane mode, key handling context) before processing next key events.
+*   **Remediation**: Harden viewer-return restore path to reestablish full ncurses paint + mode/input state atomically (window ownership, active panel mode, key handling context) before processing next key events.
 *   **Related**: `BUG-29` (same return/redraw defect family).
 *   **Status**: Confirmed.
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features & UI/UX Refinements
 - **Color Theme Engine**: Added full **256-Color Support** and a dynamic theme engine. Users can now define custom color palettes for both UI elements (`[COLORS]`) and specific file types/extensions (`[FILE_COLORS]`) in the configuration file.
 - **Hidden File Visibility**: Dotfiles and hidden directories are now filtered by default. Use the backtick (`` ` ``) key to toggle their visibility globally.
-- **Split-Screen (F8)**: Support for independent panes with separate context, cursors, and filters for efficient cross-volume operations.
+- **Split-Screen (F8)**: Support for independent panels with separate context, cursors, and filters for efficient cross-volume operations.
 - **Integrated Comparison Suite**: Added a dedicated Compare submenu supporting Directory, File, and Logged-Tree comparisons.
 - **Progress & ETA Tracking**: Implemented a universal progress display for long-running operations, providing a real-time progress bar, transfer rates, and linear ETA projections.
 - **Incremental "To" Jump**: Integrated high-speed list navigation (`/`) and "To Dir"/"To File" selection jumps with sticky-cursor logic.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -245,9 +245,9 @@ The project enforces strict architectural constraints (single-threaded event loo
 3.  **Make your changes** and commit them using **Conventional Commits** (`type(scope): summary`).
     Keep the message specific to the change and use scopes that match the area touched.
     Examples:
-    - `fix(ui): keep active pane selection after volume cycle`
+    - `fix(ui): keep active panel selection after volume cycle`
     - `docs(ai): clarify planner/executor packet handoff rules`
-    - `test(pytest): add regression for split-pane redraw ordering`
+    - `test(pytest): add regression for split-panel redraw ordering`
 4.  **Push your branch** to your fork (`git push origin feature/my-new-feature`).
 5.  **Open a Pull Request** against the `main` branch of the upstream ytree repository.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -376,7 +376,7 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 ### **Task 45: Lock Inactive Split-Panel Selection Semantics + Regression Coverage**
-*   **Goal:** Define and enforce deterministic inactive-pane cursor behavior under mirrored tree-structure changes in `F8` split mode.
+*   **Goal:** Define and enforce deterministic inactive-panel cursor behavior under mirrored tree-structure changes in `F8` split mode.
 *   **Rationale:** Real-time mirrored tree updates are useful, but must stay predictable when parent/ancestor collapse, add, or delete operations change visibility.
 *   **Scope Lock:** Selection/cursor semantics and regression coverage only; no unrelated split-layout or keybinding redesign.
 *   **Acceptance Criteria:**
@@ -506,7 +506,7 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 ### **Task 30: Replace `^F` Mode Cycling with Unified Numeric `FileInfo` Band (`1..9`, `0`)**
-*   **Goal:** Replace display-mode cycling with direct numeric `FileInfo` controls for the focused pane.
+*   **Goal:** Replace display-mode cycling with direct numeric `FileInfo` controls for the focused panel.
 *   **Behavior Contract:**
 *   `1` => Name only (default/baseline).
 *   `2` => Long.
@@ -517,10 +517,10 @@ Ordering policy (for all editors, including AI editors):
 *   `6` => toggle symlink row rendering (`name` vs `name -> target`) in list rows.
 *   `7` => toggle richer metadata/text-snippet view.
 *   `8` => toggle file-type/summary view.
-*   `9` => toggle brief/full width behavior for the focused pane.
+*   `9` => toggle brief/full width behavior for the focused panel.
 *   `0` => reset file-info state for `1..8` to profile defaults (does not affect `9` width toggle).
 *   Number keys are toggle-driven controls: `1..4` select the primary file-info layout while `5..9` toggle additive display behaviors.
-*   Applies to file-display rendering across normal list contexts for the active pane (whether focus is currently on tree/dir window or file window); not active in `F7` preview mode.
+*   Applies to file-display rendering across normal list contexts for the active panel (whether focus is currently on tree/dir window or file window); not active in `F7` preview mode.
 *   If a requested mode is unsupported in the active context (for example VFS file mode `4`), do a silent no-op (no beep).
 *   Add `FILE_SIZE_UNITS=binary|human-readable` profile setting (default `binary`) as the seed for `5`.
 *   **Keybinding Policy:** Remove `^F` from runtime behavior and help/manpage docs. This task is the explicit keybinding-change exception referenced by Task 38 scope lock.
@@ -821,13 +821,13 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 ### **Idea FE-5: Configurable Split Header Path Display (`active` or `both`)**
-*   **Goal:** Add a user option for split-mode header path display so users can choose active-pane-only path or both-pane paths.
+*   **Goal:** Add a user option for split-mode header path display so users can choose active-panel-only path or both-panel paths.
 *   **Rationale:** Active-only header is cleaner by default, while dual-path header can improve orientation for users managing two distant locations.
 *   **Scope Lock:** Header display policy only; no split navigation, selection, or command behavior changes.
 *   **Acceptance Criteria:**
 *   Default mode remains `active` (current behavior).
-*   Optional mode `both` renders left/right pane paths in split mode with deterministic truncation/clipping and no wrapping.
-*   Active pane remains visually obvious in both modes.
+*   Optional mode `both` renders left/right panel paths in split mode with deterministic truncation/clipping and no wrapping.
+*   Active panel remains visually obvious in both modes.
 *   Footer/F1 help and config docs are updated when option lands.
 *   - [ ] **Status:** Not Started.
 
@@ -878,19 +878,19 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 ### **Idea FE-11: Dual-Preview Split Mode**
-*   **Goal:** Allow each `F8` split pane to enter and retain its own `F7`-style preview state independently.
+*   **Goal:** Allow each `F8` split panel to enter and retain its own `F7`-style preview state independently.
 *   **User-Facing Behavior:**
-    *   In split mode, each pane can independently enter preview without forcing preview state changes in the other pane.
-    *   Switching active pane preserves the preview/list state already held by each side.
-    *   Entering or leaving preview on one pane must not unexpectedly reset scroll position, selection, or return-state on the other pane.
-    *   The design must keep pane ownership obvious so users can still tell which side is active, which side is in preview, and what `Enter`/`Tab`/`F7` will affect next.
-*   **Rationale:** Active-pane-only preview is useful, but independent per-pane preview would make split review/compare workflows more powerful for users who want to inspect both sides without repeatedly toggling state back and forth.
+    *   In split mode, each panel can independently enter preview without forcing preview state changes in the other panel.
+    *   Switching active panel preserves the preview/list state already held by each side.
+    *   Entering or leaving preview on one panel must not unexpectedly reset scroll position, selection, or return-state on the other panel.
+    *   The design must keep panel ownership obvious so users can still tell which side is active, which side is in preview, and what `Enter`/`Tab`/`F7` will affect next.
+*   **Rationale:** Active-panel-only preview is useful, but independent per-panel preview would make split review/compare workflows more powerful for users who want to inspect both sides without repeatedly toggling state back and forth.
 *   **Scope Lock:** This is an advanced split/preview state feature only. It does not require a broader orthodox-style layout redesign and should preserve ytree's existing xtree/unixtree/ztree-derived interaction style.
 *   **Acceptance Criteria:**
-*   Both panes can hold independent preview/list state without leaking state across panes.
+*   Both panels can hold independent preview/list state without leaking state across panels.
 *   `Tab`, `F7`, and return-to-list behavior are deterministic and documented in footer/F1/manpage text.
-*   Split-pane active/inactive indicators remain unambiguous while one or both panes are in preview.
-*   Focused regression coverage proves per-pane state retention, pane switching, and exit/return behavior.
+*   Split-panel active/inactive indicators remain unambiguous while one or both panels are in preview.
+*   Focused regression coverage proves per-panel state retention, panel switching, and exit/return behavior.
 *   - [ ] **Status:** Not Started.
 
 ### **Idea FE-12: Unified `N Create` Entry Point (Capability-Filtered by Backend)**
@@ -918,7 +918,7 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 ### **Idea FE-13: Per-Window Filter State (Split Screen Prerequisite)**
-*   Decouple the file filter (`file_spec`) from the `Volume` structure and move it into a new `WindowView` context. This architecture is required to support F8 Split Screen, enabling two independent views of the same volume with different filters (e.g., `*.c` in the left pane versus `*.h` in the right).
+*   Decouple the file filter (`file_spec`) from the `Volume` structure and move it into a new `WindowView` context. This architecture is required to support F8 Split Screen, enabling two independent views of the same volume with different filters (e.g., `*.c` in the left panel versus `*.h` in the right).
 *   - [ ] **Status:** Not Started.
 
 ### **Idea FE-14: State Preservation on Reload (`^L`)**

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -123,10 +123,10 @@ The `ytree` input system follows a layered model designed for high-speed interac
 *   **The Tree Marker Rule (`+` status):** Unlogged state is rendered only in the dedicated tree status margin column; directory names do not carry a `+` suffix.
 *   **The Volume Menu Rule (`K` menu):** Selecting the already-active volume preserves its current in-memory state (no implicit relog/reload).
 *   **The Explicit Relog Rule (`L` on current path):** Logging an already logged volume/path performs a fresh relog/reload of that volume state and reanchors selection at volume root.
-*   **The Invert Rule (`i`/`I`):** In both tree and file windows, invert tags applies to the active pane's current file-list scope (filesystem and archive contexts).
-*   **The Only-Tagged Rule (`o`/`O`):** In both tree and file windows, toggle tagged-only file-list view for the active pane's current scope; toggling never changes tag state.
+*   **The Invert Rule (`i`/`I`):** In both tree and file windows, invert tags applies to the active panel's current file-list scope (filesystem and archive contexts).
+*   **The Only-Tagged Rule (`o`/`O`):** In both tree and file windows, toggle tagged-only file-list view for the active panel's current scope; toggling never changes tag state.
 *   **The Archive/Global Jump (`\`):** In Archive Mode, jumps to the archive root. in Global/Showall views, jumps to the highlighted file's directory.
-*   **Numeric FileInfo Band (`1..9`, `0`):** Number keys are the canonical file-display controls in normal list contexts (not active in `F7` preview). These controls apply to file-display rendering for the active pane whether focus is currently in the tree/dir window or file window.
+*   **Numeric FileInfo Band (`1..9`, `0`):** Number keys are the canonical file-display controls in normal list contexts (not active in `F7` preview). These controls apply to file-display rendering for the active panel whether focus is currently in the tree/dir window or file window.
 *   **Vi-Key Collision Policy:** When `VI_KEYS=1`, lowercase `h/j/k/l` are reserved for navigation. Uppercase `H/K/L/J` are used for commands (Hex, Volume, Log, Compare).
 *   **Tagged Actions**: `^u` (Untag All) and `^d` (Delete All Tagged) provide batch operations across the visible scope.
 *   **Quit to Directory (`^q`):** Exits `ytree` to the currently highlighted directory (requires shell-level support to finalize the shell path).
@@ -153,13 +153,13 @@ When a text prompt is active, specialized conventions ensure a refined editing e
 ## 5. Split-Screen (F8) & Session Model
 
 ### 5.1 The Active-Inactive Rule
-Split mode is a two-pane session entered/exited by `F8`.
+Split mode is a two-panel session entered/exited by `F8`.
 *   **Activation:** `F8` toggles split mode on/off.
-*   **Focus Switch:** `Tab` switches the active pane.
+*   **Focus Switch:** `Tab` switches the active panel.
 *   **Active Panel:** Owns keyboard focus and receives command/navigation input.
 *   **Inactive Panel:** Does not process direct input while inactive; its own cursor/selection context is retained until focus is switched back.
-*   **Freeze/Resume Rule:** When a pane loses focus, its pane-local state is frozen; when it becomes active again (via `Tab`), it must resume exactly where it left off.
-*   **Active-Only Mutation Rule:** Commands mutate only the active pane's pane-local state. Cross-pane updates are limited to shared topology mirroring defined in §5.3.
+*   **Freeze/Resume Rule:** When a panel loses focus, its panel-local state is frozen; when it becomes active again (via `Tab`), it must resume exactly where it left off.
+*   **Active-Only Mutation Rule:** Commands mutate only the active panel's panel-local state. Cross-panel updates are limited to shared topology mirroring defined in §5.3.
 
 ### 5.2 State Persistence
 Switching panels via `Tab` must restore the exact state held when that panel last had focus for panel-local state:
@@ -168,24 +168,24 @@ Switching panels via `Tab` must restore the exact state held when that panel las
 *   **Selection:** Tags are specific to the panel session. Collapsing a directory (`Left` or `-`) or explicitly unreading/releasing it (`--`) discards saved tags beneath that directory; reloading it must not resurrect stale tags.
 *   **Compare Tagging Rule:** Compare workflows may report difference counts, but they do not implicitly mutate per-file tag state; tags change only through explicit tagging actions.
 *   **Filter (Filespec):** Independent search/filter strings.
-*   **Window/Mode Context:** Directory/File/Showall-style pane-local focus context.
+*   **Window/Mode Context:** Directory/File/Showall-style panel-local focus context.
 
 ### 5.3 Shared Tree Topology Contract
-The split panes share one logged tree topology contract for a given logged volume:
+The split panels share one logged tree topology contract for a given logged volume:
 *   **Shared Logging State:** Logged/unlogged directory-memory state is shared.
 *   **Shared Structural State:** Expand/collapse/release tree-shape changes are shared.
-*   **Mirror Rule:** Structural tree changes triggered in the active pane must be reflected in the inactive pane immediately.
-*   **Selection Retention Rule:** Mirrored structural updates must not move the inactive pane's cursor/selection when its selected node remains visible/valid.
+*   **Mirror Rule:** Structural tree changes triggered in the active panel must be reflected in the inactive panel immediately.
+*   **Selection Retention Rule:** Mirrored structural updates must not move the inactive panel's cursor/selection when its selected node remains visible/valid.
 *   **Non-Invalidating Changes Rule:** Adding siblings/ancestors, or changing sibling structure that does not invalidate the inactive selected node, must not move the inactive selection.
-*   **Frozen File-View Anchor Rule:** A pane left in file view is restored from its saved directory path and selected filename, not from the current flattened tree index. If shared-tree rebuilding leaves that directory as a visible but unloaded placeholder, the directory payload must be reloaded before the pane is rendered or resumed so the file window cannot degrade to an empty or unrelated listing.
-*   **Render Is Not Authority Rule:** Rendering may display the saved pane state, but it must not decide a new pane selection from whatever entry currently occupies the saved numeric index after a shared tree rebuild.
+*   **Frozen File-View Anchor Rule:** A panel left in file view is restored from its saved directory path and selected filename, not from the current flattened tree index. If shared-tree rebuilding leaves that directory as a visible but unloaded placeholder, the directory payload must be reloaded before the panel is rendered or resumed so the file window cannot degrade to an empty or unrelated listing.
+*   **Render Is Not Authority Rule:** Rendering may display the saved panel state, but it must not decide a new panel selection from whatever entry currently occupies the saved numeric index after a shared tree rebuild.
 *   **Deterministic Fallback Rule (When Selected Node Becomes Invalid):**
     *   Keep exact node if still visible/valid after mirror update.
     *   Else move to nearest visible ancestor of the previously selected node.
     *   Else move to next visible sibling in display order.
     *   Else move to previous visible sibling.
     *   Else move to the root visible node.
-*   **No Surprise Parent-Jump Rule:** Collapsing a parent/grandparent in the active pane must not force the inactive selection to jump to parent unless the previously selected node is no longer visible/valid.
+*   **No Surprise Parent-Jump Rule:** Collapsing a parent/grandparent in the active panel must not force the inactive selection to jump to parent unless the previously selected node is no longer visible/valid.
 
 ### 5.4 Modal Search Behavior
 *   **Persistence:** The search string is retained after the mode is exited.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -117,14 +117,14 @@ automatically default to the path of the inactive (passive) panel as the
 destination.
 
 **File Preview Mode** Activated by **F7**. The screen layout changes to
-show the file list on the left (or active panel) and the file contents
-on the right. \* **Toggle:** Press **F7** again to leave preview mode.
-\* **Navigate File List:** Use **Up/Down**, **Page Up/Down**,
-**Home/End** to move the selection in the file list. The preview pane
-updates immediately. \* **Scroll Preview:** Use **Shift+Up/Down** (or
-**^P** / **^N**) to scroll the content of the preview window line by
-line. Use **Shift+Page Up/Down** to scroll by pages. **Shift+Home/End**
-jumps to the beginning or end of the file.
+show the file list on the left (or active pane) and the file contents on
+the right. \* **Toggle:** Press **F7** again to leave preview mode. \*
+**Navigate File List:** Use **Up/Down**, **Page Up/Down**, **Home/End**
+to move the selection in the file list. The preview pane updates
+immediately. \* **Scroll Preview:** Use **Shift+Up/Down** (or **^P** /
+**^N**) to scroll the content of the preview window line by line. Use
+**Shift+Page Up/Down** to scroll by pages. **Shift+Home/End** jumps to
+the beginning or end of the file.
 
 # KEY BINDINGS
 
@@ -140,7 +140,7 @@ These commands work in most modes:
 - **F1**: Help (context-sensitive in prompts/dialogs).
 - **F5**: Refresh (same as **^L**).
 - **F6**: Toggle Statistics Panel (Wide Mode).
-- **F7**: Toggle File Preview Panel.
+- **F7**: Toggle File Preview Pane.
 - **F8**: Toggle Split Screen Mode.
 - **F10**: Edit `~/.ytree` in `$EDITOR`. If the file does not exist yet,
   the editor opens a new buffer at that path; save to create it (or run

--- a/etc/ytree.1.md
+++ b/etc/ytree.1.md
@@ -75,7 +75,7 @@ Activated by **F8**. The screen is divided vertically into two independent file 
 *   **Targeting:** Operations like **Copy** and **Move** automatically default to the path of the inactive (passive) panel as the destination.
 
 **File Preview Mode**
-Activated by **F7**. The screen layout changes to show the file list on the left (or active panel) and the file contents on the right.
+Activated by **F7**. The screen layout changes to show the file list on the left (or active pane) and the file contents on the right.
 *   **Toggle:** Press **F7** again to leave preview mode.
 *   **Navigate File List:** Use **Up/Down**, **Page Up/Down**, **Home/End** to move the selection in the file list. The preview pane updates immediately.
 *   **Scroll Preview:** Use **Shift+Up/Down** (or **^P** / **^N**) to scroll the content of the preview window line by line. Use **Shift+Page Up/Down** to scroll by pages. **Shift+Home/End** jumps to the beginning or end of the file.
@@ -90,7 +90,7 @@ These commands work in most modes:
 *   **F1**: Help (context-sensitive in prompts/dialogs).
 *   **F5**: Refresh (same as **^L**).
 *   **F6**: Toggle Statistics Panel (Wide Mode).
-*   **F7**: Toggle File Preview Panel.
+*   **F7**: Toggle File Preview Pane.
 *   **F8**: Toggle Split Screen Mode.
 *   **F10**: Edit `~/.ytree` in `$EDITOR`. If the file does not exist yet, the editor opens a new buffer at that path; save to create it (or run `ytree --init` to generate defaults first).
 *   **/** (or **F12**): **Incremental Jump** (List Jump). Start typing to jump to the first matching entry in the current list (directory names in the Directory Window, filenames in the File Window). The selection updates immediately as you type. Press **Enter** to accept the current match, or **Esc** to cancel and restore the original selection.

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -1,7 +1,7 @@
 /***************************************************************************
  *
  * src/ui/panel_anchor.c
- * Panel anchor helpers for split-pane directory/file state restoration.
+ * Panel anchor helpers for split-panel directory/file state restoration.
  *
  ***************************************************************************/
 

--- a/tests/test_display_layout.py
+++ b/tests/test_display_layout.py
@@ -191,7 +191,7 @@ def test_split_file_details_do_not_wrap_neighbor_rows_at_120x36(ytree_binary, tm
     d = tmp_path / "split_file_detail_nowrap_120x36"
     d.mkdir()
     for i in range(60):
-        # Long names force tighter detail rendering in split panes.
+        # Long names force tighter detail rendering in split panels.
         (d / f"very_long_filename_{i:03d}_for_split_wrap_check.txt").write_text(
             "x", encoding="utf-8"
         )

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -212,7 +212,7 @@ def test_split_same_directory_file_tags_are_panel_local(tmp_path, ytree_binary):
         left, right, screen = _split_segments_for_file(tui, "panel_tag_0.txt")
         assert _line_marks_file_as_tagged(left, "panel_tag_0.txt"), screen
         assert not _line_marks_file_as_tagged(right, "panel_tag_0.txt"), (
-            "Tagging the active pane leaked to the inactive peer pane.\n"
+            "Tagging the active panel leaked to the inactive peer panel.\n"
             f"{screen}"
         )
 
@@ -220,7 +220,7 @@ def test_split_same_directory_file_tags_are_panel_local(tmp_path, ytree_binary):
         left, right, screen = _split_segments_for_file(tui, "panel_tag_0.txt")
         assert _line_marks_file_as_tagged(left, "panel_tag_0.txt"), screen
         assert not _line_marks_file_as_tagged(right, "panel_tag_0.txt"), (
-            "Switching panes should not import the other pane's tags.\n"
+            "Switching panels should not import the other panel's tags.\n"
             f"{screen}"
         )
 
@@ -228,7 +228,7 @@ def test_split_same_directory_file_tags_are_panel_local(tmp_path, ytree_binary):
         tui.send_keystroke("t", wait=0.3)
         left, right, screen = _split_segments_for_file(tui, "panel_tag_1.txt")
         assert not _line_marks_file_as_tagged(left, "panel_tag_1.txt"), (
-            "Right-pane tagging leaked into the left pane.\n"
+            "Right-panel tagging leaked into the left panel.\n"
             f"{screen}"
         )
         assert _line_marks_file_as_tagged(right, "panel_tag_1.txt"), screen
@@ -539,12 +539,12 @@ def test_split_refresh_updates_inactive_tree_file_list_without_tab(
     tui.send_keystroke(Keys.F8, wait=0.4)
     tui.send_keystroke(Keys.TAB, wait=0.4)
 
-    # Right pane: select right_dir in tree mode so its small file list is visible.
+    # Right panel: select right_dir in tree mode so its small file list is visible.
     tui.send_keystroke(Keys.DOWN, wait=0.25)
     tui.send_keystroke(Keys.DOWN, wait=0.25)
     assert "right_old.txt" in "\n".join(tui.get_screen_dump())
 
-    # Keep right pane inactive while refreshing from the left pane.
+    # Keep right panel inactive while refreshing from the left panel.
     tui.send_keystroke(Keys.TAB, wait=0.35)
     (right / "right_new.txt").write_text("new\n", encoding="utf-8")
     time.sleep(0.1)
@@ -983,7 +983,7 @@ def test_f8_big_window_footer_and_separator_lost(dual_panel_sandbox, ytree_binar
 def test_f8_inactive_selection_moves_to_parent_on_mirrored_collapse(tmp_path, ytree_binary):
     """
     Regression:
-    When both panes share the same tree and active pane collapses a branch,
+    When both panels share the same tree and active panel collapses a branch,
     an inactive selection inside that branch must re-anchor to the parent.
     """
     root = tmp_path / "f8_mirrored_collapse_root"
@@ -1003,31 +1003,31 @@ def test_f8_inactive_selection_moves_to_parent_on_mirrored_collapse(tmp_path, yt
     tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
     time.sleep(1.0)
 
-    # Expand tree so parent/child are visible in both panes.
+    # Expand tree so parent/child are visible in both panels.
     tui.send_keystroke(Keys.EXPAND_ALL)
     time.sleep(0.5)
 
-    # Left pane (active): move to parent_dir.
+    # Left panel (active): move to parent_dir.
     tui.send_keystroke(Keys.DOWN)
     time.sleep(0.5)
 
-    # Split and move to right pane.
+    # Split and move to right panel.
     tui.send_keystroke(Keys.F8)
     time.sleep(0.5)
     tui.send_keystroke(Keys.TAB)
     time.sleep(0.5)
 
-    # Right pane: move inside collapsed target branch (parent -> child).
+    # Right panel: move inside collapsed target branch (parent -> child).
     tui.send_keystroke(Keys.DOWN)
     time.sleep(0.5)
 
-    # Back to left pane and collapse parent_dir.
+    # Back to left panel and collapse parent_dir.
     tui.send_keystroke(Keys.TAB)
     time.sleep(0.5)
     tui.send_keystroke(Keys.LEFT)
     time.sleep(0.6)
 
-    # Return to right pane and enter selected directory.
+    # Return to right panel and enter selected directory.
     # Expected: selection was re-anchored to parent_dir.
     tui.send_keystroke(Keys.TAB)
     time.sleep(0.5)
@@ -1044,7 +1044,7 @@ def test_f8_inactive_selection_moves_to_parent_on_mirrored_collapse(tmp_path, yt
     if "child_file.txt" in screen:
         tui.quit()
         pytest.fail(
-            "Inactive pane still entered child after parent collapse.\n"
+            "Inactive panel still entered child after parent collapse.\n"
             f"Screen:\n{screen}"
         )
 
@@ -1054,8 +1054,8 @@ def test_f8_inactive_selection_moves_to_parent_on_mirrored_collapse(tmp_path, yt
 def test_bug_f_eight_mirrored_inactive_selection_identity_stable(tmp_path, ytree_binary):
     """
     BUG-36 regression:
-    In mirrored split mode, expanding a sibling branch in the active pane must not
-    shift inactive pane selection by row index when the selected directory still
+    In mirrored split mode, expanding a sibling branch in the active panel must not
+    shift inactive panel selection by row index when the selected directory still
     exists.
     """
     root = tmp_path / "bug_f_eight_identity_root"
@@ -1073,27 +1073,27 @@ def test_bug_f_eight_mirrored_inactive_selection_identity_stable(tmp_path, ytree
     tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
     time.sleep(1.0)
 
-    # Left pane (active): select parent_dir.
+    # Left panel (active): select parent_dir.
     tui.send_keystroke(Keys.DOWN)
     time.sleep(0.4)
 
-    # Split and move to right pane (mirrored tree state).
+    # Split and move to right panel (mirrored tree state).
     tui.send_keystroke(Keys.F8)
     time.sleep(0.4)
     tui.send_keystroke(Keys.TAB)
     time.sleep(0.4)
 
-    # Right pane (inactive target): select sibling_dir.
+    # Right panel (inactive target): select sibling_dir.
     tui.send_keystroke(Keys.DOWN)
     time.sleep(0.4)
 
-    # Back to left pane and expand parent_dir.
+    # Back to left panel and expand parent_dir.
     tui.send_keystroke(Keys.TAB)
     time.sleep(0.4)
     tui.send_keystroke(Keys.RIGHT)
     time.sleep(0.6)
 
-    # Return to right pane and enter the selected directory.
+    # Return to right panel and enter the selected directory.
     # Expected: still sibling_dir (stable identity), not parent_dir/child_dir.
     tui.send_keystroke(Keys.TAB)
     time.sleep(0.4)
@@ -1104,13 +1104,13 @@ def test_bug_f_eight_mirrored_inactive_selection_identity_stable(tmp_path, ytree
     if "sibling_file.txt" not in screen:
         tui.quit()
         pytest.fail(
-            "Inactive pane selection drifted after mirrored expand.\n"
+            "Inactive panel selection drifted after mirrored expand.\n"
             f"Screen:\n{screen}"
         )
     if "child_file.txt" in screen:
         tui.quit()
         pytest.fail(
-            "Inactive pane entered child_dir after mirrored expand.\n"
+            "Inactive panel entered child_dir after mirrored expand.\n"
             f"Screen:\n{screen}"
         )
 
@@ -1198,7 +1198,7 @@ def test_source_selection_survives_destination_tree_prep_home_mkdir(
     """
     BUG-36 regression:
     Destination tree HOME+mkdir prep in same-volume split mode must not blank
-    the source pane or mutate source tagged/selection identity.
+    the source panel or mutate source tagged/selection identity.
     """
     root = tmp_path / "bug_f_eight_source_selection_tree_home_mkdir"
     root.mkdir()
@@ -1247,14 +1247,14 @@ def test_source_selection_survives_destination_tree_prep_home_mkdir(
 
         screen_while_right_active = _screen_text(tui)
         assert "source_1.txt" in screen_while_right_active, (
-            "Source pane blanked while destination tree flow remained active.\n"
+            "Source panel blanked while destination tree flow remained active.\n"
             f"{screen_while_right_active}"
         )
 
         tui.send_keystroke(Keys.TAB, wait=0.5)
         screen = _screen_text(tui)
         assert "source_1.txt" in screen, (
-            "Source pane blanked after destination tree HOME+mkdir flow.\n" f"{screen}"
+            "Source panel blanked after destination tree HOME+mkdir flow.\n" f"{screen}"
         )
         assert "hex invert j compare" in _footer_text(tui), screen
 
@@ -1380,11 +1380,11 @@ def test_bug_same_volume_home_mkdir_keeps_inactive_source_dir(tmp_path, ytree_bi
 
         screen_while_right_active = _screen_text(tui)
         assert "f0.txt" in screen_while_right_active and "f1.txt" in screen_while_right_active, (
-            "Inactive source pane lost cmd file view while destination panel stayed active.\n"
+            "Inactive source panel lost cmd file view while destination panel stayed active.\n"
             f"{screen_while_right_active}"
         )
         assert "t0.txt" not in screen_while_right_active and "t1.txt" not in screen_while_right_active, (
-            "Inactive source pane jumped to tests while destination panel stayed active.\n"
+            "Inactive source panel jumped to tests while destination panel stayed active.\n"
             f"{screen_while_right_active}"
         )
 
@@ -1393,11 +1393,11 @@ def test_bug_same_volume_home_mkdir_keeps_inactive_source_dir(tmp_path, ytree_bi
         screen = _screen_text(tui)
         assert "hex invert j compare" in _footer_text(tui), screen
         assert "f0.txt" in screen and "f1.txt" in screen and "f2.txt" in screen, (
-            "Source pane lost cmd file view after destination HOME+mkdir flow.\n"
+            "Source panel lost cmd file view after destination HOME+mkdir flow.\n"
             f"{screen}"
         )
         assert "t0.txt" not in screen and "t1.txt" not in screen, (
-            "Source pane jumped to tests file view after destination HOME+mkdir flow.\n"
+            "Source panel jumped to tests file view after destination HOME+mkdir flow.\n"
             f"{screen}"
         )
     finally:
@@ -1497,7 +1497,7 @@ def test_bug_same_volume_home_mkdir_with_repo_like_tree_keeps_inactive_source(
         screen_while_right_active = _screen_text(tui)
         assert "src_file_0.c" in screen_while_right_active, screen_while_right_active
         assert "test_file_0.py" not in screen_while_right_active, (
-            "Inactive source pane jumped to tests while destination remained active.\n"
+            "Inactive source panel jumped to tests while destination remained active.\n"
             f"{screen_while_right_active}"
         )
 
@@ -1506,7 +1506,7 @@ def test_bug_same_volume_home_mkdir_with_repo_like_tree_keeps_inactive_source(
         assert "hex invert j compare" in _footer_text(tui), screen
         assert "src_file_0.c" in screen and "src_file_1.c" in screen, screen
         assert "test_file_0.py" not in screen and "test_file_1.py" not in screen, (
-            "Source pane jumped to tests after destination ENTER+HOME+mkdir.\n"
+            "Source panel jumped to tests after destination ENTER+HOME+mkdir.\n"
             f"{screen}"
         )
     finally:
@@ -1653,11 +1653,11 @@ def test_bug_same_volume_home_mkdir_listjump_sequence_keeps_inactive_source(
         for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
             line = _find_line_with_text(tui, name)
             assert line is not None, (
-                "Source pane lost file rows after switching back from destination.\n"
+                "Source panel lost file rows after switching back from destination.\n"
                 f"{screen_after_switch}"
             )
             assert _line_marks_file_as_tagged(line, name), (
-                "Tagged files were cleared after switching back to source pane.\n"
+                "Tagged files were cleared after switching back to source panel.\n"
                 f"Row: {line}\n{screen_after_switch}"
             )
     finally:
@@ -1672,7 +1672,7 @@ def test_bug_same_volume_home_mkdir_from_home_root_keeps_inactive_file_state(
     start at HOME, expand ytree/src/cmd, enter file mode, tag three files,
     split, switch to right, HOME, mkdir.
 
-    Inactive left pane must stay in file view on src/cmd with tags intact.
+    Inactive left panel must stay in file view on src/cmd with tags intact.
     """
     home = tmp_path / "home" / "user"
     repo = home / "ytree"
@@ -1776,13 +1776,13 @@ def test_bug_same_volume_home_mkdir_from_home_root_keeps_inactive_file_state(
 
         screen_right_active = _screen_text(tui)
         assert "src_file_0.c" in screen_right_active, (
-            "Inactive left pane blanked while destination pane remained active.\n"
+            "Inactive left panel blanked while destination panel remained active.\n"
             f"{screen_right_active}"
         )
         for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
             line = _find_line_with_text(tui, name)
             assert line is not None, (
-                "Inactive source pane lost file rows after destination mkdir.\n"
+                "Inactive source panel lost file rows after destination mkdir.\n"
                 f"{screen_right_active}"
             )
             assert _line_marks_file_as_tagged(line, name) == pre_tag_state[name], (
@@ -1795,17 +1795,17 @@ def test_bug_same_volume_home_mkdir_from_home_root_keeps_inactive_file_state(
         screen_after_tab = _screen_text(tui)
         assert "hex invert j compare" in _footer_text(tui), screen_after_tab
         assert "No files" not in screen_after_tab, (
-            "Switching to source pane produced empty file view.\n"
+            "Switching to source panel produced empty file view.\n"
             f"{screen_after_tab}"
         )
         for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
             line = _find_line_with_text(tui, name)
             assert line is not None, (
-                "Source pane did not resume src/cmd file view after TAB.\n"
+                "Source panel did not resume src/cmd file view after TAB.\n"
                 f"{screen_after_tab}"
             )
             assert _line_marks_file_as_tagged(line, name) == pre_tag_state[name], (
-                "Source tag state changed after TAB back to source pane.\n"
+                "Source tag state changed after TAB back to source panel.\n"
                 f"Expected tagged={pre_tag_state[name]} Row: {line}\n"
                 f"{screen_after_tab}"
             )


### PR DESCRIPTION
This PR standardizes terminology so docs/tests/comments consistently use:
- **pane** for **F7** list+preview layout
- **panel** for **F8** active/inactive split sides

No runtime behavior changes were made.  
