### PR TITLE
fix(split): stabilize split-panel redraw and focus state

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -14,7 +14,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Description**: In `F8` split mode, after logging two volumes and releasing one, the small window can go blank, separator line can disappear, inactive panel can blank, and tabbing to the inactive panel can trigger a segmentation fault.
 *   **Impact**: Critical stability and data-safety risk (crash), plus severe UI corruption in a core split-panel workflow.
 *   **Remediation**: Harden split-panel volume-release lifecycle so panel/window ownership and active/inactive bindings are always valid after release. Add focused regression coverage for `F8` with multi-volume log/release and `Tab` switching after release.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-40: Cycle-Volumes (`<`/`>`, `,`/`.`) Leaks Dir/File View State Across Volumes**
 *   **Description**: Cycling logged volumes can cause dir/file window mode/state changes in one volume to appear in the other, instead of each volume retaining its own last-used state.

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -20,7 +20,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Description**: Cycling logged volumes can cause dir/file window mode/state changes in one volume to appear in the other, instead of each volume retaining its own last-used state.
 *   **Impact**: Breaks per-volume navigation predictability and increases wrong-target risk during fast volume switching workflows.
 *   **Remediation**: Preserve and restore per-volume dir/file window state independently when cycling volumes. Add regression coverage for repeated `<`/`>` transitions across volumes with different view states.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-39: `Write` Destination Ambiguity and Crash Path**
 *   **Description**: In `Write`, entering a plain filename (for example `report-2026-04-11.txt`) can be interpreted as a command execution path instead of file output, and user repro indicates this path can crash after command failure handling.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -83,7 +83,7 @@ The behavior of the `Enter` key on a directory node is governed by the configura
 ### 3.4 Arrow Key Navigation (Spatial Controls)
 Arrow keys provide spatial, cursor-oriented navigation through the tree. They are distinct from the structural `+`/`-`/`*` controls:
 *   **`→` (Right Arrow / Drill Down):** Progressive depth navigation. If the node is collapsed: expand one level. If already expanded: move cursor to the first child.
-*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. At the filesystem/archive root, `Left` collapses one level when children are visible; if already collapsed, `Left` is a no-op.
+*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. At the filesystem/archive root, `Left` follows progressive retreat: first collapse visible children, then release/unlog, then no-op.
 
 ### 3.5 Preview Mode (`F7`) Contract
 `F7` is the primary inspect mode for viewing file contents while retaining list-oriented navigation.
@@ -121,7 +121,7 @@ The `ytree` input system follows a layered model designed for high-speed interac
 ### 4.3 Key Behavioral Rules
 *   **The Minus Rule (`-`):** State-based memory release. First press collapses an expanded node; second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged.
 *   **The Right Arrow Rule (`→`):** Progressive drill-down. Expand collapsed → move to child. Always takes the user one step deeper into the tree.
-*   **The Root-Left Rule (`←` at root):** First `Left` collapses visible root children; subsequent `Left` on an already-collapsed root is a no-op.
+*   **The Root-Left Rule (`←` at root):** First `Left` collapses visible root children. Second `Left` releases/unlogs root contents. Further `Left` on already-unlogged root is a no-op.
 *   **The Plus/Equals Rule (`+`/`=`):** Explicit one-level expand only. No cursor movement. `=` is the unshifted alias for `+`.
 *   **The Tree Marker Rule (`+` status):** Unlogged state is rendered only in the dedicated tree status margin column; directory names do not carry a `+` suffix.
 *   **The Volume Menu Rule (`K` menu):** Selecting the already-active volume preserves its current in-memory state (no implicit relog/reload).

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -83,7 +83,7 @@ The behavior of the `Enter` key on a directory node is governed by the configura
 ### 3.4 Arrow Key Navigation (Spatial Controls)
 Arrow keys provide spatial, cursor-oriented navigation through the tree. They are distinct from the structural `+`/`-`/`*` controls:
 *   **`→` (Right Arrow / Drill Down):** Progressive depth navigation. If the node is collapsed: expand one level. If already expanded: move cursor to the first child.
-*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. At the filesystem root, `Left` is a no-op.
+*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. At the filesystem/archive root, `Left` collapses one level when children are visible; if already collapsed, `Left` is a no-op.
 
 ### 3.5 Preview Mode (`F7`) Contract
 `F7` is the primary inspect mode for viewing file contents while retaining list-oriented navigation.
@@ -121,7 +121,7 @@ The `ytree` input system follows a layered model designed for high-speed interac
 ### 4.3 Key Behavioral Rules
 *   **The Minus Rule (`-`):** State-based memory release. First press collapses an expanded node; second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged.
 *   **The Right Arrow Rule (`→`):** Progressive drill-down. Expand collapsed → move to child. Always takes the user one step deeper into the tree.
-*   **The Root-Left Rule (`←` at root):** No-op. Root content release is handled by `-`, not by `Left`.
+*   **The Root-Left Rule (`←` at root):** First `Left` collapses visible root children; subsequent `Left` on an already-collapsed root is a no-op.
 *   **The Plus/Equals Rule (`+`/`=`):** Explicit one-level expand only. No cursor movement. `=` is the unshifted alias for `+`.
 *   **The Tree Marker Rule (`+` status):** Unlogged state is rendered only in the dedicated tree status margin column; directory names do not carry a `+` suffix.
 *   **The Volume Menu Rule (`K` menu):** Selecting the already-active volume preserves its current in-memory state (no implicit relog/reload).

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -37,6 +37,9 @@ The screen is divided into non-overlapping zones. Geometry is calculated dynamic
 ### 2.3 Visual Grammar (The "XTree&trade; Look")
 *   **Junction Grammar:** Ncurses junctions (T-pieces, crosses) must **only** be used for horizontal boundary lines. Vertical separators must remain clean, unbroken lines to avoid visual clutter.
 *   **Empty State:** If a directory contains no files, the File View window must display the text: `** No files **`.
+*   **Small-Window Name Column Alignment:** In the small File View, reserve the first post-border cell for tag (`*` or space), the second as a spacer, and start all row text at the same column. This applies to regular names, symlink labels, and placeholders (e.g., `No files`, `Unlogged`).  
+    Untagged: `│  check_xml_integrit`, `│  @current`, `│  No files`, `│  Unlogged`  
+    Tagged: `│* check_xml_integrit`, `│* @current`, `│  No files`, `│  Unlogged`
 *   **Single-Row List Invariant:** Tree/File/Showall/archive list rows must never wrap to a second terminal line.
 *   **Informative Truncation Policy:** When width is insufficient, content must be truncated (not wrapped) using a deterministic strategy that preserves the most useful identity cues. Prefer `prefix…suffix` elision when both ends carry meaning (for example filename stem + extension or path tail); use one-sided clipping only when the omitted side is low-value in that context.
 *   **Static Text Rule:** Truncated UI labels are static and stable while focused; marquee/auto-scrolling text is not permitted for core list and attribute surfaces.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -76,14 +76,14 @@ The behavior of the `Enter` key on a directory node is governed by the configura
 *   **Selection Memory (Breadcrumbs):** When returning from File Mode to Tree Mode and later re-entering the same directory, the panel must restore the cursor to the **last highlighted file**.
 
 ### 3.3 Directory Memory Commands (Structural Controls)
-*   **`+` or `=` (Expand):** Shallow Log. Scans the files of the current directory and the names of immediate subdirectories. `=` is a convenience alias (unshifted `+` on most keyboard layouts).
+*   **`+` or `=` (Expand):** Expand using configured `TREEDEPTH` behavior for the node context. `=` is a convenience alias (unshifted `+` on most keyboard layouts).
 *   **`*` (Asterisk):** Deep Log. Recursively scans the entire branch.
-*   **`-` (Minus / Collapse):** State-based memory release. First press collapses an expanded node. Second press on a collapsed (but logged) node evicts the file list, sets the status indicator to `+`, and marks the directory as Unlogged. At root, use `-` to release logged contents.
+*   **`-` (Minus / Collapse):** Collapsing a directory node is a state reset for that node. When `-` collapses a currently expanded node, that subtree is released/unlogged. Re-expanding starts from normal configured depth behavior instead of restoring prior ad-hoc expansion history.
 
 ### 3.4 Arrow Key Navigation (Spatial Controls)
 Arrow keys provide spatial, cursor-oriented navigation through the tree. They are distinct from the structural `+`/`-`/`*` controls:
 *   **`→` (Right Arrow / Drill Down):** Progressive depth navigation. If the node is collapsed: expand one level. If already expanded: move cursor to the first child.
-*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. At the filesystem/archive root, `Left` follows progressive retreat: first collapse visible children, then release/unlog, then no-op.
+*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. Collapsing with `Left` is a state reset for that node; after reset at filesystem/archive root, further `Left` is a no-op.
 
 ### 3.5 Preview Mode (`F7`) Contract
 `F7` is the primary inspect mode for viewing file contents while retaining list-oriented navigation.
@@ -119,10 +119,10 @@ The `ytree` input system follows a layered model designed for high-speed interac
 | **Prompt Interactions** | Contextual shortcuts active only during text prompts. | Specialized editing and browsing tools. |
 
 ### 4.3 Key Behavioral Rules
-*   **The Minus Rule (`-`):** State-based memory release. First press collapses an expanded node; second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged.
+*   **The Minus Rule (`-`):** Collapsing an expanded node is a node-local state reset: the subtree is released/unlogged, and later expand does not restore prior ad-hoc expansion history.
 *   **The Right Arrow Rule (`→`):** Progressive drill-down. Expand collapsed → move to child. Always takes the user one step deeper into the tree.
-*   **The Root-Left Rule (`←` at root):** First `Left` collapses visible root children. Second `Left` releases/unlogs root contents. Further `Left` on already-unlogged root is a no-op.
-*   **The Plus/Equals Rule (`+`/`=`):** Explicit one-level expand only. No cursor movement. `=` is the unshifted alias for `+`.
+*   **The Root-Left Rule (`←` at root):** `Left` on expanded root performs the same node-local reset (collapse + release/unlog). Further `Left` on already-unlogged root is a no-op.
+*   **The Plus/Equals Rule (`+`/`=`):** Explicit expand using configured `TREEDEPTH`. No cursor movement. `=` is the unshifted alias for `+`.
 *   **The Tree Marker Rule (`+` status):** Unlogged state is rendered only in the dedicated tree status margin column; directory names do not carry a `+` suffix.
 *   **The Volume Menu Rule (`K` menu):** Selecting the already-active volume preserves its current in-memory state (no implicit relog/reload).
 *   **The Explicit Relog Rule (`L` on current path):** Logging an already logged volume/path performs a fresh relog/reload of that volume state and reanchors selection at volume root.

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -9,7 +9,7 @@ Process requirements:
    - git pull --ff-only
 
 2) Create and use branch:
-   - git checkout -b <type>/<short-task-name>
+   - git checkout -b codex/mixed-features-fixes <type>/<short-task-name>
    - use a suitable type (e.g. fix, feat, chore, docs)
 
 3) Before implementing:

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -3,43 +3,51 @@ You are acting as my implementation agent in ~/ytree.
 Task:
 
 Process requirements:
-1) Sync local main with GitHub main:
+1) Preflight input-quality + routing gate (before any git commands):
+   - evaluate my task input for convention and best-practice quality
+   - if scope, naming, acceptance criteria, or workflow details are weak/non-standard, warn me and recommend a better version before proceeding
+   - classify the request as either:
+     a) simple/direct implementation task (continue with this template), or
+     b) non-trivial/multi-stage task that should use relay orchestration
+   - if (b), stop and instruct me to use `docs/ai/RELAY_PROMPT_TEMPLATE.md` instead of continuing with this template
+
+2) Sync local main with GitHub main:
    - git checkout main
    - git fetch origin
    - git pull --ff-only
 
-2) Create and use branch:
+3) Create and use branch:
    - git checkout -b codex/mixed-features-fixes <type>/<short-task-name>
    - use a suitable type (e.g. fix, feat, chore, docs)
 
-3) Before implementing:
+4) Before implementing:
    - discuss the task with me first
    - confirm exact scope, intended behavior, and acceptance criteria
    - only implement after I explicitly approve
 
-4) Implementation:
+5) Implementation:
    - implement the approved task only
    - keep scope tight and avoid unrelated edits
 
-5) Validation:
+6) Validation:
    - run targeted tests as needed
    - after task completion, run full gate:
      source .venv/bin/activate
      make qa-all
    - DO NOT run full gate before task completion
 
-6) Commits:
+7) Commits:
    - use Conventional Commits
    - for follow-up corrections to the same intent, prefer amend:
      git commit --amend --no-edit
    - keep branch history workable; final merge will be rebase/ff-friendly
 
-7) Push + PR-ready summary:
+8) Push + PR-ready summary:
    - what changed (by file)
    - test evidence (commands + outcomes)
    - risks/regressions to watch
 
-8) Stay through completion:
+9) Stay through completion:
    - if checks fail, fix root cause and re-run gates
    - continue until branch is green and PR-ready
 

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -653,6 +653,7 @@ typedef struct {
 struct Volume {
   int id;
   int saved_tree_index;
+  int saved_focus;
   Statistic vol_stats;
   Statistic vol_disk_stats;
   DirEntryList *dir_entry_list;

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -116,6 +116,10 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
   if (ctx->hook_suspend_clock)
     ctx->hook_suspend_clock(ctx); /* Suspend clock during critical operations */
 
+  if (panel->vol != NULL) {
+    panel->vol->saved_focus = panel->saved_focus;
+  }
+
   /* Keep per-volume tree selection before switching away. */
   SavePanelTreeSelection(panel);
 
@@ -177,6 +181,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
       } else {
         panel->vol = found_vol;
         s = &panel->vol->vol_stats;
+        panel->saved_focus = panel->vol->saved_focus;
         ctx->global_search_term[0] = '\0';
         ctx->view_mode = panel->vol->vol_stats.log_mode;
 
@@ -320,6 +325,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
   /* Success */
   panel->vol = loaded_vol;
   s = &panel->vol->vol_stats;
+  panel->saved_focus = panel->vol->saved_focus;
   ctx->global_search_term[0] = '\0';
   ctx->view_mode = s->log_mode;
 

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -102,6 +102,7 @@ struct Volume *Volume_Create(ViewContext *ctx) {
   /* Assign a unique ID and increment the serial counter */
   new_vol->id = ctx->volume_serial++;
   new_vol->saved_tree_index = 0;
+  new_vol->saved_focus = FOCUS_TREE;
 
   /* Add the new volume to the global hash table (ctx->volumes_head)
    * The 'id' field of the Volume struct is used as the key. */

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -761,9 +761,12 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       if (dir_entry->up_tree == NULL) {
         if (!dir_entry->not_scanned && dir_entry->sub_tree != NULL) {
           HandleCollapseSubTree(ctx, dir_entry, &need_dsp_help, ctx->active);
+        } else if (!dir_entry->unlogged_flag) {
+          HandleUnreadSubTree(ctx, dir_entry, de_ptr, &need_dsp_help,
+                              ctx->active);
         }
-        /* At root, LEFT collapses one level when possible; collapsed root is
-         * a no-op. */
+        /* At root, LEFT follows progressive retreat:
+         * collapse -> release -> no-op. */
         break;
       }
 

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -759,7 +759,11 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       break;
     case ACTION_MOVE_LEFT:
       if (dir_entry->up_tree == NULL) {
-        /* Root boundary: left is a no-op. Use '-' to release root contents. */
+        if (!dir_entry->not_scanned && dir_entry->sub_tree != NULL) {
+          HandleCollapseSubTree(ctx, dir_entry, &need_dsp_help, ctx->active);
+        }
+        /* At root, LEFT collapses one level when possible; collapsed root is
+         * a no-op. */
         break;
       }
 

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -724,17 +724,6 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       DirNav_MoveEnd(ctx, &dir_entry, ctx->active);
       break;
     case ACTION_MOVE_RIGHT:
-      if (dir_entry->up_tree == NULL && dir_entry->unlogged_flag) {
-        (void)snprintf(new_log_path, sizeof(new_log_path), "%s",
-                       s->log_path);
-        if (LogDisk(ctx, ctx->active, new_log_path) == 0) {
-          s = &ctx->active->vol->vol_stats;
-          dir_entry = ResolveActiveDirEntry(ctx, s);
-          need_dsp_help = TRUE;
-        }
-        break;
-      }
-
       if (!dir_entry->not_scanned && dir_entry->sub_tree != NULL) {
         if (DirOps_SelectVisibleDirAndRefresh(ctx, ctx->active,
                                               dir_entry->sub_tree,
@@ -765,8 +754,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
           HandleUnreadSubTree(ctx, dir_entry, de_ptr, &need_dsp_help,
                               ctx->active);
         }
-        /* At root, LEFT follows progressive retreat:
-         * collapse -> release -> no-op. */
+        /* At root, LEFT collapse is a state reset; once reset, LEFT is no-op. */
         break;
       }
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -129,6 +129,24 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
       s->log_mode != ARCHIVE_MODE) {
     return;
   }
+
+  if (dir_entry && dir_entry->up_tree == NULL && dir_entry->unlogged_flag &&
+      s->log_mode == ARCHIVE_MODE) {
+    if (new_log_path) {
+      (void)snprintf(new_log_path, PATH_LENGTH + 1, "%s", s->log_path);
+      new_log_path[PATH_LENGTH] = '\0';
+      if (LogDisk(ctx, p, new_log_path) == 0) {
+        DirEntry *refreshed_dir = GetPanelDirEntry(p);
+        if (!refreshed_dir && p->vol)
+          refreshed_dir = p->vol->vol_stats.tree;
+        if (refreshed_dir)
+          RefreshView(ctx, refreshed_dir);
+        *need_dsp_help = TRUE;
+      }
+    }
+    return;
+  }
+
   if (!dir_entry->not_scanned)
     return;
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1525,7 +1525,7 @@ HandleDirWindowVolumeAction(ViewContext *ctx, YtreeAction action,
     *dir_entry_ptr = (*s_ptr)->tree;
   }
 
-  RefreshVolumeSwitchViews(ctx, *dir_entry_ptr, *s_ptr);
+  RefreshView(ctx, *dir_entry_ptr);
   *need_dsp_help_ptr = TRUE;
   return DIR_WINDOW_DISPATCH_HANDLED;
 }

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -121,6 +121,7 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
   Statistic *s = &p->vol->vol_stats;
   YtreePanel *inactive = NULL;
   DirEntry *inactive_target = NULL;
+  int read_depth = 1;
   (void)de_ptr;
 
   /* Renamed usage: s->mode -> s->log_mode */
@@ -155,7 +156,12 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
   {
     SuspendClock(ctx); /* Suspend clock before scanning */
     GetPath(dir_entry, new_log_path);
-    ReadTree(ctx, dir_entry, new_log_path, 1, s, Dir_Progress, NULL);
+    if (dir_entry->unlogged_flag) {
+      read_depth = strtol(TREEDEPTH, NULL, 0);
+      if (read_depth < 0)
+        read_depth = 0;
+    }
+    ReadTree(ctx, dir_entry, new_log_path, read_depth, s, Dir_Progress, NULL);
     ApplyFilter(dir_entry, s);
     InitClock(ctx); /* Resume clock after scanning */
 
@@ -546,9 +552,11 @@ static void CaptureInactiveFallback(ViewContext *ctx, YtreePanel *p,
 
 void HandleCollapseSubTree(ViewContext *ctx, DirEntry *dir_entry,
                            BOOL *need_dsp_help, YtreePanel *p) {
-  const Statistic *s = &p->vol->vol_stats;
+  Statistic *s = &p->vol->vol_stats;
   YtreePanel *inactive = NULL;
   DirEntry *inactive_fallback = NULL;
+  DirEntry *de_ptr;
+  FileEntry *fe_ptr, *next_fe_ptr;
 
   if (!dir_entry || dir_entry->not_scanned || dir_entry->sub_tree == NULL)
     return;
@@ -559,8 +567,16 @@ void HandleCollapseSubTree(ViewContext *ctx, DirEntry *dir_entry,
   if (ctx->right && ctx->right->vol == p->vol)
     PanelTags_PruneUnderDir(ctx->right, dir_entry);
 
+  for (de_ptr = dir_entry->sub_tree; de_ptr; de_ptr = de_ptr->next) {
+    UnReadTree(ctx, de_ptr, s);
+  }
+  for (fe_ptr = dir_entry->file; fe_ptr; fe_ptr = next_fe_ptr) {
+    next_fe_ptr = fe_ptr->next;
+    RemoveFile(ctx, fe_ptr, s);
+  }
+
   dir_entry->not_scanned = TRUE;
-  dir_entry->unlogged_flag = FALSE;
+  dir_entry->unlogged_flag = TRUE;
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
 
@@ -573,6 +589,7 @@ void HandleCollapseSubTree(ViewContext *ctx, DirEntry *dir_entry,
               p->disp_begin_pos + p->cursor_pos, TRUE);
   DisplayFileWindow(ctx, p, dir_entry);
   DisplayAvailBytes(ctx, s);
+  RecalculateSysStats(ctx, s);
   DisplayDiskStatistic(ctx, s);
   UpdateStatsPanel(ctx, dir_entry, s);
   *need_dsp_help = TRUE;

--- a/src/ui/render_file.c
+++ b/src/ui/render_file.c
@@ -12,6 +12,8 @@
 
 static char GetTypeOfFile(struct stat fst);
 static int GetVisualFileEntryLength(ViewContext *ctx, YtreePanel *p);
+static void BuildFileRowLabel(char *buffer, size_t buffer_size,
+                              const FileEntry *fe_ptr, char type_of_file);
 
 static void AddClippedAtCursor(WINDOW *win, const char *text, int width) {
   int y, x, remaining;
@@ -178,6 +180,31 @@ static char GetTypeOfFile(struct stat fst) {
     return '?';
 }
 
+static void BuildFileRowLabel(char *buffer, size_t buffer_size,
+                              const FileEntry *fe_ptr, char type_of_file) {
+  int written = 0;
+
+  if (!buffer || buffer_size == 0)
+    return;
+
+  if (!fe_ptr) {
+    buffer[0] = '\0';
+    return;
+  }
+
+  if (type_of_file == ' ') {
+    written = snprintf(buffer, buffer_size, "%s", fe_ptr->name);
+  } else {
+    written = snprintf(buffer, buffer_size, "%c%s", type_of_file, fe_ptr->name);
+  }
+
+  if (written < 0) {
+    buffer[0] = '\0';
+  } else if ((size_t)written >= buffer_size) {
+    buffer[buffer_size - 1] = '\0';
+  }
+}
+
 void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
                     int x, unsigned char hilight, int start_x, WINDOW *win) {
   char attributes[11];
@@ -207,7 +234,10 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
   int base_color_pair;
   int width;
   BOOL is_tagged;
+  BOOL align_name_col;
   int highlight_attr;
+  char row_label[PATH_LENGTH + 2];
+  const char *primary_name;
 
   if (!panel->file_entry_list)
     return;
@@ -217,6 +247,14 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
   fe_ptr = panel->file_entry_list[entry_no].file;
   if (fe_ptr == NULL)
     return;
+  type_of_file = GetTypeOfFile(fe_ptr->stat_struct);
+  align_name_col =
+      (panel->pan_small_file_window && win == panel->pan_small_file_window);
+  primary_name = fe_ptr->name;
+  if (align_name_col || panel->file_mode == MODE_3) {
+    BuildFileRowLabel(row_label, sizeof(row_label), fe_ptr, type_of_file);
+    primary_name = row_label;
+  }
   is_tagged = PanelTags_FileIsTagged(panel, fe_ptr);
   highlight_attr = (ctx->is_split_screen && panel != ctx->active)
                        ? (A_BOLD | A_UNDERLINE)
@@ -227,9 +265,11 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
     wmove(win, y, pos_x);
 
     /* Prepare Display Name */
-    char display_name[PATH_LENGTH + 1];
-    /* Reserve 2 chars for Tag and Type */
-    CutFilename(display_name, fe_ptr->name, ctx->fixed_col_width - 2);
+    char display_name[PATH_LENGTH + 2];
+    char compact_label[PATH_LENGTH + 2];
+    /* Reserve 2 chars for Tag and spacer. */
+    BuildFileRowLabel(compact_label, sizeof(compact_label), fe_ptr, type_of_file);
+    CutFilename(display_name, compact_label, ctx->fixed_col_width - 2);
 
     /* Set Attributes */
     int color = GetFileTypeColor(ctx, fe_ptr);
@@ -240,8 +280,7 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
       wattron(win, highlight_attr);
 
     /* Draw */
-    wprintw(win, "%c%c%s", (is_tagged) ? TAGGED_SYMBOL : ' ',
-            GetTypeOfFile(fe_ptr->stat_struct), display_name);
+    wprintw(win, "%c %s", (is_tagged) ? TAGGED_SYMBOL : ' ', display_name);
 
     /* Pad remaining width */
     int printed_len = 2 + StrVisualLength(display_name);
@@ -294,8 +333,6 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
   filename_width = panel->max_visual_filename_len;
   linkname_width = panel->max_visual_linkname_len;
 #endif
-
-  type_of_file = GetTypeOfFile(fe_ptr->stat_struct);
 
   /* Calculate starting column position (pos_x) based on column index `x` */
   switch (panel->file_mode) {
@@ -353,22 +390,43 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
       (void)CTime(fe_ptr->stat_struct.st_mtime, modify_time);
       if (S_ISLNK(fe_ptr->stat_struct.st_mode)) {
         /* Updated %12s to %16s */
-        (void)snprintf(format, sizeof(format),
-                       "%%c%%c%%-%ds %%10s %%3d %%11lld %%16s -> %%-%ds",
-                       filename_width, linkname_width);
-        (void)snprintf(line_buffer, line_buffer_size, format,
-                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
-                       fe_ptr->name, attributes, fe_ptr->stat_struct.st_nlink,
-                       (long long)fe_ptr->stat_struct.st_size, modify_time,
-                       sym_link_name);
+        if (align_name_col) {
+          (void)snprintf(format, sizeof(format),
+                         "%%c %%-%ds %%10s %%3d %%11lld %%16s -> %%-%ds",
+                         filename_width, linkname_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', primary_name,
+                         attributes, fe_ptr->stat_struct.st_nlink,
+                         (long long)fe_ptr->stat_struct.st_size, modify_time,
+                         sym_link_name);
+        } else {
+          (void)snprintf(format, sizeof(format),
+                         "%%c%%c%%-%ds %%10s %%3d %%11lld %%16s -> %%-%ds",
+                         filename_width, linkname_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                         fe_ptr->name, attributes, fe_ptr->stat_struct.st_nlink,
+                         (long long)fe_ptr->stat_struct.st_size, modify_time,
+                         sym_link_name);
+        }
       } else {
-        (void)snprintf(format, sizeof(format),
-                       "%%c%%c%%%c%ds %%10s %%3d %%11lld %%16s", justify,
-                       filename_width);
-        (void)snprintf(line_buffer, line_buffer_size, format,
-                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
-                       fe_ptr->name, attributes, fe_ptr->stat_struct.st_nlink,
-                       (long long)fe_ptr->stat_struct.st_size, modify_time);
+        if (align_name_col) {
+          (void)snprintf(format, sizeof(format),
+                         "%%c %%%c%ds %%10s %%3d %%11lld %%16s", justify,
+                         filename_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', primary_name,
+                         attributes, fe_ptr->stat_struct.st_nlink,
+                         (long long)fe_ptr->stat_struct.st_size, modify_time);
+        } else {
+          (void)snprintf(format, sizeof(format),
+                         "%%c%%c%%%c%ds %%10s %%3d %%11lld %%16s", justify,
+                         filename_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                         fe_ptr->name, attributes, fe_ptr->stat_struct.st_nlink,
+                         (long long)fe_ptr->stat_struct.st_size, modify_time);
+        }
       }
       break;
     case MODE_2:
@@ -383,48 +441,85 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
         group_name_ptr = group;
       }
       if (S_ISLNK(fe_ptr->stat_struct.st_mode)) {
-        (void)snprintf(format, sizeof(format),
-                       "%%c%%c%%%c%ds %%10lld %%-12s %%-12s -> %%-%ds", justify,
-                       filename_width, linkname_width);
-        (void)snprintf(line_buffer, line_buffer_size, format,
-                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
-                       fe_ptr->name, (long long)fe_ptr->stat_struct.st_ino,
-                       owner_name_ptr, group_name_ptr, sym_link_name);
+        if (align_name_col) {
+          (void)snprintf(format, sizeof(format),
+                         "%%c %%%c%ds %%10lld %%-12s %%-12s -> %%-%ds", justify,
+                         filename_width, linkname_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', primary_name,
+                         (long long)fe_ptr->stat_struct.st_ino, owner_name_ptr,
+                         group_name_ptr, sym_link_name);
+        } else {
+          (void)snprintf(format, sizeof(format),
+                         "%%c%%c%%%c%ds %%10lld %%-12s %%-12s -> %%-%ds",
+                         justify, filename_width, linkname_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                         fe_ptr->name, (long long)fe_ptr->stat_struct.st_ino,
+                         owner_name_ptr, group_name_ptr, sym_link_name);
+        }
       } else {
-        (void)snprintf(format, sizeof(format),
-                       "%%c%%c%%%c%ds %%10lld %%-12s %%-12s", justify,
-                       filename_width);
-        (void)snprintf(line_buffer, line_buffer_size, format,
-                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
-                       fe_ptr->name, (long long)fe_ptr->stat_struct.st_ino,
-                       owner_name_ptr, group_name_ptr);
+        if (align_name_col) {
+          (void)snprintf(format, sizeof(format),
+                         "%%c %%%c%ds %%10lld %%-12s %%-12s", justify,
+                         filename_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', primary_name,
+                         (long long)fe_ptr->stat_struct.st_ino, owner_name_ptr,
+                         group_name_ptr);
+        } else {
+          (void)snprintf(format, sizeof(format),
+                         "%%c%%c%%%c%ds %%10lld %%-12s %%-12s", justify,
+                         filename_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                         fe_ptr->name, (long long)fe_ptr->stat_struct.st_ino,
+                         owner_name_ptr, group_name_ptr);
+        }
       }
       break;
     case MODE_3:
-      (void)snprintf(format, sizeof(format), "%%c%%c%%%c%ds", justify,
+      (void)snprintf(format, sizeof(format), "%%c %%%c%ds", justify,
                      filename_width);
       (void)snprintf(line_buffer, line_buffer_size, format,
-                     (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
-                     fe_ptr->name);
+                     (is_tagged) ? TAGGED_SYMBOL : ' ', primary_name);
       break;
     case MODE_4:
       (void)CTime(fe_ptr->stat_struct.st_ctime, change_time);
       (void)CTime(fe_ptr->stat_struct.st_atime, access_time);
       if (S_ISLNK(fe_ptr->stat_struct.st_mode)) {
         /* Updated %12s to %16s */
-        (void)snprintf(format, sizeof(format),
-                       "%%c%%c%%%c%ds Chg: %%16s  Acc: %%16s -> %%-%ds",
-                       justify, filename_width, linkname_width);
-        (void)snprintf(line_buffer, line_buffer_size, format,
-                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
-                       fe_ptr->name, change_time, access_time, sym_link_name);
+        if (align_name_col) {
+          (void)snprintf(format, sizeof(format),
+                         "%%c %%%c%ds Chg: %%16s  Acc: %%16s -> %%-%ds",
+                         justify, filename_width, linkname_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', primary_name,
+                         change_time, access_time, sym_link_name);
+        } else {
+          (void)snprintf(format, sizeof(format),
+                         "%%c%%c%%%c%ds Chg: %%16s  Acc: %%16s -> %%-%ds",
+                         justify, filename_width, linkname_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                         fe_ptr->name, change_time, access_time, sym_link_name);
+        }
       } else {
-        (void)snprintf(format, sizeof(format),
-                       "%%c%%c%%%c%ds Chg: %%16s  Acc: %%16s", justify,
-                       filename_width);
-        (void)snprintf(line_buffer, line_buffer_size, format,
-                       (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
-                       fe_ptr->name, change_time, access_time);
+        if (align_name_col) {
+          (void)snprintf(format, sizeof(format),
+                         "%%c %%%c%ds Chg: %%16s  Acc: %%16s", justify,
+                         filename_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', primary_name,
+                         change_time, access_time);
+        } else {
+          (void)snprintf(format, sizeof(format),
+                         "%%c%%c%%%c%ds Chg: %%16s  Acc: %%16s", justify,
+                         filename_width);
+          (void)snprintf(line_buffer, line_buffer_size, format,
+                         (is_tagged) ? TAGGED_SYMBOL : ' ', type_of_file,
+                         fe_ptr->name, change_time, access_time);
+        }
       }
       break;
     case MODE_5:
@@ -467,11 +562,12 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
     if (is_tagged)
       wattron(win, A_BOLD);
 
-    /* Print tag and type */
+    /* Print tag and type/spacer */
     {
       char prefix[3];
       prefix[0] = (is_tagged) ? TAGGED_SYMBOL : ' ';
-      prefix[1] = type_of_file;
+      prefix[1] = (align_name_col || panel->file_mode == MODE_3) ? ' '
+                                                                   : type_of_file;
       prefix[2] = '\0';
       AddClippedAtCursor(win, prefix, width);
     }
@@ -503,12 +599,18 @@ void PrintFileEntry(ViewContext *ctx, YtreePanel *panel, int entry_no, int y,
     if (max_w > width - pos_x - 3)
       max_w = width - pos_x - 3;
 
-    char display_name[PATH_LENGTH + 1];
-    if ((int)strlen(fe_ptr->name) > max_w) {
-      CutFilename(display_name, fe_ptr->name, max_w);
+    char display_name[PATH_LENGTH + 2];
+    const char *name_text = fe_ptr->name;
+    char mode3_name[PATH_LENGTH + 2];
+    if (align_name_col || panel->file_mode == MODE_3) {
+      BuildFileRowLabel(mode3_name, sizeof(mode3_name), fe_ptr, type_of_file);
+      name_text = mode3_name;
+    }
+    if ((int)strlen(name_text) > max_w) {
+      CutFilename(display_name, name_text, max_w);
     } else {
       int copied_len =
-          snprintf(display_name, sizeof(display_name), "%s", fe_ptr->name);
+          snprintf(display_name, sizeof(display_name), "%s", name_text);
       if (copied_len < 0) {
         display_name[0] = '\0';
       } else if ((size_t)copied_len >= sizeof(display_name)) {

--- a/src/ui/volume_menu.c
+++ b/src/ui/volume_menu.c
@@ -9,6 +9,67 @@
 #include "ytree_fs.h"
 #include "ytree_ui.h"
 
+static void NormalizePanelCursorForVolume(YtreePanel *panel) {
+  if (!panel || !panel->vol) {
+    return;
+  }
+
+  if (panel->vol->total_dirs <= 0) {
+    panel->disp_begin_pos = 0;
+    panel->cursor_pos = 0;
+    panel->file_dir_entry = NULL;
+    return;
+  }
+
+  if (panel->disp_begin_pos < 0)
+    panel->disp_begin_pos = 0;
+  if (panel->cursor_pos < 0)
+    panel->cursor_pos = 0;
+  if (panel->disp_begin_pos >= panel->vol->total_dirs)
+    panel->disp_begin_pos = panel->vol->total_dirs - 1;
+  if (panel->disp_begin_pos + panel->cursor_pos >= panel->vol->total_dirs)
+    panel->cursor_pos = panel->vol->total_dirs - 1 - panel->disp_begin_pos;
+  if (panel->cursor_pos < 0)
+    panel->cursor_pos = 0;
+}
+
+static void EnsurePanelsReferenceActiveVolume(ViewContext *ctx) {
+  int idx;
+
+  if (!ctx || !ctx->active || !ctx->active->vol)
+    return;
+
+  if (ctx->left && ctx->left->vol == NULL)
+    ctx->left->vol = ctx->active->vol;
+  if (ctx->right && ctx->right->vol == NULL)
+    ctx->right->vol = ctx->active->vol;
+
+  if (!ctx->is_split_screen)
+    return;
+
+  if (ctx->left && ctx->left->vol == ctx->active->vol) {
+    BuildDirEntryList(ctx, ctx->left->vol, &ctx->left->current_dir_entry);
+    NormalizePanelCursorForVolume(ctx->left);
+    idx = ctx->left->disp_begin_pos + ctx->left->cursor_pos;
+    if (ctx->left->vol->total_dirs > 0) {
+      ctx->left->file_dir_entry = ctx->left->vol->dir_entry_list[idx].dir_entry;
+      BuildFileEntryList(ctx, ctx->left);
+    }
+  }
+
+  if (ctx->right && ctx->right->vol == ctx->active->vol) {
+    BuildDirEntryList(ctx, ctx->right->vol, &ctx->right->current_dir_entry);
+    NormalizePanelCursorForVolume(ctx->right);
+    idx = ctx->right->disp_begin_pos + ctx->right->cursor_pos;
+    if (ctx->right->vol->total_dirs > 0) {
+      ctx->right->file_dir_entry = ctx->right->vol->dir_entry_list[idx].dir_entry;
+      BuildFileEntryList(ctx, ctx->right);
+    }
+  }
+
+  SyncActivePanelWindows(ctx);
+}
+
 /*
  * SelectLoadedVolume
  * Displays a list of currently loaded volumes and allows the user to switch
@@ -388,6 +449,7 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
       if (target_vol != ctx->active->vol) {
         int login_result =
             LogDisk(ctx, ctx->active, target_vol->vol_stats.log_path);
+        EnsurePanelsReferenceActiveVolume(ctx);
         free(vol_array);
         return login_result;
       }
@@ -398,6 +460,7 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
         int dummy;
         BuildDirEntryList(ctx, ctx->active->vol, &dummy);
       }
+      EnsurePanelsReferenceActiveVolume(ctx);
       return 0;
     }
   }
@@ -411,6 +474,7 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
       int dummy;
       BuildDirEntryList(ctx, ctx->active->vol, &dummy);
     }
+    EnsurePanelsReferenceActiveVolume(ctx);
     return 0;
   }
 

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -661,6 +661,65 @@ def test_logged_empty_vs_unlogged_labels(tmp_path, ytree_binary):
     tui.quit()
 
 
+def test_small_window_tagged_symlink_and_empty_labels_share_name_column(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "small_window_symlink_alignment"
+    root.mkdir()
+    target = root / "check_xml_integrit"
+    target.write_text("payload", encoding="utf-8")
+    (root / "current").symlink_to(target.name)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        initial_lines = tui.get_screen_dump()
+        file_row = next(
+            (line for line in initial_lines if "check_xml_integrit" in line), ""
+        )
+        symlink_row = next((line for line in initial_lines if "@current" in line), "")
+        assert file_row, "Expected untagged file row."
+        assert symlink_row, "Expected untagged symlink row with '@' prefix."
+
+        name_col = file_row.find("check_xml_integrit")
+        symlink_col = symlink_row.find("@current")
+        assert name_col >= 0 and symlink_col >= 0
+        assert symlink_col == name_col, (
+            "Untagged symlink label must start at the same file-name column.\n"
+            f"name_col={name_col}, symlink_col={symlink_col}\n"
+            f"file_row={file_row!r}\nsymlink_row={symlink_row!r}"
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        tui.send_keystroke("\x14", wait=0.5)  # Ctrl+T (tag all)
+
+        tagged_lines = tui.get_screen_dump()
+        tagged_file_row = next(
+            (line for line in tagged_lines if "* check_xml_integrit" in line), ""
+        )
+        tagged_symlink_row = next(
+            (line for line in tagged_lines if "* @current" in line), ""
+        )
+        assert tagged_file_row, "Expected tagged file row with '* ' prefix."
+        assert tagged_symlink_row, "Expected tagged symlink row with '* @' prefix."
+
+        tagged_name_col = tagged_file_row.find("check_xml_integrit")
+        tagged_symlink_col = tagged_symlink_row.find("@current")
+        assert tagged_name_col == name_col, (
+            "Tagged file label must preserve the filename start column.\n"
+            f"expected={name_col}, actual={tagged_name_col}\n"
+            f"row={tagged_file_row!r}"
+        )
+        assert tagged_symlink_col == name_col, (
+            "Tagged symlink label must preserve the filename start column.\n"
+            f"expected={name_col}, actual={tagged_symlink_col}\n"
+            f"row={tagged_symlink_row!r}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_placeholder_dir_shows_unlogged_not_no_files(tmp_path, ytree_binary):
     root = tmp_path / "placeholder_shows_unlogged"
     root.mkdir()

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -212,6 +212,49 @@ def test_fs_left_at_root_collapses_once_then_noop(tmp_path, ytree_binary):
         tui.quit()
 
 
+def test_fs_root_left_then_right_does_not_restore_deep_state(tmp_path, ytree_binary):
+    root = tmp_path / "fs_root_left_right_reset"
+    root.mkdir()
+    (root / "alpha" / "child" / "grand").mkdir(parents=True)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # alpha
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # expand alpha
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # child
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # expand child
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # grand
+
+        before_reset = "\n".join(tui.get_screen_dump())
+        assert "grand" in before_reset, (
+            "Precondition failed: expected deep expansion before reset.\n"
+            f"Screen:\n{before_reset}"
+        )
+
+        tui.send_keystroke(Keys.UP, wait=0.2)
+        tui.send_keystroke(Keys.UP, wait=0.2)
+        tui.send_keystroke(Keys.UP, wait=0.2)     # root
+        _send_left_arrow(tui, wait=0.6)           # reset root
+        tui.send_keystroke(Keys.RIGHT, wait=0.6)  # expand root again
+
+        after_lines = tui.get_screen_dump()
+        after_reexpand = "\n".join(after_lines)
+        tree_and_footer = "\n".join(after_lines[1:])
+        assert "alpha" in after_reexpand, (
+            "Root re-expand should show immediate child directories.\n"
+            f"Screen:\n{after_reexpand}"
+        )
+        assert " mqchild" not in tree_and_footer and " mqgrand" not in tree_and_footer, (
+            "Root LEFT reset must discard prior ad-hoc deep expansion; RIGHT must"
+            " not restore it.\n"
+            f"Screen:\n{after_reexpand}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_archive_root_backslash_exits_to_parent_file_focus(tmp_path, ytree_binary):
     root = tmp_path / "a_bs"
     root.mkdir()
@@ -506,7 +549,7 @@ def test_enter_on_placeholder_dir_logs_and_reveals_first_level_only(
         tui.quit()
 
 
-def test_root_minus_resets_tree_and_right_relogs_to_profile_depth(
+def test_root_left_resets_tree_and_right_relogs_to_profile_depth(
     tmp_path, ytree_binary
 ):
     root = tmp_path / "root_minus_right_profile_depth"
@@ -539,34 +582,23 @@ def test_root_minus_resets_tree_and_right_relogs_to_profile_depth(
                 break
             tui.send_keystroke(Keys.LEFT, wait=0.3)
 
-        before_rows = tui.get_screen_dump()
-        at_root_before = "\n".join(before_rows)
+        at_root_before = _screen_text(tui)
         assert str(root) in tui.get_screen_dump()[0], (
-            "Precondition failed: expected selection at root before root-left "
-            "no-op assertion.\n"
+            "Precondition failed: expected selection at root before root-left reset.\n"
             f"{at_root_before}"
         )
 
-        tui.send_keystroke(Keys.LEFT, wait=0.5)
-        after_rows = tui.get_screen_dump()
-        at_root_after = "\n".join(after_rows)
-        assert "\n".join(after_rows[1:]) == "\n".join(before_rows[1:]), (
-            "Left at root should be a no-op; use '-' to release root contents.\n"
-            f"Before:\n{at_root_before}\n\nAfter:\n{at_root_after}"
-        )
-
-        tui.send_keystroke("-", wait=0.7)
-        tui.send_keystroke("-", wait=0.7)
-        after_minus = _screen_text(tui)
-        assert "deeper" not in after_minus, (
-            "Root '-' release should clear expanded descendant state.\n"
-            f"{after_minus}"
+        tui.send_keystroke(Keys.LEFT, wait=0.7)
+        after_left = _screen_text(tui)
+        assert "deeper" not in after_left, (
+            "Left collapse at root should reset/release expanded descendant state.\n"
+            f"{after_left}"
         )
 
         tui.send_keystroke(Keys.RIGHT, wait=0.9)
         after_right = _screen_text(tui)
         assert "src/" in after_right, (
-            "Right on reset root should relog to configured depth and show "
+            "Right on reset root should relog to configured TREEDEPTH and show "
             "first-level directory placeholders.\n"
             f"{after_right}"
         )

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -255,6 +255,39 @@ def test_fs_root_left_then_right_does_not_restore_deep_state(tmp_path, ytree_bin
         tui.quit()
 
 
+def test_archive_root_unlogged_right_does_not_show_permission_denied(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "archive_root_unlogged_right"
+    root.mkdir()
+    _create_archive(root, "roundtrip.tar")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        tui.send_keystroke(Keys.LOG, wait=0.3)
+        tui.send_keystroke(Keys.ENTER, wait=0.9)
+        assert tui.wait_for_content("ARCHIVE", timeout=3.0), _screen_text(tui)
+
+        _send_left_arrow(tui, wait=0.8)  # reset/unlog archive root
+        tui.send_keystroke(Keys.RIGHT, wait=0.9)
+
+        after = _screen_text(tui)
+        assert "Permission Denied" not in after, (
+            "Right at unlogged archive root should relog archive context, not "
+            "raise a filesystem permission error.\n"
+            f"{after}"
+        )
+        assert "ARCHIVE" in after, (
+            "Right at unlogged archive root should remain in archive mode.\n"
+            f"{after}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_archive_root_backslash_exits_to_parent_file_focus(tmp_path, ytree_binary):
     root = tmp_path / "a_bs"
     root.mkdir()

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -10,8 +10,7 @@ from ytree_keys import Keys
 
 
 def _send_left_arrow(tui, wait=0.4):
-    # Use CSI-left to assert ACTION_MOVE_LEFT behavior explicitly.
-    tui.send_keystroke("\033[D", wait=wait)
+    tui.send_keystroke(Keys.LEFT, wait=wait)
 
 
 def _create_archive(root, archive_name="sample.tar"):
@@ -61,8 +60,8 @@ def _assert_margin_plus_marker(screen_rows, dir_name, expect_slash=False):
         )
 
 
-def test_archive_left_at_root_does_not_exit_archive(tmp_path, ytree_binary):
-    """LEFT is collapse-only and must not exit archive mode at archive root."""
+def test_archive_left_at_root_collapses_once_then_noop(tmp_path, ytree_binary):
+    """At archive root: first LEFT collapses children, second LEFT is a no-op."""
     root = tmp_path / "archive_exit_root"
     root.mkdir()
 
@@ -79,17 +78,35 @@ def test_archive_left_at_root_does_not_exit_archive(tmp_path, ytree_binary):
     tui.send_keystroke(Keys.ENTER, wait=0.9)
     assert tui.wait_for_content("ARCHIVE", timeout=3.0), _screen_text(tui)
 
-    # LEFT at archive root must not exit archive mode.
+    before_left = "\n".join(tui.get_screen_dump())
+    assert "nested" in before_left, (
+        "Precondition failed: archive root should show nested child row before LEFT.\n"
+        f"Screen:\n{before_left}"
+    )
+
+    # First LEFT at archive root collapses one level but does not exit archive mode.
     _send_left_arrow(tui, wait=0.8)
 
-    screen = "\n".join(tui.get_screen_dump())
-    assert "ARCHIVE" in screen, (
-        "LEFT at archive root must not exit archive mode.\n"
-        f"Screen:\n{screen}"
+    after_first_left = "\n".join(tui.get_screen_dump())
+    assert "ARCHIVE" in after_first_left, (
+        "First LEFT at archive root must not exit archive mode.\n"
+        f"Screen:\n{after_first_left}"
     )
-    assert "inside_dir" in screen, (
-        "LEFT at archive root should keep archive tree visible.\n"
-        f"Screen:\n{screen}"
+    assert "nested" not in after_first_left, (
+        "First LEFT at archive root should collapse child rows.\n"
+        f"Screen:\n{after_first_left}"
+    )
+
+    # Second LEFT at already-collapsed archive root is a no-op.
+    _send_left_arrow(tui, wait=0.8)
+    after_second_left = "\n".join(tui.get_screen_dump())
+    assert "ARCHIVE" in after_second_left, (
+        "Second LEFT at collapsed archive root must stay in archive mode.\n"
+        f"Screen:\n{after_second_left}"
+    )
+    assert "nested" not in after_second_left, (
+        "Second LEFT at collapsed archive root should remain collapsed.\n"
+        f"Screen:\n{after_second_left}"
     )
 
     tui.quit()
@@ -156,6 +173,43 @@ def test_archive_left_non_root_does_not_exit_immediately(tmp_path, ytree_binary)
     )
 
     tui.quit()
+
+
+def test_fs_left_at_root_collapses_once_then_noop(tmp_path, ytree_binary):
+    root = tmp_path / "fs_left_root_collapse_once"
+    root.mkdir()
+    (root / "child_a").mkdir()
+    (root / "child_b").mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        before_left = "\n".join(tui.get_screen_dump())
+        assert "child_a" in before_left or "child_b" in before_left, (
+            "Precondition failed: filesystem root should show child rows before LEFT.\n"
+            f"Screen:\n{before_left}"
+        )
+
+        _send_left_arrow(tui, wait=0.6)
+        after_first_left = "\n".join(tui.get_screen_dump())
+        assert "child_a" not in after_first_left and "child_b" not in after_first_left, (
+            "First LEFT at filesystem root should collapse child rows.\n"
+            f"Screen:\n{after_first_left}"
+        )
+
+        _send_left_arrow(tui, wait=0.6)
+        after_second_left = "\n".join(tui.get_screen_dump())
+        assert "child_a" not in after_second_left and "child_b" not in after_second_left, (
+            "Second LEFT at collapsed filesystem root should keep children collapsed.\n"
+            f"Screen:\n{after_second_left}"
+        )
+        assert "Unlogged" in after_second_left, (
+            "Second LEFT at collapsed filesystem root should keep root unlogged.\n"
+            f"Screen:\n{after_second_left}"
+        )
+    finally:
+        tui.quit()
 
 
 def test_archive_root_backslash_exits_to_parent_file_focus(tmp_path, ytree_binary):

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -540,6 +540,52 @@ def test_split_mirror_stays_on_active_volume_after_volume_cycle(tmp_path, ytree_
     tui.quit()
 
 
+def test_volume_cycle_does_not_leak_file_focus_between_volumes(tmp_path, ytree_binary):
+    vol_a = tmp_path / "bug40_vol_a"
+    vol_b = tmp_path / "bug40_vol_b"
+    vol_a.mkdir()
+    vol_b.mkdir()
+    (vol_a / "a0.txt").write_text("a0\n", encoding="utf-8")
+    (vol_b / "b0.txt").write_text("b0\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(vol_a))
+    time.sleep(0.9)
+
+    try:
+        _assert_dir_mode_footer(tui, "Precondition failed: expected tree mode.")
+        assert "bug40_vol_a" in tui.get_screen_dump()[0], _screen_text(tui)
+
+        # Log second volume so cycling has two loaded targets.
+        tui.send_keystroke(Keys.LOG, wait=0.2)
+        tui.send_keystroke(Keys.CTRL_U + str(vol_b) + Keys.ENTER, wait=0.9)
+        assert "bug40_vol_b" in tui.get_screen_dump()[0], _screen_text(tui)
+        _assert_dir_mode_footer(tui, "Expected tree mode after logging volume B.")
+
+        # Return to volume A in tree mode.
+        tui.send_keystroke("<", wait=0.6)
+        assert "bug40_vol_a" in tui.get_screen_dump()[0], _screen_text(tui)
+        _assert_dir_mode_footer(tui, "Expected tree mode after cycling back to A.")
+
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke("<", wait=0.8)
+        screen = _screen_text(tui)
+        footer = _footer_text(tui)
+
+        assert "bug40_vol_b" in tui.get_screen_dump()[0], (
+            "Volume cycle did not switch to target volume.\n"
+            f"{screen}"
+        )
+        assert "hex invert j compare" not in footer and "j tree" in footer, (
+            "Cycling volumes must not leak file-mode focus from one volume to "
+            "another.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{screen}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_inactive_dir_focus_survives_tab_away_and_back(tmp_path, ytree_binary):
     root = tmp_path / "inactive_dir_focus_survives_tab"
     root.mkdir()

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -2231,3 +2231,59 @@ def test_volume_menu_cancel_restores_file_footer_immediately(tmp_path, ytree_bin
     )
 
     tui.quit()
+
+
+def test_f8_release_volume_keeps_small_window_and_tab_safe(tmp_path, ytree_binary):
+    vol_a = tmp_path / "bug41_vol_a"
+    vol_b = tmp_path / "bug41_vol_b"
+    vol_a.mkdir()
+    vol_b.mkdir()
+    (vol_a / "a_only.txt").write_text("a\n", encoding="utf-8")
+    (vol_b / "b_only.txt").write_text("b\n", encoding="utf-8")
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(vol_a),
+        args=[str(vol_b)],
+    )
+    time.sleep(1.0)
+
+    try:
+        tui.send_keystroke(Keys.F8, wait=0.5)
+
+        # Open loaded-volume menu and release selected volume.
+        tui.send_keystroke("k", wait=0.4)
+        assert tui.wait_for_content("Select Volume", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("d", wait=0.3)
+        tui.send_keystroke("y", wait=0.8)
+        if tui.wait_for_content("Select Volume", timeout=0.4):
+            tui.send_keystroke(Keys.ESC, wait=0.5)
+
+        lines = tui.get_screen_dump()
+        screen = "\n".join(lines)
+        assert "Path:" in screen, (
+            "UI header vanished after releasing a volume in split mode.\n"
+            f"{screen}"
+        )
+        assert screen.count("a_only.txt") + screen.count("b_only.txt") >= 2, (
+            "Small/file windows were not rendered in both split panes after "
+            "release-volume flow.\n"
+            f"{screen}"
+        )
+        _assert_split_column_continuous(lines, "after split release-volume flow")
+
+        # Regression: Tab after release must not blank/crash.
+        tui.send_keystroke(Keys.TAB, wait=0.6)
+        lines = tui.get_screen_dump()
+        screen = "\n".join(lines)
+        assert "Path:" in screen, (
+            "Tab after split release-volume flow blanked/crashed UI.\n"
+            f"{screen}"
+        )
+        assert screen.count("a_only.txt") + screen.count("b_only.txt") >= 2, (
+            "Tab after release-volume flow left one split pane blank.\n"
+            f"{screen}"
+        )
+        _assert_split_column_continuous(lines, "after split release + tab")
+    finally:
+        tui.quit()

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -335,6 +335,56 @@ def test_left_arrow_collapse_clears_panel_local_tags(tmp_path, ytree_binary):
     )
 
 
+def _assert_collapse_resets_subtree_expansion(tmp_path, ytree_binary, key):
+    root = tmp_path / f"collapse_reset_subtree_{ord(key[0])}"
+    root.mkdir()
+    alpha = root / "alpha"
+    (alpha / "child" / "grand" / "great").mkdir(parents=True)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # alpha
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # show child
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # child
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # show grand
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # grand
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # show great
+
+        before = _screen_text(tui)
+        assert "great" in before, (
+            "Precondition failed: deep expansion should reveal great.\n"
+            f"{before}"
+        )
+
+        tui.send_keystroke(Keys.UP, wait=0.2)     # child
+        tui.send_keystroke(Keys.UP, wait=0.2)     # alpha
+        tui.send_keystroke(key, wait=0.4)         # collapse/reset alpha
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # re-expand alpha
+
+        after = _screen_text(tui)
+        assert "child" in after, (
+            "Re-expand should restore immediate child visibility.\n"
+            f"{after}"
+        )
+        assert "grand" not in after and "great" not in after, (
+            "Collapse with Left or '-' must reset subtree expansion state for"
+            " that node.\n"
+            f"{after}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_minus_collapse_resets_subtree_expansion_state(tmp_path, ytree_binary):
+    _assert_collapse_resets_subtree_expansion(tmp_path, ytree_binary, "-")
+
+
+def test_left_collapse_resets_subtree_expansion_state(tmp_path, ytree_binary):
+    _assert_collapse_resets_subtree_expansion(tmp_path, ytree_binary, Keys.LEFT)
+
+
 def test_split_from_dir_immediately_renders_peer_panel(tmp_path, ytree_binary):
     root = tmp_path / "split_dir_immediate_render"
     root.mkdir()

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -1,5 +1,6 @@
 import pytest
 import shlex
+import tarfile
 import time
 import re
 from helpers_files import wait_for_file as _wait_for_file
@@ -2299,5 +2300,62 @@ def test_f8_release_volume_keeps_small_window_and_tab_safe(tmp_path, ytree_binar
             f"{screen}"
         )
         _assert_split_column_continuous(lines, "after split release + repeated tab")
+    finally:
+        tui.quit()
+
+
+def test_f8_release_inactive_disk_volume_while_active_archive_keeps_split_stable(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "bug41_archive_release_inactive"
+    root.mkdir()
+    disk_vol = root / "disk_vol"
+    disk_vol.mkdir()
+    (disk_vol / "disk_only.txt").write_text("disk\n", encoding="utf-8")
+
+    archive_src = root / "_archive_src"
+    archive_src.mkdir()
+    (archive_src / "inside.txt").write_text("inside\n", encoding="utf-8")
+    (archive_src / "nested").mkdir()
+    (archive_src / "nested" / "deep.txt").write_text("deep\n", encoding="utf-8")
+    archive_path = root / "sample.tar"
+    with tarfile.open(archive_path, "w") as tf:
+        tf.add(archive_src, arcname="inside_dir")
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(disk_vol),
+        args=[str(archive_path)],
+    )
+    time.sleep(1.0)
+
+    try:
+        # Move active context to archive volume first.
+        for _ in range(6):
+            if "sample.tar" in tui.get_screen_dump()[0]:
+                break
+            tui.send_keystroke("<", wait=0.5)
+        assert "sample.tar" in tui.get_screen_dump()[0], _screen_text(tui)
+
+        tui.send_keystroke(Keys.F8, wait=0.5)
+        tui.send_keystroke("k", wait=0.3)
+        assert tui.wait_for_content("Select Volume", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)  # select inactive disk volume
+        tui.send_keystroke("d", wait=0.2)
+        tui.send_keystroke("y", wait=0.8)
+        if tui.wait_for_content("Select Volume", timeout=0.4):
+            tui.send_keystroke(Keys.ESC, wait=0.5)
+
+        lines = tui.get_screen_dump()
+        screen = "\n".join(lines)
+        assert "Path:" in screen, (
+            "Release-volume flow in active archive mode blanked/crashed UI.\n"
+            f"{screen}"
+        )
+        assert screen.count("inside.txt") >= 1, (
+            "Active archive pane content disappeared after releasing inactive disk volume.\n"
+            f"{screen}"
+        )
+        _assert_split_column_continuous(lines, "archive active + inactive release")
     finally:
         tui.quit()

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -2285,5 +2285,19 @@ def test_f8_release_volume_keeps_small_window_and_tab_safe(tmp_path, ytree_binar
             f"{screen}"
         )
         _assert_split_column_continuous(lines, "after split release + tab")
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        lines = tui.get_screen_dump()
+        screen = "\n".join(lines)
+        assert "Path:" in screen, (
+            "Repeated tabbing after split release-volume flow corrupted UI.\n"
+            f"{screen}"
+        )
+        assert screen.count("a_only.txt") + screen.count("b_only.txt") >= 2, (
+            "Repeated tabbing after split release-volume flow left a pane blank.\n"
+            f"{screen}"
+        )
+        _assert_split_column_continuous(lines, "after split release + repeated tab")
     finally:
         tui.quit()


### PR DESCRIPTION
## Summary
- align small-window row text left consistently for files, symlinks, and status rows
- make tree collapse (`Left`/`-`) a node-local state reset (discard ad-hoc deep expansion/tag state)
- ensure re-expand after reset uses configured `TREEDEPTH`
- fix split-mode release-volume redraw/state issues (blank pane / missing separator / tab instability)
- preserve per-volume tree-vs-file focus when cycling volumes
- fix archive root-unlogged `Right` relog path so it does not raise `Permission Denied!`

## Validation (targeted)
- `pytest -q tests/test_archive_exit_ui.py -k "root_left_resets_tree_and_right_relogs_to_profile_depth or fs_root_left_then_right_does_not_restore_deep_state or fs_left_at_root_collapses_once_then_noop"`
- `pytest -q tests/test_archive_exit_ui.py -k "archive_root_unlogged_right_does_not_show_permission_denied or root_left_resets_tree_and_right_relogs_to_profile_depth"`
- `pytest -q tests/test_panel_isolation.py -k "collapse_resets_subtree_expansion_state or collapse_clears_panel_local_tags"`
- `pytest -q tests/test_panel_isolation.py -k "f8_release_volume_keeps_small_window_and_tab_safe or split_separator_stays_continuous_during_file_tree_toggle or split_from_file_immediate_peer_mirror_not_blank"`
- `pytest -q tests/test_panel_isolation.py -k "volume_cycle_does_not_leak_file_focus_between_volumes or f8_release_volume_keeps_small_window_and_tab_safe"`