### PR TITLE
fix(split): keep both panes stable after release-volume

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1508,7 +1508,7 @@ HandleDirWindowVolumeAction(ViewContext *ctx, YtreeAction action,
     *dir_entry_ptr = (*s_ptr)->tree;
   }
 
-  RefreshVolumeSwitchViews(ctx, *dir_entry_ptr, *s_ptr);
+  RefreshView(ctx, *dir_entry_ptr);
   *need_dsp_help_ptr = TRUE;
   return DIR_WINDOW_DISPATCH_HANDLED;
 }

--- a/src/ui/volume_menu.c
+++ b/src/ui/volume_menu.c
@@ -9,6 +9,67 @@
 #include "ytree_fs.h"
 #include "ytree_ui.h"
 
+static void NormalizePanelCursorForVolume(YtreePanel *panel) {
+  if (!panel || !panel->vol) {
+    return;
+  }
+
+  if (panel->vol->total_dirs <= 0) {
+    panel->disp_begin_pos = 0;
+    panel->cursor_pos = 0;
+    panel->file_dir_entry = NULL;
+    return;
+  }
+
+  if (panel->disp_begin_pos < 0)
+    panel->disp_begin_pos = 0;
+  if (panel->cursor_pos < 0)
+    panel->cursor_pos = 0;
+  if (panel->disp_begin_pos >= panel->vol->total_dirs)
+    panel->disp_begin_pos = panel->vol->total_dirs - 1;
+  if (panel->disp_begin_pos + panel->cursor_pos >= panel->vol->total_dirs)
+    panel->cursor_pos = panel->vol->total_dirs - 1 - panel->disp_begin_pos;
+  if (panel->cursor_pos < 0)
+    panel->cursor_pos = 0;
+}
+
+static void EnsurePanelsReferenceActiveVolume(ViewContext *ctx) {
+  int idx;
+
+  if (!ctx || !ctx->active || !ctx->active->vol)
+    return;
+
+  if (ctx->left && ctx->left->vol == NULL)
+    ctx->left->vol = ctx->active->vol;
+  if (ctx->right && ctx->right->vol == NULL)
+    ctx->right->vol = ctx->active->vol;
+
+  if (!ctx->is_split_screen)
+    return;
+
+  if (ctx->left && ctx->left->vol == ctx->active->vol) {
+    BuildDirEntryList(ctx, ctx->left->vol, &ctx->left->current_dir_entry);
+    NormalizePanelCursorForVolume(ctx->left);
+    idx = ctx->left->disp_begin_pos + ctx->left->cursor_pos;
+    if (ctx->left->vol->total_dirs > 0) {
+      ctx->left->file_dir_entry = ctx->left->vol->dir_entry_list[idx].dir_entry;
+      BuildFileEntryList(ctx, ctx->left);
+    }
+  }
+
+  if (ctx->right && ctx->right->vol == ctx->active->vol) {
+    BuildDirEntryList(ctx, ctx->right->vol, &ctx->right->current_dir_entry);
+    NormalizePanelCursorForVolume(ctx->right);
+    idx = ctx->right->disp_begin_pos + ctx->right->cursor_pos;
+    if (ctx->right->vol->total_dirs > 0) {
+      ctx->right->file_dir_entry = ctx->right->vol->dir_entry_list[idx].dir_entry;
+      BuildFileEntryList(ctx, ctx->right);
+    }
+  }
+
+  SyncActivePanelWindows(ctx);
+}
+
 /*
  * SelectLoadedVolume
  * Displays a list of currently loaded volumes and allows the user to switch
@@ -388,6 +449,7 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
       if (target_vol != ctx->active->vol) {
         int login_result =
             LogDisk(ctx, ctx->active, target_vol->vol_stats.log_path);
+        EnsurePanelsReferenceActiveVolume(ctx);
         free(vol_array);
         return login_result;
       }
@@ -398,6 +460,7 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
         int dummy;
         BuildDirEntryList(ctx, ctx->active->vol, &dummy);
       }
+      EnsurePanelsReferenceActiveVolume(ctx);
       return 0;
     }
   }
@@ -411,6 +474,7 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
       int dummy;
       BuildDirEntryList(ctx, ctx->active->vol, &dummy);
     }
+    EnsurePanelsReferenceActiveVolume(ctx);
     return 0;
   }
 

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -1,5 +1,6 @@
 import pytest
 import shlex
+import tarfile
 import time
 import re
 from helpers_files import wait_for_file as _wait_for_file
@@ -2181,3 +2182,130 @@ def test_volume_menu_cancel_restores_file_footer_immediately(tmp_path, ytree_bin
     )
 
     tui.quit()
+
+
+def test_f8_release_volume_keeps_small_window_and_tab_safe(tmp_path, ytree_binary):
+    vol_a = tmp_path / "bug41_vol_a"
+    vol_b = tmp_path / "bug41_vol_b"
+    vol_a.mkdir()
+    vol_b.mkdir()
+    (vol_a / "a_only.txt").write_text("a\n", encoding="utf-8")
+    (vol_b / "b_only.txt").write_text("b\n", encoding="utf-8")
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(vol_a),
+        args=[str(vol_b)],
+    )
+    time.sleep(1.0)
+
+    try:
+        tui.send_keystroke(Keys.F8, wait=0.5)
+
+        # Open loaded-volume menu and release selected volume.
+        tui.send_keystroke("k", wait=0.4)
+        assert tui.wait_for_content("Select Volume", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("d", wait=0.3)
+        tui.send_keystroke("y", wait=0.8)
+        if tui.wait_for_content("Select Volume", timeout=0.4):
+            tui.send_keystroke(Keys.ESC, wait=0.5)
+
+        lines = tui.get_screen_dump()
+        screen = "\n".join(lines)
+        assert "Path:" in screen, (
+            "UI header vanished after releasing a volume in split mode.\n"
+            f"{screen}"
+        )
+        assert screen.count("a_only.txt") + screen.count("b_only.txt") >= 2, (
+            "Small/file windows were not rendered in both split panes after "
+            "release-volume flow.\n"
+            f"{screen}"
+        )
+        _assert_split_column_continuous(lines, "after split release-volume flow")
+
+        # Regression: Tab after release must not blank/crash.
+        tui.send_keystroke(Keys.TAB, wait=0.6)
+        lines = tui.get_screen_dump()
+        screen = "\n".join(lines)
+        assert "Path:" in screen, (
+            "Tab after split release-volume flow blanked/crashed UI.\n"
+            f"{screen}"
+        )
+        assert screen.count("a_only.txt") + screen.count("b_only.txt") >= 2, (
+            "Tab after release-volume flow left one split pane blank.\n"
+            f"{screen}"
+        )
+        _assert_split_column_continuous(lines, "after split release + tab")
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        lines = tui.get_screen_dump()
+        screen = "\n".join(lines)
+        assert "Path:" in screen, (
+            "Repeated tabbing after split release-volume flow corrupted UI.\n"
+            f"{screen}"
+        )
+        assert screen.count("a_only.txt") + screen.count("b_only.txt") >= 2, (
+            "Repeated tabbing after split release-volume flow left a pane blank.\n"
+            f"{screen}"
+        )
+        _assert_split_column_continuous(lines, "after split release + repeated tab")
+    finally:
+        tui.quit()
+
+
+def test_f8_release_inactive_disk_volume_while_active_archive_keeps_split_stable(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "bug41_archive_release_inactive"
+    root.mkdir()
+    disk_vol = root / "disk_vol"
+    disk_vol.mkdir()
+    (disk_vol / "disk_only.txt").write_text("disk\n", encoding="utf-8")
+
+    archive_src = root / "_archive_src"
+    archive_src.mkdir()
+    (archive_src / "inside.txt").write_text("inside\n", encoding="utf-8")
+    (archive_src / "nested").mkdir()
+    (archive_src / "nested" / "deep.txt").write_text("deep\n", encoding="utf-8")
+    archive_path = root / "sample.tar"
+    with tarfile.open(archive_path, "w") as tf:
+        tf.add(archive_src, arcname="inside_dir")
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(disk_vol),
+        args=[str(archive_path)],
+    )
+    time.sleep(1.0)
+
+    try:
+        # Move active context to archive volume first.
+        for _ in range(6):
+            if "sample.tar" in tui.get_screen_dump()[0]:
+                break
+            tui.send_keystroke("<", wait=0.5)
+        assert "sample.tar" in tui.get_screen_dump()[0], _screen_text(tui)
+
+        tui.send_keystroke(Keys.F8, wait=0.5)
+        tui.send_keystroke("k", wait=0.3)
+        assert tui.wait_for_content("Select Volume", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)  # select inactive disk volume
+        tui.send_keystroke("d", wait=0.2)
+        tui.send_keystroke("y", wait=0.8)
+        if tui.wait_for_content("Select Volume", timeout=0.4):
+            tui.send_keystroke(Keys.ESC, wait=0.5)
+
+        lines = tui.get_screen_dump()
+        screen = "\n".join(lines)
+        assert "Path:" in screen, (
+            "Release-volume flow in active archive mode blanked/crashed UI.\n"
+            f"{screen}"
+        )
+        assert screen.count("inside.txt") >= 1, (
+            "Active archive pane content disappeared after releasing inactive disk volume.\n"
+            f"{screen}"
+        )
+        _assert_split_column_continuous(lines, "archive active + inactive release")
+    finally:
+        tui.quit()


### PR DESCRIPTION
## Summary
- keep split-pane references/cursors stable during release-volume flows
- refresh both panes after release so header, separator, and small windows stay intact
- add regressions for tabbing after release and releasing inactive disk volume while archive pane is active

## Validation
- source .venv/bin/activate
- pytest tests/test_panel_isolation.py::test_f8_release_volume_keeps_small_window_and_tab_safe tests/test_panel_isolation.py::test_f8_release_inactive_disk_volume_while_active_archive_keeps_split_stable