### PR TITLE
fix(archive): relog unlogged archive root on Right

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -128,6 +128,22 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
       s->log_mode != ARCHIVE_MODE) {
     return;
   }
+  if (dir_entry && dir_entry->up_tree == NULL && dir_entry->unlogged_flag &&
+      s->log_mode == ARCHIVE_MODE) {
+    if (new_log_path) {
+      (void)snprintf(new_log_path, PATH_LENGTH + 1, "%s", s->log_path);
+      new_log_path[PATH_LENGTH] = '\0';
+      if (LogDisk(ctx, p, new_log_path) == 0) {
+        DirEntry *refreshed_dir = GetPanelDirEntry(p);
+        if (!refreshed_dir && p->vol)
+          refreshed_dir = p->vol->vol_stats.tree;
+        if (refreshed_dir)
+          RefreshView(ctx, refreshed_dir);
+        *need_dsp_help = TRUE;
+      }
+    }
+    return;
+  }
   if (!dir_entry || !dir_entry->not_scanned)
     return;
 

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -255,6 +255,39 @@ def test_fs_root_left_then_right_does_not_restore_deep_state(tmp_path, ytree_bin
         tui.quit()
 
 
+def test_archive_root_unlogged_right_does_not_show_permission_denied(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "archive_root_unlogged_right"
+    root.mkdir()
+    _create_archive(root, "roundtrip.tar")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        tui.send_keystroke(Keys.LOG, wait=0.3)
+        tui.send_keystroke(Keys.ENTER, wait=0.9)
+        assert tui.wait_for_content("ARCHIVE", timeout=3.0), _screen_text(tui)
+
+        _send_left_arrow(tui, wait=0.8)  # reset/unlog archive root
+        tui.send_keystroke(Keys.RIGHT, wait=0.9)
+
+        after = _screen_text(tui)
+        assert "Permission Denied" not in after, (
+            "Right at unlogged archive root should relog archive context, not "
+            "raise a filesystem permission error.\n"
+            f"{after}"
+        )
+        assert "ARCHIVE" in after, (
+            "Right at unlogged archive root should remain in archive mode.\n"
+            f"{after}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_archive_root_backslash_exits_to_parent_file_focus(tmp_path, ytree_binary):
     root = tmp_path / "a_bs"
     root.mkdir()


### PR DESCRIPTION
## Summary
- when archive root is unlogged after collapse/reset, Right now relogs archive context instead of falling into a permission error path
- guard HandlePlus null-path handling to satisfy cppcheck null-deref checks
- add regression for Right at unlogged archive root

## Validation
- source .venv/bin/activate
- pytest tests/test_archive_exit_ui.py::test_archive_root_unlogged_right_does_not_show_permission_denied
- source .venv/bin/activate && make qa-cppcheck