### PR TITLE
docs(ai): require branch-first pull-request delivery

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -102,6 +102,14 @@ These instructions apply to all AI agents used in this repository.
 18. Dead-history notes are forbidden in active guidance: do not preserve statements about removed workflow mechanisms unless they are required migration instructions. State only the current, actionable behavior.
 19. Context budget gate is mandatory: treat startup instructions as session-scoped and load them once per conversation/session unless the underlying files changed or the user explicitly requests a reload.
 20. Delta-only reporting is mandatory: after startup, do not repeat full prompts, policies, or prior summaries. Provide only net-new state, next action, and new/changed handles unless the user asks for a full recap.
+21. GitHub branch protection workflow is mandatory: for any change intended for GitHub, create/use a non-`main` branch, push that branch, and open/update a PR. Do not push directly to `main`. If work was committed locally on `main`, branch from current HEAD before the first push and continue via PR.
+22. Hybrid PR quality workflow is mandatory:
+    - Before first push, run a quick local gate (build plus targeted smoke/tests).
+    - Open a draft PR early; red is allowed while iterating.
+    - While PR is red, prefix draft title with `WIP:` and do not request reviewers.
+    - Before marking ready for review, require full local audit gates (`make qa-all` and required audit loop).
+    - Convert draft PR to ready only after posting full QA evidence in a PR comment.
+    - Before merge, require green PR checks and reviewer signoff.
 
 ## Source Comment Contract
 

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -11,6 +11,7 @@ Process requirements:
 2) Create and use branch:
    - git checkout -b codex/mixed-features-fixes <type>/<short-task-name>
    - use a suitable type (e.g. fix, feat, chore, docs)
+   - never push directly to main; all pushes must go to the branch and PR flow
 
 3) Before implementing:
    - discuss the task with me first
@@ -22,6 +23,7 @@ Process requirements:
    - keep scope tight and avoid unrelated edits
 
 5) Validation:
+   - before first push, run a quick local gate (build + targeted smoke/tests)
    - run targeted tests as needed
    - after task completion, run full gate:
      source .venv/bin/activate
@@ -34,7 +36,10 @@ Process requirements:
      git commit --amend --no-edit
    - keep branch history workable; final merge will be rebase/ff-friendly
 
-7) Push + PR-ready summary:
+7) Push + draft PR + PR-ready summary:
+   - open a draft PR early after first push (it may be red while iterating)
+   - do not request reviewers until full gate is green
+   - convert to Ready only after posting full QA evidence in the PR
    - what changed (by file)
    - test evidence (commands + outcomes)
    - risks/regressions to watch

--- a/docs/ai/RELAY_PROMPT_TEMPLATE.md
+++ b/docs/ai/RELAY_PROMPT_TEMPLATE.md
@@ -19,8 +19,10 @@ Mandatory startup (before any repo exploration):
 Goal:
 Deliver all outcomes for $WORK_DOC $WORK_KIND $TASK by following 3.1.3 through 3.1.7 of the Agentic Loop procedure in ~/ytree/docs/ai/WORKFLOW.md, on a new branch named for this work item.
 - Branch name must not use words: “phase”, “step”, “task” and must contain no digits.
+- Never push directly to `main`; push only the work branch and deliver via PR.
 - First push: git push-fast-up
 - Subsequent pushes: git push-fast
+- Open a draft PR after first push; red is acceptable while iterating.
 
 Execution model (auto-relay runtime):
 1) Start one durable run with a stable `run_id` + idempotency key.
@@ -68,6 +70,8 @@ Commit policy:
 - Conventional Commits required.
 - Commit subject and body must contain no digits.
 - Do not use words: “phase”, “step”, “task”.
+- Do not request reviewers until full local audit gate evidence is green and posted in the PR.
+- Convert draft PR to Ready for review only after full QA/audit evidence is posted.
 - After tests are green and the commit is integrated into `main` (fast-forward, no merge commit), delete all temporary work branches once they have served their purpose, both locally and on GitHub.
 - Do not update $WORK_DOC to mark $WORK_KIND $TASK as completed/fixed until all are true: commit is done, change is integrated into `main` via fast-forward, and the temporary branch is deleted locally and on remote.
 


### PR DESCRIPTION
## Summary
- add an explicit mandatory rule that AI must use a non-main branch and PR workflow for GitHub delivery
- require branching off local main before first push when commits already exist on main

## Why
- avoids blocked direct pushes to protected main and duplicate delivery cycles