### PR TITLE
fix(nav): reset collapsed tree nodes before re-expand

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -76,14 +76,14 @@ The behavior of the `Enter` key on a directory node is governed by the configura
 *   **Selection Memory (Breadcrumbs):** When returning from File Mode to Tree Mode and later re-entering the same directory, the panel must restore the cursor to the **last highlighted file**.
 
 ### 3.3 Directory Memory Commands (Structural Controls)
-*   **`+` or `=` (Expand):** Shallow Log. Scans the files of the current directory and the names of immediate subdirectories. `=` is a convenience alias (unshifted `+` on most keyboard layouts).
+*   **`+` or `=` (Expand):** Expand using configured `TREEDEPTH` behavior for the node context. `=` is a convenience alias (unshifted `+` on most keyboard layouts).
 *   **`*` (Asterisk):** Deep Log. Recursively scans the entire branch.
-*   **`-` (Minus / Collapse):** State-based memory release. First press collapses an expanded node. Second press on a collapsed (but logged) node evicts the file list, sets the status indicator to `+`, and marks the directory as Unlogged. At root, use `-` to release logged contents.
+*   **`-` (Minus / Collapse):** Collapsing a directory node is a state reset for that node. When `-` collapses a currently expanded node, that subtree is released/unlogged. Re-expanding starts from normal configured depth behavior instead of restoring prior ad-hoc expansion history.
 
 ### 3.4 Arrow Key Navigation (Spatial Controls)
 Arrow keys provide spatial, cursor-oriented navigation through the tree. They are distinct from the structural `+`/`-`/`*` controls:
 *   **`→` (Right Arrow / Drill Down):** Progressive depth navigation. If the node is collapsed: expand one level. If already expanded: move cursor to the first child.
-*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. At the filesystem root, `Left` is a no-op.
+*   **`←` (Left Arrow):** If the selected directory is expanded, collapse it. Otherwise, move selection to its parent directory. Collapsing with `Left` is a state reset for that node; after reset at filesystem/archive root, further `Left` is a no-op.
 
 ### 3.5 Preview Mode (`F7`) Contract
 `F7` is the primary inspect mode for viewing file contents while retaining list-oriented navigation.
@@ -119,10 +119,10 @@ The `ytree` input system follows a layered model designed for high-speed interac
 | **Prompt Interactions** | Contextual shortcuts active only during text prompts. | Specialized editing and browsing tools. |
 
 ### 4.3 Key Behavioral Rules
-*   **The Minus Rule (`-`):** State-based memory release. First press collapses an expanded node; second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged.
+*   **The Minus Rule (`-`):** Collapsing an expanded node is a node-local state reset: the subtree is released/unlogged, and later expand does not restore prior ad-hoc expansion history.
 *   **The Right Arrow Rule (`→`):** Progressive drill-down. Expand collapsed → move to child. Always takes the user one step deeper into the tree.
-*   **The Root-Left Rule (`←` at root):** No-op. Root content release is handled by `-`, not by `Left`.
-*   **The Plus/Equals Rule (`+`/`=`):** Explicit one-level expand only. No cursor movement. `=` is the unshifted alias for `+`.
+*   **The Root-Left Rule (`←` at root):** `Left` on expanded root performs the same node-local reset (collapse + release/unlog). Further `Left` on already-unlogged root is a no-op.
+*   **The Plus/Equals Rule (`+`/`=`):** Explicit expand using configured `TREEDEPTH`. No cursor movement. `=` is the unshifted alias for `+`.
 *   **The Tree Marker Rule (`+` status):** Unlogged state is rendered only in the dedicated tree status margin column; directory names do not carry a `+` suffix.
 *   **The Volume Menu Rule (`K` menu):** Selecting the already-active volume preserves its current in-memory state (no implicit relog/reload).
 *   **The Explicit Relog Rule (`L` on current path):** Logging an already logged volume/path performs a fresh relog/reload of that volume state and reanchors selection at volume root.

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -724,17 +724,6 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       DirNav_MoveEnd(ctx, &dir_entry, ctx->active);
       break;
     case ACTION_MOVE_RIGHT:
-      if (dir_entry->up_tree == NULL && dir_entry->unlogged_flag) {
-        (void)snprintf(new_log_path, sizeof(new_log_path), "%s",
-                       s->log_path);
-        if (LogDisk(ctx, ctx->active, new_log_path) == 0) {
-          s = &ctx->active->vol->vol_stats;
-          dir_entry = ResolveActiveDirEntry(ctx, s);
-          need_dsp_help = TRUE;
-        }
-        break;
-      }
-
       if (!dir_entry->not_scanned && dir_entry->sub_tree != NULL) {
         if (DirOps_SelectVisibleDirAndRefresh(ctx, ctx->active,
                                               dir_entry->sub_tree,
@@ -759,7 +748,13 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       break;
     case ACTION_MOVE_LEFT:
       if (dir_entry->up_tree == NULL) {
-        /* Root boundary: left is a no-op. Use '-' to release root contents. */
+        if (!dir_entry->not_scanned && dir_entry->sub_tree != NULL) {
+          HandleCollapseSubTree(ctx, dir_entry, &need_dsp_help, ctx->active);
+        } else if (!dir_entry->unlogged_flag) {
+          HandleUnreadSubTree(ctx, dir_entry, de_ptr, &need_dsp_help,
+                              ctx->active);
+        }
+        /* At root, LEFT collapse is a state reset; once reset, LEFT is no-op. */
         break;
       }
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -128,7 +128,7 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
       s->log_mode != ARCHIVE_MODE) {
     return;
   }
-  if (!dir_entry->not_scanned)
+  if (!dir_entry || !dir_entry->not_scanned)
     return;
 
   CaptureInactiveFallback(ctx, p, NULL, &inactive, &inactive_target);
@@ -153,9 +153,16 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
   }
 
   {
+    int read_depth = 1;
+
     SuspendClock(ctx); /* Suspend clock before scanning */
     GetPath(dir_entry, new_log_path);
-    ReadTree(ctx, dir_entry, new_log_path, 1, s, Dir_Progress, NULL);
+    if (dir_entry->unlogged_flag) {
+      read_depth = strtol(TREEDEPTH, NULL, 0);
+      if (read_depth < 0)
+        read_depth = 0;
+    }
+    ReadTree(ctx, dir_entry, new_log_path, read_depth, s, Dir_Progress, NULL);
     ApplyFilter(dir_entry, s);
     InitClock(ctx); /* Resume clock after scanning */
 
@@ -546,9 +553,11 @@ static void CaptureInactiveFallback(ViewContext *ctx, YtreePanel *p,
 
 void HandleCollapseSubTree(ViewContext *ctx, DirEntry *dir_entry,
                            BOOL *need_dsp_help, YtreePanel *p) {
-  const Statistic *s = &p->vol->vol_stats;
+  Statistic *s = &p->vol->vol_stats;
   YtreePanel *inactive = NULL;
   DirEntry *inactive_fallback = NULL;
+  DirEntry *de_ptr;
+  FileEntry *fe_ptr, *next_fe_ptr;
 
   if (!dir_entry || dir_entry->not_scanned || dir_entry->sub_tree == NULL)
     return;
@@ -559,8 +568,16 @@ void HandleCollapseSubTree(ViewContext *ctx, DirEntry *dir_entry,
   if (ctx->right && ctx->right->vol == p->vol)
     PanelTags_PruneUnderDir(ctx->right, dir_entry);
 
+  for (de_ptr = dir_entry->sub_tree; de_ptr; de_ptr = de_ptr->next) {
+    UnReadTree(ctx, de_ptr, s);
+  }
+  for (fe_ptr = dir_entry->file; fe_ptr; fe_ptr = next_fe_ptr) {
+    next_fe_ptr = fe_ptr->next;
+    RemoveFile(ctx, fe_ptr, s);
+  }
+
   dir_entry->not_scanned = TRUE;
-  dir_entry->unlogged_flag = FALSE;
+  dir_entry->unlogged_flag = TRUE;
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
 
@@ -573,6 +590,7 @@ void HandleCollapseSubTree(ViewContext *ctx, DirEntry *dir_entry,
               p->disp_begin_pos + p->cursor_pos, TRUE);
   DisplayFileWindow(ctx, p, dir_entry);
   DisplayAvailBytes(ctx, s);
+  RecalculateSysStats(ctx, s);
   DisplayDiskStatistic(ctx, s);
   UpdateStatsPanel(ctx, dir_entry, s);
   *need_dsp_help = TRUE;

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -10,8 +10,7 @@ from ytree_keys import Keys
 
 
 def _send_left_arrow(tui, wait=0.4):
-    # Use CSI-left to assert ACTION_MOVE_LEFT behavior explicitly.
-    tui.send_keystroke("\033[D", wait=wait)
+    tui.send_keystroke(Keys.LEFT, wait=wait)
 
 
 def _create_archive(root, archive_name="sample.tar"):
@@ -61,8 +60,8 @@ def _assert_margin_plus_marker(screen_rows, dir_name, expect_slash=False):
         )
 
 
-def test_archive_left_at_root_does_not_exit_archive(tmp_path, ytree_binary):
-    """LEFT is collapse-only and must not exit archive mode at archive root."""
+def test_archive_left_at_root_collapses_once_then_noop(tmp_path, ytree_binary):
+    """At archive root: first LEFT collapses children, second LEFT is a no-op."""
     root = tmp_path / "archive_exit_root"
     root.mkdir()
 
@@ -79,17 +78,35 @@ def test_archive_left_at_root_does_not_exit_archive(tmp_path, ytree_binary):
     tui.send_keystroke(Keys.ENTER, wait=0.9)
     assert tui.wait_for_content("ARCHIVE", timeout=3.0), _screen_text(tui)
 
-    # LEFT at archive root must not exit archive mode.
+    before_left = "\n".join(tui.get_screen_dump())
+    assert "nested" in before_left, (
+        "Precondition failed: archive root should show nested child row before LEFT.\n"
+        f"Screen:\n{before_left}"
+    )
+
+    # First LEFT at archive root collapses one level but does not exit archive mode.
     _send_left_arrow(tui, wait=0.8)
 
-    screen = "\n".join(tui.get_screen_dump())
-    assert "ARCHIVE" in screen, (
-        "LEFT at archive root must not exit archive mode.\n"
-        f"Screen:\n{screen}"
+    after_first_left = "\n".join(tui.get_screen_dump())
+    assert "ARCHIVE" in after_first_left, (
+        "First LEFT at archive root must not exit archive mode.\n"
+        f"Screen:\n{after_first_left}"
     )
-    assert "inside_dir" in screen, (
-        "LEFT at archive root should keep archive tree visible.\n"
-        f"Screen:\n{screen}"
+    assert "nested" not in after_first_left, (
+        "First LEFT at archive root should collapse child rows.\n"
+        f"Screen:\n{after_first_left}"
+    )
+
+    # Second LEFT at already-collapsed archive root is a no-op.
+    _send_left_arrow(tui, wait=0.8)
+    after_second_left = "\n".join(tui.get_screen_dump())
+    assert "ARCHIVE" in after_second_left, (
+        "Second LEFT at collapsed archive root must stay in archive mode.\n"
+        f"Screen:\n{after_second_left}"
+    )
+    assert "nested" not in after_second_left, (
+        "Second LEFT at collapsed archive root should remain collapsed.\n"
+        f"Screen:\n{after_second_left}"
     )
 
     tui.quit()
@@ -156,6 +173,86 @@ def test_archive_left_non_root_does_not_exit_immediately(tmp_path, ytree_binary)
     )
 
     tui.quit()
+
+
+def test_fs_left_at_root_collapses_once_then_noop(tmp_path, ytree_binary):
+    root = tmp_path / "fs_left_root_collapse_once"
+    root.mkdir()
+    (root / "child_a").mkdir()
+    (root / "child_b").mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        before_left = "\n".join(tui.get_screen_dump())
+        assert "child_a" in before_left or "child_b" in before_left, (
+            "Precondition failed: filesystem root should show child rows before LEFT.\n"
+            f"Screen:\n{before_left}"
+        )
+
+        _send_left_arrow(tui, wait=0.6)
+        after_first_left = "\n".join(tui.get_screen_dump())
+        assert "child_a" not in after_first_left and "child_b" not in after_first_left, (
+            "First LEFT at filesystem root should collapse child rows.\n"
+            f"Screen:\n{after_first_left}"
+        )
+
+        _send_left_arrow(tui, wait=0.6)
+        after_second_left = "\n".join(tui.get_screen_dump())
+        assert "child_a" not in after_second_left and "child_b" not in after_second_left, (
+            "Second LEFT at collapsed filesystem root should keep children collapsed.\n"
+            f"Screen:\n{after_second_left}"
+        )
+        assert "Unlogged" in after_second_left, (
+            "Second LEFT at collapsed filesystem root should keep root unlogged.\n"
+            f"Screen:\n{after_second_left}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_fs_root_left_then_right_does_not_restore_deep_state(tmp_path, ytree_binary):
+    root = tmp_path / "fs_root_left_right_reset"
+    root.mkdir()
+    (root / "alpha" / "child" / "grand").mkdir(parents=True)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # alpha
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # expand alpha
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # child
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # expand child
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # grand
+
+        before_reset = "\n".join(tui.get_screen_dump())
+        assert "grand" in before_reset, (
+            "Precondition failed: expected deep expansion before reset.\n"
+            f"Screen:\n{before_reset}"
+        )
+
+        tui.send_keystroke(Keys.UP, wait=0.2)
+        tui.send_keystroke(Keys.UP, wait=0.2)
+        tui.send_keystroke(Keys.UP, wait=0.2)     # root
+        _send_left_arrow(tui, wait=0.6)           # reset root
+        tui.send_keystroke(Keys.RIGHT, wait=0.6)  # expand root again
+
+        after_lines = tui.get_screen_dump()
+        after_reexpand = "\n".join(after_lines)
+        tree_and_footer = "\n".join(after_lines[1:])
+        assert "alpha" in after_reexpand, (
+            "Root re-expand should show immediate child directories.\n"
+            f"Screen:\n{after_reexpand}"
+        )
+        assert " mqchild" not in tree_and_footer and " mqgrand" not in tree_and_footer, (
+            "Root LEFT reset must discard prior ad-hoc deep expansion; RIGHT must"
+            " not restore it.\n"
+            f"Screen:\n{after_reexpand}"
+        )
+    finally:
+        tui.quit()
 
 
 def test_archive_root_backslash_exits_to_parent_file_focus(tmp_path, ytree_binary):
@@ -452,7 +549,7 @@ def test_enter_on_placeholder_dir_logs_and_reveals_first_level_only(
         tui.quit()
 
 
-def test_root_minus_resets_tree_and_right_relogs_to_profile_depth(
+def test_root_left_resets_tree_and_right_relogs_to_profile_depth(
     tmp_path, ytree_binary
 ):
     root = tmp_path / "root_minus_right_profile_depth"
@@ -485,34 +582,23 @@ def test_root_minus_resets_tree_and_right_relogs_to_profile_depth(
                 break
             tui.send_keystroke(Keys.LEFT, wait=0.3)
 
-        before_rows = tui.get_screen_dump()
-        at_root_before = "\n".join(before_rows)
+        at_root_before = _screen_text(tui)
         assert str(root) in tui.get_screen_dump()[0], (
-            "Precondition failed: expected selection at root before root-left "
-            "no-op assertion.\n"
+            "Precondition failed: expected selection at root before root-left reset.\n"
             f"{at_root_before}"
         )
 
-        tui.send_keystroke(Keys.LEFT, wait=0.5)
-        after_rows = tui.get_screen_dump()
-        at_root_after = "\n".join(after_rows)
-        assert "\n".join(after_rows[1:]) == "\n".join(before_rows[1:]), (
-            "Left at root should be a no-op; use '-' to release root contents.\n"
-            f"Before:\n{at_root_before}\n\nAfter:\n{at_root_after}"
-        )
-
-        tui.send_keystroke("-", wait=0.7)
-        tui.send_keystroke("-", wait=0.7)
-        after_minus = _screen_text(tui)
-        assert "deeper" not in after_minus, (
-            "Root '-' release should clear expanded descendant state.\n"
-            f"{after_minus}"
+        tui.send_keystroke(Keys.LEFT, wait=0.7)
+        after_left = _screen_text(tui)
+        assert "deeper" not in after_left, (
+            "Left collapse at root should reset/release expanded descendant state.\n"
+            f"{after_left}"
         )
 
         tui.send_keystroke(Keys.RIGHT, wait=0.9)
         after_right = _screen_text(tui)
         assert "src/" in after_right, (
-            "Right on reset root should relog to configured depth and show "
+            "Right on reset root should relog to configured TREEDEPTH and show "
             "first-level directory placeholders.\n"
             f"{after_right}"
         )

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -335,6 +335,56 @@ def test_left_arrow_collapse_clears_panel_local_tags(tmp_path, ytree_binary):
     )
 
 
+def _assert_collapse_resets_subtree_expansion(tmp_path, ytree_binary, key):
+    root = tmp_path / f"collapse_reset_subtree_{ord(key[0])}"
+    root.mkdir()
+    alpha = root / "alpha"
+    (alpha / "child" / "grand" / "great").mkdir(parents=True)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # alpha
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # show child
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # child
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # show grand
+        tui.send_keystroke(Keys.DOWN, wait=0.2)   # grand
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # show great
+
+        before = _screen_text(tui)
+        assert "great" in before, (
+            "Precondition failed: deep expansion should reveal great.\n"
+            f"{before}"
+        )
+
+        tui.send_keystroke(Keys.UP, wait=0.2)     # child
+        tui.send_keystroke(Keys.UP, wait=0.2)     # alpha
+        tui.send_keystroke(key, wait=0.4)         # collapse/reset alpha
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)  # re-expand alpha
+
+        after = _screen_text(tui)
+        assert "child" in after, (
+            "Re-expand should restore immediate child visibility.\n"
+            f"{after}"
+        )
+        assert "grand" not in after and "great" not in after, (
+            "Collapse with Left or '-' must reset subtree expansion state for"
+            " that node.\n"
+            f"{after}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_minus_collapse_resets_subtree_expansion_state(tmp_path, ytree_binary):
+    _assert_collapse_resets_subtree_expansion(tmp_path, ytree_binary, "-")
+
+
+def test_left_collapse_resets_subtree_expansion_state(tmp_path, ytree_binary):
+    _assert_collapse_resets_subtree_expansion(tmp_path, ytree_binary, Keys.LEFT)
+
+
 def test_split_from_dir_immediately_renders_peer_panel(tmp_path, ytree_binary):
     root = tmp_path / "split_dir_immediate_render"
     root.mkdir()


### PR DESCRIPTION
## Summary
- make Left/Minus collapse act as a node-local state reset (release/unlog)
- re-expand from configured TREEDEPTH rather than restoring prior ad-hoc deep expansion
- update spec text and regression tests for root-left and collapse-reset behavior

## Validation
- source .venv/bin/activate
- pytest tests/test_archive_exit_ui.py::test_archive_left_at_root_collapses_once_then_noop tests/test_archive_exit_ui.py::test_root_left_resets_tree_and_right_relogs_to_profile_depth tests/test_panel_isolation.py::test_minus_collapse_resets_subtree_expansion_state tests/test_panel_isolation.py::test_left_collapse_resets_subtree_expansion_state