### PR TITLE
fix(split): restore redraw and split flow integrity after external actions

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -14,7 +14,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Description**: In `F8` split mode, after logging two volumes and releasing one, the small window can go blank, separator line can disappear, inactive panel can blank, and tabbing to the inactive panel can trigger a segmentation fault.
 *   **Impact**: Critical stability and data-safety risk (crash), plus severe UI corruption in a core split-panel workflow.
 *   **Remediation**: Harden split-panel volume-release lifecycle so panel/window ownership and active/inactive bindings are always valid after release. Add focused regression coverage for `F8` with multi-volume log/release and `Tab` switching after release.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-40: Cycle-Volumes (`<`/`>`, `,`/`.`) Leaks Dir/File View State Across Volumes**
 *   **Description**: Cycling logged volumes can cause dir/file window mode/state changes in one volume to appear in the other, instead of each volume retaining its own last-used state.
@@ -104,20 +104,20 @@ Ordering policy (for all editors, including AI editors):
 *   **Impact**: Corrupts primary navigation UI after a common workflow and reduces operator trust in view stability.
 *   **Remediation**: On return from external editor/config-save flow, restore/redraw directory-tree and small-window state deterministically for dir context (including path/header lines), and keep behavior consistent with file-view return path.
 *   **Related**: `BUG-15` (state/layout transition corruption family), `BUG-31` (post-`F10` apply/return family).
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-29: External Viewer Return Can Corrupt Ytree UI Redraw**
 *   **Description**: Returning from external viewer/pager flows can leave ytree in a visibly corrupted state (for example shell prompt fragments or stray text rendered into panes/footer instead of a clean ncurses repaint).
 *   **Impact**: Breaks core usability immediately after viewing, obscures navigation/help text, and reduces trust in terminal-state safety.
 *   **Remediation**: Ensure external-view return paths always restore curses mode and perform a full deterministic UI repaint (header, panes, footer/help lines), including prompt-line cleanup before accepting further input.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-28: Viewer Return (`v` -> `q`) Can Corrupt UI and Input State**
 *   **Description**: In WSL repro, running ytree, opening `View` on a file (`v`), then quitting viewer (`q`) can leave the main UI mostly vanished/artifacted (for example stray clock digits only). Follow-on input/state is also corrupted: `^L` has negligible/no effect, `Enter` no longer toggles to dir window, and a subsequent `q` exits ytree.
 *   **Impact**: Breaks core post-view workflow and can leave the session in a partially unusable state until restart.
 *   **Remediation**: Harden viewer-return restore path to reestablish full ncurses paint + mode/input state atomically (window ownership, active panel mode, key handling context) before processing next key events.
 *   **Related**: `BUG-29` (same return/redraw defect family).
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-27: Copy/Move Cancel (`Esc`) Can Leave Footer Blank**
 *   **Description**: In `Copy`/`Move` flows, canceling with `Esc` can leave footer/help lines blank instead of restoring the normal context footer.
@@ -142,6 +142,8 @@ Ordering policy (for all editors, including AI editors):
 
 ### **BUG-24: Modal Severity Messages Render as Error-Red**
 *   **Description**: Centered modal messages can render with error-red styling even when the message severity is informational or warning-level, instead of using severity-specific visual treatment.
+*   **Findings**:
+    *   Directory compare completion summary dialogs (counts + tagged-match summary) can render in error-red despite being non-error informational results.
 *   **Impact**: Blurs severity intent, increases operator confusion, and conflicts with documented message tiers and configurable color expectations.
 *   **Remediation**: Perform a full user-message surface audit (modal/footer/status paths), identify all message-producing callsites and severity-routing logic, and enforce a single severity-aware rendering contract. Ensure modal severity maps to `INFO_COLOR`, `WARN_COLOR`, and `ERR_COLOR` from `ytree.conf`, then add focused regression tests that prove correct severity-to-color routing (including config-driven overrides and safe defaults).
 *   **Related**: `docs/SPECIFICATION.md` section 6.2 modal severity tiers; `etc/ytree.conf` `[COLORS]` keys `INFO_COLOR`, `WARN_COLOR`, `ERR_COLOR`.
@@ -256,7 +258,23 @@ Ordering policy (for all editors, including AI editors):
 *   **Impact**: Makes the UI look partially broken in high-frequency workflows and reduces operator trust.
 *   **Remediation**: Harden post-command frame-restore/redraw ownership so full header/path/footer surfaces are restored atomically before next input.
 *   **Related**: `BUG-29`, `BUG-28` (return/redraw defect family).
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
+
+### **BUG-9A: Copy to Nonexistent Destination Misses Create-Dir Prompt Contract**
+*   **Description**: Copying to a nonexistent destination path did not consistently show the expected destination-create prompt contract and could fall into misleading confirmation flow.
+*   **Status**: Fixed.
+
+### **BUG-9A.1: Copy-Yes Path Could Create Destination But Leave View Incoherent**
+*   **Description**: Accepting copy to a newly created destination could complete without coherent immediate view state for resulting entries.
+*   **Status**: Fixed.
+
+### **BUG-9A.2: Copy-No Path Could Leave Footer/Frame State Corrupted**
+*   **Description**: Declining the copy confirmation in nonexistent-destination flow could leave footer/frame state degraded.
+*   **Status**: Fixed.
+
+### **BUG-9B: Execute/Return Frame Restore Could Require Extra Keystrokes**
+*   **Description**: After execute-return flow, path and frame lines could remain partially missing until extra keypresses forced redraw.
+*   **Status**: Fixed.
 
 ### **BUG-8: Attributes Name Truncation Can Hide File Identity**
 *   **Description**: In attributes/stat contexts, long file names can be truncated using a tail-only style (for example `...fy_xml_integrity.sh`) that hides too much distinguishing information and makes similarly named files harder to differentiate at a glance.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -213,6 +213,23 @@ Ordering policy (for all editors, including AI editors):
 *   Update `etc/ytree.1.md` and regenerate `docs/USAGE.md` (`make docs`) when behavior lands.
 *   - [ ] **Status:** Not Started.
 
+### **Task 59D: Add Inline `Shift+N` Create-Link Flow (Symlink/Hardlink)**
+*   **Goal:** Add an in-app link creation command that mirrors existing `mkdir/newfile/copy` prompt ergonomics without requiring external `X` shell execution.
+*   **Rationale:** Link creation is a core file-manager workflow; requiring shell fallback breaks interaction consistency and discoverability.
+*   **Scope Lock:** Filesystem link creation UX/behavior only (`symlink` and `hardlink`); no unrelated command flow redesign.
+*   **Acceptance Criteria:**
+*   Add one primary keybinding: `Shift+N` (`N`) for `Create Link`.
+*   The command is available in both directory and file contexts where filesystem mutations are valid, including showall/global file flows.
+*   Flow is single-surface (no pre-step menu): first prompt is the link-target input and footer exposes live type toggle (`s`/`h`) with a default already set.
+*   Prompt/header contract is explicit and concise (for example: `CREATE LINK [s=symlink h=hard] TARGET:`), and a second prompt captures `LINK NAME:`.
+*   Default link type is `symlink`; pressing `s`/`h` in the first prompt switches mode inline without leaving the prompt.
+*   Target prefill follows existing copy/newfile conventions for active selection context and remains overrideable by direct typing.
+*   Destination resolution in showall/global targets the owner directory of the highlighted entry (not unrelated tree cursor state).
+*   Existing `n`/`N` newfile behavior is remapped to preserve intuitive command grouping while keeping help/footer truthfully synchronized.
+*   Add focused regression coverage for: symlink create, hardlink create, cancel/no-op behavior, showall/global owner-directory resolution, split-panel isolation, and error-path messaging.
+*   Update `etc/ytree.1.md` and regenerate `docs/USAGE.md` (`make docs`) when behavior lands.
+*   - [ ] **Status:** Not Started.
+
 ### **Task 58: Add `i/I` Invert Tags in Directory Mode**
 *   **Goal:** Support `i/I` invert-tag action from directory contexts.
 *   **Rationale:** Tag inversion at the directory level is missing.
@@ -517,7 +534,7 @@ Ordering policy (for all editors, including AI editors):
 ### **Task 30: Replace `^F` Mode Cycling with Unified Numeric `FileInfo` Band (`1..9`, `0`)**
 *   **Goal:** Replace display-mode cycling with direct numeric `FileInfo` controls for the focused panel.
 *   **Behavior Contract:**
-*   `1` => Name only (default/baseline).
+*   `1` => Name only (default/baseline). This is also the reset-to-default selection.
 *   `2` => Long.
 *   `3` => Owner.
 *   `4` => Times.
@@ -527,10 +544,11 @@ Ordering policy (for all editors, including AI editors):
 *   `7` => toggle richer metadata/text-snippet view.
 *   `8` => toggle file-type/summary view.
 *   `9` => toggle brief/full width behavior for the focused panel.
-*   `0` => reset file-info state for `1..8` to profile defaults (does not affect `9` width toggle).
-*   Number keys are toggle-driven controls: `1..4` select the primary file-info layout while `5..9` toggle additive display behaviors.
+*   `0` => Git-focused file-info band (status-oriented view) when the current scope is inside a Git worktree.
+*   Number keys are toggle-driven controls: `0..4` select the primary file-info layout while `5..9` toggle additive display behaviors.
 *   Applies to file-display rendering across normal list contexts for the active panel (whether focus is currently on tree/dir window or file window); not active in `F7` preview mode.
-*   If a requested mode is unsupported in the active context (for example VFS file mode `4`), do a silent no-op (no beep).
+*   If a requested mode is unsupported in the active context (for example VFS file mode `4`, or `0` outside a Git worktree), do a silent no-op (no beep).
+*   Git band (`0`) defaults to off, uses cached/non-blocking status refresh, and must not stall list rendering in large repos.
 *   Add `FILE_SIZE_UNITS=binary|human-readable` profile setting (default `binary`) as the seed for `5`.
 *   **Keybinding Policy:** Remove `^F` from runtime behavior and help/manpage docs. This task is the explicit keybinding-change exception referenced by Task 38 scope lock.
 *   **UX/Help Policy:** Footer stays concise (`1..0 FileInfo`); full key semantics live in F1 help/manpage.
@@ -801,6 +819,19 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Future Phase 1: Post-Baseline Configurability Follow-On**
 
+### **Idea FE-37: Explicit Accessibility Mode (Screen-Reader-First Terminal Behavior)**
+*   **Goal:** Introduce an opt-in explicit accessibility mode focused on stable, low-noise behavior for screen-reader workflows.
+*   **Research Gate (Required Before Implementation):**
+    *   Audit current redraw/cursor-update hotspots (clock, spinner, status-line, dialogs, preview loops) for assistive-tech impact.
+    *   Validate behavior with real screen-reader workflows (e.g., Speakup/NVDA terminal usage patterns) before locking UX contracts.
+    *   Define measurable acceptance criteria (reduced cursor churn, reduced unsolicited announcements, no input-lag regressions).
+*   **Implementation Direction (Post-Research):**
+    *   Add a dedicated runtime/config toggle (not ad-hoc flags).
+    *   Suppress/de-rate non-essential dynamic redraws in accessibility mode (e.g., spinners/timers) and prefer deterministic refresh cadence.
+    *   Favor linear, prompt/result interaction paths where feasible; keep existing default behavior unchanged when mode is off.
+*   **Rationale:** Terminal UI is not automatically accessible; explicit mode-level contracts are needed to avoid redraw/cursor noise regressions.
+*   - [ ] **Status:** Not Started.
+
 ### **Idea FE-36: Portable Keyboard Capability Probe + `.ytree` Key Workarounds**
 *   **Goal:** Add startup-time terminal key-capability probing and user-configurable key overrides/workarounds in `~/.ytree`.
 *   **Behavior Direction:**
@@ -817,6 +848,36 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 ### **Future Phase 2: UI/UX Enhancements and Cleanup**
+
+### **Idea FE-39: Configurable VCS Provider for `0` FileInfo Band**
+*   **Goal:** Keep `0` as one stable VCS info band while allowing users to choose which backend powers it.
+*   **Config Direction (`ytree.conf`):** Add a single-provider selector (for example `VCS_PROVIDER=off|git|hg|svn|fossil|auto`).
+*   **Behavior Contract:**
+    *   Only one VCS provider is active at a time for `0`; no mixed multi-provider rendering in one view.
+    *   Default remains off for performance/noise control.
+    *   If the selected provider is unavailable in the current path/repo, `0` performs a silent no-op.
+*   **Rationale:** Preserves key stability and avoids renumbering while keeping a path open for non-Git users.
+*   - [ ] **Status:** Not Started.
+
+### **Idea FE-38: Typed Filter Modes (`glob` default, `re:`, `fz:`)**
+*   **Goal:** Extend file filtering with explicit typed terms while preserving today's glob-first behavior and key flow.
+*   **User-Facing Behavior:**
+    *   Keep existing glob syntax as default (`*.c`, `*.c,*.h`, `-*.tmp`).
+    *   Add typed terms:
+        *   `re:<expr>` for POSIX ERE regex.
+        *   `fz:<text>` for simple fuzzy subsequence matching (case-insensitive).
+        *   `glob:<pattern>` as explicit glob alias (optional but accepted).
+    *   Keep exclusion semantics explicit and deterministic: exclusion matches always win.
+    *   Matching target remains basename (`fe->name`) to preserve current expectations.
+*   **Parsing/Validation Direction:**
+    *   Support quoted terms so commas can be used inside a term (for example `re:"^x{1,3}$",*.c`).
+    *   Treat malformed specs as invalid (for example `,,`, trailing comma, unmatched quote, empty `re:`/`fz:`/`glob:` term, or bare `-` term).
+*   **UX/Help Direction:**
+    *   Keep `FILTER:` prompt flow unchanged (`key -> Enter -> result`).
+    *   Add lightweight inline hint text only (for example `glob(default) | re: | fz:`), without using `?` (reserved for backward search).
+    *   Put full syntax/examples in `F1` help and manpage source (`etc/ytree.1.md`).
+*   **Rationale:** Adds regex/fuzzy power in a Unix-style, scriptable format without breaking existing wildcard workflows or adding submenu friction.
+*   - [ ] **Status:** Not Started.
 
 ### **Idea FE-34: Prompt Input Decode Hardening (curses-first, legacy ESC fallback)**
 *   **Goal:** Replace prompt-path manual ESC sequence parsing with curses/terminfo-first decoding, while keeping legacy manual ESC parsing as controlled fallback (or config-gated compatibility mode).
@@ -1072,10 +1133,158 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 ### **Idea FE-3: Preview Helper Pipeline for Non-Text File Types**
-*   **Goal:** Investigate a very-low-priority preview-helper system that can convert non-text formats into something ytree can preview, without turning ytree itself into a giant all-format viewer.
-*   **Examples:** Route images, PDFs, office files, or database exports through user-configured helper commands that emit plain text, ANSI output, or temporary preview artifacts.
-*   **Non-Goal:** Do not make ytree responsible for natively understanding every binary/GUI format. Prefer the Unix model of helper programs and explicit pipelines.
-*   **Rationale:** This could make `F7`/viewer workflows more useful for odd file types, but it is a large, optional integration surface and should stay firmly in wishlist territory until someone explicitly wants to build it.
+*   **Goal:** Implement an F7 dual-mode preview pipeline that keeps internal preview as the guaranteed baseline while allowing helper-rendered output for non-text file types.
+*   **Non-Goal:** Do not make ytree natively decode every binary/GUI format. Keep helper-based rendering as the Unix-style extension surface.
+*   **Roadmap Fit:** This is the concrete implementation shape for the long-standing preview-helper direction, while preserving strict internal fallback behavior.
+*   **Implementation-Ready Spec:**
+    **Status:** Proposed / implementation-ready.
+
+    **Scope:** Add dual-mode preview behavior to `F7` with strict fallback guarantees:
+    * `BINARY` = internal preview path only (never executes helpers).
+    * `RENDER` = helper-driven preview path; on any failure/unavailability, fallback to `BINARY`.
+
+    **Terminology (Normative):**
+    * `BINARY`: internal preview mode only; no external helper execution; text-like content when decodable, otherwise raw/byte-oriented internal representation.
+    * `RENDER`: helper preview mode via extension mapping; output shown in preview pane; fallback to `BINARY` on no-match, error, timeout, overflow, or safety rejection.
+
+    **User Interaction Contract:**
+    * `F7` enters preview mode.
+    * `F7` or `Esc` exits preview mode and restores prior state.
+    * In `F7`, `r`/`R` toggles `BINARY` ⇄ `RENDER`.
+    * Bottom-left footer mode label must be exactly `BINARY` or `RENDER` (fixed-width, no wobble).
+    * Default F7 mode comes from config (`PREVIEW_MODE_DEFAULT`, default `binary`).
+
+    **Split-Mode Behavior:**
+    * Preview mode state is panel-local (left/right independent).
+    * Toggling mode in one panel must not mutate the other panel state.
+
+    **Helper Execution Contract:**
+    * Prefer argv-style execution (no shell interpolation).
+    * If template parsing is retained, allow `%s` only; reject all other `%` tokens.
+    * File path must be inserted as one safely quoted argument via existing command/path helpers.
+    * Bound command length by existing command-line limits.
+
+    **Render Safety & Limits:**
+    * Enforce timeout (`PREVIEW_RENDER_TIMEOUT_MS`).
+    * Enforce captured output cap (`PREVIEW_RENDER_MAX_BYTES`).
+    * Enforce ANSI policy (`RENDER_ALLOW_ANSI`).
+    * On any violation/failure, fallback to `BINARY`.
+
+    **Extension Matching Rules (Deterministic):**
+    1. Exact extension rule match (single-ext entry).
+    2. First matching multi-extension rule in config order.
+    3. No match ⇒ `BINARY`.
+    * Extension matching is case-insensitive.
+    * No MIME probing in v1.
+
+    **Cache Contract:**
+    * RENDER cache key must include:
+      * path (canonical key)
+      * file mtime
+      * file size
+      * preview mode
+      * resolved helper command string
+      * ANSI policy
+      * timeout value
+      * output-cap value
+    * This ensures config/helper edits invalidate cached renders.
+
+    **Failure UX Contract:**
+    * On RENDER failure, continue showing `BINARY`.
+    * Optional one-shot notice: `RENDER unavailable; using BINARY`.
+    * Anti-spam:
+      * deduplicate by `(file, helper, error_class)`
+      * rate-limit global notices during cursor movement (recommended ≥ 750ms interval)
+
+    **Configuration (Canonical Defaults + User Override):**
+    * Canonical defaults source-of-truth:
+      * `etc/ytree.conf`
+      * `src/core/default_profile_template.h`
+
+    **Global keys:**
+
+    | Key | Type | Allowed | Default | Meaning |
+    |---|---|---|---|---|
+    | `PREVIEW_MODE_DEFAULT` | enum | `binary` \| `render` | `binary` | Initial F7 mode on entry |
+    | `PREVIEW_AUTOPLAY_MEDIA` | bool-int | `0` \| `1` | `0` | Whether media render helpers may autoplay |
+    | `PREVIEW_RENDER_TIMEOUT_MS` | int | `100..10000` | `1200` | Max helper runtime in milliseconds |
+    | `PREVIEW_RENDER_MAX_BYTES` | int | `4096..1048576` | `262144` | Max captured helper output bytes |
+    | `RENDER_ALLOW_ANSI` | bool-int | `0` \| `1` | `0` | ANSI handling policy for RENDER output |
+
+    **`[PREVIEW_RENDER]` section format:**
+    ```ini
+    [PREVIEW_RENDER]
+    .ext=command %s
+    .ext1,.ext2,.ext3=command %s
+    ```
+    * Extensions are case-insensitive.
+    * `%s` is the selected file path token.
+    * Comment out/remove mappings to keep those types in `BINARY`.
+
+    **Example:**
+    ```ini
+    PREVIEW_MODE_DEFAULT=binary
+    PREVIEW_AUTOPLAY_MEDIA=0
+    PREVIEW_RENDER_TIMEOUT_MS=1200
+    PREVIEW_RENDER_MAX_BYTES=262144
+    RENDER_ALLOW_ANSI=0
+
+    [PREVIEW_RENDER]
+    .pdf=gs -q -dNOPAUSE -dBATCH -sDEVICE=txtwrite -sOutputFile=- %s
+    .jpg,.jpeg,.png,.gif=chafa --animate off %s
+    .mp3,.flac=ffprobe -hide_banner %s
+    .mp4,.mkv,.avi,.mpg=ffprobe -hide_banner %s
+    ```
+
+    **Error-State Matrix (Normative):**
+
+    | Condition | Active Mode | Action | Displayed Mode | User Notice |
+    |---|---|---|---|---|
+    | Helper mapping found, helper succeeds | RENDER | Show helper output | RENDER | none |
+    | No helper mapping for extension | RENDER | Fallback | BINARY | optional one-shot |
+    | Helper command parse invalid (`%` token not allowed) | RENDER | Reject + fallback | BINARY | optional one-shot |
+    | Helper executable missing / spawn failure | RENDER | Fallback | BINARY | optional one-shot |
+    | Helper timeout exceeded | RENDER | Stop helper, fallback | BINARY | optional one-shot |
+    | Helper output exceeds max bytes | RENDER | Reject + fallback | BINARY | optional one-shot |
+    | ANSI disallowed and output contains ANSI (`RENDER_ALLOW_ANSI=0`) | RENDER | Strip ANSI; if strip fails, fallback | BINARY or RENDER* | optional one-shot on fallback |
+    | Any internal render-path error | BINARY or fallback target | Show safe error line; remain in preview | BINARY | yes |
+    | Toggle key pressed (`r`/`R`) | F7 | Flip mode state | BINARY or RENDER | footer update |
+    | Exit key (`F7`/`Esc`) | F7 | Exit preview | N/A | none |
+
+    \* If ANSI strip succeeds, remain `RENDER`; if strip fails, fallback `BINARY`.
+
+    **Security & Robustness Requirements:**
+    * No unsafe shell concatenation of untrusted paths.
+    * Command construction must remain bounded.
+    * Fail closed to `BINARY`.
+    * Preserve curses/terminal integrity across helper invocation and return.
+
+    **Acceptance Criteria:**
+    1. F7 opens in configured default mode (`binary` by default).
+    2. `r`/`R` toggles mode and footer shows exact `BINARY` or `RENDER`.
+    3. Footer alignment does not move on mode toggle.
+    4. `BINARY` path never executes helpers.
+    5. `RENDER` falls back to `BINARY` for all matrix failure classes.
+    6. Media autoplay is disabled by default (`PREVIEW_AUTOPLAY_MEDIA=0`).
+    7. Commented/removed mappings keep file types in `BINARY`.
+    8. Split-mode state is panel-local.
+    9. Failure notices are deduplicated and rate-limited.
+    10. Manpage/profile/template docs are synced.
+
+    **Minimum Test Requirements:**
+    * Config parsing coverage for all new keys.
+    * `[PREVIEW_RENDER]` single + multi-ext parse tests.
+    * Invalid token rejection (`%x`, `%%`, etc.).
+    * Matching/precedence tests (case-insensitive extension behavior).
+    * Runtime tests: toggle + footer, no-helper fallback, timeout fallback, overflow fallback, ANSI policy handling.
+    * Split tests: panel-local independence.
+    * Regression tests: existing F7 nav/exit behavior unchanged; no redraw corruption after helper return.
+
+    **Documentation Sync Requirements (when implemented):**
+    * `etc/ytree.1.md` (canonical manpage source)
+    * generated `docs/USAGE.md`
+    * `etc/ytree.conf` defaults/comments
+    * `src/core/default_profile_template.h` defaults/comments
 *   - [ ] **Status:** Not Started.
 
 ### **Idea FE-2: Terminal-Independent TUI Runtime (ncurses-Decoupling Investigation)**

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -69,6 +69,7 @@ The behavior of the `Enter` key on a directory node is governed by the configura
 *   **Staged Navigation (`SMALLWINDOWSKIP=0`):**
     *   `Enter` on a logged directory in Tree -> **Focus Shift**. Focus moves to the File View (Small Window). Tree remains visible.
     *   `Enter` on Small Window -> **Zoom**. File Window expands to full height.
+    *   `Enter` on Zoomed Window -> Returns focus to the **Tree View**.
 *   **Navigation Stability:** Moving the cursor through the Tree must **never** automatically trigger a transition into File Mode or Zoom.
 
 ### 3.2 Directory Protocols

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -13,7 +13,14 @@ Work item:
 Scope gate (mandatory):
 - This prompt is for exactly one quick developer unit (single focused fix/change).
 - If the request is broader than a single quick developer unit, STOP and reply exactly:
-  "No — more than a single dev/quick. Use RELAY_PROMPT_TEMPLATE.md for this."
+  "No — this is more than a single quick development task. Use RELAY_PROMPT_TEMPLATE.md for this."
+
+## Subagent-safe prompt profile (required)
+
+- Keep worker prompts to minimal technical payload only (scope, acceptance, commands, blockers).
+- Avoid long policy/governance prose in worker prompts.
+- If worker creation is policy-blocked, auto-retry once with a reduced prompt profile.
+- Relay proceeds autonomously; maintainer interruption is only for blockers and commit-message approval gate.
 
 Process requirements:
 1) Sync local main with GitHub main:
@@ -36,6 +43,7 @@ Process requirements:
    - keep scope tight and avoid unrelated edits
 
 5) Validation:
+   - do not run checks or QA until I explicitly agree
    - before first push, run a quick local gate (build + targeted smoke/tests)
    - run targeted tests as needed
    - after task completion, run full gate:
@@ -51,6 +59,7 @@ Process requirements:
 
 7) Push + draft PR + PR-ready summary:
    - open a draft PR early after first push (it may be red while iterating)
+   - when using `gh pr create`, provide PR text via `--body-file` (or heredoc/file), never escaped `\n` in `--body`
    - do not request reviewers until full gate is green
    - convert to Ready only after posting full QA evidence in the PR
    - what changed (by file)

--- a/docs/ai/RELAY_PROMPT_TEMPLATE.md
+++ b/docs/ai/RELAY_PROMPT_TEMPLATE.md
@@ -53,6 +53,7 @@ Prompt/report artifact rules:
 Stall/escalation policy:
 - If a unit exceeds timeout or misses heartbeat, watchdog MUST emit a stall event.
 - Watchdog then retries/reassigns within retry policy; if retries are exhausted, mark terminal failure and escalate.
+- Do not run checks or QA until maintainer explicitly agrees.
 
 Developer prompt requirements (for each unit):
 - Strict scope and explicit non-goals
@@ -70,6 +71,7 @@ Auditor prompt requirements (same unit):
 Commit policy:
 - Commit only after developer + auditor evidence is accepted and maintainer approves commit message.
 - Do not commit unless the maintainer has explicitly approved the commit message.
+- For PR creation/edit via `gh`, provide PR text via file/heredoc (`--body-file` or API body), never escaped `\n` in `--body`.
 - Conventional Commits required.
 - Commit subject and body must contain no digits.
 - Do not use words: “phase”, “step”, “task”.

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -336,16 +336,18 @@ watch -n 5 'python3 scripts/relay_runtime.py dashboard --verbose --limit 20'
     *   expired lease or stale heartbeat -> `stall_detected` event,
     *   requeue/reassign with bounded retry,
     *   terminal fail when retry budget is exhausted.
-3.  Before commit, architect MUST ensure fresh full-gate evidence (`make qa-all`) for accepted branch state.
-4.  If accepted:
+    *   if worker creation is policy-blocked, retry once with a reduced subagent-safe prompt profile (minimal technical payload only).
+3.  Relay execution remains autonomous end-to-end; maintainer interruption is reserved for explicit blockers and commit-message approval gate.
+4.  Before commit, architect MUST ensure fresh full-gate evidence (`make qa-all`) for accepted branch state.
+5.  If accepted:
     *   commit only code/doc files (no relay/runtime artifacts),
     *   use maintainer-approved commit message describing durable behavior (no task numbering),
     *   include explicit work-item status text in the same commit (for example `Status: Confirmed.`, `Status: In Progress.`, or `Status: Fixed.`) so no status transition is left ambiguous,
     *   first push: `git push-fast-up`; tracked branch: `git push-fast`.
-5.  If correction is needed for the same logical change set, amend and repush:
+6.  If correction is needed for the same logical change set, amend and repush:
     *   `git commit --amend --no-edit`
     *   push with the branch rule above.
-6.  Cleanup consumed transient artifacts after usefulness ends (for example `compile_commands.json`, `valgrind.log`, temporary relay scratch files).
+7.  Cleanup consumed transient artifacts after usefulness ends (for example `compile_commands.json`, `valgrind.log`, temporary relay scratch files).
 
 #### 3.1.7 Completion Gate, Merge, and Manual Fallback
 

--- a/include/ytree_cmd.h
+++ b/include/ytree_cmd.h
@@ -216,6 +216,7 @@ extern int DeleteDirectory(ViewContext *ctx, DirEntry *dir_entry,
 extern int UI_ChoiceResolver(ViewContext *ctx, const char *prompt,
                              const char *choices);
 extern int UI_ArchiveCallback(int status, const char *msg, void *user_data);
+extern void RefreshView(ViewContext *ctx, DirEntry *dir_entry);
 extern int GetCommandLine(ViewContext *ctx, char *command_line);
 extern int GetSearchCommandLine(ViewContext *ctx, char *command_line,
                                 char *raw_pattern);

--- a/include/ytree_ui.h
+++ b/include/ytree_ui.h
@@ -123,6 +123,12 @@ extern BOOL DirOps_SelectVisibleDirAndRefresh(ViewContext *ctx,
                                               YtreePanel *panel,
                                               const DirEntry *target,
                                               DirEntry **dir_entry_ptr);
+extern DirEntry *DirOps_FindDirEntryByPath(const ViewContext *ctx,
+                                           const char *dir_path);
+extern DirEntry *DirOps_ResolveCopyMoveRefreshAnchor(ViewContext *ctx,
+                                                     const char *src_path,
+                                                     const char *dest_dir_path,
+                                                     DirEntry *fallback);
 
 /* render_dir.c */
 extern void DisplayTree(ViewContext *ctx, struct Volume *vol, WINDOW *win,
@@ -340,6 +346,7 @@ HandleDirWindowLogAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
                          size_t new_log_path_size);
 
 /* ui_edit_config.c */
+extern BOOL ParseSmallWindowSkipValue(const char *value);
 extern void UI_OpenConfigProfile(ViewContext *ctx, DirEntry *dir_entry);
 
 /* dir_nav.c */

--- a/src/cmd/view.c
+++ b/src/cmd/view.c
@@ -47,7 +47,9 @@ static int ViewFile(ViewContext *ctx, DirEntry *dir_entry, char *file_path) {
     return (-1);
   }
 
-  result = SilentSystemCall(ctx, command_line, &ctx->active->vol->vol_stats);
+  result = SystemCall(ctx, command_line, &ctx->active->vol->vol_stats);
+  if (dir_entry != NULL)
+    RefreshView(ctx, dir_entry);
 
   return (result);
 }
@@ -83,7 +85,7 @@ static int ViewArchiveFile(ViewContext *ctx, char *file_path) {
     goto cleanup;
   }
 
-  result = SilentSystemCall(ctx, command_line, &ctx->active->vol->vol_stats);
+  result = SystemCall(ctx, command_line, &ctx->active->vol->vol_stats);
 
 cleanup:
   if (fd != -1) {

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -89,6 +89,26 @@ static int CoreInitUINotice(ViewContext *ctx, const char *msg) {
   return ctx->core_init_ops.ui_notice(ctx, msg);
 }
 
+BOOL ParseSmallWindowSkipValue(const char *value) {
+  char *end_ptr;
+  long parsed;
+
+  if (!value)
+    return FALSE;
+
+  errno = 0;
+  parsed = strtol(value, &end_ptr, 10);
+  if (errno != 0)
+    return FALSE;
+
+  while (end_ptr && *end_ptr && isspace((unsigned char)*end_ptr))
+    ++end_ptr;
+  if (end_ptr && *end_ptr != '\0')
+    return FALSE;
+
+  return (parsed == 1) ? TRUE : FALSE;
+}
+
 void Layout_Recalculate(ViewContext *ctx) {
   if (!ctx)
     return;
@@ -793,8 +813,7 @@ int Init(ViewContext *ctx, const char *configuration_file,
   DEBUG_LOG("Init: locale fallback done");
 
   ctx->bypass_small_window =
-      (strtol(CoreInitGetProfileValue(ctx, "SMALLWINDOWSKIP"), NULL, 0)) ? TRUE
-                                                                          : FALSE;
+      ParseSmallWindowSkipValue(CoreInitGetProfileValue(ctx, "SMALLWINDOWSKIP"));
   ctx->highlight_full_line =
       (strtol(CoreInitGetProfileValue(ctx, "HIGHLIGHT_FULL_LINE"), NULL, 0))
           ? TRUE

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -11,7 +11,6 @@
 #include "ytree_fs.h"
 #include "ytree_panel_anchor.h"
 #include "ytree_ui.h"
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -89,12 +88,12 @@ static BOOL BuildDirOpCommand(BOOL move_dir, const char *quoted_src,
 
 static int ResolveDirTargetPath(DirEntry *dir_entry, const char *to_dir_in,
                                 const char *to_file, char *src_path,
-                                char *dest_path) {
+                                char *dest_dir_path, char *dest_path) {
   char resolved_dir[PATH_LENGTH + 1];
   const char *leaf;
 
   if (!dir_entry || !to_dir_in || !to_file || !*to_file || !src_path ||
-      !dest_path)
+      !dest_dir_path || !dest_path)
     return -1;
 
   GetPath(dir_entry, src_path);
@@ -128,6 +127,7 @@ static int ResolveDirTargetPath(DirEntry *dir_entry, const char *to_dir_in,
   if (!leaf || !*leaf)
     return -1;
 
+  (void)snprintf(dest_dir_path, PATH_LENGTH + 1, "%s", resolved_dir);
   if (Path_Join(dest_path, PATH_LENGTH + 1, resolved_dir, leaf) != 0)
     return -1;
   return 0;
@@ -138,13 +138,18 @@ static DirEntry *HandleDirCopyMove(ViewContext *ctx, DirEntry *dir_entry,
   char to_file[PATH_LENGTH + 1];
   char to_dir[PATH_LENGTH + 1];
   char src_path[PATH_LENGTH + 1];
+  char dest_dir_path[PATH_LENGTH + 1];
   char dest_path[PATH_LENGTH + 1];
   char quoted_src[PATH_LENGTH * 4 + 8];
   char quoted_dst[PATH_LENGTH * 4 + 8];
   char command_line[COMMAND_LINE_LENGTH + 1];
+  DirEntry *dest_dir_entry = NULL;
   struct stat st;
+  BOOL created = FALSE;
+  int dir_create_mode = 0;
   int cmd_res;
   DirEntry *anchor;
+  DirEntry *source_entry = NULL;
   const char *prompt;
 
   if (!ctx || !ctx->active || !ctx->active->vol || !dir_entry)
@@ -168,15 +173,21 @@ static DirEntry *HandleDirCopyMove(ViewContext *ctx, DirEntry *dir_entry,
   to_file[0] = '\0';
   to_dir[0] = '\0';
   if (move_dir) {
-    if (GetMoveParameter(ctx, dir_entry->name, to_file, to_dir) != 0)
+    if (GetMoveParameter(ctx, dir_entry->name, to_file, to_dir) != 0) {
+      if (need_dsp_help)
+        *need_dsp_help = TRUE;
       return dir_entry;
+    }
   } else {
-    if (GetCopyParameter(ctx, dir_entry->name, FALSE, to_file, to_dir) != 0)
+    if (GetCopyParameter(ctx, dir_entry->name, FALSE, to_file, to_dir) != 0) {
+      if (need_dsp_help)
+        *need_dsp_help = TRUE;
       return dir_entry;
+    }
   }
 
-  if (ResolveDirTargetPath(dir_entry, to_dir, to_file, src_path, dest_path) !=
-      0) {
+  if (ResolveDirTargetPath(dir_entry, to_dir, to_file, src_path, dest_dir_path,
+                           dest_path) != 0) {
     UI_ShowStatusLineError(ctx, "Invalid destination path");
     if (need_dsp_help)
       *need_dsp_help = TRUE;
@@ -192,6 +203,13 @@ static DirEntry *HandleDirCopyMove(ViewContext *ctx, DirEntry *dir_entry,
   if (IsPathInside(src_path, dest_path)) {
     UI_ShowStatusLineError(ctx,
                            "Destination cannot be inside the source directory");
+    if (need_dsp_help)
+      *need_dsp_help = TRUE;
+    return dir_entry;
+  }
+  if (EnsureDirectoryExists(ctx, dest_dir_path, ctx->active->vol->vol_stats.tree,
+                            &created, &dest_dir_entry, &dir_create_mode,
+                            (ChoiceCallback)UI_ChoiceResolver) == -1) {
     if (need_dsp_help)
       *need_dsp_help = TRUE;
     return dir_entry;
@@ -230,8 +248,11 @@ static DirEntry *HandleDirCopyMove(ViewContext *ctx, DirEntry *dir_entry,
     prompt = "Copy directory now (Y/N) ? ";
   }
 
-  if (UI_ChoiceResolver(ctx, prompt, "YN\033") != 'Y')
+  if (UI_ChoiceResolver(ctx, prompt, "YN\033") != 'Y') {
+    if (need_dsp_help)
+      *need_dsp_help = TRUE;
     return dir_entry;
+  }
 
   cmd_res = SystemCall(ctx, command_line, &ctx->active->vol->vol_stats);
   if (cmd_res != 0) {
@@ -242,9 +263,21 @@ static DirEntry *HandleDirCopyMove(ViewContext *ctx, DirEntry *dir_entry,
     return dir_entry;
   }
 
-  anchor = dir_entry->up_tree ? dir_entry->up_tree
-                              : ctx->active->vol->vol_stats.tree;
+  if (!move_dir && dest_dir_entry != NULL) {
+    anchor = dest_dir_entry;
+  } else {
+    anchor = DirOps_ResolveCopyMoveRefreshAnchor(
+        ctx, src_path, dest_dir_path,
+        dir_entry->up_tree ? dir_entry->up_tree : ctx->active->vol->vol_stats.tree);
+  }
   dir_entry = RefreshTreeSafe(ctx, ctx->active, anchor);
+  if (!move_dir) {
+    source_entry = DirOps_FindDirEntryByPath(ctx, src_path);
+    if (source_entry != NULL) {
+      (void)DirOps_SelectVisibleDirAndRefresh(ctx, ctx->active, source_entry,
+                                              &dir_entry);
+    }
+  }
   RefreshView(ctx, dir_entry);
   if (need_dsp_help)
     *need_dsp_help = TRUE;
@@ -642,6 +675,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
     case ACTION_EDIT_CONFIG:
       UI_OpenConfigProfile(ctx, dir_entry);
+      RefreshView(ctx, dir_entry);
       need_dsp_help = TRUE;
       break;
 
@@ -877,6 +911,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       need_dsp_help = TRUE;
       break;
     case ACTION_ENTER: {
+      ctx->bypass_small_window =
+          ParseSmallWindowSkipValue(GetProfileValue(ctx, "SMALLWINDOWSKIP"));
       DirWindowDispatchResult enter_result =
           HandleDirWindowEnterAction(ctx, &dir_entry, &s, &start_vol,
                                      &need_dsp_help, &ch, &unput_char, &action);
@@ -895,6 +931,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
                         &ctx->active->vol->vol_stats, UI_ArchiveCallback);
           dir_entry = RefreshTreeSafe(
               ctx, ctx->active, dir_entry); /* Auto-Refresh after command */
+          RefreshView(ctx, dir_entry);
         }
       }
       need_dsp_help = TRUE;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -294,6 +294,66 @@ static DirEntry *FindDirByPath(const struct Volume *vol, const char *path) {
   return FindDirByPathInSubTree(vol->vol_stats.tree, path);
 }
 
+DirEntry *DirOps_FindDirEntryByPath(const ViewContext *ctx,
+                                    const char *dir_path) {
+  if (!ctx || !ctx->active || !ctx->active->vol || !dir_path ||
+      dir_path[0] != FILE_SEPARATOR_CHAR) {
+    return NULL;
+  }
+
+  return FindDirByPath(ctx->active->vol, dir_path);
+}
+
+DirEntry *DirOps_ResolveCopyMoveRefreshAnchor(ViewContext *ctx,
+                                              const char *src_path,
+                                              const char *dest_dir_path,
+                                              DirEntry *fallback) {
+  DirEntry *tree;
+  DirEntry *anchor;
+  char common_path[PATH_LENGTH + 1];
+  size_t i;
+  size_t last_separator = (size_t)-1;
+
+  if (!ctx || !ctx->active || !ctx->active->vol)
+    return fallback;
+
+  tree = ctx->active->vol->vol_stats.tree;
+  if (!tree)
+    return fallback;
+
+  if (!src_path || !dest_dir_path)
+    return tree;
+  if (src_path[0] != FILE_SEPARATOR_CHAR ||
+      dest_dir_path[0] != FILE_SEPARATOR_CHAR) {
+    return tree;
+  }
+
+  for (i = 0; src_path[i] != '\0' && dest_dir_path[i] != '\0'; ++i) {
+    if (src_path[i] != dest_dir_path[i])
+      break;
+    if (src_path[i] == FILE_SEPARATOR_CHAR)
+      last_separator = i;
+  }
+
+  if (last_separator == (size_t)-1)
+    return tree;
+
+  if (last_separator == 0) {
+    common_path[0] = FILE_SEPARATOR_CHAR;
+    common_path[1] = '\0';
+  } else {
+    if (last_separator >= PATH_LENGTH)
+      return tree;
+    memcpy(common_path, src_path, last_separator);
+    common_path[last_separator] = '\0';
+  }
+
+  anchor = DirOps_FindDirEntryByPath(ctx, common_path);
+  if (anchor)
+    return anchor;
+  return tree;
+}
+
 static BOOL EnsureDirVisible(ViewContext *ctx, YtreePanel *panel, DirEntry *target) {
   BOOL changed = FALSE;
   DirEntry *ancestor;

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -631,9 +631,6 @@ static BOOL IsActivePanelBigFileMode(const ViewContext *ctx,
   if (!ctx)
     return FALSE;
 
-  if (ctx->focused_window == FOCUS_FILE)
-    return TRUE;
-
   if (!dir_entry)
     return FALSE;
 

--- a/src/ui/file_compare.c
+++ b/src/ui/file_compare.c
@@ -13,24 +13,32 @@
 #include <string.h>
 #include <sys/stat.h>
 
-static int ResolveFileCompareTargetPath(FileEntry *source_file,
+static int ResolveFileCompareTargetPath(const char *source_path,
                                         const char *target_input,
                                         char *resolved_target_path) {
   char source_dir[PATH_LENGTH + 1];
+  char source_name[PATH_LENGTH + 1];
+  char source_copy[PATH_LENGTH + 1];
   char raw_target_path[(PATH_LENGTH * 2) + 2];
   const char *home = NULL;
   int written;
 
-  if (!source_file || !source_file->dir_entry || !target_input ||
-      !resolved_target_path) {
+  if (!source_path || !target_input || !resolved_target_path) {
     return -1;
   }
 
   if (!String_HasNonWhitespace(target_input))
     return -1;
 
-  GetPath(source_file->dir_entry, source_dir);
+  strncpy(source_copy, source_path, PATH_LENGTH);
+  source_copy[PATH_LENGTH] = '\0';
+  Fnsplit(source_copy, source_dir, source_name);
   source_dir[PATH_LENGTH] = '\0';
+  source_name[PATH_LENGTH] = '\0';
+  if (source_dir[0] == '\0')
+    return -1;
+  if (source_name[0] == '\0')
+    return -1;
 
   if (target_input[0] == FILE_SEPARATOR_CHAR) {
     written =
@@ -42,8 +50,10 @@ static int ResolveFileCompareTargetPath(FileEntry *source_file,
     written = snprintf(raw_target_path, sizeof(raw_target_path), "%s%s", home,
                        target_input + 1);
   } else {
-    written = snprintf(raw_target_path, sizeof(raw_target_path), "%s%c%s",
-                       source_dir, FILE_SEPARATOR_CHAR, target_input);
+    if (Path_Join(raw_target_path, sizeof(raw_target_path), source_dir,
+                  target_input) != 0)
+      return -1;
+    written = (int)strlen(raw_target_path);
   }
 
   if (written < 0 || (size_t)written >= sizeof(raw_target_path))
@@ -73,7 +83,9 @@ void FileCompare_LaunchExternal(ViewContext *ctx, FileEntry *source_file) {
   struct stat target_stat;
   char source_path[PATH_LENGTH + 1];
   char target_path[PATH_LENGTH + 1];
+  char source_path_copy[PATH_LENGTH + 1];
   char source_dir[PATH_LENGTH + 1];
+  char source_name[PATH_LENGTH + 1];
   char command_line[COMMAND_LINE_LENGTH + 1];
   const char *filediff = NULL;
   int start_dir_fd = -1;
@@ -106,10 +118,23 @@ void FileCompare_LaunchExternal(ViewContext *ctx, FileEntry *source_file) {
 
   strncpy(source_path, request.source_path, PATH_LENGTH);
   source_path[PATH_LENGTH] = '\0';
-  if (ResolveFileCompareTargetPath(source_file, request.target_path,
+  if (ResolveFileCompareTargetPath(source_path, request.target_path,
                                    target_path) != 0) {
     UI_Message(ctx,
                "Compare target is empty or invalid.*Choose a file target.");
+    return;
+  }
+  strncpy(source_path_copy, source_path, PATH_LENGTH);
+  source_path_copy[PATH_LENGTH] = '\0';
+  Fnsplit(source_path_copy, source_dir, source_name);
+  source_dir[PATH_LENGTH] = '\0';
+  source_name[PATH_LENGTH] = '\0';
+  if (source_dir[0] == '\0') {
+    UI_Message(ctx, "Compare source path is invalid.*Select a file again.");
+    return;
+  }
+  if (source_name[0] == '\0') {
+    UI_Message(ctx, "Compare source path is invalid.*Select a file again.");
     return;
   }
 
@@ -144,9 +169,6 @@ void FileCompare_LaunchExternal(ViewContext *ctx, FileEntry *source_file) {
         "FILEDIFF command is invalid or too long.*Check FILEDIFF in ~/.ytree.");
     return;
   }
-
-  GetPath(source_file->dir_entry, source_dir);
-  source_dir[PATH_LENGTH] = '\0';
 
   start_dir_fd = open(".", O_RDONLY);
   if (start_dir_fd == -1) {

--- a/src/ui/interactions.c
+++ b/src/ui/interactions.c
@@ -173,10 +173,11 @@ int GetCopyParameter(ViewContext *ctx, const char *from_file, BOOL path_copy,
   }
 
   if (path_copy) {
-    (void)snprintf(prompt_header, sizeof(prompt_header), "PATHCOPY: %s",
+    (void)snprintf(prompt_header, sizeof(prompt_header), "PATHCOPY: %s AS:",
                    from_file);
   } else {
-    (void)snprintf(prompt_header, sizeof(prompt_header), "COPY: %s", from_file);
+    (void)snprintf(prompt_header, sizeof(prompt_header), "COPY: %s AS:",
+                   from_file);
   }
 
   ClearHelp(ctx);
@@ -772,4 +773,3 @@ void UI_HandleSort(ViewContext *ctx, DirEntry *dir_entry, Statistic *s,
     }
   }
 }
-

--- a/src/ui/ui_edit_config.c
+++ b/src/ui/ui_edit_config.c
@@ -13,6 +13,7 @@
 #include "ytree_cmd.h"
 #include "ytree_ui.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 void UI_OpenConfigProfile(ViewContext *ctx, DirEntry *dir_entry) {
   char profile_path[PATH_LENGTH + 1];
@@ -30,6 +31,18 @@ void UI_OpenConfigProfile(ViewContext *ctx, DirEntry *dir_entry) {
   if (!profile_path[0])
     (void)snprintf(profile_path, sizeof(profile_path), "%s", PROFILE_FILENAME);
 
-  if (Edit(ctx, dir_entry, profile_path) != 0)
+  if (Edit(ctx, dir_entry, profile_path) != 0) {
     MESSAGE(ctx, "Can't edit \"%s\"", profile_path);
+    return;
+  }
+
+  if (ctx->core_init_ops.read_profile != NULL) {
+    if (ctx->core_init_ops.read_profile(ctx, profile_path) == 0) {
+      ctx->bypass_small_window =
+          ParseSmallWindowSkipValue(GetProfileValue(ctx, "SMALLWINDOWSKIP"));
+      if (ctx->core_init_ops.reinit_color_pairs != NULL) {
+        ctx->core_init_ops.reinit_color_pairs(ctx);
+      }
+    }
+  }
 }

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -60,6 +60,19 @@ def _assert_margin_plus_marker(screen_rows, dir_name, expect_slash=False):
         )
 
 
+def _has_tree_row_for_dir(screen_rows, dir_name):
+    for line in screen_rows:
+        if (
+            dir_name in line
+            and "Path:" not in line
+            and "CURRENT DIR" not in line
+            and "CURRENT FILE" not in line
+            and ("mq" in line or "tq" in line)
+        ):
+            return True
+    return False
+
+
 def test_archive_left_at_root_collapses_once_then_noop(tmp_path, ytree_binary):
     """At archive root: first LEFT collapses children, second LEFT is a no-op."""
     root = tmp_path / "archive_exit_root"
@@ -728,6 +741,193 @@ def test_enter_on_placeholder_dir_is_consistent_with_smallwindowskip_zero(
             "Enter on placeholder dir should remain in directory view when "
             "SMALLWINDOWSKIP=0.\n"
             f"Footer:\n{footer}\n\nScreen:\n{after}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_smallwindowskip_negative_value_falls_back_to_staged_navigation(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "smallwindowskip_negative_value"
+    root.mkdir()
+    target = root / "target"
+    target.mkdir()
+    (target / "file0.txt").write_text("x", encoding="utf-8")
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nSMALLWINDOWSKIP=-1\n", encoding="utf-8"
+    )
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        footer = _footer_text(tui).lower()
+        assert "file" in footer and "tree" not in footer, (
+            "SMALLWINDOWSKIP=-1 should be treated as staged navigation "
+            "(same as SMALLWINDOWSKIP=0), not bypass mode.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_smallwindowskip_trailing_junk_value_falls_back_to_staged_navigation(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "smallwindowskip_trailing_junk_value"
+    root.mkdir()
+    target = root / "target"
+    target.mkdir()
+    (target / "file0.txt").write_text("x", encoding="utf-8")
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nSMALLWINDOWSKIP=1junk\n", encoding="utf-8"
+    )
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        footer = _footer_text(tui).lower()
+        assert "file" in footer and "tree" not in footer, (
+            "SMALLWINDOWSKIP=1junk should be treated as staged navigation "
+            "(same as SMALLWINDOWSKIP=0), not bypass mode.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_smallwindowskip_config_edit_applies_immediately_in_session(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "smallwindowskip_live_apply"
+    root.mkdir()
+    target = root / "target"
+    target.mkdir()
+    (target / "file0.txt").write_text("x", encoding="utf-8")
+
+    toggle_editor = root / "toggle_smallwindowskip.sh"
+    toggle_editor.write_text(
+        "#!/bin/sh\n"
+        "f=\"$1\"\n"
+        "if grep -q '^SMALLWINDOWSKIP=' \"$f\"; then\n"
+        "  sed -i 's/^SMALLWINDOWSKIP=.*/SMALLWINDOWSKIP=1/' \"$f\"\n"
+        "else\n"
+        "  printf '\\nSMALLWINDOWSKIP=1\\n' >> \"$f\"\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    toggle_editor.chmod(0o755)
+
+    (root / ".ytree").write_text(
+        "[GLOBAL]\n"
+        "SMALLWINDOWSKIP=0\n"
+        f"EDITOR={toggle_editor}\n",
+        encoding="utf-8",
+    )
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)  # select target dir
+
+        # Baseline (SMALLWINDOWSKIP=0): two ENTER presses stay in file views.
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        assert "file" in _footer_text(tui).lower(), (
+            "Precondition failed: SMALLWINDOWSKIP=0 should still be in file view "
+            "after two ENTER presses.\n"
+            f"{_screen_text(tui)}"
+        )
+        tui.send_keystroke(Keys.ENTER, wait=0.5)  # back to dir
+
+        # Edit config via F10 and let the configured editor switch value to 1.
+        tui.send_keystroke("\x1b[21~", wait=0.9)
+        assert "SMALLWINDOWSKIP=1" in (root / ".ytree").read_text(
+            encoding="utf-8"
+        ), "Config edit flow did not update SMALLWINDOWSKIP in profile file."
+
+        # After live apply: two ENTER presses should return to dir mode.
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        footer_after = _footer_text(tui).lower()
+        footer_after_lines = [line.strip().lower() for line in _footer_lines(tui)]
+        assert footer_after_lines and footer_after_lines[0].startswith("dir"), (
+            "SMALLWINDOWSKIP change from config edit did not apply in-session.\n"
+            f"Footer:\n{footer_after}\n\nScreen:\n{_screen_text(tui)}"
+        )
+        assert "tree" in footer_after, (
+            "Directory footer should be restored after returning with "
+            "SMALLWINDOWSKIP=1.\n"
+            f"Footer:\n{footer_after}\n\nScreen:\n{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_smallwindowskip_zero_enter_chain_is_small_then_big_then_tree(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "smallwindowskip_zero_enter_chain"
+    root.mkdir()
+    target = root / "target"
+    target.mkdir()
+    (target / "file0.txt").write_text("x", encoding="utf-8")
+    (target / "file1.txt").write_text("x", encoding="utf-8")
+    (root / ".ytree").write_text("[GLOBAL]\nSMALLWINDOWSKIP=0\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+
+        before_rows = tui.get_screen_dump()
+        assert _has_tree_row_for_dir(before_rows, "target"), (
+            "Precondition failed: tree row for selected directory was not visible.\n"
+            f"{_screen_text(tui)}"
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        first_rows = tui.get_screen_dump()
+        assert "file" in _footer_text(tui).lower(), (
+            "First ENTER should move from tree to file mode.\n"
+            f"{_screen_text(tui)}"
+        )
+        assert _has_tree_row_for_dir(first_rows, "target"), (
+            "SMALLWINDOWSKIP=0 first ENTER must keep tree pane visible (small file window).\n"
+            f"{_screen_text(tui)}"
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        second_rows = tui.get_screen_dump()
+        assert "file" in _footer_text(tui).lower(), (
+            "Second ENTER should remain in file mode (big window).\n"
+            f"{_screen_text(tui)}"
+        )
+        assert not _has_tree_row_for_dir(second_rows, "target"), (
+            "Second ENTER must switch to big file window and hide tree pane.\n"
+            f"{_screen_text(tui)}"
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        footer_third = _footer_text(tui).lower()
+        footer_third_lines = [line.strip().lower() for line in _footer_lines(tui)]
+        assert footer_third_lines and footer_third_lines[0].startswith("dir"), (
+            "Third ENTER should return to tree mode.\n"
+            f"Footer:\n{footer_third}\n\nScreen:\n{_screen_text(tui)}"
+        )
+        assert "tree" in footer_third, (
+            "Tree footer should be visible after returning from big file window.\n"
+            f"Footer:\n{footer_third}\n\nScreen:\n{_screen_text(tui)}"
         )
     finally:
         tui.quit()

--- a/tests/test_display_layout.py
+++ b/tests/test_display_layout.py
@@ -728,6 +728,301 @@ def test_dir_copy_move_keeps_full_frame_after_command(
     tui.quit()
 
 
+def test_dir_copy_to_missing_destination_prompts_create_and_no_restores_footer(
+    ytree_binary, tmp_path
+):
+    root = tmp_path / "dir_copy_missing_dest_no"
+    root.mkdir()
+    src = root / "src_dir"
+    src.mkdir()
+    (src / "nested").mkdir()
+    (src / "nested" / "payload.txt").write_text("x", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    tui.child.setwinsize(36, 140)
+    tui.screen.resize(36, 140)
+    time.sleep(1.0)
+    tui.send_keystroke("", wait=0.2)
+
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+    tui.child.send("c")
+    tui.child.expect("COPY:")
+    tui.child.send("\x15")
+    tui.child.send("copied_src\r")
+    tui.child.expect("To Directory")
+    tui.child.send("\x15")
+    tui.child.send("./new_parent\r")
+    tui.child.expect("Directory does not exist; create", timeout=2.0)
+    tui.child.send("N")
+    tui.send_keystroke("", wait=0.6)
+
+    assert not (root / "new_parent").exists()
+    assert (root / "src_dir" / "nested" / "payload.txt").exists()
+
+    post = "\n".join(tui.get_screen_dump())
+    footer = _footer_text(tui).lower()
+    assert "Path:" in post, "Header/path row disappeared after canceling create prompt"
+    assert "tree" in footer and "help" in footer, (
+        "Footer/help row was not restored after canceling create prompt.\n"
+        f"Footer:\n{footer}\n\nScreen:\n{post}"
+    )
+
+    tui.quit()
+
+
+def test_dir_copy_to_missing_destination_create_yes_copies_and_restores_frame(
+    ytree_binary, tmp_path
+):
+    root = tmp_path / "dir_copy_missing_dest_yes"
+    root.mkdir()
+    src = root / "src_dir"
+    src.mkdir()
+    (src / "nested").mkdir()
+    (src / "nested" / "payload.txt").write_text("x", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    tui.child.setwinsize(36, 140)
+    tui.screen.resize(36, 140)
+    time.sleep(1.0)
+    tui.send_keystroke("", wait=0.2)
+
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+    tui.child.send("c")
+    tui.child.expect("COPY:")
+    tui.child.send("\x15")
+    tui.child.send("copied_src\r")
+    tui.child.expect("To Directory")
+    tui.child.send("\x15")
+    tui.child.send("./new_parent\r")
+    tui.child.expect("Directory does not exist; create", timeout=2.0)
+    tui.child.send("Y")
+    tui.child.expect("Copy directory now", timeout=2.0)
+    tui.child.send("Y")
+    tui.send_keystroke("", wait=0.8)
+
+    copied = root / "new_parent" / "copied_src" / "nested" / "payload.txt"
+    assert copied.exists(), "Directory copy did not complete after confirming create"
+
+    post = "\n".join(tui.get_screen_dump())
+    footer = _footer_text(tui).lower()
+    assert "Path:" in post, "Header/path row disappeared after create+copy flow"
+    assert "tree" in footer and "f1" in footer and "help" in footer, (
+        "Footer/help row was not restored after create+copy flow.\n"
+        f"Footer:\n{footer}\n\nScreen:\n{post}"
+    )
+
+    tui.quit()
+
+
+def test_dir_copy_prompt_shows_source_and_as_target(ytree_binary, tmp_path):
+    root = tmp_path / "dir_copy_prompt_as"
+    root.mkdir()
+    src = root / "src_dir"
+    src.mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    tui.child.setwinsize(36, 140)
+    tui.screen.resize(36, 140)
+    time.sleep(1.0)
+    tui.send_keystroke("", wait=0.2)
+
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+    tui.child.send("c")
+    tui.child.expect(r"COPY:\s+src_dir\s+AS:", timeout=2.0)
+    tui.child.send(Keys.ESC)
+    tui.send_keystroke("", wait=0.2)
+    tui.quit()
+
+
+def test_dir_copy_refreshes_destination_branch_without_relog(ytree_binary, tmp_path):
+    root = tmp_path / "dir_copy_cross_branch_refresh"
+    root.mkdir()
+    source_bucket = root / "source_bucket"
+    target_bucket = root / "target_bucket"
+    source_bucket.mkdir()
+    target_bucket.mkdir()
+    src = source_bucket / "src_dir"
+    src.mkdir()
+    (src / "nested").mkdir()
+    (src / "nested" / "payload.txt").write_text("x", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    tui.child.setwinsize(36, 140)
+    tui.screen.resize(36, 140)
+    time.sleep(1.0)
+    tui.send_keystroke("", wait=0.2)
+
+    # root -> source_bucket -> src_dir
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+    tui.send_keystroke(Keys.RIGHT, wait=0.6)
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+
+    tui.child.send("c")
+    tui.child.expect("COPY:")
+    tui.child.send("\x15")
+    tui.child.send("copied_src\r")
+    tui.child.expect("To Directory")
+    tui.child.send("\x15")
+    tui.child.send("../target_bucket/new_parent\r")
+    tui.child.expect("Directory does not exist; create", timeout=2.0)
+    tui.child.send("Y")
+    tui.child.expect("Copy directory now", timeout=2.0)
+    tui.child.send("Y")
+    tui.send_keystroke("", wait=1.0)
+
+    copied = root / "target_bucket" / "new_parent" / "copied_src" / "nested" / "payload.txt"
+    assert copied.exists(), "Directory copy did not complete"
+
+    # Move to target_bucket and verify the copied branch is visible immediately.
+    for _ in range(16):
+        if "target_bucket" in tui.get_screen_dump()[0]:
+            break
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+    assert "target_bucket" in tui.get_screen_dump()[0], "\n".join(tui.get_screen_dump())
+
+    tui.send_keystroke(Keys.ENTER, wait=0.6)
+    after_target_enter = "\n".join(tui.get_screen_dump())
+    assert "new_parent" in after_target_enter, (
+        "Created destination directory is not visible in-session after copy "
+        "(requires relog today).\n"
+        f"{after_target_enter}"
+    )
+
+    for _ in range(16):
+        if "new_parent" in tui.get_screen_dump()[0]:
+            break
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+    assert "new_parent" in tui.get_screen_dump()[0], "\n".join(tui.get_screen_dump())
+
+    tui.send_keystroke(Keys.ENTER, wait=0.6)
+    after_new_parent_enter = "\n".join(tui.get_screen_dump())
+    assert "copied_src" in after_new_parent_enter, (
+        "Copied subtree is not visible immediately after destination creation.\n"
+        f"{after_new_parent_enter}"
+    )
+
+    tui.quit()
+
+
+def test_dir_copy_delete_created_destination_updates_in_session(ytree_binary, tmp_path):
+    root = tmp_path / "dir_copy_delete_created_destination"
+    root.mkdir()
+    source_bucket = root / "source_bucket"
+    target_bucket = root / "target_bucket"
+    source_bucket.mkdir()
+    target_bucket.mkdir()
+    src = source_bucket / "src_dir"
+    src.mkdir()
+    (src / "nested").mkdir()
+    (src / "nested" / "payload.txt").write_text("x", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    tui.child.setwinsize(36, 140)
+    tui.screen.resize(36, 140)
+    time.sleep(1.0)
+    tui.send_keystroke("", wait=0.2)
+
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+    tui.send_keystroke(Keys.RIGHT, wait=0.6)
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+
+    tui.child.send("c")
+    tui.child.expect("COPY:")
+    tui.child.send("\x15")
+    tui.child.send("copied_src\r")
+    tui.child.expect("To Directory")
+    tui.child.send("\x15")
+    tui.child.send("../target_bucket/new_parent\r")
+    tui.child.expect("Directory does not exist; create", timeout=2.0)
+    tui.child.send("Y")
+    tui.child.expect("Copy directory now", timeout=2.0)
+    tui.child.send("Y")
+    tui.send_keystroke("", wait=1.0)
+
+    # Navigate to created destination directory and delete it.
+    for _ in range(16):
+        if "target_bucket" in tui.get_screen_dump()[0]:
+            break
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+    assert "target_bucket" in tui.get_screen_dump()[0], "\n".join(tui.get_screen_dump())
+    tui.send_keystroke(Keys.ENTER, wait=0.6)
+
+    for _ in range(16):
+        if "new_parent" in tui.get_screen_dump()[0]:
+            break
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+    assert "new_parent" in tui.get_screen_dump()[0], "\n".join(tui.get_screen_dump())
+
+    tui.child.send(Keys.DELETE)
+    tui.child.expect(r"(Delete this directory|PRUNE)", timeout=2.0)
+    tui.child.send("Y")
+    tui.send_keystroke("", wait=0.8)
+
+    assert not (root / "target_bucket" / "new_parent").exists(), (
+        "Deleting the created destination directory had no filesystem effect."
+    )
+    after_delete = "\n".join(tui.get_screen_dump())
+    assert "new_parent" not in after_delete, (
+        "Created destination directory still rendered after in-session delete.\n"
+        f"{after_delete}"
+    )
+
+    tui.quit()
+
+
+def test_dir_copy_absolute_destination_refreshes_without_relog(ytree_binary, tmp_path):
+    root = tmp_path / "dir_copy_absolute_destination_refresh"
+    root.mkdir()
+    source_bucket = root / "source_bucket"
+    target_bucket = root / "target_bucket"
+    source_bucket.mkdir()
+    target_bucket.mkdir()
+    src = source_bucket / "src_dir"
+    src.mkdir()
+    (src / "nested").mkdir()
+    (src / "nested" / "payload.txt").write_text("x", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    tui.child.setwinsize(36, 140)
+    tui.screen.resize(36, 140)
+    time.sleep(1.0)
+    tui.send_keystroke("", wait=0.2)
+
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+    tui.send_keystroke(Keys.RIGHT, wait=0.6)
+    tui.send_keystroke(Keys.DOWN, wait=0.3)
+
+    tui.child.send("c")
+    tui.child.expect("COPY:")
+    tui.child.send("\x15")
+    tui.child.send("copied_src\r")
+    tui.child.expect("To Directory")
+    tui.child.send("\x15")
+    tui.child.send(f"{target_bucket}/new_parent\r")
+    tui.child.expect("Directory does not exist; create", timeout=2.0)
+    tui.child.send("Y")
+    tui.child.expect("Copy directory now", timeout=2.0)
+    tui.child.send("Y")
+    tui.send_keystroke("", wait=1.0)
+
+    copied = root / "target_bucket" / "new_parent" / "copied_src" / "nested" / "payload.txt"
+    assert copied.exists(), "Directory copy to absolute destination did not complete"
+
+    for _ in range(16):
+        if "target_bucket" in tui.get_screen_dump()[0]:
+            break
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+    assert "target_bucket" in tui.get_screen_dump()[0], "\n".join(tui.get_screen_dump())
+    tui.send_keystroke(Keys.ENTER, wait=0.6)
+    after_target_enter = "\n".join(tui.get_screen_dump())
+    assert "new_parent" in after_target_enter, (
+        "Absolute-path destination not visible in-session after copy.\n"
+        f"{after_target_enter}"
+    )
+
+    tui.quit()
+
+
 def test_jump_prompt_uses_footer_without_bleed(ytree_binary, tmp_path):
     """
     REGRESSION:

--- a/tests/test_viewer_return_ui.py
+++ b/tests/test_viewer_return_ui.py
@@ -1,0 +1,115 @@
+import time
+import tarfile
+import shutil
+
+from helpers_ui import footer_text as _footer_text
+from helpers_ui import screen_text as _screen_text
+from tui_harness import YtreeTUI
+from ytree_keys import Keys
+
+
+def _create_archive(root, archive_name="sample.tar"):
+    archive_source = root / "_archive_src"
+    archive_source.mkdir()
+    (archive_source / "inside.txt").write_text("inside", encoding="utf-8")
+
+    archive_path = root / archive_name
+    with tarfile.open(archive_path, "w") as tf:
+        tf.add(archive_source, arcname="inside_dir")
+    shutil.rmtree(archive_source)
+    return archive_path
+
+
+def test_external_viewer_return_restores_full_ui_frame(tmp_path, ytree_binary):
+    root = tmp_path / "external_viewer_return"
+    root.mkdir()
+    (root / "alpha.txt").write_text("alpha", encoding="utf-8")
+
+    pager_script = root / "pager_clobber.sh"
+    pager_script.write_text(
+        "#!/bin/sh\n"
+        "printf '\\033[2J\\033[HEXTERNAL VIEWER\\n'\n"
+        "cat \"$1\" >/dev/null\n",
+        encoding="utf-8",
+    )
+    pager_script.chmod(0o755)
+    (root / ".ytree").write_text(
+        f"[GLOBAL]\nPAGER={pager_script}\n", encoding="utf-8"
+    )
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        assert "file" in _footer_text(tui).lower(), _screen_text(tui)
+
+        tui.send_keystroke("v", wait=0.8)
+        screen = _screen_text(tui)
+        footer = _footer_text(tui).lower()
+        assert "Path:" in screen, f"Header row not restored after external viewer.\n{screen}"
+        assert "hex" in footer and "compare" in footer, (
+            "Footer row not restored after external viewer.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{screen}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_internal_viewer_return_restores_full_ui_frame(tmp_path, ytree_binary):
+    root = tmp_path / "internal_viewer_return"
+    root.mkdir()
+    (root / "alpha.txt").write_text("alpha", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        assert "file" in _footer_text(tui).lower(), _screen_text(tui)
+
+        tui.send_keystroke("h", wait=0.7)
+        tui.send_keystroke("q", wait=0.8)
+
+        screen = _screen_text(tui)
+        footer = _footer_text(tui).lower()
+        assert "Path:" in screen, f"Header row not restored after internal viewer.\n{screen}"
+        assert "hex" in footer and "compare" in footer, (
+            "Footer row not restored after internal viewer.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{screen}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_internal_viewer_return_in_archive_mode_restores_full_ui_frame(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "internal_viewer_archive_return"
+    root.mkdir()
+    _create_archive(root, "archive.tar")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        tui.send_keystroke(Keys.LOG, wait=0.3)
+        tui.send_keystroke(Keys.ENTER, wait=0.9)
+        assert tui.wait_for_content("ARCHIVE", timeout=2.0), _screen_text(tui)
+
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "file" in _footer_text(tui).lower(), _screen_text(tui)
+
+        tui.send_keystroke("h", wait=0.7)
+        tui.send_keystroke("q", wait=0.8)
+
+        screen = _screen_text(tui)
+        footer = _footer_text(tui).lower()
+        assert "ARCHIVE" in screen, f"Archive context not restored after internal viewer.\n{screen}"
+        assert "compare" in footer and "hex" in footer, (
+            "Archive file footer not restored after internal viewer.\n"
+            f"Footer:\n{footer}\n\nScreen:\n{screen}"
+        )
+    finally:
+        tui.quit()


### PR DESCRIPTION
- Restore full panel redraw consistency after returning from viewer, editor,
and execute flows.
- Repair split navigation and small window enter cycling so focus transitions
stay deterministic and recover cleanly.
- Fix directory copy destination prompts and refresh behavior so newly created
targets and copied entries appear immediately.
- Stabilize compare helper launch context across panel switches and logged
volume changes.
- Add regression coverage for redraw return paths, split navigation semantics,
copy destination handling, and compare execution flows.
