### PR TITLE
ci(workflows): skip heavy qa jobs for doc-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,39 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect QA-relevant changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      qa_relevant: ${{ steps.force.outputs.qa_relevant || steps.filter.outputs.qa_relevant }}
+    steps:
+    - name: Force QA on main pushes
+      id: force
+      if: github.event_name == 'push'
+      run: echo "qa_relevant=true" >> "$GITHUB_OUTPUT"
+
+    - name: Detect PR file changes
+      id: filter
+      if: github.event_name == 'pull_request'
+      uses: dorny/paths-filter@v4
+      with:
+        filters: |
+          qa_relevant:
+            - 'src/**'
+            - 'include/**'
+            - 'tests/**'
+            - 'scripts/**'
+            - 'Makefile'
+            - '.github/workflows/**'
+
   guard-fuzz-sync:
     name: Guard fuzz harness sync
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.qa_relevant == 'true'
 
     steps:
     - uses: actions/checkout@v6
@@ -47,7 +77,8 @@ jobs:
   qa-fileops-integrity:
     name: File mutation integrity gate
     runs-on: ubuntu-latest
-    needs: guard-fuzz-sync
+    needs: [changes, guard-fuzz-sync]
+    if: github.event_name == 'push' || needs.changes.outputs.qa_relevant == 'true'
     env:
       CC: ccache cc
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -100,7 +131,8 @@ jobs:
   qa-pytest-coverage:
     name: Full coverage baseline gate
     runs-on: ubuntu-latest
-    needs: guard-fuzz-sync
+    needs: [changes, guard-fuzz-sync]
+    if: github.event_name == 'push' || needs.changes.outputs.qa_relevant == 'true'
     env:
       CC: ccache cc
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -166,7 +198,8 @@ jobs:
   qa-fuzz:
     name: Fuzz baseline gate
     runs-on: ubuntu-latest
-    needs: guard-fuzz-sync
+    needs: [changes, guard-fuzz-sync]
+    if: github.event_name == 'push' || needs.changes.outputs.qa_relevant == 'true'
     env:
       FUZZ_CC: ccache clang
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/full-qa.yml
+++ b/.github/workflows/full-qa.yml
@@ -3,17 +3,6 @@ name: C/C++ Full QA
 on:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - "src/**/*.c"
-      - "src/**/*.cpp"
-      - "**/*.h"
-      - "**/*.yml"
-      - "**/*.yaml"
-      - "tests/**/*.py"
-      - "scripts/**/*.py"
-      - "scripts/requirements.txt"
-      - "Makefile"
-      - ".github/workflows/full-qa.yml"
   workflow_dispatch:
 
 permissions:
@@ -24,9 +13,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  changes:
+    name: Detect full-QA relevant changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      qa_relevant: ${{ steps.force.outputs.qa_relevant || steps.filter.outputs.qa_relevant }}
+    steps:
+    - name: Force full QA for manual dispatch
+      id: force
+      if: github.event_name == 'workflow_dispatch'
+      run: echo "qa_relevant=true" >> "$GITHUB_OUTPUT"
+
+    - name: Detect PR file changes
+      id: filter
+      if: github.event_name == 'pull_request'
+      uses: dorny/paths-filter@v4
+      with:
+        filters: |
+          qa_relevant:
+            - 'src/**'
+            - 'include/**'
+            - 'tests/**'
+            - 'scripts/**'
+            - 'Makefile'
+            - '.github/workflows/**'
+
   qa-all:
     name: Full local-equivalent QA gate (qa-all)
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.qa_relevant == 'true'
     timeout-minutes: 90
     env:
       CC: ccache cc
@@ -112,6 +131,8 @@ jobs:
   qa-sanitize:
     name: Sanitizer gate (qa-sanitize)
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.qa_relevant == 'true'
     timeout-minutes: 120
     env:
       CC: ccache cc


### PR DESCRIPTION
## Summary
- add workflow-level file-change detection for baseline CI and full QA
- keep required workflow/job check names present while skipping expensive jobs on doc-only pull requests
- preserve full execution for pushes to `main` and manual full-QA dispatch

## Why
Force-pushes and doc-only edits currently re-run heavyweight QA jobs. This change keeps branch protection checks healthy while reducing unnecessary runtime on non-code PR updates.

## Verification
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` for `.github/workflows/ci.yml` and `.github/workflows/full-qa.yml`
