### PR TITLE
fix(nav): keep per-volume focus mode when cycling volumes

### DIFF
--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -653,6 +653,7 @@ typedef struct {
 struct Volume {
   int id;
   int saved_tree_index;
+  int saved_focus;
   Statistic vol_stats;
   Statistic vol_disk_stats;
   DirEntryList *dir_entry_list;

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -116,6 +116,10 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
   if (ctx->hook_suspend_clock)
     ctx->hook_suspend_clock(ctx); /* Suspend clock during critical operations */
 
+  if (panel->vol != NULL) {
+    panel->vol->saved_focus = panel->saved_focus;
+  }
+
   /* Keep per-volume tree selection before switching away. */
   SavePanelTreeSelection(panel);
 
@@ -177,6 +181,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
       } else {
         panel->vol = found_vol;
         s = &panel->vol->vol_stats;
+        panel->saved_focus = panel->vol->saved_focus;
         ctx->global_search_term[0] = '\0';
         ctx->view_mode = panel->vol->vol_stats.log_mode;
 
@@ -320,6 +325,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
   /* Success */
   panel->vol = loaded_vol;
   s = &panel->vol->vol_stats;
+  panel->saved_focus = panel->vol->saved_focus;
   ctx->global_search_term[0] = '\0';
   ctx->view_mode = s->log_mode;
 

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -102,6 +102,7 @@ struct Volume *Volume_Create(ViewContext *ctx) {
   /* Assign a unique ID and increment the serial counter */
   new_vol->id = ctx->volume_serial++;
   new_vol->saved_tree_index = 0;
+  new_vol->saved_focus = FOCUS_TREE;
 
   /* Add the new volume to the global hash table (ctx->volumes_head)
    * The 'id' field of the Volume struct is used as the key. */

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -489,6 +489,52 @@ def test_split_mirror_stays_on_active_volume_after_volume_cycle(tmp_path, ytree_
     tui.quit()
 
 
+def test_volume_cycle_does_not_leak_file_focus_between_volumes(tmp_path, ytree_binary):
+    vol_a = tmp_path / "bug40_vol_a"
+    vol_b = tmp_path / "bug40_vol_b"
+    vol_a.mkdir()
+    vol_b.mkdir()
+    (vol_a / "a0.txt").write_text("a0\n", encoding="utf-8")
+    (vol_b / "b0.txt").write_text("b0\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(vol_a))
+    time.sleep(0.9)
+
+    try:
+        _assert_dir_mode_footer(tui, "Precondition failed: expected tree mode.")
+        assert "bug40_vol_a" in tui.get_screen_dump()[0], _screen_text(tui)
+
+        # Log second volume so cycling has two loaded targets.
+        tui.send_keystroke(Keys.LOG, wait=0.2)
+        tui.send_keystroke(Keys.CTRL_U + str(vol_b) + Keys.ENTER, wait=0.9)
+        assert "bug40_vol_b" in tui.get_screen_dump()[0], _screen_text(tui)
+        _assert_dir_mode_footer(tui, "Expected tree mode after logging volume B.")
+
+        # Return to volume A in tree mode.
+        tui.send_keystroke("<", wait=0.6)
+        assert "bug40_vol_a" in tui.get_screen_dump()[0], _screen_text(tui)
+        _assert_dir_mode_footer(tui, "Expected tree mode after cycling back to A.")
+
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke("<", wait=0.8)
+        screen = _screen_text(tui)
+        footer = _footer_text(tui)
+
+        assert "bug40_vol_b" in tui.get_screen_dump()[0], (
+            "Volume cycle did not switch to target volume.\n"
+            f"{screen}"
+        )
+        assert "hex invert j compare" not in footer and "j tree" in footer, (
+            "Cycling volumes must not leak file-mode focus from one volume to "
+            "another.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{screen}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_inactive_dir_focus_survives_tab_away_and_back(tmp_path, ytree_binary):
     root = tmp_path / "inactive_dir_focus_survives_tab"
     root.mkdir()


### PR DESCRIPTION
## Summary
- persist panel focus mode per volume instead of leaking file-mode focus across volume cycles
- restore saved focus when switching to an already-loaded volume
- add regression coverage for cycling between two logged volumes where only one side entered file mode

## Validation
- source .venv/bin/activate
- pytest tests/test_panel_isolation.py::test_volume_cycle_does_not_leak_file_focus_between_volumes