### PR TITLE
fix(security): remove race-prone file checks and harden pipe execution

### DIFF
--- a/.github/workflows/nightly-deep-valgrind.yml
+++ b/.github/workflows/nightly-deep-valgrind.yml
@@ -3,6 +3,9 @@ name: C/C++ Nightly Deep Valgrind
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-deep-valgrind-${{ github.ref }}
   cancel-in-progress: true

--- a/src/cmd/copy.c
+++ b/src/cmd/copy.c
@@ -479,12 +479,10 @@ int CopyFile(ViewContext *ctx, Statistic *statistic_ptr, FileEntry *fe_ptr,
           target_tree ? target_stats : &ctx->active->vol->vol_stats, choice_cb);
     }
   } else {
-    /* use access */
-    /*------------*/
+    int existing_fd = open(to_path, O_RDONLY);
+    if (existing_fd >= 0) {
+      close(existing_fd);
 
-    if (!access(to_path, F_OK)) {
-      /* file exists */
-      /*-------------*/
       if (!(overwrite_mode && *overwrite_mode == CONFLICT_ALL) && cb) {
         conflict_res = cb(ctx, from_path, to_path, overwrite_mode);
         if (conflict_res == CONFLICT_ABORT) {
@@ -502,6 +500,8 @@ int CopyFile(ViewContext *ctx, Statistic *statistic_ptr, FileEntry *fe_ptr,
         /* MESSAGE( "Can't unlink*\"%s\"*%s", to_path, strerror(errno) ); */
         ESCAPE;
       }
+    } else if (errno != ENOENT) {
+      ESCAPE;
     }
   }
 

--- a/src/cmd/edit.c
+++ b/src/cmd/edit.c
@@ -16,6 +16,7 @@
 
 int Edit(ViewContext *ctx, DirEntry *dir_entry, char *file_path) {
   char *command_line;
+  const char *editor_command;
   int result = -1;
   char *file_p_aux = NULL;
   char path[PATH_LENGTH + 1];
@@ -45,9 +46,10 @@ int Edit(ViewContext *ctx, DirEntry *dir_entry, char *file_path) {
     free(file_p_aux);
     goto FNC_XIT;
   }
+  editor_command = GetProfileValue(ctx, "EDITOR");
   {
     int written = snprintf(command_line, COMMAND_LINE_LENGTH, "%s %s",
-                           (GetProfileValue)(ctx, "EDITOR"), file_p_aux);
+                           editor_command, file_p_aux);
     if (written < 0 || written >= COMMAND_LINE_LENGTH) {
       UI_Message(ctx, "Edit not possible!*\"%s\"*command line too long",
                  file_path);

--- a/src/cmd/mkfile.c
+++ b/src/cmd/mkfile.c
@@ -18,7 +18,6 @@ int MakeFile(ViewContext *ctx, DirEntry *dir_entry, const char *name,
   char parent_path[PATH_LENGTH + 1];
   char buffer[PATH_LENGTH + 1];
   int result = -1;
-  struct stat stat_struct;
 
   DEBUG_LOG("ENTER MakeFile: file_name=%s", name);
 
@@ -38,15 +37,17 @@ int MakeFile(ViewContext *ctx, DirEntry *dir_entry, const char *name,
 
   DEBUG_LOG("MakeFile: path=%s", buffer);
 
-  if (stat(buffer, &stat_struct) == 0) {
-    DEBUG_LOG("MakeFile: File already exists!");
-    result = 1;
-  } else {
+  {
     int fd;
     fd = open(buffer, O_CREAT | O_EXCL | O_WRONLY, 0644);
     if (fd == -1) {
-      DEBUG_LOG("MakeFile: open failed, errno=%d (%s)", errno, strerror(errno));
-      result = -1;
+      if (errno == EEXIST) {
+        DEBUG_LOG("MakeFile: File already exists!");
+        result = 1;
+      } else {
+        DEBUG_LOG("MakeFile: open failed, errno=%d (%s)", errno, strerror(errno));
+        result = -1;
+      }
     } else {
       DEBUG_LOG("MakeFile: successfully created file");
       close(fd);

--- a/src/cmd/move.c
+++ b/src/cmd/move.c
@@ -180,12 +180,10 @@ int MoveFile(ViewContext *ctx, FileEntry *fe_ptr, const char *to_file,
           target_stats_ptr ? target_stats_ptr : s, choice_cb);
     }
   } else {
-    /* use access */
-    /*------------*/
+    int existing_fd = open(to_path, O_RDONLY);
+    if (existing_fd >= 0) {
+      close(existing_fd);
 
-    if (!access(to_path, F_OK)) {
-      /* file exists */
-      /*-------------*/
       if (!(overwrite_mode && *overwrite_mode == CONFLICT_ALL) && cb) {
         conflict_res = cb(ctx, from_path, to_path, overwrite_mode);
         if (conflict_res == CONFLICT_ABORT) {
@@ -202,6 +200,8 @@ int MoveFile(ViewContext *ctx, FileEntry *fe_ptr, const char *to_file,
         /* MESSAGE( "Can't unlink*\"%s\"*%s", to_path, strerror(errno) ); */
         ESCAPE;
       }
+    } else if (errno != ENOENT) {
+      ESCAPE;
     }
   }
 

--- a/src/cmd/pipe.c
+++ b/src/cmd/pipe.c
@@ -7,16 +7,171 @@
 
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
+
+#define PIPE_ARGV_MAX 64
+
+static int ParsePipeCommand(char *command_line, char **argv, size_t argv_len) {
+  size_t argc = 0;
+  char *p = command_line;
+
+  if (!command_line || !argv || argv_len < 2) {
+    return -1;
+  }
+
+  while (*p) {
+    while (*p == ' ' || *p == '\t') {
+      p++;
+    }
+    if (!*p) {
+      break;
+    }
+    if (argc + 1 >= argv_len) {
+      return -1;
+    }
+    argv[argc++] = p;
+    while (*p && *p != ' ' && *p != '\t') {
+      p++;
+    }
+    if (*p) {
+      *p = '\0';
+      p++;
+    }
+  }
+
+  if (argc == 0) {
+    return -1;
+  }
+
+  argv[argc] = NULL;
+  return 0;
+}
+
+static int OpenPipeWriter(const char *pipe_command, FILE **pipe_fp_out,
+                          pid_t *child_pid_out) {
+  int pipefd[2];
+  int copied_len;
+  FILE *pipe_fp;
+  pid_t child_pid;
+  size_t argc;
+  size_t i;
+  char command_line[PATH_LENGTH + 1];
+  char *argv[PIPE_ARGV_MAX];
+  char *redirect_path = NULL;
+  BOOL redirect_append = FALSE;
+
+  if (!pipe_command || !pipe_fp_out || !child_pid_out) {
+    return -1;
+  }
+
+  copied_len = snprintf(command_line, sizeof(command_line), "%s", pipe_command);
+  if (copied_len < 0 || (size_t)copied_len >= sizeof(command_line)) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (ParsePipeCommand(command_line, argv, PIPE_ARGV_MAX) != 0) {
+    errno = EINVAL;
+    return -1;
+  }
+  for (argc = 0; argc < PIPE_ARGV_MAX && argv[argc]; argc++) {
+  }
+  for (i = 0; i < argc; i++) {
+    if (!strcmp(argv[i], ">") || !strcmp(argv[i], ">>")) {
+      if (i + 1 >= argc) {
+        errno = EINVAL;
+        return -1;
+      }
+      redirect_path = argv[i + 1];
+      redirect_append = (argv[i][1] == '>');
+      argv[i] = NULL;
+      argc = i;
+      break;
+    }
+  }
+  if (argc == 0 || !argv[0]) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (pipe(pipefd) != 0) {
+    return -1;
+  }
+
+  child_pid = fork();
+  if (child_pid == -1) {
+    close(pipefd[0]);
+    close(pipefd[1]);
+    return -1;
+  }
+
+  if (child_pid == 0) {
+    if (dup2(pipefd[0], STDIN_FILENO) == -1) {
+      _exit(127);
+    }
+    if (redirect_path) {
+      int out_fd;
+      int flags = O_WRONLY | O_CREAT | (redirect_append ? O_APPEND : O_TRUNC);
+      out_fd = open(redirect_path, flags, 0666);
+      if (out_fd == -1) {
+        _exit(127);
+      }
+      if (dup2(out_fd, STDOUT_FILENO) == -1) {
+        close(out_fd);
+        _exit(127);
+      }
+      close(out_fd);
+    }
+    close(pipefd[0]);
+    close(pipefd[1]);
+    execvp(argv[0], argv);
+    _exit(127);
+  }
+
+  close(pipefd[0]);
+  pipe_fp = fdopen(pipefd[1], "w");
+  if (!pipe_fp) {
+    close(pipefd[1]);
+    (void)waitpid(child_pid, NULL, 0);
+    return -1;
+  }
+
+  *pipe_fp_out = pipe_fp;
+  *child_pid_out = child_pid;
+  return 0;
+}
+
+static int ClosePipeWriter(FILE *pipe_fp, pid_t child_pid) {
+  int wait_status;
+  int close_status;
+
+  if (!pipe_fp) {
+    return -1;
+  }
+
+  close_status = fclose(pipe_fp);
+  do {
+    wait_status = waitpid(child_pid, NULL, 0);
+  } while (wait_status == -1 && errno == EINTR);
+
+  if (close_status != 0 || wait_status == -1) {
+    return -1;
+  }
+  return 0;
+}
 
 int Pipe(ViewContext *ctx, DirEntry *dir_entry, FileEntry *file_entry,
          char *pipe_command) {
   char file_name_path[PATH_LENGTH + 1];
   int result = -1;
-  FILE *pipe_fp;
+  FILE *pipe_fp = NULL;
+  pid_t child_pid = -1;
   char path[PATH_LENGTH + 1];
   int start_dir_fd;
 
@@ -66,8 +221,7 @@ int Pipe(ViewContext *ctx, DirEntry *dir_entry, FileEntry *file_entry,
   if (ctx->hook_suspend_clock)
     ctx->hook_suspend_clock(ctx);
 
-  pipe_fp = popen(pipe_command, "w");
-  if (pipe_fp == NULL) {
+  if (OpenPipeWriter(pipe_command, &pipe_fp, &child_pid) != 0) {
     /* Restore curses mode */
     if (ctx->hook_init_clock)
       ctx->hook_init_clock(ctx);
@@ -102,7 +256,7 @@ int Pipe(ViewContext *ctx, DirEntry *dir_entry, FileEntry *file_entry,
       ExtractArchiveEntry(archive, file_name_path, fileno(pipe_fp), NULL, NULL);
 #endif
     }
-    result = pclose(pipe_fp);
+    result = ClosePipeWriter(pipe_fp, child_pid);
 
     /* Wait for user to see output */
     if (ctx->hook_hit_return_to_continue)
@@ -126,10 +280,11 @@ int Pipe(ViewContext *ctx, DirEntry *dir_entry, FileEntry *file_entry,
 
 int PipeDirectory(ViewContext *ctx, DirEntry *dir_entry, char *pipe_command) {
   char path[PATH_LENGTH + 1];
-  FILE *pipe_fp;
+  FILE *pipe_fp = NULL;
   FileEntry *fe;
   int result = -1;
   int start_dir_fd;
+  pid_t child_pid = -1;
 
   (void)GetPath(dir_entry, path);
 
@@ -151,7 +306,7 @@ int PipeDirectory(ViewContext *ctx, DirEntry *dir_entry, char *pipe_command) {
   if (ctx->hook_suspend_clock)
     ctx->hook_suspend_clock(ctx);
 
-  if ((pipe_fp = popen(pipe_command, "w")) == NULL) {
+  if (OpenPipeWriter(pipe_command, &pipe_fp, &child_pid) != 0) {
     /* Restore curses mode */
     if (ctx->hook_init_clock)
       ctx->hook_init_clock(ctx);
@@ -175,7 +330,9 @@ int PipeDirectory(ViewContext *ctx, DirEntry *dir_entry, char *pipe_command) {
     }
   }
 
-  pclose(pipe_fp);
+  if (ClosePipeWriter(pipe_fp, child_pid) != 0) {
+    goto PIPE_CLOSE_FAILURE;
+  }
 
   /* Wait for user to see output */
   if (ctx->hook_hit_return_to_continue)
@@ -197,6 +354,21 @@ int PipeDirectory(ViewContext *ctx, DirEntry *dir_entry, char *pipe_command) {
   close(start_dir_fd);
 
   return (result);
+
+PIPE_CLOSE_FAILURE:
+  /* Restore curses mode */
+  if (ctx->hook_init_clock)
+    ctx->hook_init_clock(ctx);
+  touchwin(stdscr);
+  wnoutrefresh(stdscr);
+  if (ctx->hook_refresh_ui)
+    ctx->hook_refresh_ui();
+
+  /* Restore CWD */
+  if (fchdir(start_dir_fd) == -1) {
+  }
+  close(start_dir_fd);
+  return -1;
 }
 
 /* GetPipeCommand moved to UI layer */

--- a/src/cmd/rename.c
+++ b/src/cmd/rename.c
@@ -232,14 +232,8 @@ int RenameFile(ViewContext *ctx, FileEntry *fe_ptr, const char *new_name,
 /* GetRenameParameter moved to UI layer */
 
 static int RenameDirEntry(const char *to_path, const char *from_path) {
-  struct stat fdstat;
-
   if (!strcmp(to_path, from_path)) {
     return (0);
-  }
-
-  if (stat(to_path, &fdstat) == 0) {
-    return (-1);
   }
 
   /*

--- a/src/cmd/rmdir.c
+++ b/src/cmd/rmdir.c
@@ -77,9 +77,7 @@ int DeleteDirectory(ViewContext *ctx, DirEntry *dir_entry,
                                     "YN\033") == 'Y') {
     (void)GetPath(dir_entry, buffer);
 
-    if (access(buffer, W_OK)) {
-      return -1;
-    } else if (rmdir(buffer)) {
+    if (rmdir(buffer)) {
       return -1;
     } else {
       /* Directory geloescht
@@ -138,10 +136,6 @@ static int DeleteSingleDirectory(ViewContext *ctx, DirEntry *dir_entry,
   int force = 1;
 
   (void)GetPath(dir_entry, buffer);
-
-  if (access(buffer, W_OK)) {
-    return -1;
-  }
 
   for (fe_ptr = dir_entry->file; fe_ptr; fe_ptr = next_fe_ptr) {
     next_fe_ptr = fe_ptr->next;

--- a/src/ui/tagged_view.c
+++ b/src/ui/tagged_view.c
@@ -9,6 +9,7 @@
 #include "ytree_fs.h"
 #include "ytree_ui.h"
 #include <dirent.h>
+#include <errno.h>
 #include <libgen.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -58,6 +59,7 @@ int recursive_rmdir(const char *path) {
   DIR *d = opendir(path);
   const struct dirent *entry;
   char fullpath[PATH_LENGTH];
+  int written;
 
   if (!d)
     return -1;
@@ -65,13 +67,22 @@ int recursive_rmdir(const char *path) {
   while ((entry = readdir(d))) {
     if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
       continue;
-    snprintf(fullpath, sizeof(fullpath), "%s/%s", path, entry->d_name);
-    struct stat st;
-    if (stat(fullpath, &st) == 0) {
-      if (S_ISDIR(st.st_mode)) {
-        recursive_rmdir(fullpath);
+    written = snprintf(fullpath, sizeof(fullpath), "%s/%s", path, entry->d_name);
+    if (written < 0 || (size_t)written >= sizeof(fullpath)) {
+      closedir(d);
+      errno = ENAMETOOLONG;
+      return -1;
+    }
+
+    if (recursive_rmdir(fullpath) != 0) {
+      if (errno == ENOTDIR || errno == EINVAL) {
+        if (unlink(fullpath) != 0) {
+          closedir(d);
+          return -1;
+        }
       } else {
-        unlink(fullpath);
+        closedir(d);
+        return -1;
       }
     }
   }

--- a/src/ui/view_internal.c
+++ b/src/ui/view_internal.c
@@ -724,13 +724,17 @@ int InternalView(ViewContext *ctx, char *file_path,
   ctx->viewer.hexoffset =
       (!strcmp((GetProfileValue)(ctx, "HEXEDITOFFSET"), "HEX")) ? TRUE : FALSE;
 
-  if (stat(file_path, &fdstat) != 0)
-    return -1;
-  if (!(S_ISREG(fdstat.st_mode)) || S_ISBLK(fdstat.st_mode))
-    return -1;
   fd = open(file_path, O_RDONLY);
   if (fd == -1)
     return -1;
+  if (fstat(fd, &fdstat) != 0) {
+    close(fd);
+    return -1;
+  }
+  if (!(S_ISREG(fdstat.st_mode)) || S_ISBLK(fdstat.st_mode)) {
+    close(fd);
+    return -1;
+  }
   SetupViewWindow(ctx, file_path, geometry);
   current_line = 1;
   update_all_lines(ctx, ctx->viewer.view, ctx->viewer.wlines - 1);


### PR DESCRIPTION
## Summary
- eliminate race-prone check-then-use file operations flagged by CodeQL
- harden pipe execution path and preserve output redirection behavior
- add workflow permissions stanza for code scanning workflow hygiene

## Validation
- make clean && make
- pytest
- make qa-fileops-integrity
- make qa-module-boundaries
- make qa-unsafe-apis