### PR TITLE
fix: harden relay runtime autonomy and visibility guards

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -10,6 +10,18 @@ These instructions apply to all AI agents used in this repository.
 - Testing: Python `pytest` and `pexpect` from the local `.venv`
 - For non-trivial missions, follow the stateless relay workflow in `docs/ai/WORKFLOW.md` ("Stateless Multi-AI Delivery Workflow"): architect plans one task at a time, developer executes one task at a time, with maintainer-approved per-task commits and QA-gated merge/cleanup.
 
+## Relay Autonomy Hard Requirement
+
+- Relay execution must be autonomous after kickoff: no maintainer prodding for recoverable failures.
+- Policy-blocked worker prompt failures must auto-retry once with a reduced prompt profile.
+- Watchdog behavior is mandatory and explicit: stale heartbeat/timeout -> `stall_detected` -> bounded retry/reassign -> terminal escalation when retries are exhausted.
+- Maintainer pause gate is strict: relay may pause only for `true_blocker_decision` or `commit_message_approval`.
+- Recoverable failures must not trigger maintainer pause/prompt gates.
+- Canonical relay autonomy policy tokens (required):
+  - `policy_block_retry_once`
+  - `watchdog_stall_retry_terminal`
+  - `maintainer_pause_gate=true_blocker_decision|commit_message_approval`
+
 ## Persona Routing
 
 - Start every assistant response with: `<name>:`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,10 @@ jobs:
         ccache --set-config=sloppiness=time_macros
         ccache --zero-stats
 
-    - name: Run unsafe API and file mutation gate
+    - name: Run unsafe API, relay policy config, and file mutation gate
       run: |
         make qa-unsafe-apis
+        make qa-ai-config
         make qa-fileops-integrity
 
     - name: Report ccache stats

--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ qa-module-boundaries:
 qa-ai-config:
 	python3 scripts/check_project_ai_config.py
 
-ci-baseline: qa-unsafe-apis qa-fileops-integrity qa-pytest-coverage qa-fuzz
+ci-baseline: qa-unsafe-apis qa-ai-config qa-fileops-integrity qa-pytest-coverage qa-fuzz
 
 # Comprehensive local gate: static/runtime checks + full pytest once.
 # Run qa-fileops-integrity explicitly when file/archive mutation flows are touched.

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -1,69 +1,30 @@
 # **Bugs and Defects Requiring Fixes**
 
 This file tracks fix-required bugs, architectural violations, and naming inconsistencies that require remediation.
+Buglist is forward-looking (`planned`/`in-progress`). Completed items will be removed after fixed.
 
 Ordering policy (for all editors, including AI editors):
 - Put bugs that are high-impact first after that order remaining bugs by ease of implementation.
 - Insert new approved bugs at the correct priority position (do not append by default).
-- Bug numbering is a priority countdown where practical (`highest number = highest priority`).
+- Bug numbering is top-to-bottom ascending (`BUG-30` = highest priority).
 - Bug IDs are unstable labels and are likely to change often due to reprioritization/renumbering.
 
 ## **Current Runtime Defects (Highest Priority First)**
 
-### **BUG-41: F8 Release-Volume Flow Can Blank Panel and Crash on Tab**
-*   **Description**: In `F8` split mode, after logging two volumes and releasing one, the small window can go blank, separator line can disappear, inactive panel can blank, and tabbing to the inactive panel can trigger a segmentation fault.
-*   **Impact**: Critical stability and data-safety risk (crash), plus severe UI corruption in a core split-panel workflow.
-*   **Remediation**: Harden split-panel volume-release lifecycle so panel/window ownership and active/inactive bindings are always valid after release. Add focused regression coverage for `F8` with multi-volume log/release and `Tab` switching after release.
-*   **Status**: Fixed.
-
-### **BUG-40: Cycle-Volumes (`<`/`>`, `,`/`.`) Leaks Dir/File View State Across Volumes**
+### **BUG-1: Cycle-Volumes (`<`/`>`, `,`/`.`) Leaks Dir/File View State Across Volumes**
 *   **Description**: Cycling logged volumes can cause dir/file window mode/state changes in one volume to appear in the other, instead of each volume retaining its own last-used state.
 *   **Impact**: Breaks per-volume navigation predictability and increases wrong-target risk during fast volume switching workflows.
 *   **Remediation**: Preserve and restore per-volume dir/file window state independently when cycling volumes. Add regression coverage for repeated `<`/`>` transitions across volumes with different view states.
 *   **Status**: Confirmed.
 
-### **BUG-39: `Write` Destination Ambiguity and Crash Path**
-*   **Description**: In `Write`, entering a plain filename (for example `report-2026-04-11.txt`) can be interpreted as a command execution path instead of file output, and user repro indicates this path can crash after command failure handling.
-*   **Impact**: Violates least-surprise behavior, risks data-loss/confusion for new users, and introduces a stability defect (segmentation fault).
-*   **Remediation**: Make destination handling explicit and safe: default plain filename/path input to file output, provide an explicit File vs Command destination choice in the flow, keep expert shortcuts as optional aliases, and harden all command/file-open failure paths to eliminate crashes.
-*   **Status**: Fixed.
-
-### **BUG-38: Right Arrow Does Not Drill Down on Expanded Nodes**
-*   **Description**: In Directory Mode, `Right Arrow` expands a collapsed node correctly, but performs a no-op when the node is already expanded.
-*   **Findings**:
-    *   `Right Arrow` on collapsed node: expands one level (works).
-    *   `Right Arrow` on already expanded node: no-op (incorrect).
-*   **Expected Behavior**:
-    *   `Right Arrow` should be progressive: expand if collapsed; if already expanded, move selection to the first child.
-*   **Note**:
-    *   Right as “expand-or-drill-down” and Left as “collapse-or-parent” is the common expectation.
-*   **Impact**: Breaks common tree-navigation muscle memory and slows keyboard-only navigation.
-*   **Remediation**: Align `Right Arrow` handling with documented progressive drill-down behavior in Directory Mode.
-*   **Status**: Fixed.
-
-### **BUG-37: F8 Mirrored Tree Changes Can Move Inactive Selection to Wrong Node**
-*   **Description**: In `F8` split mode, mirrored expand/collapse changes can move the inactive panel selection unexpectedly to another sibling/ancestor even when the original inactive selection should remain valid.
-*   **Repro (Confirmed)**:
-*   Select `~/ytree/obj/cmd`, then enter split mode (`F8`).
-    *   Collapse `obj`: inactive cursor moves to `obj`; expand `obj`: inactive remains on `obj`.
-    *   Collapse a sibling of `obj`: inactive remains on `obj`.
-    *   Expand/collapse a sibling above `obj`: inactive selection can jump to another sibling above (pattern not deterministic).
-*   **Expected Behavior**:
-    *   Inactive selection remains stable under mirrored tree-shape updates while its selected node is still visible/valid.
-    *   If invalidated, fallback target must follow a deterministic rule.
-*   **Impact**: Breaks split-panel predictability and makes inactive-panel targeting unreliable for copy/move/compare workflows.
-*   **Remediation**: Preserve inactive selection by stable node identity (not row/index), and apply deterministic fallback only when the selected node becomes invalid.
-*   **Related**: `ROADMAP` Task 45 (inactive split-panel selection semantics + regression coverage).
-*   **Status**: Fixed.
-
-### **BUG-36: F8 Same-Volume Destination Navigation Can Lose Source Selection/Tagged Set**
+### **BUG-2: F8 Same-Volume Destination Navigation Can Lose Source Selection/Tagged Set**
 *   **Description**: In `F8` split mode on the same volume, navigating the destination side (including creating/changing directories during copy/move preparation) can cause the original source file selection/tagged set to disappear or be replaced by the destination-context file list.
 *   **Impact**: Breaks split-panel isolation and creates high wrong-target risk in copy/move workflows because source intent is lost while preparing destination paths.
 *   **Remediation**: Enforce source-vs-destination state isolation in split mode so destination-side `mkdir`/`cd` and tree navigation cannot mutate source selection/tag state. Preserve source tagged/selection state by stable file identity across destination context changes, and apply deterministic fallback only when a selected source entry truly no longer exists.
-*   **Related**: `BUG-37` (inactive split selection stability), `ROADMAP` Task 45 (split selection semantics/regression coverage).
+*   **Related**: `ROADMAP` Task 23 (split selection semantics/regression coverage).
 *   **Status**: Confirmed.
 
-### **BUG-35: F7 Preview Over-Restricts Command Availability**
+### **BUG-3: F7 Preview Over-Restricts Command Availability**
 *   **Description**: `F7` mode is currently incomplete for inspect-and-act workflows. Too many common file actions are disabled, so users must leave preview to continue work.
 *   **Expected Behavior**:
     *   `F7` should allow a practical command subset for in-context file work (for example attributes/copy/delete/edit/filter/compare/move/new-date/open/print/rename/tag/untag/view/execute/quit paths as applicable).
@@ -75,72 +36,52 @@ Ordering policy (for all editors, including AI editors):
 *   **Related**: Existing regression intent for `F8`-in-`F7` state safety should remain preserved and extended to `Tab`.
 *   **Status**: Confirmed.
 
-### **BUG-34: `Write` Offers/Describes Actions That Are Not Context-Valid**
+### **BUG-4: `Write` Offers/Describes Actions That Are Not Context-Valid**
 *   **Description**: `Write` format/options/prompt/help are not consistently aligned with context (`dir`/`file`/`archive`/`tagged`) and can imply workflows that are unavailable or misleading in the active mode.
 *   **Impact**: Reduces discoverability and trust, and creates avoidable trial-and-error in critical output/export flows.
 *   **Remediation**: Define and enforce a context-valid option matrix for `Write`, expose only valid options in each mode, and keep prompt/help text explicit and non-jargon (including destination examples such as file output and printer-command output). Keep `SPECIFICATION`, `F1` help, and manpage/USAGE text synchronized with the same destination semantics.
 *   **Status**: Confirmed.
 
-### **BUG-33: `F10` Hard-Fails When `~/.ytree` Is Missing**
+### **BUG-5: `F10` Hard-Fails When `~/.ytree` Is Missing**
 *   **Description**: If `~/.ytree` does not exist, pressing `F10` fails with an edit error instead of letting users proceed with configuration editing.
 *   **Impact**: Creates avoidable first-run friction in a common workflow and forces users to discover `--init` before they can use in-app config editing.
 *   **Remediation**: On `F10` with missing `~/.ytree`, open an editable default config buffer immediately and create `~/.ytree` only if the user saves; if they exit without saving, do not create the file.
 *   **Status**: Confirmed.
 
-### **BUG-32: `SMALLWINDOWSKIP=0` Is Ignored**
+### **BUG-6: `SMALLWINDOWSKIP=0` Is Ignored**
 *   **Description**: Setting `SMALLWINDOWSKIP=0` does not re-enable the small window; runtime still behaves as if small-window skipping is active.
 *   **Impact**: Breaks configuration trust and blocks users from restoring a primary layout element through documented config.
 *   **Remediation**: Ensure `SMALLWINDOWSKIP` is parsed/applied correctly so `0` reliably enables the small window and `1` skips it across relevant contexts.
 *   **Status**: Confirmed.
 
-### **BUG-31: `F10` Save Does Not Reload Configuration in-Session**
+### **BUG-7: `F10` Save Does Not Reload Configuration in-Session**
 *   **Description**: Editing and saving configuration via `F10` does not update active runtime behavior until ytree is quit and restarted.
 *   **Impact**: Violates expected interactive-config workflow and adds avoidable friction after in-app edits.
 *   **Remediation**: Live-apply is preferred: reload and apply safe settings immediately after `F10` save. For settings that are not safe to rebind mid-session, show a concise explicit notice that restart is required.
 *   **Status**: Confirmed.
 
-### **BUG-30: Dir/Tree View Loses Lines/Path After Returning From `F10` Editor**
-*   **Description**: From directory/tree context, running `F10` to edit config and returning to ytree can leave directory and small-window lines/path missing; the same flow from file view does not show this symptom.
-*   **Impact**: Corrupts primary navigation UI after a common workflow and reduces operator trust in view stability.
-*   **Remediation**: On return from external editor/config-save flow, restore/redraw directory-tree and small-window state deterministically for dir context (including path/header lines), and keep behavior consistent with file-view return path.
-*   **Related**: `BUG-15` (state/layout transition corruption family), `BUG-31` (post-`F10` apply/return family).
-*   **Status**: Fixed.
-
-### **BUG-29: External Viewer Return Can Corrupt Ytree UI Redraw**
-*   **Description**: Returning from external viewer/pager flows can leave ytree in a visibly corrupted state (for example shell prompt fragments or stray text rendered into panes/footer instead of a clean ncurses repaint).
-*   **Impact**: Breaks core usability immediately after viewing, obscures navigation/help text, and reduces trust in terminal-state safety.
-*   **Remediation**: Ensure external-view return paths always restore curses mode and perform a full deterministic UI repaint (header, panes, footer/help lines), including prompt-line cleanup before accepting further input.
-*   **Status**: Fixed.
-
-### **BUG-28: Viewer Return (`v` -> `q`) Can Corrupt UI and Input State**
-*   **Description**: In WSL repro, running ytree, opening `View` on a file (`v`), then quitting viewer (`q`) can leave the main UI mostly vanished/artifacted (for example stray clock digits only). Follow-on input/state is also corrupted: `^L` has negligible/no effect, `Enter` no longer toggles to dir window, and a subsequent `q` exits ytree.
-*   **Impact**: Breaks core post-view workflow and can leave the session in a partially unusable state until restart.
-*   **Remediation**: Harden viewer-return restore path to reestablish full ncurses paint + mode/input state atomically (window ownership, active panel mode, key handling context) before processing next key events.
-*   **Related**: `BUG-29` (same return/redraw defect family).
-*   **Status**: Fixed.
-
-### **BUG-27: Copy/Move Cancel (`Esc`) Can Leave Footer Blank**
+### **BUG-8: Copy/Move Cancel (`Esc`) Can Leave Footer Blank**
 *   **Description**: In `Copy`/`Move` flows, canceling with `Esc` can leave footer/help lines blank instead of restoring the normal context footer.
 *   **Impact**: Hides command discoverability immediately after a canceled mutation flow and makes the UI look partially broken.
 *   **Remediation**: On all `Copy`/`Move` cancel/exit paths (`Esc` and equivalent cancel keys), restore footer/help ownership deterministically to the active view context and force a full footer redraw before accepting the next command.
-*   **Related**: `BUG-6` (footer restore consistency during input flows), `ROADMAP` Task 31 (footer/F1 context parity).
+*   **Related**: `BUG-25` (footer restore consistency during input flows), `ROADMAP` Task 36 (footer/F1 context parity).
 *   **Status**: Confirmed.
 
-### **BUG-26: Prompt Footer/F1 Parity Can Hide Available Prompt Actions**
+### **BUG-9: Prompt Footer/F1 Parity Can Hide Available Prompt Actions**
 *   **Description**: In prompt-driven workflows, footer/F1 coverage can omit active prompt actions and semantics (for example completion/browse controls and compare/archive prompt meanings), leaving available behavior under-discoverable.
 *   **Impact**: Creates hidden-feature workflow confusion and high-friction issue reports during routine operations.
 *   **Remediation**: Enforce a prompt-context parity contract: footer shows currently available prompt actions; F1 may add concise semantics/examples for those same actions, but must not advertise unavailable actions.
-*   **Related**: `ROADMAP` Task 31 (footer/F1 context parity), `BUG-21` (hidden archive action), `BUG-34` (prompt/help context mismatch).
+*   **Related**: `ROADMAP` Task 36 (footer/F1 context parity), `BUG-14` (hidden archive action), `BUG-4` (prompt/help context mismatch).
 *   **Status**: Confirmed.
 
-### **BUG-25: Progress Spinner Can Overwrite Footer/Prompt Help Surfaces**
+### **BUG-10: Progress Spinner Can Overwrite Footer/Prompt Help Surfaces**
 *   **Description**: During long-running operations, spinner/progress rendering can overwrite footer/prompt help text instead of using a non-obtrusive status area.
 *   **Impact**: Hides available actions and makes active workflows look unstable or hung.
 *   **Remediation**: Preserve footer/prompt/F1 ownership during progress updates. Render progress in a dedicated non-obtrusive status surface, and degrade to a compact indicator when space is constrained rather than overwriting help text.
-*   **Related**: `ROADMAP` Task 54 (progress indicators), `ROADMAP` Task 31 (footer/F1 parity contract).
+*   **Related**: `ROADMAP` Task 14 (progress indicators), `ROADMAP` Task 36 (footer/F1 parity contract).
 *   **Status**: Confirmed.
 
-### **BUG-24: Modal Severity Messages Render as Error-Red**
+### **BUG-11: Modal Severity Messages Render as Error-Red**
 *   **Description**: Centered modal messages can render with error-red styling even when the message severity is informational or warning-level, instead of using severity-specific visual treatment.
 *   **Findings**:
     *   Directory compare completion summary dialogs (counts + tagged-match summary) can render in error-red despite being non-error informational results.
@@ -149,20 +90,20 @@ Ordering policy (for all editors, including AI editors):
 *   **Related**: `docs/SPECIFICATION.md` section 6.2 modal severity tiers; `etc/ytree.conf` `[COLORS]` keys `INFO_COLOR`, `WARN_COLOR`, `ERR_COLOR`.
 *   **Status**: Confirmed.
 
-### **BUG-23: Copy/Move/PathCopy Rename Prompt Missing Explicit `AS:` Label**
+### **BUG-12: Copy/Move/PathCopy Rename Prompt Missing Explicit `AS:` Label**
 *   **Description**: The first rename-target prompt in `Copy`, `Move`, and `PathCopy` can appear as `COPY: <source> <edited_target>` (and equivalents) without explicit `AS:` labeling, making source vs new-name intent ambiguous.
 *   **Impact**: Increases wrong-target risk and slows high-frequency copy/move workflows because users must infer prompt semantics from field behavior.
 *   **Remediation**: Make rename intent explicit in prompt text for all three flows (for example `COPY: <source> AS: <target>`), keep one-flow interaction depth, and keep destination-dir prompt behavior unchanged. Add focused regression coverage for prompt text/flow parity in `Copy`, `Move`, and `PathCopy`. Keep `F1` help, manpage/USAGE text, and specification wording synchronized with final prompt contract.
-*   **Related**: `ROADMAP` Task 32 (prompt/help clarity).
+*   **Related**: `ROADMAP` Task 35 (prompt/help clarity).
 *   **Status**: Confirmed.
 
-### **BUG-22: Archive Unavailable-Action Message Reports Wrong Shortcut**
+### **BUG-13: Archive Unavailable-Action Message Reports Wrong Shortcut**
 *   **Description**: In archive mode, triggering `^W` can show an error message for a different shortcut (`^P is not available in archive mode`).
 *   **Impact**: Misleading feedback increases operator confusion and undermines trust in key/action hints.
 *   **Remediation**: Ensure unavailable-action messaging reports the actual attempted action/shortcut in archive context.
 *   **Status**: Confirmed.
 
-### **BUG-21: Archive Footer Omits Available `Pipe` Action**
+### **BUG-14: Archive Footer Omits Available `Pipe` Action**
 *   **Description**: In archive directory context, `Pipe` works but is not shown in footer/help, while users rely on footer discoverability to know what is available.
 *   **Findings**:
     *   `Pipe` is available but omitted from archive footer/help lines.
@@ -170,37 +111,11 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Ensure archive footer/help reflects all currently available actions (including `Pipe`) and keeps unavailable actions hidden.
 *   **Status**: Confirmed.
 
-### **BUG-20: F8 File-Window Active/Inactive Indicators Aren't Distinct**
-*   **Description**: In F8 split mode, active (inverted) versus inactive (bold and underlined) panel cursors are correct in directory view, but both are inverted in file view.
-*   **Impact**: Users can't distinguish the active panel during file navigation.
-*   **Remediation**: Make active/inactive indicator rendering consistent between directory and file views in split mode.
-*   **Status**: Fixed.
-
-### **BUG-19: Unlogged Tree Nodes Mislabel as `No files` and Use Misleading `dir/` Suffix**
-*   **Description**: In directory tree navigation (for example log `~`, expand `ytree/src`), an unlogged directory like `cmd` can render as `cmd/` with `No files`; expanding it then reveals files.
-*   **Findings**:
-    *   The node is shown with an empty-state label before discovery/logging completes.
-    *   The trailing slash cues subtree semantics even when the immediate user question is file-presence state.
-    *   Repeated collapse input (`Left` or `-` twice) can preserve/return to the misleading empty-state text instead of a truthful unlogged state.
-*   **Expected Behavior**:
-    *   Unscanned/unlogged nodes must render as `Unlogged` (or equivalent), never `No files`.
-    *   `No files` must be reserved for scanned-and-empty directories only.
-    *   Collapse behavior (`Left` / `-`) must be idempotent for content state and must not mutate status classification.
-*   **Impact**: Misleads users about whether files exist, breaks trust in tree-state cues, and increases navigation friction in common expand/collapse workflows.
-*   **Remediation**: Enforce a strict tree-state contract (`unlogged` vs `empty` vs `has files`) with deterministic render precedence; avoid suffix/label combinations that imply false emptiness; and add regression coverage for expand/collapse (including repeated `Left`/`-`) on unlogged nodes.
-*   **Status**: Fixed.
-
-### **BUG-18: Tree `+` Status Marker Renders in Name Text Instead of Margin Slot**
-*   **Description**: When a directory is Unlogged/released, the `+` state marker can appear appended to the directory name text rather than in the dedicated tree status/margin position.
-*   **Impact**: Blurs directory identity with state signaling and makes tree-state scanning less reliable in navigation-heavy flows.
-*   **Remediation**: Render `+` only in the tree status/margin slot for Unlogged entries and keep directory name text unchanged.
-*   **Status**: Fixed.
-
-### **BUG-17: Single-Empty-Directory Archive Can Collapse Tree Rendering**
+### **BUG-15: Single-Empty-Directory Archive Can Collapse Tree Rendering**
 *   **Description**: In archive mode, when the archive contains only one empty directory, ytree can skip normal tree-node rendering and show that directory identity as appended archive-name/path text instead.
 *   **Impact**: Obscures archive structure and creates high-friction navigation confusion in a common edge case.
 *   **Remediation**: Keep archive tree rendering consistent in this edge case: render a proper directory node in the tree and keep archive identity separate from child directory labels.
-*   **Related**: `BUG-18` (name-text rendering contamination), `ROADMAP` Task 59A (path/message formatting hygiene).
+*   **Related**: `BUG-13` (name-text rendering contamination), `ROADMAP` Task 7 (path/message formatting hygiene).
 *   **Status**: Confirmed.
 
 ### **BUG-16: File-View Focus Leak After Parent Jump (`\\`)**
@@ -212,7 +127,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Keep navigation scope in the file list after `\\` parent jump and require explicit `Enter` transition before directory-pane navigation is allowed.
 *   **Status**: Confirmed.
 
-### **BUG-15: Zoom/Split State Corruption After Parent/View Toggles**
+### **BUG-17: Zoom/Split State Corruption After Parent/View Toggles**
 *   **Description**: After a sequence involving show-all, repeated view-mode toggles, parent jump (`\\`), and another view toggle, the UI exits the expected zoomed state and shows an empty small pane.
 *   **Findings**:
     *   Layout unexpectedly switches back to tree + small window.
@@ -222,81 +137,58 @@ Ordering policy (for all editors, including AI editors):
 *   **Related**: File-View Focus Leak After Parent Jump (`\\`) (same focus/state-transition family).
 *   **Status**: Confirmed.
 
-### **BUG-14: Long Lines Wrap Instead of Truncate in List Views**
+### **BUG-18: Long Lines Wrap Instead of Truncate in List Views**
 *   **Description**: Long entries wrap to additional rows instead of truncating in single-row list rendering contexts (reported in `^f` small-window flow and dir/tree list views).
 *   **Impact**: Breaks scanability, corrupts row alignment, and causes ambiguous cursor context in navigation-heavy views.
 *   **Remediation**: Enforce truncate/clipping semantics for list-row rendering in these views and add regression tests that fail on wrapping behavior.
 *   **Status**: Confirmed.
 
-### **BUG-13: Intermittent Showall/Global Filter Can Hide Matching Files**
+### **BUG-19: Intermittent Showall/Global Filter Can Hide Matching Files**
 *   **Description**: In intermittent edge-case `Showall/Global` + filter combinations, directories can show no files even when matching files exist.
 *   **Impact**: Breaks trust in filter correctness and can make users miss valid results.
 *   **Remediation**: Capture a minimal deterministic repro and add regression coverage; verify file-list build/count/filter logic remains consistent in `Showall/Global` contexts with active filters.
 *   **Status**: Confirmed.
 
-### **BUG-12: Directory Copy Prompt Does Not Clearly State Recursive Behavior**
+### **BUG-20: Directory Copy Prompt Does Not Clearly State Recursive Behavior**
 *   **Description**: Directory copy flow prompt text is not explicit enough that directory copy is recursive, so users cannot reliably predict whether descendants are included.
 *   **Impact**: Creates avoidable trust/friction issues in backup-style workflows and increases accidental over-copy concern.
 *   **Remediation**: Make directory-copy prompts/confirmation text explicit about recursive behavior and resulting destination semantics before execution.
 *   **Status**: Confirmed.
 
-### **BUG-11: Directory Copy Can Appear Successful While Producing No Effective Update**
+### **BUG-21: Directory Copy Can Appear Successful While Producing No Effective Update**
 *   **Description**: In some destination states (for example existing target or edge-case destination handling), directory-copy flow can look like it executed successfully while leaving destination contents unchanged or unclear to the user.
 *   **Impact**: High wrong-assurance risk for repeat backup workflows where users expect an update on each run.
 *   **Remediation**: Report explicit copy outcome (`updated`, `skipped`, `destination exists`, or error) and never leave no-op outcomes ambiguous. Add regression coverage for existing-destination and missing-parent edge paths.
 *   **Status**: Confirmed.
 
-### **BUG-10: Archive Mutations Do Not Show Immediate Results in Archive View**
+### **BUG-22: Archive Mutations Do Not Show Immediate Results in Archive View**
 *   **Description**: In archive mode, mutating actions (for example `rename`, `mkdir`, and copy-in flows) can succeed but the current archive listing does not reflect the change immediately.
 *   **Impact**: Creates false-failure perception and high-friction workflow confusion because users may repeat operations that already succeeded.
 *   **Remediation**: After any successful archive mutation, update the archive view in-place so users immediately see the effect in the same archive context, with no manual refresh/re-entry/relog required. Preserve cursor/selection when possible.
-*   **Related**: `BUG-11` (copy outcome clarity).
+*   **Related**: `BUG-21` (copy outcome clarity).
 *   **Status**: Confirmed.
 
-### **BUG-9: After Directory Copy/Execute Return, Header/Footer Lines Can Disappear**
-*   **Description**: After directory-copy flow or execute-return paths, ncurses header/footer/path lines can disappear while stats/clock remain, and users must press additional keys to restore full frame.
-*   **Impact**: Makes the UI look partially broken in high-frequency workflows and reduces operator trust.
-*   **Remediation**: Harden post-command frame-restore/redraw ownership so full header/path/footer surfaces are restored atomically before next input.
-*   **Related**: `BUG-29`, `BUG-28` (return/redraw defect family).
-*   **Status**: Fixed.
-
-### **BUG-9A: Copy to Nonexistent Destination Misses Create-Dir Prompt Contract**
-*   **Description**: Copying to a nonexistent destination path did not consistently show the expected destination-create prompt contract and could fall into misleading confirmation flow.
-*   **Status**: Fixed.
-
-### **BUG-9A.1: Copy-Yes Path Could Create Destination But Leave View Incoherent**
-*   **Description**: Accepting copy to a newly created destination could complete without coherent immediate view state for resulting entries.
-*   **Status**: Fixed.
-
-### **BUG-9A.2: Copy-No Path Could Leave Footer/Frame State Corrupted**
-*   **Description**: Declining the copy confirmation in nonexistent-destination flow could leave footer/frame state degraded.
-*   **Status**: Fixed.
-
-### **BUG-9B: Execute/Return Frame Restore Could Require Extra Keystrokes**
-*   **Description**: After execute-return flow, path and frame lines could remain partially missing until extra keypresses forced redraw.
-*   **Status**: Fixed.
-
-### **BUG-8: Attributes Name Truncation Can Hide File Identity**
+### **BUG-23: Attributes Name Truncation Can Hide File Identity**
 *   **Description**: In attributes/stat contexts, long file names can be truncated using a tail-only style (for example `...fy_xml_integrity.sh`) that hides too much distinguishing information and makes similarly named files harder to differentiate at a glance.
 *   **Impact**: Increases wrong-target risk during metadata workflows and slows navigation in dense directories with similar filenames.
 *   **Remediation**: Apply an identity-preserving truncation policy for filename-bearing attribute surfaces: keep static deterministic text (no marquee/auto-scroll), prefer `prefix…suffix` for plain filenames, and use suffix-focused clipping only where path-tail context is explicitly higher-value.
-*   **Related**: `BUG-14` (no-wrap/truncate contract), `ROADMAP` Task 56 (manual file-column width controls).
+*   **Related**: `BUG-18` (no-wrap/truncate contract), `ROADMAP` Task 12 (manual file-column width controls).
 *   **Status**: Confirmed.
 
-### **BUG-7: Internal Preview Down-Scroll Can Pass EOF and Repeat Last Page**
+### **BUG-24: Internal Preview Down-Scroll Can Pass EOF and Repeat Last Page**
 *   **Description**: In internal preview paths (`F7` preview and internal `^V` tagged viewer), down-scroll/page-down can continue past EOF and keep redisplaying the last page. Up-scroll behavior does not show this defect. External viewer mode stops correctly at EOF.
 *   **Impact**: Produces misleading navigation state and inconsistent behavior between internal and external viewing paths.
 *   **Remediation**: Clamp downward preview offsets at the last valid page in shared internal preview rendering paths so bottom-of-file is a hard stop.
 *   **Related**: `F7` preview and internal `^V` tagged viewer should be treated as one defect family.
 *   **Status**: Confirmed.
 
-### **BUG-6: `/` Jump Replaces Footer Help with Prompt UI**
+### **BUG-25: `/` Jump Replaces Footer Help with Prompt UI**
 *   **Description**: Pressing `/` currently switches footer content to a `Jump to:` prompt UI instead of keeping the normal footer help text visible while incremental jump runs.
 *   **Impact**: Breaks the expected inline jump flow and creates avoidable UI churn during frequent navigation.
 *   **Remediation**: Keep footer help text unchanged during `/` incremental jump and apply immediate selection movement as characters are typed (for example `/y` jumps to the first matching entry) without footer prompt takeover.
 *   **Status**: Confirmed.
 
-### **BUG-5: Recursive Scan Interrupt Responsiveness**
+### **BUG-26: Recursive Scan Interrupt Responsiveness**
 *   **Description**: Interrupting a recursive expansion (`*`) via `ESC` is supported but requires multiple keypresses (Prompt Y/N).
 *   **Impact**: Users cannot instantly halt accidental large-branch scans.
 *   **Remediation**: Evaluate if `ESC` during `ReadTree` should immediately halt the scan once instead of prompting, given that partial results are preserved.
@@ -304,7 +196,7 @@ Ordering policy (for all editors, including AI editors):
 
 ## **Correctness, Consistency, and Naming Defects (Priority Ordered)**
 
-### **BUG-4: Configuration Template Drift (`VI_KEYS`)**
+### **BUG-27: Configuration Template Drift (`VI_KEYS`)**
 *   **Description**: Discrepancy in default visibility and documentation for `VI_KEYS`.
 *   **Findings**:
     *   `default_profile_template.h` uses `VI_KEYS=0`.
@@ -314,7 +206,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Ensure the `ytree --init` generation path strictly matches the `etc/ytree.conf` provided in the distribution.
 *   **Status**: Confirmed.
 
-### **BUG-3: VI Mode Key Ambiguity and Collisions**
+### **BUG-28: VI Mode Key Ambiguity and Collisions**
 *   **Description**: When `VI_KEYS=1` is enabled, lowercase navigation keys (`h/j/k/l`) collide with primary command keys without clear UI signaling.
 *   **Findings**:
     *   `j` maps to both `ACTION_MOVE_DOWN` (via `VI_KEY_DOWN`) and historically to `ACTION_LOG_VOLUME` (though currently `l/L` is the log volume key, older documentation/muscle memory remains confused).
@@ -323,14 +215,14 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Audit all `VI_KEY` remappings in `key_engine.c` and ensure the footer help lines (`display.c`) dynamically update to show the uppercase variants when `VI_KEYS=1`.
 *   **Status**: Confirmed.
 
-### **BUG-2: Incremental Search Legacy Mapping (`F12`)**
+### **BUG-29: Incremental Search Legacy Mapping (`F12`)**
 *   **Description**: `F12` is used as an alias for `/` (Incremental Search/Jump), but its presence is inconsistent in help strings and documentation.
 *   **Impact**: Confuses users about "hidden" keys.
 *   **Remediation**: Explicitly document `F12` as a legacy alias or deprecate it in favor of standard `/`.
 *   **Parity Principle:** Treat this as a documentation-parity defect class: no active keybinding may exist in runtime without consistent footer, `F1`, and manpage/USAGE coverage.
 *   **Status**: Confirmed.
 
-### **BUG-1: Misleading Tree Expansion Action Names**
+### **BUG-30: Misleading Tree Expansion Action Names**
 *   **Description**: The internal `YtreeAction` names for tree expansion are swapped relative to their behavior and documentation.
 *   **Findings**:
     *   `+` key maps to `ACTION_TREE_EXPAND_ALL`, but only expands **one level**.

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Scope policy: `docs/CHANGES.md` records major user-visible or project-level milestones only.
+Minor/trivial fixes are tracked in git history.
+
 ## [3.0.0-alpha] - 2026-04-29
 
 *Modernization Project initiated 30 Oct 2025. This release represents a comprehensive architectural refactor from the legacy 2.10 codebase to modern C99/POSIX standards, introducing significant power-user features, enhanced safety, and robust quality assurance.*
@@ -55,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Path Utility Standardization**: Migrated all command-layer path compositions to a centralized, bounds-safe `Path_Join` utility.
 - **Internal Viewer Geometry Encapsulation**: Implemented an explicit viewer geometry contract and removed direct layout reads from `src/ui/view_internal.c`.
 - **CI and QA Suite**: Introduced GitHub Actions CI and a comprehensive local QA gate with `clang-tidy`, `cppcheck`, `scan-build`, Valgrind (including automated interactive runs), `pytest`/`pexpect`, and a module-boundary guard (`make qa-all`).
+- **Controller Hotspot Decomposition**: Broke up high-risk controller "god function" paths into smaller, cohesive units to reduce regression blast radius and improve maintainability.
+- **Permanent Security Regression Gates**: Added durable security/file-operation integrity checks so previously fixed exploitability classes are continuously guarded in QA/CI.
+- **QA Cadence Optimization**: Reorganized QA gate cadence and overlap to improve iteration feedback speed while preserving strict pre-merge and release assurance depth.
 - **Build System**: Updated Makefile for dependency tracking and unified documentation sourcing (`docs/USAGE.md` and `ytree.1.md` are now generated from a single `etc/ytree.1.md` source).
 - **Silent Refresh-Scan Handling**: Suppressed transient `stat` errors during directory refreshes to prevent non-fatal race conditions.
 - **Overwrite-All Conflict Hardening**: Unified COPY/MOVE overwrite-all behavior so selecting `A` on the first conflict suppresses repeated prompts across remaining tagged-file conflicts.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,6 +38,13 @@ For the continuous audit workflow (during development and PRs) plus final releas
 For maintainer copy/paste prompts, see **[ai/PROMPT_TEMPLATE.md](ai/PROMPT_TEMPLATE.md)** (single quick unit) and **[ai/RELAY_PROMPT_TEMPLATE.md](ai/RELAY_PROMPT_TEMPLATE.md)** (multi-unit relay).
 For pull-request governance and conflict triage policy, see **[PR_GATE.md](PR_GATE.md)**.
 
+## Planning and History Docs Policy
+
+- `docs/ROADMAP.md` and `docs/BUGS.md` are forward-looking (`planned`/`in-progress`).
+- Completed items may be removed from those active planning docs after landing/fix.
+- `docs/CHANGES.md` is milestone-level only; do not add every trivial fix.
+- Git history is the complete detailed archive of all changes.
+
 ## Development Setup
 
 This project uses a combination of C for the application and Python for the test suite and AI assistance tools.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,93 +6,93 @@ Ordering policy (for all editors, including AI editors):
 - Organize work as `Current Delivery Roadmap` and `Future Enhancements / Wishlist`, then by phase.
 - Inside each phase: put items that are high-impact first after that order remaining items by ease of implementation.
 - Insert new approved items at the correct priority position (do not append by default).
-- In `Current Delivery Roadmap`, keep `Task` numbering as a priority countdown where practical (`highest number = highest priority`).
-- In `Future Enhancements / Wishlist`, use `Idea FE-*` IDs to avoid collisions with current-delivery task IDs.
+- In `Current Delivery Roadmap`, number `Task` items top-to-bottom in ascending order (`1` = highest priority).
+- In `Future Enhancements / Wishlist`, use `Idea FE-*` IDs in top-to-bottom ascending order (`FE-1` = highest priority in wishlist).
 - IDs are unstable labels and are likely to change often due to reprioritization/renumbering.
-
-## **Current Delivery Roadmap**
+- Roadmap is forward-looking (`planned`/`in-progress`). Completed items will be removed after landing; add only significant outcomes to `docs/CHANGES.md` and use git history as the full archive.
 
 ---
 
-## **Phase 0: Exploitability-First Security Hardening (Pre-Alpha Release Blocker)**
+## **Phase 1: Exploitability-First Security Hardening (Pre-Alpha Release Blocker)**
 *This phase is first by priority for real-world security readiness. Ship only after these classes are closed or explicitly risk-accepted.*
 
-### **Task 73: Fix command-buffer overflow (`COLS+1` vs `COMMAND_LINE_LENGTH`)**
-*   **Goal:** Replace `malloc(COLS + 1)` command/search buffers used with `GetCommandLine` / `GetSearchCommandLine` by `COMMAND_LINE_LENGTH + 1` storage and enforce one size contract.
-*   **Scope:** `src/ui/ctrl_file_ops.c`, `src/ui/interactions.c`, `include/ytree_defs.h`.
-*   **Acceptance Criteria:**
-*   Red test first: very long tagged command/search input reproducer asserts no crash/corruption.
-*   No dynamic command buffer sized by `COLS` remains in these flows.
-*   Long input truncates safely and regression test passes.
-*   - [x] **Status:** Completed.
+## **Phase 2: Architecture and Clean-Code Guardrails (Early Prevention)**
+*This phase codifies architectural and coding-discipline guardrails early so regressions are blocked before they become backlog debt.*
 
-### **Task 72: Remove or hard-gate `/tmp` debug keystroke logging**
-*   **Goal:** Ensure plaintext key/debug logs are not emitted in normal runtime.
-*   **Scope:** `src/ui/key_engine.c`, `src/ui/ctrl_file.c`, `src/ui/dir_ops.c`.
+### **Task 72: Eliminate Oversized Controller Functions (Dispatch-Only End State)**
+*   **Goal:** Decompose all oversized controller functions so controllers remain dispatch-focused and behavior logic is extracted into dedicated modules.
+*   **Scope:** `src/ui/ctrl_*.c` and any controller-dispatch hotspots identified by `qa-module-boundaries`.
+*   **Mechanism:** Set explicit per-function and per-file budgets, split by action family, and keep controller functions as thin routing layers.
 *   **Acceptance Criteria:**
-*   Debug logging is compile-time gated and off by default.
-*   Log path handling is secure (no predictable world-readable temp logs).
-*   Red test first: default build writes no such logs during normal interaction.
-*   - [x] **Status:** Completed.
+*   No controller function exceeds approved line budget.
+*   No controller file exceeds approved line budget.
+*   `make qa-module-boundaries` and `make qa-all` pass.
+*   Split/extracted code preserves existing behavior (no UX/command semantic drift).
+*   - [ ] **Status:** Not Started.
 
-### **Task 71: Tighten shell-exec attack surface**
-*   **Goal:** Separate trusted template execution from raw user shell commands; prefer argv-based exec where possible and keep shell-required paths explicit and user-confirmed.
-*   **Scope:** `src/cmd/system.c`, `src/cmd/pipe.c`, `src/cmd/print_ops.c`, `src/ui/ctrl_file_ops.c`.
+### **Task 73: Remove Dead-History Comments + Add Anti-History Comment Gate**
+*   **Goal:** Remove comments that describe removed code/history and prevent their reintroduction.
+*   **Policy:** Source comments may describe only invariants, ownership/lifetime assumptions, aliasing constraints, or non-obvious design rationale.
+*   **Forbidden Comment Classes:** "removed/obsolete/used to", "original code did X", instruction-transcript comments, and commented-out declarations retained as history.
+*   **Mechanism:** Add a QA guard script (wired into `qa-all`) that fails on forbidden dead-history comment patterns, with allowlist-only exceptions for migration-required cases.
 *   **Acceptance Criteria:**
-*   Red test first: malicious filenames/inputs with shell metacharacters do not execute unintended commands in templated flows.
-*   Templated flows are quote-safe end-to-end; shell-required flows are explicit.
-*   - [x] **Status:** Completed.
+*   Existing dead-history comments in first-party code are removed or rewritten to durable design intent.
+*   New guard fails on forbidden patterns and passes on current baseline.
+*   `make qa-all` passes with the new guard enabled.
+*   - [ ] **Status:** Not Started.
 
-### **Task 70: Make `NormPath` fail-safe on deep component stacks**
-*   **Goal:** Stop silent component drop; return explicit error on overflow (or move to dynamic component list) and propagate failure.
-*   **Scope:** `src/util/path_utils.c` plus impacted callsites (`src/cmd/log.c`, `src/cmd/mkdir.c`, `src/fs/tree_utils.c`).
+### **Task 74: Unified Clean-Code Compliance Gate**
+*   **Goal:** Enforce clean-code rules continuously through one measurable gate instead of ad-hoc review.
+*   **Scope:** Naming quality, function size/argument/side-effect discipline, duplication control, boundary-condition encapsulation, and test clarity/independence.
+*   **Mechanism:** Add `qa-clean-code` (included in `qa-all`) that combines static checks + targeted meta-tests:
+    *   **Naming checks:** fail on new ambiguous/abbreviated single-letter identifiers outside accepted loop/index conventions; fail on new magic-number literals outside approved constant contexts.
+    *   **Function checks:** enforce max function-size budget, max argument-count budget, and fail on new flag-argument signatures; require explicit annotation/wrapper for approved side-effect functions.
+    *   **Duplication checks:** fail on new duplicate blocks above threshold unless explicitly allowlisted with rationale.
+    *   **Boundary checks:** fail when boundary logic (path bounds/index guards/null-termination guards) is duplicated across modules instead of using shared helpers.
+    *   **Test checks:** fail on tests that combine unrelated assertions/flows without clear phase separation; require independent setup/teardown (no order-coupled fixtures or shared mutable global state).
 *   **Acceptance Criteria:**
-*   Red test first: paths with >256 segments fail explicitly.
-*   No silent truncation to an incorrect normalized path.
-*   - [x] **Status:** Completed.
+*   `qa-clean-code` exists, is documented, and is wired into `qa-all`.
+*   Baseline debt is explicitly allowlisted with owner + removal plan; no silent grandfathering.
+*   New violations fail local gate and CI evidence.
+*   `make qa-all` passes with `qa-clean-code` enabled on the current baseline.
+*   - [ ] **Status:** Not Started.
 
-### **Task 69: Temp-file lifecycle hardening across archive/view/execute paths**
-*   **Goal:** Unify secure temp creation, ensure cleanup on all error/cancel paths, and prefer unlink-after-open where practical.
-*   **Scope:** `src/cmd/execute.c`, `src/cmd/view.c`, `src/cmd/hex.c`, `src/ui/view_preview.c`.
+### **Task 49: Compiler Warning Baseline + No-New-Warnings Gate**
+*   **Goal:** Reduce `-Wall/-Wextra` warning debt to a maintained baseline and prevent warning regressions on supported toolchains.
+*   **Rationale:** A low-noise warning profile improves signal quality and catches real defects earlier without forcing brittle all-or-nothing local builds.
+*   **Scope:** Build/QA policy and warning remediation only; no feature behavior changes in this task.
 *   **Acceptance Criteria:**
-*   Red test first: forced failures leave no temp artifacts.
-*   No temp-file leaks across success/failure/cancel paths.
-*   - [x] **Status:** Completed.
+*   Define and document baseline warning counts for `gcc` and `clang` under current default flags.
+*   Add strict QA mode (for example `STRICT=1`) that enables `-Werror` for CI/QA gates while preserving a portable default developer build.
+*   Burn down existing warning debt in prioritized batches (safety/correctness first), keeping suppressions minimal and justified.
+*   CI/QA fails on new warnings in strict mode for supported compilers.
+*   - [ ] **Status:** Not Started.
 
-### **Task 68: Remove `exit(1)` from user-triggered runtime paths**
-*   **Goal:** Convert hard aborts to propagated errors + UI messages so the process stays alive.
-*   **Scope:** `src/cmd/edit.c`, `src/ui/ctrl_file_ops.c`, `src/util/path_utils.c`.
-*   **Acceptance Criteria:**
-*   Red test first: injected allocation/IO failure returns gracefully without process termination.
-*   No hard process exit remains in interactive command paths.
-*   - [x] **Status:** Completed.
+### **Task 55: Code-Smell Gate (Audit + Detect + Block)**
+*   **Goal:** Add explicit QA and merge-gate enforcement that audits current code smells and blocks new/reintroduced structural smell debt.
+*   **Scope:** controller growth, god-function budgets, module-boundary violations, complexity hotspots, and architecture drift.
+*   **Acceptance Criteria:** Smell baseline audit evidence exists, recurring smell checks are mandatory in `qa-all`/PR evidence, and merge is blocked on unapproved new smell violations.
+*   - [ ] **Status:** Not Started.
 
-### **Task 67: Break up high-risk god functions to cut regression risk**
-*   **Goal:** Extract isolated command handlers/modules without behavior change.
-*   **Scope:** `src/ui/ctrl_dir.c`, `src/ui/ctrl_file.c`, `src/ui/ctrl_file_ops.c`.
-*   **Acceptance Criteria:**
-*   Red test first: snapshot existing behavior with focused regression tests.
-*   Complexity drops materially with unchanged behavior/tests.
-*   Coordinate with decomposition work in current-delivery module-hotspot tasks.
-*   - [x] **Status:** Completed.
+#### **Task 56: Baseline Code-Smell Audit and Debt Register**
+*   **Goal:** Audit current codebase for structural smells and categorize debt with explicit remediation sequencing.
+*   **Deliverables:** baseline report covering hotspots, oversized controllers/functions, boundary exceptions, and tracked rationale for retained debt.
+*   - [ ] **Status:** Not Started.
 
-### **Task 66: Add permanent security regression gates**
-*   **Goal:** Add durable regression checks for command-buffer sizing, no default debug logs, temp-file cleanup, and shell-quoting integrity.
-*   **Scope:** `tests/` and QA scripts (`pytest` / `qa-all` integration).
-*   **Acceptance Criteria:**
-*   Introduce a dedicated integrity gate target (`qa-fileops-integrity`) and wire it into `qa-all`/CI.
-*   The gate runs deterministic pre/post integrity assertions (file counts + content hashes) for mutation paths: `Copy`, `Move`, `Delete`, `Rename`, and archive write/edit flows.
-*   The gate covers cancel/interruption/failure paths and asserts no partial or corrupt leftovers, including archive rewrite paths.
-*   The gate covers overwrite/self-target, same-path, cross-device boundaries, permission/no-space failures, odd filenames, and archive path edge cases.
-*   Release/merge evidence requires all core QA gates, including `qa-fileops-integrity`, to be green before sign-off.
-*   These vulnerability classes fail CI if reintroduced.
-*   Evidence/gating aligns with Security Risk Gate tasks in this roadmap.
-*   - [x] **Status:** Completed.
+#### **Task 57: Strengthen Smell-Prevention Guards**
+*   **Goal:** Prevent reintroduction of known smell patterns via automated policy checks.
+*   **Mechanism:** Tighten module-boundary/controller-growth policies and require explicit approval paths for exceptions.
+*   - [ ] **Status:** Not Started.
 
-## **Phase 1: Build System, Documentation, and CI**
+#### **Task 58: Smell Gate Evidence as Merge Prerequisite**
+*   **Goal:** Ensure smell-audit results are part of mandatory merge evidence, not optional review notes.
+*   **Mechanism:** Require successful smell checks in QA artifacts and block integration on unresolved unapproved violations.
+*   - [ ] **Status:** Not Started.
+
+## **Phase 3: Build System, Documentation, and CI**
 *This phase focuses on project infrastructure, developer experience, and release readiness.*
 
-### **Task 65: Add Automated Coverage Reporting and CI Threshold Gate**
+### **Task 1: Add Automated Coverage Reporting and CI Threshold Gate**
 *   **Goal:** Integrate `gcov`/`lcov` into Makefile and CI to generate automated statement-coverage reports and enforce a minimum coverage threshold.
 *   **Rationale:** Coverage reporting gives a measurable quality signal and prevents silent regression of test effectiveness.
 *   **Scope Lock:** Coverage instrumentation, report generation, and CI gating only; no feature behavior changes in this task.
@@ -104,7 +104,7 @@ Ordering policy (for all editors, including AI editors):
 *   Update `docs/AUDIT.md` in the same change so audit policy reflects implemented coverage commands/gates (not planned-only wording).
 *   - [ ] **Status:** Not Started.
 
-### **Task 64: Restructure and Expand Test Suite**
+### **Task 2: Restructure and Expand Test Suite**
 *   **Goal:** Tidy up existing test scripts into a coherent, modular structure and thoroughly expand the regression suite for comprehensive coverage.
 *   **Rationale:** A well-structured test suite is easier to maintain and extend. Thorough, systematic coverage ensures reliability and prevents regressions across complex file operations.
 *   **Scope Lock:** Test architecture, fixtures, and regression coverage expansion only; no runtime feature behavior changes in this task.
@@ -116,38 +116,17 @@ Ordering policy (for all editors, including AI editors):
 *   Document fixture/helper conventions so new contributors can add mutation-integrity tests consistently.
 *   - [ ] **Status:** Not Started.
 
-### **Task 63: Optimize QA Gate Organization and Test Runtime Without Safety Loss**
-*   **Goal:** Reduce local/CI feedback time by reorganizing QA cadence, de-duplicating overlapping checks/tests, and improving harness efficiency while preserving (or strengthening) regression/security confidence.
-*   **Rationale:** Delivery speed is constrained by repeated heavy gates and runtime-heavy test patterns; optimization must improve iteration speed without weakening merge/release assurance.
-*   **Scope Lock:** QA/check/test architecture, policy, workflow triggers, and harness improvements only; no runtime feature behavior changes in this task.
-*   **Scope Boundary (Strict):** Non-QA workflow-policy edits (for example PR title/body wording rules) are out of scope for this work item and must be tracked in a separate task/PR.
-*   **Policy Anchor:** `docs/AUDIT.md` section **1.3 Gate Organization & Efficiency** (tier ownership matrix, branch-protection readiness criteria, runtime trend reporting, rollout/rollback risk register) and `.ai/shared.md` branch/PR + hybrid quality workflow rules.
-*   **Acceptance Criteria:**
-*   Define and document tiered QA cadence with explicit ownership and triggers:
-*   Tier A (local fast iteration), Tier B (draft PR CI), Tier C (ready-for-review full gate), Tier D (merge/release gate).
-*   Preserve all beneficial checks in the system (unsafe APIs, module boundaries, ai-config, gitleaks, fuzz, fileops integrity, full pytest, static analyzers, valgrind/sanitize/deep valgrind), allowing cadence changes but no silent removals.
-*   Remove redundant same-stage overlap between targeted and full suites where equivalent coverage is already provided; each gate must have explicit non-overlapping default intent.
-*   Define required PR branch-protection checks and readiness criteria so draft iteration can be fast while pre-merge assurance remains strict.
-*   De-duplicate near-identical tests using parametrization/shared helpers where behavior equivalence is provable, with unchanged or stronger assertion strength.
-*   Replace avoidable fixed sleeps with deterministic condition/poll-based waits and centralized timeout policy (defaults + justified exceptions), preserving PTY safety constraints.
-*   Add runtime-budget and trend reporting (local/CI) with measurable before/after evidence:
-*   median draft feedback time, time-to-green, full-gate runtime, and flake rate.
-*   Define provisional numeric targets for auditability (for example Tier B p50 runtime, full-gate p50 runtime, max flake rate, and target time-to-green) so completion is evidence-based.
-*   Provide phased rollout + rollback criteria and a risk register showing how coverage/signal quality is preserved during transition.
-*   Demonstrate no loss of critical-path coverage across core file operations, archive workflows, and split/panel isolation flows.
-*   - [x] **Status:** Completed.
-
-### **Task 62: Finalize Documentation**
+### **Task 3: Finalize Documentation**
 *   **Goal:** Update the `CHANGELOG`, `README.md`, and `CONTRIBUTING.md` files to reflect all new features and changes before a release.
 *   **Rationale:** Ensures users and developers have accurate, up-to-date information about the project.
 *   - [ ] **Status:** Not Started.
 
-### **Task 61: Initialize Distributed Issue Tracking (git-bug)**
+### **Task 4: Initialize Distributed Issue Tracking (git-bug)**
 *   **Goal:** Configure `git-bug` to act as a bridge between the local repository and GitHub Issues. Migrate the contents of `BUGS.md` and `TODO.txt` into this system prior to public release.
 *   **Rationale:** Allows the developer to maintain a simple local text-based workflow during heavy development, while ensuring that all tracking data can be synchronized to the public web interface when the project goes live.
 *   - [ ] **Status:** Not Started.
 
-### **Task 60: Config Source-of-Truth + Generation/Verification Gate**
+### **Task 5: Config Source-of-Truth + Generation/Verification Gate**
 *   **Goal:** Enforce one canonical editable default profile source and make generated artifacts deterministic and verifiable.
 *   **Source-of-Truth Policy:** `etc/ytree.conf` is the only human-edited default profile source; `src/core/default_profile_template.h` is generated-only and consumed by `--init`.
 *   **Mechanism:** Add a reproducible generator path (`etc/ytree.conf` -> `src/core/default_profile_template.h`) and a QA/CI check that fails when generated output is stale or hand-edited.
@@ -160,12 +139,12 @@ Ordering policy (for all editors, including AI editors):
 
 ---
 
-## **Phase 2: UI/UX Enhancements and Cleanup**
+## **Phase 4: UI/UX Enhancements and Cleanup**
 *This phase adds user-facing improvements, cleans up the remaining artifacts, and ensures a clean, modern, and portable codebase.*
 
 ### **Immediate Quick Wins**
 
-### **Task 59: Footer Action Parity in Archive Mode (`Pipe`)**
+### **Task 6: Footer Action Parity in Archive Mode (`Pipe`)**
 *   **Goal:** Make archive-mode footer/help lines accurately reflect runtime-available actions, starting with `Pipe`.
 *   **Rationale:** Footer/help is the primary discoverability surface; available actions must not be hidden.
 *   **Scope Lock:** No command semantics or keybinding behavior changes; visibility/alignment only.
@@ -175,7 +154,7 @@ Ordering policy (for all editors, including AI editors):
 *   A focused regression test (or existing footer/help test extension) verifies archive footer/action parity.
 *   - [ ] **Status:** Not Started.
 
-### **Task 59A: Path Message Formatting Audit (`//` Artifact Prevention)**
+### **Task 7: Path Message Formatting Audit (`//` Artifact Prevention)**
 *   **Goal:** Audit user-facing message/path rendering and eliminate accidental double-slash artifacts in status/error/footer output.
 *   **Rationale:** Message correctness is a trust surface; inconsistent path rendering invites avoidable bug reports and operator confusion.
 *   **Scope Lock:** Message/path formatting and tests only; no navigation, keybinding, or filesystem behavior changes.
@@ -186,7 +165,7 @@ Ordering policy (for all editors, including AI editors):
 *   Preserve valid POSIX-leading `//` semantics where intentional; do not blanket-collapse legitimate leading doubles.
 *   - [ ] **Status:** Not Started.
 
-### **Task 59B: Copy Include-Paths Base/Result Preview Contract (Predictable Root Semantics)**
+### **Task 8: Copy Include-Paths Base/Result Preview Contract (Predictable Root Semantics)**
 *   **Goal:** Make `Copy` with `Preserve ancestor paths` explicit and predictable by showing a compact computed preview of base root, relative segment, and resulting destination path.
 *   **Rationale:** Users cannot infer include-path base semantics from UI alone, which makes destination depth feel arbitrary and increases wrong-target risk.
 *   **Scope Lock:** Prompt/help/docs and regression coverage only; do not change underlying copy/sync semantics in this task.
@@ -200,7 +179,7 @@ Ordering policy (for all editors, including AI editors):
 *   Update `docs/SPECIFICATION.md`, `etc/ytree.1.md`, generated `docs/USAGE.md`, and F1/context help text so include-path root/relative/result contract and `[`/`]` controls are explicit and consistent.
 *   - [ ] **Status:** Not Started.
 
-### **Task 59C: Proactive Missing-Destination Directory Creation Prompt**
+### **Task 9: Proactive Missing-Destination Directory Creation Prompt**
 *   **Goal:** When a destination directory is missing in destination-driven workflows, detect it before execution and offer an explicit one-step create confirmation.
 *   **Rationale:** Prevents avoidable late failures, reduces wrong-target mistakes from typos, and improves alpha-readiness of copy/move-style flows.
 *   **Scope Lock:** Destination validation and confirmation behavior only; no command semantic/keybinding changes.
@@ -213,7 +192,7 @@ Ordering policy (for all editors, including AI editors):
 *   Update `etc/ytree.1.md` and regenerate `docs/USAGE.md` (`make docs`) when behavior lands.
 *   - [ ] **Status:** Not Started.
 
-### **Task 59D: Add Inline `Shift+N` Create-Link Flow (Symlink/Hardlink)**
+### **Task 10: Add Inline `Shift+N` Create-Link Flow (Symlink/Hardlink)**
 *   **Goal:** Add an in-app link creation command that mirrors existing `mkdir/newfile/copy` prompt ergonomics without requiring external `X` shell execution.
 *   **Rationale:** Link creation is a core file-manager workflow; requiring shell fallback breaks interaction consistency and discoverability.
 *   **Scope Lock:** Filesystem link creation UX/behavior only (`symlink` and `hardlink`); no unrelated command flow redesign.
@@ -230,20 +209,7 @@ Ordering policy (for all editors, including AI editors):
 *   Update `etc/ytree.1.md` and regenerate `docs/USAGE.md` (`make docs`) when behavior lands.
 *   - [ ] **Status:** Not Started.
 
-### **Task 58: Add `i/I` Invert Tags in Directory Mode**
-*   **Goal:** Support `i/I` invert-tag action from directory contexts.
-*   **Rationale:** Tag inversion at the directory level is missing.
-*   **Scope Lock:** Add directory-context invert behavior only; do not change existing file-mode invert semantics.
-*   **Acceptance Criteria:**
-*   In filesystem and archive directory modes, `i`/`I` inverts tag state for files in the selected/current directory scope.
-*   File-mode `i`/`I` behavior remains unchanged.
-*   Split-panel isolation remains intact (only active-panel scope is mutated).
-*   If the scope has no files, the action is a silent no-op (no beep/modal).
-*   Add focused regression tests for dir-mode invert behavior (filesystem + archive coverage).
-*   Update `etc/ytree.1.md` and regenerate `docs/USAGE.md` (`make docs`) when behavior lands.
-*   - [x] **Status:** Completed.
-
-### **Task 57: F7 Top Path Line Must Preserve Full `filename.ext`**
+### **Task 11: F7 Top Path Line Must Preserve Full `filename.ext`**
 *   **Goal:** In F7 preview mode, the top line above the directory window must display file context as `path + filename.ext` for the selected file.
 *   **Rationale:** In preview workflows, the selected file identity must remain explicit and unambiguous.
 *   **Scope Lock:** F7 top-line rendering contract only; no preview navigation/keybinding changes in this task.
@@ -255,7 +221,7 @@ Ordering policy (for all editors, including AI editors):
 *   Update `etc/ytree.1.md` and regenerate `docs/USAGE.md` (`make docs`) when behavior lands.
 *   - [ ] **Status:** Not Started.
 
-### **Task 56: Manual File-Column Width Controls (`[` Narrower, `]` Wider, `{` / `}` Reset)**
+### **Task 12: Manual File-Column Width Controls (`[` Narrower, `]` Wider, `{` / `}` Reset)**
 *   **Goal:** Add explicit keyboard controls for file-list column width so users can quickly trade density vs readability in the file window.
 *   **Rationale:** Long-name workflows need fast, deterministic control over visible filename identity without terminal resize churn.
 *   **Scope Lock:** File-window list column width controls only; no F7 split-preview width redesign in this task.
@@ -266,10 +232,10 @@ Ordering policy (for all editors, including AI editors):
 *   Behavior is deterministic and static (no marquee/auto-scrolling text).
 *   Footer/F1 help documents these keys in file contexts where they apply.
 *   Add focused regression coverage for width adjust left/right/reset behavior and bounds handling.
-*   **Related:** Task 55 (F7 pane-width tuning).
+*   **Related:** Task 13 (F7 pane-width tuning).
 *   - [ ] **Status:** Not Started.
 
-### **Task 55: Adjustable List/Preview Width in `F7` Mode**
+### **Task 13: Adjustable List/Preview Width in `F7` Mode**
 *   **Goal:** Allow users to adjust the relative width of file-list and preview panes while in `F7` preview mode.
 *   **Rationale:** Different file types and terminal sizes benefit from quick width tuning during inspect workflows.
 *   **Scope Lock:** `F7` pane-width behavior only; no split-mode (`F8`) layout redesign.
@@ -281,7 +247,7 @@ Ordering policy (for all editors, including AI editors):
 *   Footer/F1 help and config docs are updated when behavior lands.
 *   - [ ] **Status:** Not Started.
 
-### **Task 54: Progress Indicators for Copy/Move/Delete/Archive Workflows**
+### **Task 14: Progress Indicators for Copy/Move/Delete/Archive Workflows**
 *   **Goal:** Add consistent progress feedback for long-running mutation workflows (`Copy`, `Move`, `Delete`, archive create/extract/rewrite).
 *   **Rationale:** Users need immediate confidence that work is active and not hung, especially during large operations.
 *   **Scope Lock:** Progress signaling and UI/status messaging only; no changes to command semantics, confirmation policies, or keybindings.
@@ -294,7 +260,7 @@ Ordering policy (for all editors, including AI editors):
 *   Add focused regression coverage for progress-state selection (indeterminate vs measurable) and completion/error transitions.
 *   - [ ] **Status:** Not Started.
 
-### **Task 53: Clarify Internal `^V` Navigation for File vs Hit Traversal**
+### **Task 15: Clarify Internal `^V` Navigation for File vs Hit Traversal**
 *   **Goal:** Make internal `View Tagged` (`^V`) navigation unambiguous by separating file-to-file movement from hit-to-hit movement.
 *   **Rationale:** Current flow is easy to misinterpret (`Space` paging, `S` sort, and `^S` tagged search/filter context), which increases user friction during review workflows.
 *   **Scope Lock:** Internal `^V` viewer behavior/help only; do not change tagged-filter semantics in file/archive list mode.
@@ -308,7 +274,7 @@ Ordering policy (for all editors, including AI editors):
 *   Add focused regression coverage for key behavior and help discoverability in this mode.
 *   - [ ] **Status:** Not Started.
 
-### **Task 52: Harden `Write` Destination UX (Least Surprise)**
+### **Task 16: Harden `Write` Destination UX (Least Surprise)**
 *   **Goal:** Make `Write` destination handling explicit and predictable for both Unix power users and new users, while keeping the interaction path shallow.
 *   **Rationale:** Current destination parsing is ambiguous and error-prone; users should not need hidden syntax to perform a basic file write.
 *   **Scope Lock:** Keep key as `W` labeled `Write`; no extra submenu layers.
@@ -323,7 +289,7 @@ Ordering policy (for all editors, including AI editors):
 *   No crash on command-not-found or destination-open failures.
 *   - [ ] **Status:** Not Started.
 
-### **Task 51: Enforce `Write` Context-Valid Option Matrix + Regression Gate**
+### **Task 17: Enforce `Write` Context-Valid Option Matrix + Regression Gate**
 *   **Goal:** Ensure `Write` offers only valid formats/actions per active context (`dir`/`file`/`archive`/`tagged`) and that prompt/help always match runtime behavior.
 *   **Rationale:** UI option surfaces must be truthful to reduce friction and prevent hidden-feature drift.
 *   **Scope Lock:** Behavior alignment and tests only; no new keybindings in this task.
@@ -336,7 +302,7 @@ Ordering policy (for all editors, including AI editors):
 *   `docs/SPECIFICATION.md`, `etc/ytree.1.md`, and generated `docs/USAGE.md` are updated in the same delivery so docs match runtime behavior.
 *   - [ ] **Status:** Not Started.
 
-### **Task 50: Add `Catalog` Output Mode to `Write`**
+### **Task 18: Add `Catalog` Output Mode to `Write`**
 *   **Goal:** Extend the existing `Write` format dialog with a `Catalog` mode that exports a deterministic file/directory inventory (similar intent to `ls -1pR`) instead of file contents.
 *   **Rationale:** Users need an in-app way to generate list/report output to command or file without dropping to shell-specific workflows.
 *   **Scope Lock:** Add format behavior only; do not define or change keybindings in this task.
@@ -347,7 +313,7 @@ Ordering policy (for all editors, including AI editors):
 *   Focused regression tests cover at least one filesystem case and one archive case.
 *   - [ ] **Status:** Not Started.
 
-### **Task 49: Remove Footer Prompt for / Search**
+### **Task 19: Remove Footer Prompt for / Search**
 *   Goal: Keep existing / search behavior in all contexts (Dir, File, Showall, Global), but stop using the footer prompt area for search input.
 *   Rationale: Current search semantics already work; only the footer prompt is unnecessary UI churn.
 *   Requirements:
@@ -357,7 +323,7 @@ Ordering policy (for all editors, including AI editors):
 *   Use a non-footer inline input/render path for search text and match feedback.
 *   Status: Not Started
 
-### **Task 48: Enforce One-Level Primary Action Depth (Prompt-Chain Audit)**
+### **Task 20: Enforce One-Level Primary Action Depth (Prompt-Chain Audit)**
 *   **Goal:** Audit and remediate primary interactive workflows so the common path stays `key -> Enter -> result` with at most one submenu/prompt layer.
 *   **Rationale:** Deep prompt chains increase friction and slow high-frequency workflows.
 *   **Scope Lock:** Interaction depth, defaults, and prompt composition only; no command semantic changes in this task.
@@ -372,10 +338,10 @@ Ordering policy (for all editors, including AI editors):
 *   Add regression coverage for at least one remediated deep flow to prevent prompt-chain regressions.
 *   - [ ] **Status:** Not Started.
 
-### **Task 47: Simplify Compare Mode Flow with Persistent Presets**
+### **Task 21: Simplify Compare Mode Flow with Persistent Presets**
 *   **Goal:** Keep compare fast and explicit by consolidating options in compare mode while preserving current safe defaults and target confirmation.
 *   **Rationale:** Compare is high-frequency and should require fewer chained prompts without hiding safety-critical target selection.
-*   **Dependency:** Sequence after Task 48 prompt-chain simplification baseline.
+*   **Dependency:** Sequence after Task 20 prompt-chain simplification baseline.
 *   **Scope Lock:** Compare flow only (`j/J` entry behavior); no unrelated keybinding or footer redesign.
 *   **Acceptance Criteria:**
 *   Compare remains a modal state and compare footer/help owns the footer while active.
@@ -389,7 +355,7 @@ Ordering policy (for all editors, including AI editors):
 *   Update compare docs/help text in `etc/ytree.1.md` and regenerate `docs/USAGE.md`.
 *   - [ ] **Status:** Not Started.
 
-### **Task 46: Add Recursive Directory Compare in `J` Flow**
+### **Task 22: Add Recursive Directory Compare in `J` Flow**
 *   **Goal:** Support recursive directory-tree compare from the existing `J` compare flow.
 *   **Rationale:** Recursive compare is a practical file-manager workflow and improves alpha usefulness for real tree-diff tasks.
 *   **Scope Lock:** Add recursive compare capability and prompt/menu wiring only; do not redesign unrelated compare UI.
@@ -401,7 +367,7 @@ Ordering policy (for all editors, including AI editors):
 *   `etc/ytree.1.md` and generated `docs/USAGE.md` are updated when behavior lands.
 *   - [ ] **Status:** Not Started.
 
-### **Task 45: Lock Inactive Split-Panel Selection Semantics + Regression Coverage**
+### **Task 23: Lock Inactive Split-Panel Selection Semantics + Regression Coverage**
 *   **Goal:** Define and enforce deterministic inactive-panel cursor behavior under mirrored tree-structure changes in `F8` split mode.
 *   **Rationale:** Real-time mirrored tree updates are useful, but must stay predictable when parent/ancestor collapse, add, or delete operations change visibility.
 *   **Scope Lock:** Selection/cursor semantics and regression coverage only; no unrelated split-layout or keybinding redesign.
@@ -412,7 +378,7 @@ Ordering policy (for all editors, including AI editors):
 *   Update `docs/SPECIFICATION.md` contract references if implementation details differ during delivery.
 *   - [ ] **Status:** Not Started.
 
-### **Task 44: Enable Practical Command Subset in `F7` Preview (Keep `F8`/`Tab` Blocked)**
+### **Task 24: Enable Practical Command Subset in `F7` Preview (Keep `F8`/`Tab` Blocked)**
 *   **Goal:** Finish `F7` as an in-place work mode: users can run common file actions without leaving preview, while `F8`/`Tab` stay blocked for preview-state safety.
 *   **Rationale:** `F7` currently feels unfinished because common workflows still require repeated exits.
 *   **Scope Lock:** `F7` command availability contract, help/footer parity, and regression coverage only; no split-layout redesign.
@@ -428,7 +394,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Phase Follow-On Work**
 
-### **Task 43: Harden Build Source Discovery (Recursive + Deterministic)**
+### **Task 25: Harden Build Source Discovery (Recursive + Deterministic)**
 *   **Goal:** Update build source discovery so all C files under `src/` are discovered recursively with deterministic ordering.
 *   **Rationale:** Current discovery only covers up to one subdirectory level and will miss files after module reorganization.
 *   **Scope Lock:** Build discovery and related guard/test updates only. No feature behavior changes.
@@ -438,7 +404,7 @@ Ordering policy (for all editors, including AI editors):
 *   Source file list ordering is deterministic across runs.
 *   - [ ] **Status:** Not Started.
 
-### **Task 42: Reorganize Modules into Shallow Hierarchical Folders**
+### **Task 26: Reorganize Modules into Shallow Hierarchical Folders**
 *   **Goal:** Group modules into shallow, purpose-based subfolders and update build/header/linkage references accordingly.
 *   **Rationale:** Improves discoverability and ownership without changing behavior.
 *   **Scope Lock:** File moves + include/path/build/script/test reference updates only. No feature behavior changes.
@@ -449,44 +415,38 @@ Ordering policy (for all editors, including AI editors):
 *   Folder depth remains shallow (max one extra level under `src/ui` and `src/cmd`).
 *   - [ ] **Status:** Not Started.
 
-### **Task 41: Decompose Remaining Hotspot Modules (Atomic Subtasks)**
+### **Task 27: Decompose Remaining Hotspot Modules (Atomic Subtasks)**
 *   **Goal:** Reduce complexity in remaining hotspot files by extracting cohesive action families into focused modules while preserving behavior.
 *   **Rationale:** These files remain risk hotspots after controller decomposition and slow safe feature delivery.
 *   **Execution Rule:** Must be delivered one atomic subtask at a time (3.1 to 3.5), each with its own architect plan, developer pass, auditor pass, and QA evidence.
 *   - [ ] **Status:** Not Started.
 
-### **Task 40: Decompose `src/ui/interactions.c`**
-*   **Goal:** Split mixed responsibilities in `interactions.c` into cohesive UI interaction modules (for example compare prompts/builders, archive payload UI, attribute/ownership/date UI, tagged-view flow).
-*   **Scope Lock:** No behavior changes in prompts, key paths, or command execution semantics.
-*   **Acceptance Criteria:** Reduced file size/complexity, stable exported API surface, and green QA.
-*   - [x] **Status:** Completed.
-
-### **Task 39: Decompose `src/ui/ctrl_file_ops.c` (`handle_tag_file_action` focus)**
+### **Task 28: Decompose `src/ui/ctrl_file_ops.c` (`handle_tag_file_action` focus)**
 *   **Goal:** Extract large tagged-action branches from `handle_tag_file_action` into focused helpers/modules.
 *   **Scope Lock:** Preserve all tagged-file behavior and command semantics.
 *   **Acceptance Criteria:** Smaller dispatcher function, unchanged behavior, green QA.
 *   - [ ] **Status:** Not Started.
 
-### **Task 38: Decompose `src/ui/key_engine.c`**
+### **Task 29: Decompose `src/ui/key_engine.c`**
 *   **Goal:** Separate key mapping/dispatch concerns from input-loop mechanics and context-specific action routing.
 *   **Action Name Cleanup:** Normalize tree-expand action identifiers so names match behavior: shallow expand (`+`) is `ACTION_TREE_EXPAND`, recursive expand (`*`) is `ACTION_TREE_EXPAND_RECURSIVE`, and any redundant tree-expand identifier is merged or removed. Update key/action mappings and related tests with no behavior change.
 *   **Scope Lock:** No keybinding behavior change unless explicitly approved in a separate task.
 *   **Acceptance Criteria:** Cleaner dispatch boundaries, consistent action naming, unchanged key behavior, green QA.
 *   - [ ] **Status:** Not Started.
 
-### **Task 37: Decompose `src/cmd/copy.c`**
+### **Task 30: Decompose `src/cmd/copy.c`**
 *   **Goal:** Isolate copy conflict handling, path/precondition validation, and transfer orchestration into focused units.
 *   **Scope Lock:** No copy/move/archive user-visible behavior changes.
 *   **Acceptance Criteria:** Reduced complexity in core copy path, unchanged behavior, green QA.
 *   - [ ] **Status:** Not Started.
 
-### **Task 36: Decompose `src/cmd/profile.c`**
+### **Task 31: Decompose `src/cmd/profile.c`**
 *   **Goal:** Split profile parsing, validation/defaulting, and apply/update logic into focused units.
 *   **Scope Lock:** No configuration semantic changes.
 *   **Acceptance Criteria:** Clear parser/apply separation, unchanged config behavior, green QA.
 *   - [ ] **Status:** Not Started.
 
-### **Task 35: Refactor Tab Completion for Command Arguments**
+### **Task 32: Refactor Tab Completion for Command Arguments**
 *   **Goal:** Update the tab completion logic in `src/util/tabcompl.c` to handle command-line arguments correctly and resolve ambiguous matches using Longest Common Prefix (LCP).
 *   **Rationale:** Currently, the completion engine treats the entire input line as a single path. This causes failures when trying to complete arguments for commands (e.g., `x ls /us<TAB>` fails because it looks for a file named "ls /us"). It also fails to partial-complete when multiple matches exist (e.g., `/s` matching both `/sys` and `/srv`).
 *   **Mechanism:**
@@ -496,7 +456,7 @@ Ordering policy (for all editors, including AI editors):
     *   Reassemble the command string (prefix + completed token) before returning.
 *   - [ ] **Status:** Not Started.
 
-### **Task 34: Implement Responsive Adaptive Footer**
+### **Task 33: Implement Responsive Adaptive Footer**
 *   **Goal:** Make the two-line command footer dynamic based on terminal width.
     *   **Compact (constrained dimensions):** Show all currently available actions as bound-key hints only (minimal/no labels), and always keep `(F1)` visible for full help.
     *   **Standard (80-120 cols):** Show the standard set (current behavior).
@@ -505,19 +465,19 @@ Ordering policy (for all editors, including AI editors):
 *   **Mechanism:** Define command groups (Priority 1, 2, 3). In `DisplayDirHelp` / `DisplayFileHelp`, construct the string dynamically based on `COLS`.
 *   - [ ] **Status:** Not Started.
 
-### **Task 33: Implement Integrated Help System**
+### **Task 34: Implement Integrated Help System**
 *   **Goal:** Create a pop-up, scrollable help window (activated by F1) that displays context-sensitive command information.
 *   **Rationale:** Replaces the limited static help lines with a comprehensive and user-friendly help system, making the application easier to learn and use without consulting external documentation.
 *   - [ ] **Status:** Not Started.
 
-### **Task 32: Refine In-App Help Text**
+### **Task 35: Refine In-App Help Text**
 *   **Goal:** Review all user prompts and help lines to be clear and provide context for special syntax (e.g., `{}`). The menu should be decluttered by only showing a `^` shortcut if its action differs from the base key (e.g., `(C)opy/(^K)` is good; redundant duplicate bindings should not be listed).
 *   **VI Mode Signaling**: Ensure footer help lines dynamically reflect uppercase commands (e.g., `(K) Vol` instead of `(k) Vol`) when `VI_KEYS=1` is active to avoid navigation collisions.
 *   **Ctrl-Held Footer Signaling:** While `Ctrl` is physically held, show the `Ctrl` shortcut footer and keep it visible for the full hold duration. On `Ctrl` release, immediately restore the normal context footer. This is transient key-state feedback, not a toggle mode.
 *   **Rationale:** Fulfills the "No Hidden Features" principle and improves UI clarity by removing redundant information.
 *   - [ ] **Status:** Not Started.
 
-### **Task 31: Enforce Footer/F1 Context-Parity Contract (gettext-ready)**
+### **Task 36: Enforce Footer/F1 Context-Parity Contract (gettext-ready)**
 *   **Goal:** Ensure F1 help is concise, context-specific, and complete for each footer/help variant, with no missing commands.
 *   **Rationale:** Footer and F1 are the primary in-app guidance surfaces; they must match exactly while keeping F1 brief and pushing detail to manpage/USAGE.
 *   **Scope Lock:** Help contract, coverage matrix, and text-structure readiness only; no command behavior changes in this task.
@@ -531,7 +491,7 @@ Ordering policy (for all editors, including AI editors):
 *   Add a keybinding parity audit gate that verifies active runtime keybindings remain consistently documented across footer, `F1`, and `etc/ytree.1.md`/`docs/USAGE.md`.
 *   - [ ] **Status:** Not Started.
 
-### **Task 30: Replace `^F` Mode Cycling with Unified Numeric `FileInfo` Band (`1..9`, `0`)**
+### **Task 37: Replace `^F` Mode Cycling with Unified Numeric `FileInfo` Band (`1..9`, `0`)**
 *   **Goal:** Replace display-mode cycling with direct numeric `FileInfo` controls for the focused panel.
 *   **Behavior Contract:**
 *   `1` => Name only (default/baseline). This is also the reset-to-default selection.
@@ -550,11 +510,11 @@ Ordering policy (for all editors, including AI editors):
 *   If a requested mode is unsupported in the active context (for example VFS file mode `4`, or `0` outside a Git worktree), do a silent no-op (no beep).
 *   Git band (`0`) defaults to off, uses cached/non-blocking status refresh, and must not stall list rendering in large repos.
 *   Add `FILE_SIZE_UNITS=binary|human-readable` profile setting (default `binary`) as the seed for `5`.
-*   **Keybinding Policy:** Remove `^F` from runtime behavior and help/manpage docs. This task is the explicit keybinding-change exception referenced by Task 38 scope lock.
+*   **Keybinding Policy:** Remove `^F` from runtime behavior and help/manpage docs. This task is the explicit keybinding-change exception referenced by Task 29 scope lock.
 *   **UX/Help Policy:** Footer stays concise (`1..0 FileInfo`); full key semantics live in F1 help/manpage.
 *   - [ ] **Status:** Not Started.
 
-### **Task 29: Add Case-Sensitive Sort Toggle + Profile Default**
+### **Task 38: Add Case-Sensitive Sort Toggle + Profile Default**
 *   **Goal:** Add case-sensitivity as a sort option in the existing sort flow and profile defaults.
 *   **Rationale:** Users need deterministic lexical control without introducing extra global keybindings.
 *   **Scope Lock:** Sort comparison behavior only; no tree/file model changes.
@@ -564,7 +524,7 @@ Ordering policy (for all editors, including AI editors):
 *   Footer/F1/help/manpage text are synchronized for the new sort option.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 28: Create Watcher Infrastructure (`watcher.c`)**
+#### **Task 39: Create Watcher Infrastructure (`watcher.c`)**
 *   **Task:** Create a new module `watcher.c` to abstract the OS-specific file monitoring APIs.
 *   **Logic:**
     *   **Init:** Call `inotify_init1(IN_NONBLOCK)`.
@@ -573,7 +533,7 @@ Ordering policy (for all editors, including AI editors):
     *   **Portability:** Guard everything with `#ifdef __linux__`. On other systems, these functions act as empty stubs.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 27: Refactor Input Loop for Event Handling**
+#### **Task 40: Refactor Input Loop for Event Handling**
 *   **Task:** Modify `key_engine.c` to support non-blocking input handling.
 *   **Logic:**
     *   Currently, `Getch()` blocks indefinitely waiting for a key.
@@ -584,7 +544,7 @@ Ordering policy (for all editors, including AI editors):
     *   If STDIN triggers, proceed to `wgetch()`.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 26: Implement Live Refresh Logic**
+#### **Task 41: Implement Live Refresh Logic**
 *   **Task:** Connect the `refresh_needed` flag to the main window logic.
 *   **Logic:**
     *   In `dirwin.c` (`HandleDirWindow`) and `filewin.c` (`HandleFileWindow`), inside the input loop:
@@ -597,7 +557,7 @@ Ordering policy (for all editors, including AI editors):
     *   *Note:* We must ensure the cursor stays on the same file if possible (by saving the filename before rescan and finding it after).
 *   - [ ] **Status:** Not Started.
 
-#### **Task 25: Update Watch Context on Navigation (Current-Directory Auto-Refresh Context)**
+#### **Task 42: Update Watch Context on Navigation (Current-Directory Auto-Refresh Context)**
 *   **Task:** Ensure the watcher always monitors the *current* directory so the file list the user is looking at stays fresh without a manual reload.
 *   **Logic:**
     *   In `dirwin.c`: Whenever the user moves the cursor to a new directory (UP/DOWN), update the watcher.
@@ -606,7 +566,7 @@ Ordering policy (for all editors, including AI editors):
     *   **Implementation:** Call `Watcher_SetDir(dir_entry->name)` inside `HandleDirWindow` navigation logic (possibly debounced) and definitely inside `HandleFileWindow`.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 24: Implement Directory Filtering (Non-Recursive)**
+#### **Task 43: Implement Directory Filtering (Non-Recursive)**
 *   **Description:** Extend Filter to support directory-pattern tokens identified by a trailing slash.
     *   `dir/` means include matching directories in the current tree view.
     *   `-dir/` means exclude matching directories in the current tree view.
@@ -614,68 +574,57 @@ Ordering policy (for all editors, including AI editors):
     *   This logic is non-recursive and visibility-only: it affects what is shown in the current view, not internal directory state.
 *   - [ ] **Status:** Not Started.
 
-### **Task 23: Add Configurable Bypass for External Viewers**
+### **Task 44: Add Configurable Bypass for External Viewers**
 *   **Goal:** Add a configuration option to globally disable external viewers, forcing the use of the internal viewer.
 *   **UI Note:** Expose this in the planned `F10` configuration UI when that panel is implemented.
 *   **Rationale:** Provides flexibility for cases where the user wants to quickly inspect the raw bytes of a file (e.g., a PDF) without launching a heavy external application.
 *   **Coverage Clarification:** This task also covers single-file `V` parity with tagged viewing: users must be able to choose internal vs external behavior consistently for both single-file view and tagged-view workflows.
 *   - [ ] **Status:** Not Started.
 
-### **Task 22: Implement Auto-Execute on Command Termination**
+### **Task 45: Implement Auto-Execute on Command Termination**
 *   **Goal:** Allow users to execute shell commands (`X` or `P`) immediately by ending the input string with a specific terminator (e.g., `\n` or `;`), without needing to press Enter explicitly.
 *   **Rationale:** Accelerates command entry for power users who want to "fire and forget" commands rapidly.
 *   - [ ] **Status:** Not Started.
 
-### **Task 21: Standardize Internal Viewer Layout**
+### **Task 46: Standardize Internal Viewer Layout**
 *   **Goal:** Ensure the internal viewer's layout geometry matches the main application (borders, headers, and footer).
 *   - [ ] **Status:** Not Started.
 
-#### **Task 20: Implement Archive Move (`M`) Support**
+#### **Task 47: Implement Archive Move (`M`) Support**
 *   **Description:** Implement `M` (Move) for archives. Intra-archive moves use the Rewrite Engine to rename paths. Cross-volume moves use Copy-Extract + Delete.
 *   - [ ] **Status:** Not Started.
 
-### **Task 19: Nested Archive Traversal**
+### **Task 48: Nested Archive Traversal**
 *   Allow transparently entering an archive that is itself inside another archive.
 *   - [ ] **Status:** Not Started.
 
 ---
 
-## **Phase 3: Permanent Security and Code-Quality Gates**
-*This phase is an enforcement gate: audit the current codebase for existing debt, then detect and block introduced/reintroduced security risks and code smells on every non-trivial change.*
+## **Phase 5: Permanent Security Gates**
+*This phase is an enforcement gate for security risk classes: audit baseline debt, then detect and block introduced/reintroduced security findings on every non-trivial change.*
 
-### **Task 18: Compiler Warning Baseline + No-New-Warnings Gate**
-*   **Goal:** Reduce `-Wall/-Wextra` warning debt to a maintained baseline and prevent warning regressions on supported toolchains.
-*   **Rationale:** A low-noise warning profile improves signal quality and catches real defects earlier without forcing brittle all-or-nothing local builds.
-*   **Scope:** Build/QA policy and warning remediation only; no feature behavior changes in this task.
-*   **Acceptance Criteria:**
-*   Define and document baseline warning counts for `gcc` and `clang` under current default flags.
-*   Add strict QA mode (for example `STRICT=1`) that enables `-Werror` for CI/QA gates while preserving a portable default developer build.
-*   Burn down existing warning debt in prioritized batches (safety/correctness first), keeping suppressions minimal and justified.
-*   CI/QA fails on new warnings in strict mode for supported compilers.
-*   - [ ] **Status:** Not Started.
-
-### **Task 17: Security Risk Gate (Audit + Detect + Block)**
+### **Task 50: Security Risk Gate (Audit + Detect + Block)**
 *   **Goal:** Add explicit QA and merge-gate enforcement that audits the current codebase for security risks and blocks new or reintroduced security findings.
 *   **Scope:** shell-command construction and escaping boundaries, archive path trust policy, tempfile lifecycle, and unsafe API usage.
 *   **Acceptance Criteria:** Security baseline audit evidence exists, recurring security checks are mandatory in `qa-all`/PR evidence, and merge is blocked on unresolved blocker/high security findings.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 16: Baseline Security Debt Audit and Classification**
+#### **Task 51: Baseline Security Debt Audit and Classification**
 *   **Goal:** Run and document a focused baseline audit of current security risk classes already in scope for Phase 0.
 *   **Deliverables:** findings inventory with severity, owner, disposition (fix now vs tracked debt), and explicit residual-risk notes.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 15: Expand Security Guard Coverage to Block Reintroduction**
+#### **Task 52: Expand Security Guard Coverage to Block Reintroduction**
 *   **Goal:** Ensure banned/legacy security-sensitive APIs and patterns are explicitly rejected by automated guard scripts.
 *   **Mechanism:** Extend guard checks for legacy unsafe escaping/runtime paths and other approved denylisted APIs/patterns.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 14: Security Regression Gate in CI + Merge Workflow**
+#### **Task 53: Security Regression Gate in CI + Merge Workflow**
 *   **Goal:** Make security verification non-optional in routine change flow.
 *   **Mechanism:** Require security gate evidence for non-trivial PRs and keep merge blocked until gates pass.
 *   - [ ] **Status:** Not Started.
 
-### **Task 13: Add Security Fuzzing Harness for High-Risk Input Paths**
+### **Task 54: Add Security Fuzzing Harness for High-Risk Input Paths**
 *   **Goal:** Add fuzzing coverage (for example libFuzzer) for archive parsing and shell-command construction paths to detect malformed-input crashes and security-critical edge cases early.
 *   **Rationale:** Complements static checks and regression tests with adversarial input exploration.
 *   **Scope Lock:** Harness, seed corpus, and reproducible crash-minimization workflow only; no feature UX changes in this task.
@@ -685,39 +634,18 @@ Ordering policy (for all editors, including AI editors):
 *   Findings flow into the existing security gate workflow.
 *   - [ ] **Status:** Not Started.
 
-### **Task 12: Code-Smell Gate (Audit + Detect + Block)**
-*   **Goal:** Add explicit QA and merge-gate enforcement that audits current code smells and blocks new/reintroduced structural smell debt.
-*   **Scope:** controller growth, god-function budgets, module-boundary violations, complexity hotspots, and architecture drift.
-*   **Acceptance Criteria:** Smell baseline audit evidence exists, recurring smell checks are mandatory in `qa-all`/PR evidence, and merge is blocked on unapproved new smell violations.
-*   - [ ] **Status:** Not Started.
-
-#### **Task 11: Baseline Code-Smell Audit and Debt Register**
-*   **Goal:** Audit current codebase for structural smells and categorize debt with explicit remediation sequencing.
-*   **Deliverables:** baseline report covering hotspots, oversized controllers/functions, boundary exceptions, and tracked rationale for retained debt.
-*   - [ ] **Status:** Not Started.
-
-#### **Task 10: Strengthen Smell-Prevention Guards**
-*   **Goal:** Prevent reintroduction of known smell patterns via automated policy checks.
-*   **Mechanism:** Tighten module-boundary/controller-growth policies and require explicit approval paths for exceptions.
-*   - [ ] **Status:** Not Started.
-
-#### **Task 9: Smell Gate Evidence as Merge Prerequisite**
-*   **Goal:** Ensure smell-audit results are part of mandatory merge evidence, not optional review notes.
-*   **Mechanism:** Require successful smell checks in QA artifacts and block integration on unresolved unapproved violations.
-*   - [ ] **Status:** Not Started.
-
 ---
 
-## **Phase 4: Current Delivery Completion Queue**
+## **Phase 6: Current Delivery Completion Queue**
 *This phase is still current-delivery scope and contains implementation work that is planned to land.*
 
-### **Task 8: Implement Advanced Batch Rename**
+### **Task 59: Implement Advanced Batch Rename**
 *   **Goal:** Add a ytree-native batch rename flow for tagged files with numbering support, casing changes (`Tab`), substring replacement, and pattern-based keep/remove operations.
 *   **Rationale:** Essential power-user feature for managing large file sets without forcing one-by-one rename loops.
 *   **Preview/Apply Contract:** Batch rename is preview-first. Show `old -> new` results before mutation and support per-item apply controls: `y` (apply current), `n` (skip current), `a` (apply all remaining), `Esc` (cancel remaining).
 *   - [ ] **Status:** Not Started.
 
-### **Task 7: Unify Copy Semantics and Add Directory Sync (`Y`)**
+### **Task 60: Unify Copy Semantics and Add Directory Sync (`Y`)**
 *   **Goal:** Define one clear `Copy` contract (with optional ancestor-path preservation) and add a guided directory-sync flow from dir footer `Y`, backed by `rsync` where practical.
 *   **User-Facing Behavior:**
     *   **Copy (file/tagged files):** Non-recursive single-item copy behavior is explicit and predictable.
@@ -739,7 +667,7 @@ Ordering policy (for all editors, including AI editors):
     *   The synchronize path prefers `rsync` for plain filesystem paths and does not require ytree to own a new recursive sync engine.
 *   - [ ] **Status:** Not Started.
 
-### **Task 7B: Promote Applications Menu (`F9`) with Safe Default Presets**
+### **Task 61: Promote Applications Menu (`F9`) with Safe Default Presets**
 *   **Goal:** Bring `F9` Applications Menu into current-delivery scope as a visible, contributor-friendly command surface with sensible default entries.
 *   **Semantics:** Entries are user commands/templates (with optional placeholders/parameters) that execute commands; this is not keystroke recording.
 *   **Default Presets (initial set):**
@@ -755,12 +683,56 @@ Ordering policy (for all editors, including AI editors):
     *   Command completion reporting is explicit (`success` on zero exit, actionable error summary on non-zero exit).
 *   - [ ] **Status:** Not Started.
 
+### **Task 62: Define Extension Surface Contract (`F9` Apps + `F7` Preview Plugins)**
+*   **Goal:** Define one explicit extension contract for external-tool integrations so command apps (`F9`) and preview plugins (`F7`) follow the same safety, UX, and fallback rules.
+*   **Scope:** Contract/spec-only delivery for external execution surfaces (`X`, `P`, `W`, `FILEDIFF`, `F9`, and `F7` preview-helper boundary).
+*   **Rationale:** ytree should reuse mature external tools without accumulating ad-hoc one-off behavior per feature.
+*   **Acceptance Criteria:**
+    *   Contract defines provider types (`app`, `preview`) and shared lifecycle semantics.
+    *   Contract defines placeholder/token policy, argument safety rules, and bounded command construction.
+    *   Contract defines deterministic completion/failure reporting and fallback behavior.
+    *   Footer/F1/manpage wording aligns with the new contract language.
+*   - [ ] **Status:** Not Started.
+
+### **Task 63: Implement Shared Provider Registry (Plugin-Lite, External-Tool-First)**
+*   **Goal:** Implement a shared provider registry/runtime for extension providers instead of isolated one-off paths.
+*   **Non-Goal:** Do not add in-process arbitrary binary/plugin loading; providers remain external-tool adapters.
+*   **Rationale:** A unified provider runtime keeps behavior predictable and lowers maintenance risk while preserving Unix-style composability.
+*   **Acceptance Criteria:**
+    *   Shared provider model supports at least `app` and `preview` provider classes.
+    *   Common execution/safety controls are centralized (timeouts, output caps, exit-code mapping, fallback policy).
+    *   Config/profile format is documented and validated with focused regression tests.
+*   - [ ] **Status:** Not Started.
+
+### **Task 64: Add Optional Background App Execution (`bg`)**
+*   **Goal:** Allow selected external commands to run in background so users can continue navigating immediately.
+*   **Entry Direction:** Prefer `F9` as the primary UX surface, with optional command-prompt parity where it fits cleanly.
+*   **Scope Lock:** External commands/apps only (no async copy/move/delete queue in this task).
+*   **Rationale:** This captures high-value "run and continue" workflow speed without requiring an embedded subshell model.
+*   **Acceptance Criteria:**
+    *   Users can launch an app in foreground or background using explicit UI choice/marker.
+    *   Background job state is visible and queryable (running/success/failure) with actionable completion messaging.
+    *   Failed background runs return clear diagnostics without destabilizing curses state.
+*   - [ ] **Status:** Not Started.
+
+### **Task 65: Implement F7 Preview Helper Pipeline (Promote Preview-Helper Pipeline into Current Delivery)**
+*   **Goal:** Deliver the beta-scope F7 helper pipeline with strict fallback guarantees.
+*   **Baseline Contract:** `BINARY` (internal preview, no helpers) and `RENDER` (helper-rendered output with guaranteed fallback to `BINARY` on failure).
+*   **Scope Lock:** Ship the baseline safety/fallback pipeline now; defer optional advanced renderer ergonomics until later phases.
+*   **Rationale:** This provides practical plugin-like preview extensibility while keeping ytree's internal preview as the reliability floor.
+*   **Acceptance Criteria:**
+    *   `F7` supports deterministic `BINARY` <-> `RENDER` mode toggling with stable footer labeling.
+    *   Helper execution is bounded and safe (argv-first execution, timeout, output cap, failure fallback).
+    *   Panel-local mode state is preserved in split mode.
+    *   Config/docs/tests are synchronized for the delivered baseline behavior.
+*   - [ ] **Status:** Not Started.
+
 ---
 
-## **Phase 5: Internationalization and Configurability**
+## **Phase 7: Internationalization and Configurability**
 *   **Goal:** Refactor the application to support localization and user-defined keybindings, moving away from hardcoded English-centric values.
 
-### **Task 6: Externalize UI Strings with GNU gettext (i18n Foundation)**
+### **Task 66: Externalize UI Strings with GNU gettext (i18n Foundation)**
 *   **Description:** Replace hardcoded user-facing strings with gettext-backed message lookups (`gettext`/`_()`), initialize locale/domain at startup, and add a standard catalog workflow (`.pot` -> `.po` -> compiled catalogs). Keep default locale as English while enabling translation packs.
 *   **Documentation i18n split:** Use `po4a` for manpage/doc translation workflow (source: `etc/ytree.1.md`; generated docs stay derived artifacts). Use gettext for runtime UI surfaces (`F1`, footer labels/help, prompts, status/error/info text).
 *   **Translation path policy:** Define default translation discovery paths for system and user installs (for example system locale catalogs under `/usr/share/locale/.../LC_MESSAGES/ytree.mo` with a user-level override path), and document contributor workflow for adding a language.
@@ -768,7 +740,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** For C/POSIX terminal software, GNU gettext is the most conventional and broadly understood approach. It has mature tooling, standard translator workflow, and broad ecosystem familiarity; a custom loadable language-file system would add avoidable maintenance and onboarding cost.
 *   - [ ] **Status:** Not Started.
 
-### **Task 5: Implement Configurable Keymap**
+### **Task 67: Implement Configurable Keymap**
 *   **Description:** Abstract all hardcoded key commands (e.g., 'm', '^N') into a configurable keymap loaded from a separate keymap profile file. The core application logic will respond to command identifiers (e.g., `CMD_MOVE`), not raw characters. This will allow users to customize their workflow and resolve keybinding conflicts.
 *   **Config contract:** Select profile via `ytree.conf` (opt-in), keeping a stable default keymap for existing users.
 *   **Display contract:** Footer/help text must render active key + localized command label together (for example active binding `C` + translated `Copy` -> `(C)opy`) so runtime hints always match active bindings.
@@ -776,15 +748,15 @@ Ordering policy (for all editors, including AI editors):
 
 ---
 
-## **Phase 6: Final Polish (Post-Alpha, Pre-v3.0.0)**
-*This phase focuses on release polish. Security, module-boundary, and quality gates remain continuous from Phase 2 and are not deferred to this phase.*
+## **Phase 8: Final Polish (Post-Alpha, Pre-v3.0.0)**
+*This phase focuses on release polish. Security, module-boundary, and quality gates remain continuous from earlier phases and are not deferred to this phase.*
 
-### **Task 4: UI/UX Snappiness Polish (Targeted Optimization)**
+### **Task 68: UI/UX Snappiness Polish (Targeted Optimization)**
 *   **Goal:** Improve perceived responsiveness in high-frequency flows using profiling-driven optimizations.
 *   **Rationale:** Premature optimization is avoided; final polish applies targeted improvements where bottlenecks are measured.
 *   - [ ] **Status:** Not Started.
 
-### **Task 3: Source Comment Hygiene Pass**
+### **Task 69: Source Comment Hygiene Pass**
 *   **Goal:** Tidy comments for clarity and maintainability before v3.0.0.
 *   **Policy:** Keep comments for invariants and design rationale; remove redundant narration of obvious control flow.
 *   **Check:** Verify banner comments are only used where they add design/invariant context.
@@ -795,12 +767,12 @@ Ordering policy (for all editors, including AI editors):
 *   **Excluded:** Do not modify third-party `uthash.h`.
 *   - [ ] **Status:** Not Started.
 
-### **Task 2: Final Consistency Sweep (Style, Docs, UX Wording)**
+### **Task 70: Final Consistency Sweep (Style, Docs, UX Wording)**
 *   **Goal:** Run a final consistency pass across style-sensitive surfaces (code style guardrails, docs wording, and help/footer terminology).
 *   **Rationale:** Multi-contributor consistency is enforced continuously via guardrails and review; this task is a final convergence pass.
 *   - [ ] **Status:** Not Started.
 
-### **Task 1: Multi-Round Adversarial Security Review**
+### **Task 71: Multi-Round Adversarial Security Review**
 *   **Goal:** Perform a pre-v3.0.0 multi-round security review using adversarial and AppSec perspectives.
 *   **Examples:** Senior AppSec reviewer, penetration-tester mindset, and insider-knowledge threat modeling.
 *   **Rationale:** Final pre-release pressure test on top of continuous Phase 2 security gates.
@@ -819,7 +791,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Future Phase 1: Post-Baseline Configurability Follow-On**
 
-### **Idea FE-37: Explicit Accessibility Mode (Screen-Reader-First Terminal Behavior)**
+### **Idea FE-1: Explicit Accessibility Mode (Screen-Reader-First Terminal Behavior)**
 *   **Goal:** Introduce an opt-in explicit accessibility mode focused on stable, low-noise behavior for screen-reader workflows.
 *   **Research Gate (Required Before Implementation):**
     *   Audit current redraw/cursor-update hotspots (clock, spinner, status-line, dialogs, preview loops) for assistive-tech impact.
@@ -832,7 +804,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Terminal UI is not automatically accessible; explicit mode-level contracts are needed to avoid redraw/cursor noise regressions.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-36: Portable Keyboard Capability Probe + `.ytree` Key Workarounds**
+### **Idea FE-2: Portable Keyboard Capability Probe + `.ytree` Key Workarounds**
 *   **Goal:** Add startup-time terminal key-capability probing and user-configurable key overrides/workarounds in `~/.ytree`.
 *   **Behavior Direction:**
     *   Probe optional key availability once at startup (cache results; no per-keystroke probing overhead).
@@ -841,7 +813,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Improves old-terminal portability while keeping runtime input handling fast.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-35: Keymap Follow-On Work (Post-Baseline)**
+### **Idea FE-3: Keymap Follow-On Work (Post-Baseline)**
 *   **Description:** Follow-up keymap work after baseline keymap support lands (preset profiles, conflict diagnostics, import/export format hardening, and migration notes for existing users).
 *   **Localized keymap profiles:** Add opt-in locale-oriented profiles as separate keymap files (not automatic locale remapping), while keeping the default keymap stable.
 *   **Best-practice guardrails:** Preserve a universal core of stable bindings (function keys/Ctrl/digits/arrows), allow locale mnemonic aliases where safe, and enforce strict collision/unbound-action validation with clear diagnostics.
@@ -849,7 +821,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Future Phase 2: UI/UX Enhancements and Cleanup**
 
-### **Idea FE-39: Configurable VCS Provider for `0` FileInfo Band**
+### **Idea FE-4: Configurable VCS Provider for `0` FileInfo Band**
 *   **Goal:** Keep `0` as one stable VCS info band while allowing users to choose which backend powers it.
 *   **Config Direction (`ytree.conf`):** Add a single-provider selector (for example `VCS_PROVIDER=off|git|hg|svn|fossil|auto`).
 *   **Behavior Contract:**
@@ -859,7 +831,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Preserves key stability and avoids renumbering while keeping a path open for non-Git users.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-38: Typed Filter Modes (`glob` default, `re:`, `fz:`)**
+### **Idea FE-5: Typed Filter Modes (`glob` default, `re:`, `fz:`)**
 *   **Goal:** Extend file filtering with explicit typed terms while preserving today's glob-first behavior and key flow.
 *   **User-Facing Behavior:**
     *   Keep existing glob syntax as default (`*.c`, `*.c,*.h`, `-*.tmp`).
@@ -879,18 +851,18 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Adds regex/fuzzy power in a Unix-style, scriptable format without breaking existing wildcard workflows or adding submenu friction.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-34: Prompt Input Decode Hardening (curses-first, legacy ESC fallback)**
+### **Idea FE-6: Prompt Input Decode Hardening (curses-first, legacy ESC fallback)**
 *   **Goal:** Replace prompt-path manual ESC sequence parsing with curses/terminfo-first decoding, while keeping legacy manual ESC parsing as controlled fallback (or config-gated compatibility mode).
 *   **Rationale:** Reduces xterm-specific assumptions in prompt entry and improves cross-terminal correctness on older UNIX environments.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-33: Input Portability Regression Matrix (`TERM`)**
+### **Idea FE-7: Input Portability Regression Matrix (`TERM`)**
 *   **Goal:** Expand UI regression coverage with a terminal-profile matrix and action-level assertions for keyboard behavior.
 *   **Initial Matrix Target:** `xterm`, `vt100`, `screen`, `tmux`, `linux`.
 *   **Rationale:** Existing UI tests prove behavior well in xterm-like sequences, but matrix runs provide stronger evidence for old/variant terminal compatibility.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-32: Extended `sYsinfo` in Directory-Window Mode**
+### **Idea FE-8: Extended `sYsinfo` in Directory-Window Mode**
 *   **Goal:** Add an on-demand extended stats/system-info surface (`sYsinfo`) for directory-window workflows without replacing the default compact stats panel.
 *   **Rationale:** Advanced disk/system context is useful for planning operations, but should stay opt-in to avoid clutter in normal navigation.
 *   **Keybinding Direction:** Keep context-specific `Y` behavior collision-free: directory-window `Y` may expose `sYsinfo`; file-window `Y` may expose sync workflow entry.
@@ -900,17 +872,17 @@ Ordering policy (for all editors, including AI editors):
 *   Footer/F1/manpage wording explicitly documents context split where `Y` differs by mode.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-31: Implement In-App Configuration Editor (F10)**
+### **Idea FE-9: Implement In-App Configuration Editor (F10)**
 *   **Goal:** Implement a user-friendly configuration editor (activated by `F10`) that supports guided editing for common options in `~/.ytree` (e.g., `CONFIRMQUIT`, colors), while retaining an expert raw-text path.
 *   **Rationale:** Reduces configuration friction for most users without removing power-user flexibility.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-30: Implement Mouse Support**
+### **Idea FE-10: Implement Mouse Support**
 *   **Goal:** Add mouse support for core navigation and selection actions within the terminal (e.g., click to select, double-click to enter, wheel scrolling).
 *   **Rationale:** In capable terminal environments, mouse support can improve speed and ease of use for navigation and selection without changing the keyboard-first design.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-29: Configurable Split Header Path Display (`active` or `both`)**
+### **Idea FE-11: Configurable Split Header Path Display (`active` or `both`)**
 *   **Goal:** Add a user option for split-mode header path display so users can choose active-panel-only path or both-panel paths.
 *   **Rationale:** Active-only header is cleaner by default, while dual-path header can improve orientation for users managing two distant locations.
 *   **Scope Lock:** Header display policy only; no split navigation, selection, or command behavior changes.
@@ -921,7 +893,7 @@ Ordering policy (for all editors, including AI editors):
 *   Footer/F1 help and config docs are updated when option lands.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-28: Prompt Path Entry, Shell-Style Completion, and ncurses-Native Input Editing**
+### **Idea FE-12: Prompt Path Entry, Shell-Style Completion, and ncurses-Native Input Editing**
 *   **Goal:** Replace the current history-biased prompt input with a first-class path-entry workflow that is good enough for deep navigation, destination entry, and command prompts.
 *   **Scope:** This task subsumes the previous separate ideas for shell-style tab completion, deep path jump, and advanced ncurses-native command-line editing.
 *   **Behavior to Deliver:**
@@ -932,7 +904,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Prompt entry should be strong enough that common path-based workflows stay direct: "type path -> complete/adjust -> Enter -> result" without forcing a separate browser/menu detour.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-27: Tagged-Only Results View**
+### **Idea FE-13: Tagged-Only Results View**
 *   **Goal:** Add a view mode that shows only tagged files without altering the tag set itself.
 *   **User-Facing Behavior:**
     *   `F4` toggles **Tagged-Only** view mode.
@@ -942,13 +914,13 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** After tagging, compare, or grep operations, users often want a focused "show me only the files I marked" result view instead of manually navigating through the full list.
 *   - [ ] **Status:** In Progress (tagged-only toggle shipped on `o/O`; broader workflow/key-shape refinements remain).
 
-### **Idea FE-26: Investigate Recursive Tagging vs Existing Showall/Global Workflow**
+### **Idea FE-14: Investigate Recursive Tagging vs Existing Showall/Global Workflow**
 *   **Goal:** Determine whether recursive tagging provides enough real workflow benefit over the current `log dir -> Showall/Global -> tag` path to justify added complexity.
 *   **Rationale:** Recursive tagging may reduce steps in some trees, but can also add command ambiguity and accidental broad-selection risk.
 *   **Investigation Output:** Document concrete user workflows, interaction-depth impact, and safety tradeoffs; propose either (a) no change, or (b) a minimal, default-safe recursive tagging design with clear scope/confirmation semantics.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-25: Richer Compare Result Views**
+### **Idea FE-15: Richer Compare Result Views**
 *   **Goal:** Extend compare workflows so the result can be viewed directly, not just turned into tags on the active side.
 *   **User-Facing Behavior:**
     *   After comparing two directories/trees, users can narrow the result to categories such as **left/source only**, **right/target only**, **newer**, **older**, **size different**, **content different**, or **identical**.
@@ -957,7 +929,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Current compare behavior is useful but blunt. A richer result view makes compare a practical review tool rather than only a tag generator.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-24: Recent-Directory Bookmarks and Pinned Favorites**
+### **Idea FE-16: Recent-Directory Bookmarks and Pinned Favorites**
 *   **Goal:** Add a first-class recent-directory and pinned-favorites picker for fast return to commonly visited locations.
 *   **User-Facing Behavior:**
     *   Show a compact list of recently visited directories together with user-pinned favorites.
@@ -967,7 +939,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Prompt history helps when the user remembers what they typed. A dedicated recent-directory/favorites list helps when the user remembers the place, not the exact command string.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-23: Dual-Preview Split Mode**
+### **Idea FE-17: Dual-Preview Split Mode**
 *   **Goal:** Allow each `F8` split panel to enter and retain its own `F7`-style preview state independently.
 *   **User-Facing Behavior:**
     *   In split mode, each panel can independently enter preview without forcing preview state changes in the other panel.
@@ -983,7 +955,7 @@ Ordering policy (for all editors, including AI editors):
 *   Focused regression coverage proves per-panel state retention, panel switching, and exit/return behavior.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-22: Directory-Focus Small-File Peek Navigation (`Shift` + Nav Keys)**
+### **Idea FE-18: Directory-Focus Small-File Peek Navigation (`Shift` + Nav Keys)**
 *   **Goal:** In directory focus, allow `Shift+Up/Down/Page/Home/End` to scroll the small file window for the selected directory without switching to full file-window focus.
 *   **Rationale:** This gives a fast "peek and keep tree focus" workflow and mirrors the existing `Shift`-navigation feel used in `F7` preview.
 *   **Scope Lock:** Directory-focus small-file-window navigation only; no new submenu flow, no change to normal unshifted tree navigation, and no change to `F7` preview behavior.
@@ -996,7 +968,7 @@ Ordering policy (for all editors, including AI editors):
 *   Add focused regression coverage for shifted small-window navigation bounds/offset behavior and isolation from directory navigation.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-21: Unified `N Create` Entry Point (Capability-Filtered by Backend)**
+### **Idea FE-19: Unified `N Create` Entry Point (Capability-Filtered by Backend)**
 *   **Goal:** Replace the narrow `NewFile` entry point with a single explicit `Create` chooser whose available options are filtered by the active backend and context.
 *   **User-Facing Behavior:**
     *   Where creation is supported, `n`/`N` opens `Create:` with only the actions that are valid for the active backend/context.
@@ -1024,77 +996,77 @@ Ordering policy (for all editors, including AI editors):
 *   Decouple the file filter (`file_spec`) from the `Volume` structure and move it into a new `WindowView` context. This architecture is required to support F8 Split Screen, enabling two independent views of the same volume with different filters (e.g., `*.c` in the left panel versus `*.h` in the right).
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-19: State Preservation on Reload (`^L`)**
+### **Idea FE-21: State Preservation on Reload (`^L`)**
 *   Modify the Refresh command to preserve directory expansion states. Cache open paths prior to the re-scan and restore the previous view structure instead of resetting to the default depth.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-18: Preserve Tree Expansion on Refresh**
+### **Idea FE-22: Preserve Tree Expansion on Refresh**
 *   Modify the Refresh/Rescan logic (`^L`, `F5`) to cache the list of currently expanded directories before reading the disk. After the scan is complete, programmatically re-expand those paths if they still exist.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-17: Scroll Bars**
+### **Idea FE-23: Scroll Bars**
 *   On left border of the file and directory windows to indicate the relative position of the highlighted item in the entire list (configurable to char or line).
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-16: Callback API Constification Cleanup (cppcheck strict mode)**
+### **Idea FE-24: Callback API Constification Cleanup (cppcheck strict mode)**
 *   `cppcheck` suggests const-qualifying callback `user_data`, but doing this correctly likely requires changing callback typedef/API signatures (e.g., `RewriteCallback`) and related call sites. Defer this to a focused API pass to avoid scattered casts and partial churn.
 *   - [ ] **Status:** Not Started.
 
 ### **Future Phase 3: Long-Horizon Experiments**
 
-### **Idea FE-15: Implement VFS Abstraction Layer** (Use the Architect persona here)
+### **Idea FE-25: Implement VFS Abstraction Layer** (Use the Architect persona here)
 *   **Goal:** Replace hardcoded filesystem logic with a driver-based architecture. This allows `ytree` to treat any data source (Local FS, Archive, SSH, SQL) uniformly as a `Volume`.
 *   **Context:** Currently, `log.c` decides between "Disk" and "Archive". We will change this so `log.c` asks a Registry: "Who can handle this path?"
 *   **Follow-on Direction:** Include remote logging backends under this VFS model (FTP/SFTP candidates), with final protocol choice deferred until security and maintenance review.
 
-### **Idea FE-14: Define VFS Interface & Volume Integration** (Use the Architect persona here)
+### **Idea FE-26: Define VFS Interface & Volume Integration** (Use the Architect persona here)
 *   **Goal:** Define the `VFS_Driver` contract (struct of function pointers) and update the `Volume` struct to hold a pointer to its active driver.
 *   **Mechanism:**
     *   Create `include/ytree_vfs.h`.
     *   Define function pointers: `scan`, `stat`, `lstat`, `extract`, `get_path` (for internal addressing).
     *   Update `include/ytree_defs.h` to add `const VFS_Driver *driver` and `void *driver_data` to `struct Volume`.
 
-### **Idea FE-13: Implement VFS Registry** (Use the Architect persona here)
+### **Idea FE-27: Implement VFS Registry** (Use the Architect persona here)
 *   **Goal:** Create the core logic to register drivers and probe paths.
 *   **Mechanism:**
     *   Create `src/fs/vfs.c`.
     *   Implement `VFS_Init()` (registers built-in drivers).
     *   Implement `VFS_Probe(path)` which iterates drivers asking "Can you handle this?" and returns the best match.
 
-### **Idea FE-12: Implement "Local" VFS Driver** (Use the Architect persona here)
+### **Idea FE-28: Implement "Local" VFS Driver** (Use the Architect persona here)
 *   **Goal:** Wrap the existing POSIX `opendir`/`readdir` logic into a `VFS_Driver`.
 *   **Mechanism:**
     *   Create `src/fs/drv_local.c`.
     *   Move logic from `src/fs/tree_read.c` into the driver's `.scan` method.
     *   Ensure it populates `DirEntry` structures exactly as before.
 
-### **Idea FE-11: Implement "Archive" VFS Driver** (Use the Architect persona here)
+### **Idea FE-29: Implement "Archive" VFS Driver** (Use the Architect persona here)
 *   **Goal:** Wrap the existing `libarchive` logic into a `VFS_Driver`.
 *   **Mechanism:**
     *   Create `src/fs/drv_archive.c`.
     *   Move logic from `src/fs/archive_read.c` and `src/fs/archive_write.c` into the driver.
     *   Implement `.extract` to handle the temporary file creation for viewing/copying.
 
-### **Idea FE-10: Switch `LogDisk` to VFS** (Use the Architect persona here)
+### **Idea FE-30: Switch `LogDisk` to VFS** (Use the Architect persona here)
 *   **Goal:** Update the main entry point to use the new system.
 *   **Mechanism:**
     *   Refactor `src/cmd/log.c`.
     *   Replace the `stat`/`S_ISDIR` check with `VFS_Probe(path)`.
     *   Call `vol->driver->scan()` instead of calling `ReadTree` or `ReadTreeFromArchive` directly.
 
-### **Idea FE-9: Refactor Consumers (Polymorphism)** (Use the Architect persona here)
+### **Idea FE-31: Refactor Consumers (Polymorphism)** (Use the Architect persona here)
 *   **Goal:** Remove `if (mode == ARCHIVE)` from the rest of the codebase.
 *   **Mechanism:**
     *   Update `view.c`, `copy.c`, `execute.c`.
     *   Replace specific calls with `vol->driver->extract(...)` or `vol->driver->stat(...)`.
 
-### **Idea FE-8: Database Browsing and Editing via Virtual Filesystem Drivers**
+### **Idea FE-32: Database Browsing and Editing via Virtual Filesystem Drivers**
 *   **Goal:** After the driver-based VFS abstraction exists, allow ytree to browse supported database formats as navigable virtual filesystems and eventually edit them through driver-defined operations.
 *   **User-Facing Direction:** Treat a database as a structured volume (for example database -> tables -> rows/records or exported views) rather than as one opaque file blob.
 *   **Rationale:** This is a specialized extension of the VFS model, not a core file-manager requirement. Keep it as a future experiment until a clear driver design and real use-case exist.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-7: Implement Recursive Directory Watching**
+### **Idea FE-33: Implement Recursive Directory Watching**
 *   **Goal:** Keep visible tree and file-list state fresh by watching all currently expanded filesystem directories, not only the active cursor directory.
 *   **Rationale:** Without recursive watch coverage, edits in visible sibling/child directories can leave the UI stale until manual refresh.
 *   **Scope Lock:** Filesystem watcher behavior only; no archive-internal recursive watching.
@@ -1110,17 +1082,17 @@ Ordering policy (for all editors, including AI editors):
     *   `ENOSPC` fallback is explicit, stable, and non-fatal.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-6: Implement Shell Script Generator**
+### **Idea FE-34: Implement Shell Script Generator**
 *   **Goal:** Generate a shell script from tagged files using user-defined templates (e.g., `cp %f /backup/%f.bak`), replacing the "Batch" concept.
 *   **Rationale:** Offers complex templating logic that goes beyond simple pipe/xargs, and critically allows the user to review/edit the generated script before execution for safety.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-5: Implement Keyboard Macros (F12 Record/Playback)**
+### **Idea FE-35: Implement Keyboard Macros (F12 Record/Playback)**
 *   **Goal:** Implement keystroke recording and replay. `F12` starts/stops recording command/input sequences for deterministic playback.
 *   **Rationale:** Allows automation of repetitive interaction sequences (for example "Tag, Move, Rename, Repeat") without creating shell command templates.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-4: Enhance Built-In Viewer**
+### **Idea FE-36: Enhance Built-In Viewer**
 *   **Goal:** Evolve ytree's internal viewer from a basic fallback inspector into a more capable built-in viewing tool for normal terminal workflows.
 *   **Builds On:** Current-delivery viewer work such as `Add Configurable Bypass for External Viewers` and `Standardize Internal Viewer Layout`.
 *   **Candidate Scope:**
@@ -1132,167 +1104,13 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** A stronger built-in viewer would make ytree more self-contained for terminal inspection work, while still keeping the project focused on file management rather than format-specific rendering.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-3: Preview Helper Pipeline for Non-Text File Types**
-*   **Goal:** Implement an F7 dual-mode preview pipeline that keeps internal preview as the guaranteed baseline while allowing helper-rendered output for non-text file types.
-*   **Non-Goal:** Do not make ytree natively decode every binary/GUI format. Keep helper-based rendering as the Unix-style extension surface.
-*   **Roadmap Fit:** This is the concrete implementation shape for the long-standing preview-helper direction, while preserving strict internal fallback behavior.
-*   **Implementation-Ready Spec:**
-    **Status:** Proposed / implementation-ready.
 
-    **Scope:** Add dual-mode preview behavior to `F7` with strict fallback guarantees:
-    * `BINARY` = internal preview path only (never executes helpers).
-    * `RENDER` = helper-driven preview path; on any failure/unavailability, fallback to `BINARY`.
-
-    **Terminology (Normative):**
-    * `BINARY`: internal preview mode only; no external helper execution; text-like content when decodable, otherwise raw/byte-oriented internal representation.
-    * `RENDER`: helper preview mode via extension mapping; output shown in preview pane; fallback to `BINARY` on no-match, error, timeout, overflow, or safety rejection.
-
-    **User Interaction Contract:**
-    * `F7` enters preview mode.
-    * `F7` or `Esc` exits preview mode and restores prior state.
-    * In `F7`, `r`/`R` toggles `BINARY` ⇄ `RENDER`.
-    * Bottom-left footer mode label must be exactly `BINARY` or `RENDER` (fixed-width, no wobble).
-    * Default F7 mode comes from config (`PREVIEW_MODE_DEFAULT`, default `binary`).
-
-    **Split-Mode Behavior:**
-    * Preview mode state is panel-local (left/right independent).
-    * Toggling mode in one panel must not mutate the other panel state.
-
-    **Helper Execution Contract:**
-    * Prefer argv-style execution (no shell interpolation).
-    * If template parsing is retained, allow `%s` only; reject all other `%` tokens.
-    * File path must be inserted as one safely quoted argument via existing command/path helpers.
-    * Bound command length by existing command-line limits.
-
-    **Render Safety & Limits:**
-    * Enforce timeout (`PREVIEW_RENDER_TIMEOUT_MS`).
-    * Enforce captured output cap (`PREVIEW_RENDER_MAX_BYTES`).
-    * Enforce ANSI policy (`RENDER_ALLOW_ANSI`).
-    * On any violation/failure, fallback to `BINARY`.
-
-    **Extension Matching Rules (Deterministic):**
-    1. Exact extension rule match (single-ext entry).
-    2. First matching multi-extension rule in config order.
-    3. No match ⇒ `BINARY`.
-    * Extension matching is case-insensitive.
-    * No MIME probing in v1.
-
-    **Cache Contract:**
-    * RENDER cache key must include:
-      * path (canonical key)
-      * file mtime
-      * file size
-      * preview mode
-      * resolved helper command string
-      * ANSI policy
-      * timeout value
-      * output-cap value
-    * This ensures config/helper edits invalidate cached renders.
-
-    **Failure UX Contract:**
-    * On RENDER failure, continue showing `BINARY`.
-    * Optional one-shot notice: `RENDER unavailable; using BINARY`.
-    * Anti-spam:
-      * deduplicate by `(file, helper, error_class)`
-      * rate-limit global notices during cursor movement (recommended ≥ 750ms interval)
-
-    **Configuration (Canonical Defaults + User Override):**
-    * Canonical defaults source-of-truth:
-      * `etc/ytree.conf`
-      * `src/core/default_profile_template.h`
-
-    **Global keys:**
-
-    | Key | Type | Allowed | Default | Meaning |
-    |---|---|---|---|---|
-    | `PREVIEW_MODE_DEFAULT` | enum | `binary` \| `render` | `binary` | Initial F7 mode on entry |
-    | `PREVIEW_AUTOPLAY_MEDIA` | bool-int | `0` \| `1` | `0` | Whether media render helpers may autoplay |
-    | `PREVIEW_RENDER_TIMEOUT_MS` | int | `100..10000` | `1200` | Max helper runtime in milliseconds |
-    | `PREVIEW_RENDER_MAX_BYTES` | int | `4096..1048576` | `262144` | Max captured helper output bytes |
-    | `RENDER_ALLOW_ANSI` | bool-int | `0` \| `1` | `0` | ANSI handling policy for RENDER output |
-
-    **`[PREVIEW_RENDER]` section format:**
-    ```ini
-    [PREVIEW_RENDER]
-    .ext=command %s
-    .ext1,.ext2,.ext3=command %s
-    ```
-    * Extensions are case-insensitive.
-    * `%s` is the selected file path token.
-    * Comment out/remove mappings to keep those types in `BINARY`.
-
-    **Example:**
-    ```ini
-    PREVIEW_MODE_DEFAULT=binary
-    PREVIEW_AUTOPLAY_MEDIA=0
-    PREVIEW_RENDER_TIMEOUT_MS=1200
-    PREVIEW_RENDER_MAX_BYTES=262144
-    RENDER_ALLOW_ANSI=0
-
-    [PREVIEW_RENDER]
-    .pdf=gs -q -dNOPAUSE -dBATCH -sDEVICE=txtwrite -sOutputFile=- %s
-    .jpg,.jpeg,.png,.gif=chafa --animate off %s
-    .mp3,.flac=ffprobe -hide_banner %s
-    .mp4,.mkv,.avi,.mpg=ffprobe -hide_banner %s
-    ```
-
-    **Error-State Matrix (Normative):**
-
-    | Condition | Active Mode | Action | Displayed Mode | User Notice |
-    |---|---|---|---|---|
-    | Helper mapping found, helper succeeds | RENDER | Show helper output | RENDER | none |
-    | No helper mapping for extension | RENDER | Fallback | BINARY | optional one-shot |
-    | Helper command parse invalid (`%` token not allowed) | RENDER | Reject + fallback | BINARY | optional one-shot |
-    | Helper executable missing / spawn failure | RENDER | Fallback | BINARY | optional one-shot |
-    | Helper timeout exceeded | RENDER | Stop helper, fallback | BINARY | optional one-shot |
-    | Helper output exceeds max bytes | RENDER | Reject + fallback | BINARY | optional one-shot |
-    | ANSI disallowed and output contains ANSI (`RENDER_ALLOW_ANSI=0`) | RENDER | Strip ANSI; if strip fails, fallback | BINARY or RENDER* | optional one-shot on fallback |
-    | Any internal render-path error | BINARY or fallback target | Show safe error line; remain in preview | BINARY | yes |
-    | Toggle key pressed (`r`/`R`) | F7 | Flip mode state | BINARY or RENDER | footer update |
-    | Exit key (`F7`/`Esc`) | F7 | Exit preview | N/A | none |
-
-    \* If ANSI strip succeeds, remain `RENDER`; if strip fails, fallback `BINARY`.
-
-    **Security & Robustness Requirements:**
-    * No unsafe shell concatenation of untrusted paths.
-    * Command construction must remain bounded.
-    * Fail closed to `BINARY`.
-    * Preserve curses/terminal integrity across helper invocation and return.
-
-    **Acceptance Criteria:**
-    1. F7 opens in configured default mode (`binary` by default).
-    2. `r`/`R` toggles mode and footer shows exact `BINARY` or `RENDER`.
-    3. Footer alignment does not move on mode toggle.
-    4. `BINARY` path never executes helpers.
-    5. `RENDER` falls back to `BINARY` for all matrix failure classes.
-    6. Media autoplay is disabled by default (`PREVIEW_AUTOPLAY_MEDIA=0`).
-    7. Commented/removed mappings keep file types in `BINARY`.
-    8. Split-mode state is panel-local.
-    9. Failure notices are deduplicated and rate-limited.
-    10. Manpage/profile/template docs are synced.
-
-    **Minimum Test Requirements:**
-    * Config parsing coverage for all new keys.
-    * `[PREVIEW_RENDER]` single + multi-ext parse tests.
-    * Invalid token rejection (`%x`, `%%`, etc.).
-    * Matching/precedence tests (case-insensitive extension behavior).
-    * Runtime tests: toggle + footer, no-helper fallback, timeout fallback, overflow fallback, ANSI policy handling.
-    * Split tests: panel-local independence.
-    * Regression tests: existing F7 nav/exit behavior unchanged; no redraw corruption after helper return.
-
-    **Documentation Sync Requirements (when implemented):**
-    * `etc/ytree.1.md` (canonical manpage source)
-    * generated `docs/USAGE.md`
-    * `etc/ytree.conf` defaults/comments
-    * `src/core/default_profile_template.h` defaults/comments
-*   - [ ] **Status:** Not Started.
-
-### **Idea FE-2: Terminal-Independent TUI Runtime (ncurses-Decoupling Investigation)**
+### **Idea FE-37: Terminal-Independent TUI Runtime (ncurses-Decoupling Investigation)**
 *   **Goal:** Investigate a runtime path where ytree's TUI is not tightly coupled to ncurses.
 *   **Rationale:** This is a platform/input architecture effort intended to evaluate whether backend decoupling can reduce current control-key handling constraints (including limitations around mappings like `^M`) while preserving ytree interaction semantics.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-1: Implement "Safe Delete" (Trash Can)**
+### **Idea FE-38: Implement "Safe Delete" (Trash Can)**
 *   **Goal:** Add optional trash-backed delete where the active filesystem/backend supports it.
 *   **Config:** Add a `ytree.conf` switch for trash-delete with default `1` (enabled).
 *   **Fallback:** If trash-delete is disabled or unsupported for the active backend, use permanent delete with explicit confirmation.

--- a/docs/ai/GOVERNANCE.md
+++ b/docs/ai/GOVERNANCE.md
@@ -57,5 +57,6 @@ For common governance edits, use these canonical targets:
 Prompt templates live in `docs/ai/` and are maintained as copy/paste entrypoints:
 - `PROMPT_TEMPLATE.md`: single quick developer unit only; includes a hard redirect to relay if scope is broader.
 - `RELAY_PROMPT_TEMPLATE.md`: architect-supervised relay workflow for non-trivial, multi-unit missions.
+- Both templates enforce facts-first relay visibility updates (completed evidence before planned next action).
 
 When template behavior or routing rules change, update both the template file and `docs/ai/WORKFLOW.md`.

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -19,8 +19,12 @@ Scope gate (mandatory):
 
 - Keep worker prompts to minimal technical payload only (scope, acceptance, commands, blockers).
 - Avoid long policy/governance prose in worker prompts.
-- If worker creation is policy-blocked, auto-retry once with a reduced prompt profile.
-- Relay proceeds autonomously; maintainer interruption is only for blockers and commit-message approval gate.
+- If worker creation is policy-blocked, auto-retry once with a reduced prompt profile and continue without maintainer interruption for that recoverable path.
+- Relay proceeds autonomously; maintainer interruption is only for `true_blocker_decision` and `commit_message_approval`.
+- Canonical relay autonomy policy tokens (required):
+  - `policy_block_retry_once`
+  - `watchdog_stall_retry_terminal`
+  - `maintainer_pause_gate=true_blocker_decision|commit_message_approval`
 
 Process requirements:
 1) Sync local main with GitHub main:
@@ -46,6 +50,7 @@ Process requirements:
    - do not run checks or QA until I explicitly agree
    - before first push, run a quick local gate (build + targeted smoke/tests)
    - run targeted tests as needed
+   - if I approve full QA for a unit state, run `make qa-all` at most once for that exact accepted state; rerun only after code changes
    - after task completion, run full gate:
      source .venv/bin/activate
      make qa-all
@@ -73,5 +78,6 @@ Process requirements:
 Important guardrails:
 - Do not rewrite or drop prior merged work from main.
 - Do not broaden scope beyond the approved task.
+- Status updates must be facts-first: report what was completed (with evidence handle) before stating next action.
 - If uncertain, ask before choosing behavior-changing options.
 - If anything is ambiguous, ask me to clarify instead of guessing.

--- a/docs/ai/RELAY_PROMPT_TEMPLATE.md
+++ b/docs/ai/RELAY_PROMPT_TEMPLATE.md
@@ -49,11 +49,20 @@ Prompt/report artifact rules:
 - Stream relay visibility live: post a maintainer update immediately after each runtime event.
 - Do not wait for unit completion to publish relay visibility.
 - In each live update, include only net-new state + next action + changed handles.
+- Visibility contract is facts-first, not intent-first:
+  - Every update MUST include a completed-action line in past tense before any next-action text.
+  - Include concrete evidence in every runtime update (`report_handle`, command output excerpt, or event-log handle).
+  - Heartbeat-only updates are liveness pings and MUST include elapsed runtime + current executing action.
+  - Do not emit “will do X” updates unless the prior event already emitted “did X” evidence for the previous action.
+- Runtime event labels should prefer explicit completion facts (`worker_command_started`, `worker_command_completed`, `worker_command_failed`, `unit_completed`, `unit_failed`, `retry_scheduled`, `workflow_completed`, `workflow_failed`).
 
 Stall/escalation policy:
 - If a unit exceeds timeout or misses heartbeat, watchdog MUST emit a stall event.
 - Watchdog then retries/reassigns within retry policy; if retries are exhausted, mark terminal failure and escalate.
 - Do not run checks or QA until maintainer explicitly agrees.
+- When maintainer approves checks/QA for a unit state, avoid duplicate full-gate churn:
+  - `make qa-all` runs at most once per accepted unit state.
+  - Re-run full gate only if code changed after the last full-gate evidence.
 
 Developer prompt requirements (for each unit):
 - Strict scope and explicit non-goals

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -314,10 +314,15 @@ watch -n 5 'python3 scripts/relay_runtime.py dashboard --verbose --limit 20'
 4.  Verification cadence inside one atomic unit remains mandatory:
     *   initial pass: full verification set listed for the unit,
     *   correction/rework pass: rerun failing checks + directly impacted targeted tests,
-    *   avoid full `make qa-all` reruns unless risk materially changed or architect requests it.
+    *   avoid full `make qa-all` reruns unless risk materially changed or architect requests it,
+    *   once maintainer has approved QA for a given accepted unit state, run `make qa-all` at most once for that state and rerun only after subsequent code changes.
 5.  Worker MUST NOT mark unit complete while required checks are failing.
 6.  On success/failure/timeout, worker MUST emit explicit event log entries (no silent loops).
 7.  Developer status line to maintainer must be delta-only: net-new state + next action + changed handles only.
+8.  Developer/architect relay updates are facts-first:
+    *   state completed work in past tense before planned next actions,
+    *   include concrete evidence handles for each completion event (`report_handle`, event seq, command excerpt),
+    *   heartbeat-only updates are liveness-only and must include elapsed runtime plus current active action.
 
 #### 3.1.5 Auditor Pass (systemd Worker, Lease + Heartbeat, Single Unit)
 
@@ -335,19 +340,24 @@ watch -n 5 'python3 scripts/relay_runtime.py dashboard --verbose --limit 20'
 2.  Watchdog continuously enforces liveness:
     *   expired lease or stale heartbeat -> `stall_detected` event,
     *   requeue/reassign with bounded retry,
-    *   terminal fail when retry budget is exhausted.
-    *   if worker creation is policy-blocked, retry once with a reduced subagent-safe prompt profile (minimal technical payload only).
-3.  Relay execution remains autonomous end-to-end; maintainer interruption is reserved for explicit blockers and commit-message approval gate.
-4.  Before commit, architect MUST ensure fresh full-gate evidence (`make qa-all`) for accepted branch state.
-5.  If accepted:
+    *   terminal fail when retry budget is exhausted (no silent stop states),
+    *   if worker creation is policy-blocked, retry once with a reduced subagent-safe prompt profile (minimal technical payload only) and do not pause maintainer for that recoverable path.
+3.  Relay execution remains autonomous end-to-end; maintainer interruption is reserved strictly for `true_blocker_decision` and `commit_message_approval`.
+4.  Canonical relay autonomy policy tokens (required in docs + guards):
+    *   `policy_block_retry_once`: policy-blocked worker prompt failure is auto-retried once with reduced prompt profile and no maintainer interruption.
+    *   `watchdog_stall_retry_terminal`: stale heartbeat/timeout must emit `stall_detected`, then bounded retry/reassign, then terminal escalation on retry exhaustion.
+    *   `maintainer_pause_gate=true_blocker_decision|commit_message_approval`: pause gate allows maintainer interruption only for those two reasons.
+    *   Runtime event naming should prefer explicit completion semantics (`worker_command_started`, `worker_command_completed`, `worker_command_failed`, `unit_completed`, `unit_failed`) so maintainers can distinguish done-vs-next without prompt interpretation.
+5.  Before commit, architect MUST ensure fresh full-gate evidence (`make qa-all`) for accepted branch state.
+6.  If accepted:
     *   commit only code/doc files (no relay/runtime artifacts),
     *   use maintainer-approved commit message describing durable behavior (no task numbering),
     *   include explicit work-item status text in the same commit (for example `Status: Confirmed.`, `Status: In Progress.`, or `Status: Fixed.`) so no status transition is left ambiguous,
     *   first push: `git push-fast-up`; tracked branch: `git push-fast`.
-6.  If correction is needed for the same logical change set, amend and repush:
+7.  If correction is needed for the same logical change set, amend and repush:
     *   `git commit --amend --no-edit`
     *   push with the branch rule above.
-7.  Cleanup consumed transient artifacts after usefulness ends (for example `compile_commands.json`, `valgrind.log`, temporary relay scratch files).
+8.  Cleanup consumed transient artifacts after usefulness ends (for example `compile_commands.json`, `valgrind.log`, temporary relay scratch files).
 
 #### 3.1.7 Completion Gate, Merge, and Manual Fallback
 

--- a/infra/systemd/relay.env.example
+++ b/infra/systemd/relay.env.example
@@ -3,6 +3,12 @@
 RELAY_DB=%h/.local/state/ytree/relay.db
 RELAY_EVENT_LOG=%h/.local/state/ytree/relay-events.jsonl
 
+# Relay autonomy controls (mandatory defaults)
+RELAY_POLICY_BLOCK_RETRY_LIMIT=1
+RELAY_MAINTAINER_HEARTBEAT_SECONDS=300
+RELAY_NO_PROGRESS_STALL_SECONDS=900
+RELAY_MAINTAINER_INTERRUPT_REASONS=true_blocker_decision,commit_message_approval
+
 # Worker command hooks
 # Developer worker command should exit 0 on success.
 RELAY_DEVELOPER_CMD=/usr/bin/true

--- a/scripts/check_project_ai_config.py
+++ b/scripts/check_project_ai_config.py
@@ -9,9 +9,46 @@ from pathlib import Path
 from typing import Any
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / ".codex" / "config.toml"
+REPO_ROOT = Path(__file__).resolve().parent.parent
 MODEL_INSTRUCTIONS_RELATIVE = ".ai/codex.md"
 SERVERS = ("serena", "jcodemunch")
 REQUIRED_ENV_KEYS = ("UV_CACHE_DIR", "UV_TOOL_DIR")
+RELAY_POLICY_FILES = (
+    "docs/ai/WORKFLOW.md",
+    "docs/ai/PROMPT_TEMPLATE.md",
+    ".ai/shared.md",
+)
+RELAY_POLICY_TOKENS = (
+    "policy_block_retry_once",
+    "watchdog_stall_retry_terminal",
+    "maintainer_pause_gate=true_blocker_decision|commit_message_approval",
+)
+RELAY_ENV_TEMPLATE = "infra/systemd/relay.env.example"
+REQUIRED_RELAY_ENV_SETTINGS = {
+    "RELAY_POLICY_BLOCK_RETRY_LIMIT": "1",
+    "RELAY_MAINTAINER_HEARTBEAT_SECONDS": None,
+    "RELAY_NO_PROGRESS_STALL_SECONDS": None,
+    "RELAY_MAINTAINER_INTERRUPT_REASONS": "true_blocker_decision,commit_message_approval",
+}
+RELAY_RUNTIME_FILE = "scripts/relay_runtime.py"
+RELAY_RUNTIME_REQUIRED_MARKERS = (
+    "--retry-limit",
+    "--heartbeat-stale",
+    "--maintainer-heartbeat-seconds",
+    "--no-progress-stall-seconds",
+    "POLICY_BLOCK_RETRY_LIMIT",
+    "_is_policy_block_failure",
+    "policy_block_detected",
+    "policy_retry_recovered",
+    "policy_retry_exhausted",
+    "RELAY_REDUCED_PROMPT_PROFILE",
+    "STRICT_MAINTAINER_INTERRUPT_REASONS",
+    "_maintainer_pause_allowed",
+    "maintainer_pause_required",
+    "stall_detected",
+    "retry_scheduled",
+    "workflow_failed",
+)
 
 
 def _normalize_args(value: Any) -> list[str]:
@@ -82,8 +119,65 @@ def check_config(path: Path) -> list[str]:
     return failures
 
 
+def _parse_env_lines(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def check_relay_policy_requirements(repo_root: Path) -> list[str]:
+    failures: list[str] = []
+    for relative_path in RELAY_POLICY_FILES:
+        policy_path = repo_root / relative_path
+        if not policy_path.exists():
+            failures.append(f"missing relay policy doc: {relative_path}")
+            continue
+        content = policy_path.read_text(encoding="utf-8")
+        for token in RELAY_POLICY_TOKENS:
+            if token not in content:
+                failures.append(f"{relative_path}: missing relay policy token '{token}'")
+
+    env_path = repo_root / RELAY_ENV_TEMPLATE
+    if not env_path.exists():
+        failures.append(f"missing relay env template: {RELAY_ENV_TEMPLATE}")
+        return failures
+
+    env_values = _parse_env_lines(env_path)
+    for key, expected in REQUIRED_RELAY_ENV_SETTINGS.items():
+        value = env_values.get(key)
+        if value is None or value == "":
+            failures.append(f"{RELAY_ENV_TEMPLATE}: missing setting {key}")
+            continue
+        if expected is not None and value != expected:
+            failures.append(f"{RELAY_ENV_TEMPLATE}: expected {key}={expected}")
+        if key in {"RELAY_MAINTAINER_HEARTBEAT_SECONDS", "RELAY_NO_PROGRESS_STALL_SECONDS"}:
+            try:
+                if int(value) < 1:
+                    failures.append(f"{RELAY_ENV_TEMPLATE}: {key} must be >= 1")
+            except ValueError:
+                failures.append(f"{RELAY_ENV_TEMPLATE}: {key} must be an integer")
+
+    runtime_path = repo_root / RELAY_RUNTIME_FILE
+    if not runtime_path.exists():
+        failures.append(f"missing relay runtime file: {RELAY_RUNTIME_FILE}")
+        return failures
+    runtime_content = runtime_path.read_text(encoding="utf-8")
+    for marker in RELAY_RUNTIME_REQUIRED_MARKERS:
+        if marker not in runtime_content:
+            failures.append(f"{RELAY_RUNTIME_FILE}: missing runtime marker '{marker}'")
+    return failures
+
+
 def main() -> int:
     failures = check_config(CONFIG_PATH)
+    failures.extend(check_relay_policy_requirements(REPO_ROOT))
     if failures:
         for failure in failures:
             print(f"FAIL: {failure}")

--- a/scripts/relay_runtime.py
+++ b/scripts/relay_runtime.py
@@ -18,7 +18,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 RUN_STATUS_RUNNING = "running"
 RUN_STATUS_COMPLETED = "completed"
@@ -51,7 +51,7 @@ _NOOP_PLACEHOLDER_COMMANDS: set[tuple[str, ...]] = {
     ("/bin/true",),
 }
 
-_REPORT_HANDLE_PATTERN = re.compile(r"(?:^|\s)report_handle=(\S+)")
+_REPORT_HANDLE_PATTERN = re.compile(r"(?:^|\s)report_handle=([^\s;]+)")
 DEFAULT_MAINTAINER_HEARTBEAT_SECONDS = max(
     30, int(os.environ.get("RELAY_MAINTAINER_HEARTBEAT_SECONDS", "300"))
 )
@@ -63,6 +63,26 @@ DEFAULT_NO_PROGRESS_STALL_SECONDS = max(
             str(DEFAULT_MAINTAINER_HEARTBEAT_SECONDS * 3),
         )
     ),
+)
+POLICY_BLOCK_RETRY_LIMIT = 1
+STRICT_MAINTAINER_INTERRUPT_REASONS = frozenset(
+    {"true_blocker_decision", "commit_message_approval"}
+)
+_MAINTAINER_INTERRUPT_REASON_ENV = os.environ.get(
+    "RELAY_MAINTAINER_INTERRUPT_REASONS",
+    "true_blocker_decision,commit_message_approval",
+)
+_CONFIGURED_MAINTAINER_INTERRUPT_REASONS = frozenset(
+    part.strip() for part in _MAINTAINER_INTERRUPT_REASON_ENV.split(",") if part.strip()
+)
+MAINTAINER_INTERRUPT_REASONS = (
+    _CONFIGURED_MAINTAINER_INTERRUPT_REASONS
+    if _CONFIGURED_MAINTAINER_INTERRUPT_REASONS == STRICT_MAINTAINER_INTERRUPT_REASONS
+    else STRICT_MAINTAINER_INTERRUPT_REASONS
+)
+_POLICY_BLOCK_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b(can(?:not|'t)\s+comply|unable\s+to\s+comply|refus(?:e|ed|al))\b", re.IGNORECASE),
+    re.compile(r"\b(policy|safety)\b.*\b(block|blocked|reject|rejected|violat|disallow|restricted)\b", re.IGNORECASE),
 )
 
 
@@ -784,6 +804,11 @@ class TemporalRelayStore:
                     )
                 else:
                     final_status = UNIT_STATUS_FAILED
+                    pause_reason = _extract_maintainer_pause_reason(message)
+                    pause_allowed = (
+                        pause_reason is not None
+                        and _maintainer_pause_allowed(reason=pause_reason, recoverable=False)
+                    )
                     conn.execute(
                         """
                         UPDATE units
@@ -829,6 +854,22 @@ class TemporalRelayStore:
                             },
                         ]
                     )
+                    if pause_allowed:
+                        events.append(
+                            {
+                                "run_id": lease.run_id,
+                                "unit_id": lease.unit_id,
+                                "role": ROLE_ARCHITECT,
+                                "event_type": "maintainer_pause_required",
+                                "status": "blocked",
+                                "message": (
+                                    "relay paused for maintainer decision gate "
+                                    f"({pause_reason})"
+                                ),
+                                "metadata": {"pause_reason": pause_reason},
+                                "ts": stamp,
+                            }
+                        )
 
             self._record_events(conn, events)
 
@@ -1183,8 +1224,11 @@ class DashboardReader:
 
         lines: list[str] = []
         for event in events:
+            metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+            evidence = metadata.get("report_handle")
+            suffix = f" evidence={evidence}" if isinstance(evidence, str) and evidence else ""
             lines.append(
-                "[{ts}] seq={seq} run={run} unit={unit} role={role} {etype} {status}: {message}".format(
+                "[{ts}] seq={seq} run={run} unit={unit} role={role} {etype} {status}: {message}{suffix}".format(
                     ts=event.get("ts_utc_iso", "-"),
                     seq=event.get("seq", "-"),
                     run=event.get("run_id", "-"),
@@ -1193,6 +1237,7 @@ class DashboardReader:
                     etype=event.get("event_type", "-"),
                     status=event.get("status", "-"),
                     message=event.get("message", ""),
+                    suffix=suffix,
                 )
             )
 
@@ -1214,6 +1259,32 @@ def _parse_command(command_text: str) -> list[str]:
     if not parts:
         raise ValueError("worker command is empty")
     return parts
+
+
+def _is_policy_block_failure(message: str) -> bool:
+    if not message:
+        return False
+    return any(pattern.search(message) for pattern in _POLICY_BLOCK_PATTERNS)
+
+
+def _maintainer_pause_allowed(*, reason: str, recoverable: bool) -> bool:
+    if recoverable:
+        return False
+    return reason in MAINTAINER_INTERRUPT_REASONS
+
+
+def _extract_maintainer_pause_reason(reason: str) -> str | None:
+    normalized = reason.strip().lower()
+    if normalized in MAINTAINER_INTERRUPT_REASONS:
+        return normalized
+    if "true blocker" in normalized or "maintainer decision required" in normalized:
+        return "true_blocker_decision"
+    if "commit message approval" in normalized:
+        return "commit_message_approval"
+    for token in MAINTAINER_INTERRUPT_REASONS:
+        if f"pause_reason={token}" in normalized:
+            return token
+    return None
 
 
 def _preflight_worker_command(command: Sequence[str], *, role: str) -> str | None:
@@ -1262,6 +1333,15 @@ def _extract_report_handle(command_output: str) -> str | None:
     return matches[-1]
 
 
+def _summarize_worker_output(command_output: str, *, limit: int = 240) -> str:
+    lines = [line.strip() for line in command_output.splitlines() if line.strip()]
+    filtered = [line for line in lines if _REPORT_HANDLE_PATTERN.search(line) is None]
+    summary = filtered[-1] if filtered else "worker command completed"
+    if len(summary) <= limit:
+        return summary
+    return f"{summary[: limit - 1]}…"
+
+
 def _validate_worker_success_output(*, lease: Lease, command_output: str) -> tuple[bool, str]:
     report_handle = _extract_report_handle(command_output)
     if not report_handle:
@@ -1299,6 +1379,7 @@ def _run_command_with_heartbeats(
     lease: Lease,
     command: Sequence[str],
     heartbeat_interval: int,
+    extra_env: Mapping[str, str] | None = None,
 ) -> tuple[bool, str]:
     stop = threading.Event()
     heartbeat_failed = threading.Event()
@@ -1313,12 +1394,17 @@ def _run_command_with_heartbeats(
     heartbeat_thread.start()
 
     try:
+        env: dict[str, str] | None = None
+        if extra_env:
+            env = dict(os.environ)
+            env.update(extra_env)
         proc = subprocess.run(
             command,
             capture_output=True,
             text=True,
             timeout=lease.activity_timeout_seconds,
             check=False,
+            env=env,
         )
         if heartbeat_failed.is_set():
             return False, "heartbeat renewal failed while command was running"
@@ -1331,7 +1417,8 @@ def _run_command_with_heartbeats(
             )
             if not output_is_valid:
                 return False, output_message
-            return True, (stdout or stderr or "command completed")[:400]
+            summary = _summarize_worker_output(combined_output)
+            return True, f"worker command completed; report_handle={output_message}; summary={summary}"
         stderr = proc.stderr.strip() or proc.stdout.strip() or f"exit={proc.returncode}"
         return False, f"command failed: {stderr[:400]}"
     except subprocess.TimeoutExpired:
@@ -1407,11 +1494,79 @@ def _run_worker_loop(
             time.sleep(poll_seconds)
             continue
 
+        store.event_log.append(
+            run_id=lease.run_id,
+            unit_id=lease.unit_id,
+            role=lease.role,
+            event_type="worker_command_started",
+            status=UNIT_STATUS_RUNNING,
+            message="worker command execution started",
+            metadata={
+                "lease_owner": lease.lease_owner,
+                "lease_token": lease.lease_token,
+            },
+        )
         success, message = _run_command_with_heartbeats(
             worker=worker,
             lease=lease,
             command=parsed_command,
             heartbeat_interval=heartbeat_interval,
+        )
+        if not success and _is_policy_block_failure(message):
+            store.event_log.append(
+                run_id=lease.run_id,
+                unit_id=lease.unit_id,
+                role=lease.role,
+                event_type="policy_block_detected",
+                status=UNIT_STATUS_RUNNING,
+                message="worker reported policy block; retrying once with reduced prompt profile",
+            )
+            retry_success, retry_message = _run_command_with_heartbeats(
+                worker=worker,
+                lease=lease,
+                command=parsed_command,
+                heartbeat_interval=heartbeat_interval,
+                extra_env={
+                    "RELAY_REDUCED_PROMPT_PROFILE": "1",
+                    "RELAY_POLICY_BLOCK_RETRY_ATTEMPT": str(POLICY_BLOCK_RETRY_LIMIT),
+                },
+            )
+            if retry_success:
+                store.event_log.append(
+                    run_id=lease.run_id,
+                    unit_id=lease.unit_id,
+                    role=lease.role,
+                    event_type="policy_retry_recovered",
+                    status=UNIT_STATUS_RUNNING,
+                    message="policy-block failure recovered automatically via reduced prompt profile",
+                )
+                success, message = True, retry_message
+            else:
+                store.event_log.append(
+                    run_id=lease.run_id,
+                    unit_id=lease.unit_id,
+                    role=lease.role,
+                    event_type="policy_retry_exhausted",
+                    status=UNIT_STATUS_RUNNING,
+                    message="policy-block recovery retry exhausted",
+                )
+                message = f"{message}; reduced profile retry failed: {retry_message}"
+        status = UNIT_STATUS_RUNNING if success else "error"
+        completion_metadata: dict[str, Any] = {
+            "lease_owner": lease.lease_owner,
+            "lease_token": lease.lease_token,
+        }
+        report_handle = _extract_report_handle(message)
+        if report_handle:
+            completion_metadata["report_handle"] = report_handle
+        store.event_log.append(
+            run_id=lease.run_id,
+            unit_id=lease.unit_id,
+            role=lease.role,
+            event_type="worker_command_completed" if success else "worker_command_failed",
+            status=status,
+            message=message,
+            metadata=completion_metadata,
         )
         worker.complete(lease, success=success, message=message)
 

--- a/scripts/setup_relay_runtime.sh
+++ b/scripts/setup_relay_runtime.sh
@@ -106,6 +106,25 @@ if grep -Eq '^RELAY_CODE_AUDITOR_CMD=(/usr/bin/true|/bin/true|true)$' "$env_targ
   echo "       Set RELAY_CODE_AUDITOR_CMD to your real auditor worker command before start-run." >&2
   exit 1
 fi
+for required_key in \
+  RELAY_POLICY_BLOCK_RETRY_LIMIT \
+  RELAY_MAINTAINER_HEARTBEAT_SECONDS \
+  RELAY_NO_PROGRESS_STALL_SECONDS \
+  RELAY_MAINTAINER_INTERRUPT_REASONS
+do
+  if ! grep -q "^${required_key}=" "$env_target"; then
+    echo "ERROR: ${required_key} missing in $env_target" >&2
+    exit 1
+  fi
+done
+if ! grep -Eq '^RELAY_POLICY_BLOCK_RETRY_LIMIT=1$' "$env_target"; then
+  echo "ERROR: RELAY_POLICY_BLOCK_RETRY_LIMIT must be set to 1 in $env_target" >&2
+  exit 1
+fi
+if ! grep -Eq '^RELAY_MAINTAINER_INTERRUPT_REASONS=true_blocker_decision,commit_message_approval$' "$env_target"; then
+  echo "ERROR: RELAY_MAINTAINER_INTERRUPT_REASONS must be true_blocker_decision,commit_message_approval in $env_target" >&2
+  exit 1
+fi
 
 if [[ "$SYSTEM_MODE" -eq 1 ]]; then
   echo "[setup-relay] Installing system services"

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -620,8 +620,15 @@ void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
     }
 
     if (panel->pan_file_window) {
-      DisplayFiles(ctx, panel, de, render_start, -1, 0, panel->pan_file_window);
-      wnoutrefresh(panel->pan_file_window);
+      if (panel->saved_focus != FOCUS_FILE && ctx &&
+          ctx->focused_window == FOCUS_FILE && panel->file_count == 0) {
+        werase(panel->pan_file_window);
+        wnoutrefresh(panel->pan_file_window);
+      } else {
+        DisplayFiles(ctx, panel, de, render_start, -1, 0,
+                     panel->pan_file_window);
+        wnoutrefresh(panel->pan_file_window);
+      }
     }
   }
 }

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -698,6 +698,79 @@ int WGetch(ViewContext *ctx, WINDOW *win) {
 
 int Getch(ViewContext *ctx) { return WGetch(ctx, stdscr); }
 
+static int NormalizeEscSequence(int ch) {
+  int seq1;
+  int seq2;
+
+  if (ch != ESC)
+    return ch;
+
+  nodelay(stdscr, TRUE);
+  seq1 = wgetch(stdscr);
+  if (seq1 == ERR) {
+    nodelay(stdscr, FALSE);
+    return ESC;
+  }
+
+  if (seq1 != '[' && seq1 != 'O') {
+    ungetch(seq1);
+    nodelay(stdscr, FALSE);
+    return ESC;
+  }
+
+  seq2 = wgetch(stdscr);
+  if (seq2 == ERR) {
+    ungetch(seq1);
+    nodelay(stdscr, FALSE);
+    return ESC;
+  }
+
+  switch (seq2) {
+  case 'A':
+    ch = KEY_UP;
+    break;
+  case 'B':
+    ch = KEY_DOWN;
+    break;
+  case 'C':
+    ch = KEY_RIGHT;
+    break;
+  case 'D':
+    ch = KEY_LEFT;
+    break;
+  case 'H':
+    ch = KEY_HOME;
+    break;
+  case 'F':
+    ch = KEY_END;
+    break;
+  case '1':
+  case '4':
+  case '7':
+  case '8': {
+    int seq3 = wgetch(stdscr);
+    if (seq3 == '~') {
+      ch = (seq2 == '1' || seq2 == '7') ? KEY_HOME : KEY_END;
+    } else {
+      if (seq3 != ERR)
+        ungetch(seq3);
+      ungetch(seq2);
+      ungetch(seq1);
+      ch = ESC;
+    }
+    break;
+  }
+  default:
+    ungetch(seq2);
+    ungetch(seq1);
+    ch = ESC;
+    break;
+  }
+
+  nodelay(stdscr, FALSE);
+  return ch;
+}
+
 int GetEventOrKey(ViewContext *ctx) {
   int ch;
   int w_fd = Watcher_GetFD(ctx);
@@ -717,7 +790,7 @@ int GetEventOrKey(ViewContext *ctx) {
   nodelay(stdscr, FALSE);
 
   if (ch != ERR) {
-    return ch;
+    return NormalizeEscSequence(ch);
   }
 
   if (ctx && ctx->resize_request)
@@ -759,7 +832,7 @@ int GetEventOrKey(ViewContext *ctx) {
         ch = WGetch(ctx, stdscr);
         nodelay(stdscr, FALSE);
         if (ch != ERR)
-          return ch;
+          return NormalizeEscSequence(ch);
         if (ctx && ctx->resize_request)
           return KEY_RESIZE;
 
@@ -777,7 +850,7 @@ int GetEventOrKey(ViewContext *ctx) {
 
     if (FD_ISSET(STDIN_FILENO, &fds)) {
       /* Input available, perform WGetch */
-      return WGetch(ctx, stdscr);
+      return NormalizeEscSequence(WGetch(ctx, stdscr));
     }
   }
 }

--- a/tests/test_project_ai_config_guard.py
+++ b/tests/test_project_ai_config_guard.py
@@ -108,6 +108,115 @@ def test_check_config_accepts_absolute_model_instructions_file(tmp_path: Path) -
     assert not any("model_instructions_file" in failure for failure in failures)
 
 
+def _write_relay_policy_files(repo_root: Path) -> None:
+    for relative_path in guard.RELAY_POLICY_FILES:
+        path = repo_root / relative_path
+        _write(
+            path,
+            "\n".join(
+                [
+                    "# relay policy",
+                    "policy_block_retry_once",
+                    "watchdog_stall_retry_terminal",
+                    "maintainer_pause_gate=true_blocker_decision|commit_message_approval",
+                ]
+            )
+            + "\n",
+        )
+
+
+def _write_relay_runtime_stub(repo_root: Path) -> None:
+    _write(
+        repo_root / guard.RELAY_RUNTIME_FILE,
+        "\n".join(["# relay runtime markers", *guard.RELAY_RUNTIME_REQUIRED_MARKERS]) + "\n",
+    )
+
+
+def _write_required_relay_env(repo_root: Path) -> None:
+    _write(
+        repo_root / guard.RELAY_ENV_TEMPLATE,
+        textwrap.dedent(
+            """\
+            RELAY_POLICY_BLOCK_RETRY_LIMIT=1
+            RELAY_MAINTAINER_HEARTBEAT_SECONDS=300
+            RELAY_NO_PROGRESS_STALL_SECONDS=900
+            RELAY_MAINTAINER_INTERRUPT_REASONS=true_blocker_decision,commit_message_approval
+            """
+        ),
+    )
+
+
+def test_relay_policy_requirements_pass_when_markers_are_present(tmp_path: Path) -> None:
+    _write_relay_policy_files(tmp_path)
+    _write_required_relay_env(tmp_path)
+    _write_relay_runtime_stub(tmp_path)
+
+    failures = guard.check_relay_policy_requirements(tmp_path)
+    assert failures == []
+
+
+def test_relay_policy_requirements_fail_when_token_missing(tmp_path: Path) -> None:
+    _write_relay_policy_files(tmp_path)
+    _write_relay_runtime_stub(tmp_path)
+    _write(
+        tmp_path / guard.RELAY_POLICY_FILES[0],
+        "# relay policy\npolicy_block_retry_once\nwatchdog_stall_retry_terminal\n",
+    )
+    _write_required_relay_env(tmp_path)
+
+    failures = guard.check_relay_policy_requirements(tmp_path)
+    assert any("missing relay policy token" in failure for failure in failures)
+
+
+def test_relay_policy_requirements_fail_when_env_setting_missing(tmp_path: Path) -> None:
+    _write_relay_policy_files(tmp_path)
+    _write_relay_runtime_stub(tmp_path)
+    _write(
+        tmp_path / guard.RELAY_ENV_TEMPLATE,
+        textwrap.dedent(
+            """\
+            RELAY_MAINTAINER_HEARTBEAT_SECONDS=300
+            RELAY_NO_PROGRESS_STALL_SECONDS=900
+            RELAY_MAINTAINER_INTERRUPT_REASONS=true_blocker_decision,commit_message_approval
+            """
+        ),
+    )
+
+    failures = guard.check_relay_policy_requirements(tmp_path)
+    assert any("RELAY_POLICY_BLOCK_RETRY_LIMIT" in failure for failure in failures)
+
+
+def test_relay_policy_requirements_fail_when_interrupt_reasons_not_strict(tmp_path: Path) -> None:
+    _write_relay_policy_files(tmp_path)
+    _write_relay_runtime_stub(tmp_path)
+    _write(
+        tmp_path / guard.RELAY_ENV_TEMPLATE,
+        textwrap.dedent(
+            """\
+            RELAY_POLICY_BLOCK_RETRY_LIMIT=1
+            RELAY_MAINTAINER_HEARTBEAT_SECONDS=300
+            RELAY_NO_PROGRESS_STALL_SECONDS=900
+            RELAY_MAINTAINER_INTERRUPT_REASONS=true_blocker_decision
+            """
+        ),
+    )
+
+    failures = guard.check_relay_policy_requirements(tmp_path)
+    assert any("RELAY_MAINTAINER_INTERRUPT_REASONS" in failure for failure in failures)
+
+
+def test_relay_policy_requirements_fail_when_runtime_marker_missing(tmp_path: Path) -> None:
+    _write_relay_policy_files(tmp_path)
+    _write_required_relay_env(tmp_path)
+    _write(
+        tmp_path / guard.RELAY_RUNTIME_FILE,
+        "\n".join(["# relay runtime markers", "--retry-limit", "stall_detected"]) + "\n",
+    )
+
+    failures = guard.check_relay_policy_requirements(tmp_path)
+    assert any("missing runtime marker" in failure for failure in failures)
+
+
 def test_current_repository_baseline_passes() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     run = subprocess.run(

--- a/tests/test_relay_runtime.py
+++ b/tests/test_relay_runtime.py
@@ -58,6 +58,24 @@ def _start_run_custom_lease(
     )
 
 
+def _start_run_custom_retry(
+    store: relay.TemporalRelayStore,
+    run_id: str,
+    *,
+    now: float,
+    max_attempts: int,
+    backoff_seconds: int = 0,
+) -> None:
+    store.start_or_resume_run(
+        run_id=run_id,
+        idempotency_key=f"idem-{run_id}",
+        retry_policy=relay.RetryPolicy(max_attempts=max_attempts, backoff_seconds=backoff_seconds),
+        lease_policy=relay.LeasePolicy(lease_ttl_seconds=2, heartbeat_late_seconds=3, heartbeat_stale_seconds=4),
+        activity_timeout_seconds=30,
+        now=now,
+    )
+
+
 def _write_executable_script(path: Path, body: str) -> Path:
     path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
@@ -116,6 +134,8 @@ def test_watchdog_marks_stale_and_requeues(tmp_path: Path) -> None:
     event_types = [event["event_type"] for event in event_log.read_events()]
     assert "stall_detected" in event_types
     assert "retry_scheduled" in event_types
+    assert "maintainer_update_required" not in event_types
+    assert "maintainer_pause_required" not in event_types
 
 
 def test_watchdog_emits_maintainer_update_required_for_long_running_unit(tmp_path: Path) -> None:
@@ -194,6 +214,27 @@ def test_watchdog_no_progress_stall_requeues_when_heartbeats_continue(tmp_path: 
     event_types = [event["event_type"] for event in event_log.read_events()]
     assert "stall_detected_no_progress" in event_types
     assert "retry_scheduled" in event_types
+
+
+def test_watchdog_terminal_escalation_when_retry_budget_exhausted(tmp_path: Path) -> None:
+    store, event_log, _db_path, _log_path = _new_store(tmp_path)
+    _start_run_custom_retry(store, "run-watchdog-terminal", now=2600.0, max_attempts=1)
+
+    developer = relay.RelayWorker(store, role=relay.ROLE_DEVELOPER, worker_id="developer-terminal")
+    lease = developer.claim_next(now=2600.0)
+    assert lease is not None
+    assert developer.heartbeat(lease, now=2601.0)
+
+    result = store.watchdog_scan(now=2608.0)
+    assert result == {"stalled": 1, "requeued": 0, "failed": 1}
+
+    run_state = store.run_state("run-watchdog-terminal")
+    assert run_state is not None
+    assert run_state["status"] == relay.RUN_STATUS_FAILED
+
+    event_types = [event["event_type"] for event in event_log.read_events()]
+    assert "stall_detected" in event_types
+    assert "workflow_failed" in event_types
 
 
 def test_concurrent_contention_allows_single_lease_owner(tmp_path: Path) -> None:
@@ -312,6 +353,196 @@ def test_preflight_rejects_placeholder_worker_commands() -> None:
     error = relay._preflight_worker_command(["/usr/bin/true"], role=relay.ROLE_DEVELOPER)
     assert error is not None
     assert "placeholder" in error
+
+
+def test_worker_policy_block_retry_is_recovered_without_maintainer_prompt(tmp_path: Path) -> None:
+    store, event_log, _db_path, _log_path = _new_store(tmp_path)
+    _start_run(store, "run-policy-recover", now=9000.0)
+
+    report_path = tmp_path / "run-policy-recover_developer_run_report.md"
+    command = _write_executable_script(
+        tmp_path / "policy_retry_worker.sh",
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                "if [[ \"${RELAY_REDUCED_PROMPT_PROFILE:-0}\" != \"1\" ]]; then",
+                "  echo \"policy blocked: safety policy rejected worker prompt\" >&2",
+                "  exit 7",
+                "fi",
+                f"echo ok > {report_path}",
+                f"echo report_handle={report_path}",
+            ]
+        )
+        + "\n",
+    )
+
+    rc = relay._run_worker_loop(
+        store=store,
+        role=relay.ROLE_DEVELOPER,
+        worker_id="developer-policy-recover",
+        command_text=str(command),
+        once=True,
+        poll_seconds=1,
+        heartbeat_interval=10,
+    )
+    assert rc == 0
+
+    unit = [row for row in store.list_units(run_id="run-policy-recover") if row["unit_id"] == "developer_run"][0]
+    assert unit["status"] == relay.UNIT_STATUS_SUCCEEDED
+
+    event_types = [event["event_type"] for event in event_log.read_events()]
+    assert "worker_command_started" in event_types
+    assert "worker_command_completed" in event_types
+    assert "policy_block_detected" in event_types
+    assert "policy_retry_recovered" in event_types
+    assert "maintainer_update_required" not in event_types
+    assert "maintainer_pause_required" not in event_types
+    completion_events = [event for event in event_log.read_events() if event["event_type"] == "worker_command_completed"]
+    assert completion_events
+    assert completion_events[-1]["metadata"]["report_handle"] == str(report_path)
+
+
+def test_worker_policy_block_retryable_failure_does_not_prompt_maintainer(tmp_path: Path) -> None:
+    store, event_log, _db_path, _log_path = _new_store(tmp_path)
+    _start_run(store, "run-policy-retryable", now=9050.0)
+
+    command = _write_executable_script(
+        tmp_path / "policy_retryable_worker.sh",
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                "echo \"policy blocked: safety policy rejected worker prompt\" >&2",
+                "exit 7",
+            ]
+        )
+        + "\n",
+    )
+
+    rc = relay._run_worker_loop(
+        store=store,
+        role=relay.ROLE_DEVELOPER,
+        worker_id="developer-policy-retryable",
+        command_text=str(command),
+        once=True,
+        poll_seconds=1,
+        heartbeat_interval=10,
+    )
+    assert rc == 0
+
+    unit = [row for row in store.list_units(run_id="run-policy-retryable") if row["unit_id"] == "developer_run"][0]
+    assert unit["status"] == relay.UNIT_STATUS_RETRYABLE
+
+    event_types = [event["event_type"] for event in event_log.read_events()]
+    assert "worker_command_started" in event_types
+    assert "worker_command_failed" in event_types
+    assert "policy_block_detected" in event_types
+    assert "policy_retry_exhausted" in event_types
+    assert "retry_scheduled" in event_types
+    assert "maintainer_update_required" not in event_types
+    assert "maintainer_pause_required" not in event_types
+
+
+def test_worker_timeout_failure_is_retryable_without_maintainer_prompt(tmp_path: Path) -> None:
+    store, event_log, _db_path, _log_path = _new_store(tmp_path)
+    store.start_or_resume_run(
+        run_id="run-timeout-retry",
+        idempotency_key="idem-run-timeout-retry",
+        retry_policy=relay.RetryPolicy(max_attempts=3, backoff_seconds=0),
+        lease_policy=relay.LeasePolicy(lease_ttl_seconds=2, heartbeat_late_seconds=3, heartbeat_stale_seconds=4),
+        activity_timeout_seconds=1,
+        now=9060.0,
+    )
+
+    command = _write_executable_script(
+        tmp_path / "timeout_retry_worker.sh",
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                "sleep 2",
+            ]
+        )
+        + "\n",
+    )
+
+    rc = relay._run_worker_loop(
+        store=store,
+        role=relay.ROLE_DEVELOPER,
+        worker_id="developer-timeout-retry",
+        command_text=str(command),
+        once=True,
+        poll_seconds=1,
+        heartbeat_interval=1,
+    )
+    assert rc == 0
+
+    unit = [row for row in store.list_units(run_id="run-timeout-retry") if row["unit_id"] == "developer_run"][0]
+    assert unit["status"] == relay.UNIT_STATUS_RETRYABLE
+    assert "command exceeded timeout (1s)" in unit["last_error"]
+
+    event_types = [event["event_type"] for event in event_log.read_events()]
+    assert "retry_scheduled" in event_types
+    assert "maintainer_update_required" not in event_types
+    assert "maintainer_pause_required" not in event_types
+
+
+def test_maintainer_pause_gate_allows_only_blocker_and_commit_approval() -> None:
+    assert relay._maintainer_pause_allowed(reason="true_blocker_decision", recoverable=False)
+    assert relay._maintainer_pause_allowed(reason="commit_message_approval", recoverable=False)
+    assert not relay._maintainer_pause_allowed(reason="policy_block_recoverable", recoverable=False)
+    assert not relay._maintainer_pause_allowed(reason="true_blocker_decision", recoverable=True)
+
+
+def test_maintainer_pause_event_emitted_only_for_allowed_terminal_reason(tmp_path: Path) -> None:
+    store, event_log, _db_path, _log_path = _new_store(tmp_path)
+    _start_run_custom_retry(store, "run-pause-allowed", now=9100.0, max_attempts=1)
+
+    developer = relay.RelayWorker(store, role=relay.ROLE_DEVELOPER, worker_id="developer-pause-allowed")
+    lease = developer.claim_next(now=9100.0)
+    assert lease is not None
+    developer.complete(
+        lease,
+        success=False,
+        message="pause_reason=true_blocker_decision: maintainer decision required",
+        now=9100.1,
+    )
+
+    pause_events = [event for event in event_log.read_events() if event["event_type"] == "maintainer_pause_required"]
+    assert len(pause_events) == 1
+    assert pause_events[0]["metadata"]["pause_reason"] == "true_blocker_decision"
+
+    store2, event_log2, _db_path2, _log_path2 = _new_store(tmp_path / "second")
+    _start_run_custom_retry(store2, "run-pause-commit", now=9200.0, max_attempts=1)
+    developer2 = relay.RelayWorker(store2, role=relay.ROLE_DEVELOPER, worker_id="developer-pause-commit")
+    lease2 = developer2.claim_next(now=9200.0)
+    assert lease2 is not None
+    developer2.complete(
+        lease2,
+        success=False,
+        message="pause_reason=commit_message_approval: commit message approval required",
+        now=9200.1,
+    )
+
+    commit_pause_events = [event for event in event_log2.read_events() if event["event_type"] == "maintainer_pause_required"]
+    assert len(commit_pause_events) == 1
+    assert commit_pause_events[0]["metadata"]["pause_reason"] == "commit_message_approval"
+
+    store3, event_log3, _db_path3, _log_path3 = _new_store(tmp_path / "third")
+    _start_run_custom_retry(store3, "run-pause-denied", now=9300.0, max_attempts=1)
+    developer3 = relay.RelayWorker(store3, role=relay.ROLE_DEVELOPER, worker_id="developer-pause-denied")
+    lease3 = developer3.claim_next(now=9300.0)
+    assert lease3 is not None
+    developer3.complete(
+        lease3,
+        success=False,
+        message="policy-blocked failure after reduced profile retry",
+        now=9300.1,
+    )
+
+    denied_events = [event for event in event_log3.read_events() if event["event_type"] == "maintainer_pause_required"]
+    assert denied_events == []
 
 
 def test_worker_success_rejects_stale_report_handle(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
This PR makes the relay runtime more reliable and easier to monitor.

In plain language:
- relay runs stay durable and recover cleanly when a worker stalls
- watchdog and heartbeat behavior enforce stall detection and bounded retry/terminal handling
- maintainer updates now use facts-first event visibility with explicit evidence/report handles
- relay docs and tests were tightened to keep runtime behavior stable and reduce QA churn

## Large PR note
### Why this is not split right now
This change set is intentionally kept together because runtime lifecycle logic, watchdog behavior, maintainer visibility format, and their tests/docs are tightly coupled and were failing together in integration. Splitting now would likely produce intermediate states with broken relay contracts and flaky QA evidence.

Related PRs: none.

### What could break
- relay unit handoff sequencing between architect/developer/auditor/validation
- watchdog retry and terminal-failure handling under stale heartbeat conditions
- maintainer event visibility formatting and report-handle propagation
- tests that assert relay runtime contract details and workflow text alignment

## Validation
- `pytest tests/test_relay_runtime.py -q` (17 passed)
- `pytest tests/test_project_ai_config_guard.py -q` (9 passed)
- `python3 -m py_compile scripts/relay_runtime.py` (pass)
- `make qa-all` (green)