### PR TITLE
fix(config): stabilize first run defaults and editor behavior

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,5 +1,48 @@
 # Frequently Asked Questions
 
+## Development Decisions
+
+### How can I trust a file manager written with AI assistance on my filesystem?
+
+Ytree performs standard file operations (rename, move, copy, delete) through normal OS APIs, just like other file managers.
+
+This is the same trust model you should use for any file manager: do not assume zero risk, verify behavior, keep backups, and, at first, try it out in a non-critical directory.
+
+### How is AI used in this project?
+
+AI is used as an implementation assistant, not as an autonomous authority.
+
+The human maintainer owns design decisions, architecture constraints, and merge quality. AI helps accelerate coding and refactoring work, but changes are accepted only after manual review plus repository QA gates. This workflow is iterative and often slow: a lot of the effort is in steering, verification, and correction.
+
+For the concrete checks and evidence model, see:
+- [`docs/AUDIT.md`](AUDIT.md)
+- [`docs/TRUST.md`](TRUST.md)
+- [`docs/PR_GATE.md`](PR_GATE.md)
+
+### Why release an alpha before beta?
+
+The alpha is published early so users and contributors can inspect the code, test real workflows, and provide feedback while major design decisions are still adjustable.
+
+In short: the project is usable now, but not stable yet. Expect rough edges, occasional regressions, and evolving UX details until beta and then stable release.
+
+### Why refactor the existing code instead of writing a new one from scratch?
+
+The decision was made to modernize the existing codebase because Ytree is a known application with an established look and feel.
+
+Creating a new file manager from scratch would have resulted in a loss of identity and name recognition. By refactoring, we preserve the specific behavior and interface style of the original application while significantly enhancing the user experience and replacing the underlying architecture. This approach revitalizes the project without discarding its history.
+
+### Why is this not written in Rust?
+
+The primary objective of this phase was the architectural cleanup and restoration of the existing C codebase.
+
+Switching languages immediately would constitute a total rewrite rather than a modernization. However, now that the architecture has been simplified, legacy dependencies removed, and the project stabilized, a port to a modern memory-safe language like Rust is a possibility for a future version.
+
+### Why ncurses, why not termbox2 or notcurses?
+
+Ytree only needs fast, reliable text/line-box terminal UI for file and VFS browsing, and ncurses already provides that cleanly, while switching to termbox2 or notcurses would add backend complexity for features outside ytree’s core scope (like richer in-app media rendering) that are better handled by external helper programs.
+
+---
+
 ## Project Philosophy
 
 ### Why modernize Ytree when UnixTree already exists?
@@ -44,40 +87,3 @@ Ytree specifically targets:
 1.  **XTree&trade; Veterans:** Users who developed "muscle memory" for the XTree&trade; layout and keybindings in the DOS era and find the Midnight Commander style unintuitive.
 2.  **Terminal Power Users:** Developers and Admins who want a fast, lightweight file manager that integrates seamlessly with their shell history and standard CLI tools.
 3.  **Open Source Archivists:** Those interested in keeping classic Unix tools alive, compilable, and secure on modern hardware.
-
----
-
-## Development Decisions
-
-### Why refactor the existing code instead of writing a new one from scratch?
-
-The decision was made to modernize the existing codebase because Ytree is a known application with an established look and feel.
-
-Creating a new file manager from scratch would have resulted in a loss of identity and name recognition. By refactoring, we preserve the specific behavior and interface style of the original application while significantly enhancing the user experience and replacing the underlying architecture. This approach revitalizes the project without discarding its history.
-
-### Why is this not written in Rust?
-
-The primary objective of this phase was the architectural cleanup and restoration of the existing C codebase.
-
-Switching languages immediately would constitute a total rewrite rather than a modernization. However, now that the architecture has been simplified, legacy dependencies removed, and the project stabilized, a port to a modern memory-safe language like Rust is a possibility for a future version.
-
-### Why ncurses, why not termbox2 or notcurses?
-
-Ytree only needs fast, reliable text/line-box terminal UI for file and VFS browsing, and ncurses already provides that cleanly, while switching to termbox2 or notcurses would add backend complexity for features outside ytree’s core scope (like richer in-app media rendering) that are better handled by external helper programs.
-
-### How is AI used in this project?
-
-AI is used as an implementation assistant, not as an autonomous authority.
-
-The human maintainer owns design decisions, architecture constraints, and merge quality. AI helps accelerate coding and refactoring work, but changes are accepted only after manual review plus repository QA gates. This workflow is iterative and often slow: a lot of the effort is in steering, verification, and correction.
-
-For the concrete checks and evidence model, see:
-- [`docs/AUDIT.md`](AUDIT.md)
-- [`docs/TRUST.md`](TRUST.md)
-- [`docs/PR_GATE.md`](PR_GATE.md)
-
-### Why release an alpha before beta?
-
-The alpha is published early so users and contributors can inspect the code, test real workflows, and provide feedback while major design decisions are still adjustable.
-
-In short: the project is usable now, but not stable yet. Expect rough edges, occasional regressions, and evolving UX details until beta and then stable release.

--- a/etc/ytree.conf
+++ b/etc/ytree.conf
@@ -13,7 +13,7 @@
 # 2 Refresh on Directory Navigation selection.
 # 4 Refresh when entering the File Window.
 AUTO_REFRESH=3
-TREEDEPTH=1
+TREEDEPTH=2
 FILEMODE=2
 NUMBERSEP=.
 SMALLWINDOWSKIP=1

--- a/include/config.h
+++ b/include/config.h
@@ -6,7 +6,7 @@
  ***************************************************************************/
 
 /* Default (max) TreeDepth on startup */
-#define DEFAULT_TREEDEPTH     "1"
+#define DEFAULT_TREEDEPTH     "2"
 #define DEFAULT_FILEMODE      "2"
 #define DEFAULT_SMALLWINDOWSKIP "1"
 #define DEFAULT_NUMBERSEP     "."

--- a/src/core/default_profile_template.h
+++ b/src/core/default_profile_template.h
@@ -15,7 +15,7 @@ static const char default_profile_template[] =
     "# 2 Refresh on Directory Navigation selection.\n"
     "# 4 Refresh when entering the File Window.\n"
     "AUTO_REFRESH=3\n"
-    "TREEDEPTH=1\n"
+    "TREEDEPTH=2\n"
     "FILEMODE=2\n"
     "NUMBERSEP=.\n"
     "SMALLWINDOWSKIP=1\n"

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -10,6 +10,10 @@
 
 #include "ytree_defs.h"
 #include "ytree_debug.h"
+#include "default_profile_template.h"
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
 
 #define SORT_BY_NAME 1
 
@@ -43,6 +47,7 @@ static const char *CoreInitGetProfileValue(const ViewContext *ctx,
 static void CoreInitWbkgdSet(const ViewContext *ctx, WINDOW *win, chtype c);
 static int CoreInitUINotice(ViewContext *ctx, const char *msg);
 static void BoundaryClearPromptLine(ViewContext *ctx);
+static int CoreInitLoadDefaultProfileTemplate(ViewContext *ctx);
 extern int RuntimePort_MainInit(ViewContext *ctx, const char *configuration_file,
                                 const char *history_file);
 extern void RuntimePort_MainSetProfileValue(const ViewContext *ctx, char *name,
@@ -56,6 +61,45 @@ extern int RuntimePort_MainHandleDirWindow(ViewContext *ctx,
 extern void RuntimePort_MainSuspendClock(ViewContext *ctx);
 extern void RuntimePort_MainShutdownCurses(ViewContext *ctx);
 extern void RuntimePort_MainVolumeFreeAll(ViewContext *ctx);
+
+static int CoreInitWriteAll(int fd, const char *buf, size_t len) {
+  size_t written_total = 0;
+
+  while (written_total < len) {
+    ssize_t written_now = write(fd, buf + written_total, len - written_total);
+    if (written_now <= 0)
+      return -1;
+    written_total += (size_t)written_now;
+  }
+
+  return 0;
+}
+
+static int CoreInitLoadDefaultProfileTemplate(ViewContext *ctx) {
+  char template_path[] = "/tmp/ytree-default-profile-XXXXXX";
+  int fd;
+  size_t template_len;
+  int result = -1;
+
+  if (!ctx || !ctx->core_init_ops.read_profile)
+    return -1;
+
+  fd = mkstemp(template_path);
+  if (fd == -1)
+    return -1;
+
+  template_len = strlen(default_profile_template);
+  if (CoreInitWriteAll(fd, default_profile_template, template_len) == 0) {
+    if (close(fd) == 0) {
+      fd = -1;
+      result = ctx->core_init_ops.read_profile(ctx, template_path);
+    }
+  }
+  if (fd != -1)
+    close(fd);
+  unlink(template_path);
+  return result;
+}
 
 #ifdef XCURSES
 char *XCursesProgramName = "ytree";
@@ -768,11 +812,30 @@ int Init(ViewContext *ctx, const char *configuration_file,
     if (ctx->core_init_ops.read_profile != NULL)
       ctx->core_init_ops.read_profile(ctx, configuration_file);
   } else if ((home = getenv("HOME"))) {
+    int read_profile_result = -1;
     snprintf(buffer, sizeof(buffer), "%s%c%s", home, FILE_SEPARATOR_CHAR,
              PROFILE_FILENAME);
     DEBUG_LOG("Init: Reading profile %s", buffer);
     if (ctx->core_init_ops.read_profile != NULL)
-      ctx->core_init_ops.read_profile(ctx, buffer);
+      read_profile_result = ctx->core_init_ops.read_profile(ctx, buffer);
+    if (read_profile_result != 0) {
+      const char *editor_env = getenv("EDITOR");
+      const char *pager_env = getenv("PAGER");
+
+      DEBUG_LOG("Init: Profile missing or unreadable, loading built-in default "
+                "profile template");
+      if (CoreInitLoadDefaultProfileTemplate(ctx) == 0 &&
+          ctx->core_main_ops.set_profile_value != NULL) {
+        if (editor_env && *editor_env) {
+          char editor_key[] = "EDITOR";
+          ctx->core_main_ops.set_profile_value(ctx, editor_key, editor_env);
+        }
+        if (pager_env && *pager_env) {
+          char pager_key[] = "PAGER";
+          ctx->core_main_ops.set_profile_value(ctx, pager_key, pager_env);
+        }
+      }
+    }
   }
   DEBUG_LOG("Init: ReadProfile done");
 

--- a/src/ui/ui_edit_config.c
+++ b/src/ui/ui_edit_config.c
@@ -10,14 +10,138 @@
  ***************************************************************************/
 
 #define NO_YTREE_MACROS
+#include "../core/default_profile_template.h"
 #include "ytree_cmd.h"
 #include "ytree_ui.h"
+#include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int WriteAll(int fd, const char *buf, size_t len) {
+  size_t written_total = 0;
+
+  while (written_total < len) {
+    ssize_t written_now =
+        write(fd, buf + written_total, len - written_total);
+    if (written_now <= 0)
+      return -1;
+    written_total += (size_t)written_now;
+  }
+  return 0;
+}
+
+static int FileMatchesDefaultProfileTemplate(const char *path) {
+  FILE *fp;
+  size_t expected_len;
+  char *buffer;
+  size_t bytes_read;
+  int matches = 0;
+
+  fp = fopen(path, "r");
+  if (!fp)
+    return -1;
+
+  expected_len = strlen(default_profile_template);
+  buffer = (char *)malloc(expected_len + 1);
+  if (!buffer) {
+    fclose(fp);
+    return -1;
+  }
+
+  bytes_read = fread(buffer, 1, expected_len + 1, fp);
+  if (!ferror(fp) && bytes_read == expected_len &&
+      memcmp(buffer, default_profile_template, expected_len) == 0) {
+    matches = 1;
+  }
+
+  free(buffer);
+  fclose(fp);
+  return matches;
+}
+
+static int WasConfigBufferSaved(const char *path, const struct stat *before) {
+  struct stat after;
+  int template_match;
+
+  if (stat(path, &after) != 0)
+    return 0;
+
+  if (after.st_ino != before->st_ino || after.st_size != before->st_size ||
+      after.st_mtime != before->st_mtime || after.st_ctime != before->st_ctime)
+    return 1;
+
+  template_match = FileMatchesDefaultProfileTemplate(path);
+  if (template_match < 0)
+    return 1;
+  return template_match == 0;
+}
+
+static int EditMissingProfileFromDefault(ViewContext *ctx, DirEntry *dir_entry,
+                                         const char *profile_path) {
+  char temp_path[PATH_LENGTH + 1];
+  int fd;
+  size_t template_len;
+  struct stat temp_before_edit;
+  int written;
+
+  written = snprintf(temp_path, sizeof(temp_path), "%s.tmp.XXXXXX",
+                     profile_path);
+  if (written < 0 || written >= (int)sizeof(temp_path)) {
+    MESSAGE(ctx, "Can't stage default config for \"%s\"", profile_path);
+    return -1;
+  }
+  if (!strstr(temp_path, "XXXXXX")) {
+    MESSAGE(ctx, "Can't stage default config for \"%s\"", profile_path);
+    return -1;
+  }
+
+  fd = mkstemp(temp_path);
+  if (fd == -1) {
+    MESSAGE(ctx, "Can't stage default config for \"%s\"*%s", profile_path,
+            strerror(errno));
+    return -1;
+  }
+
+  template_len = strlen(default_profile_template);
+  if (WriteAll(fd, default_profile_template, template_len) != 0 ||
+      fstat(fd, &temp_before_edit) != 0) {
+    int saved_errno = errno;
+    close(fd);
+    unlink(temp_path);
+    MESSAGE(ctx, "Can't stage default config for \"%s\"*%s", profile_path,
+            strerror(saved_errno));
+    return -1;
+  }
+  close(fd);
+
+  if (Edit(ctx, dir_entry, temp_path) != 0) {
+    unlink(temp_path);
+    return -1;
+  }
+
+  if (!WasConfigBufferSaved(temp_path, &temp_before_edit)) {
+    unlink(temp_path);
+    return 0;
+  }
+
+  if (rename(temp_path, profile_path) != 0) {
+    int saved_errno = errno;
+    unlink(temp_path);
+    MESSAGE(ctx, "Can't save \"%s\"*%s", profile_path, strerror(saved_errno));
+    return -1;
+  }
+
+  return 0;
+}
 
 void UI_OpenConfigProfile(ViewContext *ctx, DirEntry *dir_entry) {
   char profile_path[PATH_LENGTH + 1];
   const char *home;
+  int profile_exists;
 
   profile_path[0] = '\0';
   home = getenv("HOME");
@@ -31,12 +155,21 @@ void UI_OpenConfigProfile(ViewContext *ctx, DirEntry *dir_entry) {
   if (!profile_path[0])
     (void)snprintf(profile_path, sizeof(profile_path), "%s", PROFILE_FILENAME);
 
-  if (Edit(ctx, dir_entry, profile_path) != 0) {
-    MESSAGE(ctx, "Can't edit \"%s\"", profile_path);
-    return;
+  profile_exists = (access(profile_path, F_OK) == 0);
+  if (profile_exists) {
+    if (Edit(ctx, dir_entry, profile_path) != 0) {
+      MESSAGE(ctx, "Can't edit \"%s\"", profile_path);
+      return;
+    }
+  } else {
+    if (EditMissingProfileFromDefault(ctx, dir_entry, profile_path) != 0) {
+      MESSAGE(ctx, "Can't edit \"%s\"", profile_path);
+      return;
+    }
   }
 
-  if (ctx->core_init_ops.read_profile != NULL) {
+  if (ctx->core_init_ops.read_profile != NULL &&
+      access(profile_path, F_OK) == 0) {
     if (ctx->core_init_ops.read_profile(ctx, profile_path) == 0) {
       ctx->bypass_small_window =
           ParseSmallWindowSkipValue(GetProfileValue(ctx, "SMALLWINDOWSKIP"));

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -228,6 +228,7 @@ def test_fs_left_at_root_collapses_once_then_noop(tmp_path, ytree_binary):
 def test_fs_root_left_then_right_does_not_restore_deep_state(tmp_path, ytree_binary):
     root = tmp_path / "fs_root_left_right_reset"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     (root / "alpha" / "child" / "grand").mkdir(parents=True)
 
     tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
@@ -536,7 +537,7 @@ def test_unlogged_placeholder_with_subdirs_shows_slash_suffix(
 ):
     root = tmp_path / "unlogged_placeholder_slash_suffix"
     root.mkdir()
-    (root / ".ytree").write_text("TREEDEPTH=0\n", encoding="utf-8")
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     top = root / "top"
     top.mkdir()
     (top / "child").mkdir()
@@ -556,6 +557,7 @@ def test_enter_on_placeholder_dir_logs_and_reveals_first_level_only(
 ):
     root = tmp_path / "placeholder_enter_reveals_first_level"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     src = root / "src"
     src.mkdir()
     (src / "cmd").mkdir()
@@ -600,7 +602,7 @@ def test_root_left_resets_tree_and_right_relogs_to_profile_depth(
 ):
     root = tmp_path / "root_minus_right_profile_depth"
     root.mkdir()
-    (root / ".ytree").write_text("TREEDEPTH=1\n", encoding="utf-8")
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     src = root / "src"
     src.mkdir()
     cmd = src / "cmd"
@@ -661,7 +663,9 @@ def test_enter_on_placeholder_dir_is_consistent_with_smallwindowskip_one(
 ):
     root = tmp_path / "placeholder_enter_smallwindowskip_one"
     root.mkdir()
-    (root / ".ytree").write_text("SMALLWINDOWSKIP=1\n", encoding="utf-8")
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=1\nSMALLWINDOWSKIP=1\n", encoding="utf-8"
+    )
 
     src = root / "src"
     src.mkdir()
@@ -706,7 +710,9 @@ def test_enter_on_placeholder_dir_is_consistent_with_smallwindowskip_zero(
 ):
     root = tmp_path / "placeholder_enter_smallwindowskip_zero"
     root.mkdir()
-    (root / ".ytree").write_text("SMALLWINDOWSKIP=0\n", encoding="utf-8")
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=1\nSMALLWINDOWSKIP=0\n", encoding="utf-8"
+    )
 
     src = root / "src"
     src.mkdir()
@@ -868,6 +874,103 @@ def test_smallwindowskip_config_edit_applies_immediately_in_session(
             "Directory footer should be restored after returning with "
             "SMALLWINDOWSKIP=1.\n"
             f"Footer:\n{footer_after}\n\nScreen:\n{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_missing_profile_f10_no_save_does_not_create_profile(tmp_path, ytree_binary):
+    root = tmp_path / "missing_profile_f10_no_save"
+    root.mkdir()
+    target = root / "target"
+    target.mkdir()
+    (target / "file0.txt").write_text("x", encoding="utf-8")
+
+    editor_capture = root / "f10_default_buffer_snapshot.txt"
+    noop_editor = root / "noop_profile_editor.sh"
+    noop_editor.write_text(
+        "#!/bin/sh\n"
+        "f=\"$1\"\n"
+        f"cp \"$f\" \"{editor_capture}\"\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    noop_editor.chmod(0o755)
+
+    profile_path = root / ".ytree"
+    assert not profile_path.exists()
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(root),
+        env_extra={"EDITOR": str(noop_editor)},
+    )
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke("\x1b[21~", wait=0.9)
+
+        for _ in range(20):
+            if editor_capture.exists():
+                break
+            time.sleep(0.1)
+        assert editor_capture.exists(), (
+            "F10 on missing ~/.ytree must open an editable default profile buffer."
+        )
+        assert "[GLOBAL]" in editor_capture.read_text(encoding="utf-8"), (
+            "Default profile buffer should include [GLOBAL] section header."
+        )
+        assert not profile_path.exists(), (
+            "Exiting config edit without save must not create ~/.ytree."
+        )
+    finally:
+        tui.quit()
+
+
+def test_missing_profile_f10_save_creates_profile(tmp_path, ytree_binary):
+    root = tmp_path / "missing_profile_f10_save"
+    root.mkdir()
+    target = root / "target"
+    target.mkdir()
+    (target / "file0.txt").write_text("x", encoding="utf-8")
+
+    editor_capture = root / "f10_saved_buffer_snapshot.txt"
+    save_editor = root / "save_profile_editor.sh"
+    save_editor.write_text(
+        "#!/bin/sh\n"
+        "f=\"$1\"\n"
+        "printf '\\nSMALLWINDOWSKIP=1\\n' >> \"$f\"\n"
+        f"cp \"$f\" \"{editor_capture}\"\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    save_editor.chmod(0o755)
+
+    profile_path = root / ".ytree"
+    assert not profile_path.exists()
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(root),
+        env_extra={"EDITOR": str(save_editor)},
+    )
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke("\x1b[21~", wait=0.9)
+
+        for _ in range(20):
+            if editor_capture.exists():
+                break
+            time.sleep(0.1)
+        assert editor_capture.exists(), (
+            "F10 on missing ~/.ytree must open an editable default profile buffer."
+        )
+        assert profile_path.exists(), "Saving config edit must create ~/.ytree."
+        assert "SMALLWINDOWSKIP=1" in profile_path.read_text(encoding="utf-8"), (
+            "Saved missing-profile edit must persist into ~/.ytree."
         )
     finally:
         tui.quit()
@@ -1042,6 +1145,7 @@ def test_small_window_tagged_symlink_and_empty_labels_share_name_column(
 def test_placeholder_dir_shows_unlogged_not_no_files(tmp_path, ytree_binary):
     root = tmp_path / "placeholder_shows_unlogged"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     src = root / "src"
     src.mkdir()
     (src / "cmd").mkdir()

--- a/tests/test_compare_actions.py
+++ b/tests/test_compare_actions.py
@@ -627,6 +627,8 @@ def test_tree_compare_logged_only_relative_path_and_skipped_unlogged_reporting(
     target_root = tmp_path / "compare_tree_logged_only_target"
     source_root.mkdir()
     target_root.mkdir()
+    (source_root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
+    (target_root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     (source_root / "top").mkdir()
     (target_root / "top").mkdir()
     (source_root / "top" / "deep").mkdir()

--- a/tests/test_display_layout.py
+++ b/tests/test_display_layout.py
@@ -837,6 +837,7 @@ def test_dir_copy_prompt_shows_source_and_as_target(ytree_binary, tmp_path):
 def test_dir_copy_refreshes_destination_branch_without_relog(ytree_binary, tmp_path):
     root = tmp_path / "dir_copy_cross_branch_refresh"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     source_bucket = root / "source_bucket"
     target_bucket = root / "target_bucket"
     source_bucket.mkdir()
@@ -907,6 +908,7 @@ def test_dir_copy_refreshes_destination_branch_without_relog(ytree_binary, tmp_p
 def test_dir_copy_delete_created_destination_updates_in_session(ytree_binary, tmp_path):
     root = tmp_path / "dir_copy_delete_created_destination"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     source_bucket = root / "source_bucket"
     target_bucket = root / "target_bucket"
     source_bucket.mkdir()
@@ -973,6 +975,7 @@ def test_dir_copy_delete_created_destination_updates_in_session(ytree_binary, tm
 def test_dir_copy_absolute_destination_refreshes_without_relog(ytree_binary, tmp_path):
     root = tmp_path / "dir_copy_absolute_destination_refresh"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     source_bucket = root / "source_bucket"
     target_bucket = root / "target_bucket"
     source_bucket.mkdir()

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -248,6 +248,7 @@ def test_split_same_directory_file_tags_are_panel_local(tmp_path, ytree_binary):
 def test_unreading_directory_clears_panel_local_tags(tmp_path, ytree_binary):
     root = tmp_path / "unread_clears_panel_tags"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     alpha = root / "alpha"
     (alpha / "child").mkdir(parents=True)
     (alpha / "panel_tag_0.txt").write_text("tag\n", encoding="utf-8")
@@ -289,6 +290,7 @@ def test_unreading_directory_clears_panel_local_tags(tmp_path, ytree_binary):
 def _assert_collapse_action_clears_panel_local_tags(tmp_path, ytree_binary, key):
     root = tmp_path / f"collapse_clears_panel_tags_{ord(key[0])}"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     alpha = root / "alpha"
     (alpha / "child").mkdir(parents=True)
     (alpha / "panel_tag_0.txt").write_text("tag\n", encoding="utf-8")
@@ -339,6 +341,7 @@ def test_left_arrow_collapse_clears_panel_local_tags(tmp_path, ytree_binary):
 def _assert_collapse_resets_subtree_expansion(tmp_path, ytree_binary, key):
     root = tmp_path / f"collapse_reset_subtree_{ord(key[0])}"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     alpha = root / "alpha"
     (alpha / "child" / "grand" / "great").mkdir(parents=True)
 
@@ -928,6 +931,8 @@ def test_navigation_does_not_expand(tmp_path, ytree_binary):
     """
     # Create nested structure: test_root/parent/child/file.txt
     root = tmp_path / "test_root"
+    root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
     child_dir = root / "parent" / "child"
     child_dir.mkdir(parents=True)
     (child_dir / "file.txt").touch()
@@ -1157,6 +1162,7 @@ def test_bug_f_eight_mirrored_inactive_selection_identity_stable(tmp_path, ytree
     """
     root = tmp_path / "bug_f_eight_identity_root"
     root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
 
     parent_dir = root / "parent_dir"
     child_dir = parent_dir / "child_dir"


### PR DESCRIPTION
## Plain-language summary
This change makes first-run behavior predictable when `~/.ytree` does not exist. Ytree now loads safe built-in defaults instead of failing on missing profile, and F10 editing starts from a valid default config template. Default tree depth is now `2`, including the first-run template used by F10.

## Summary
- load built-in profile defaults when the user profile is missing or unreadable
- make first-run F10 config editing start from a staged default template
- set default `TREEDEPTH=2` consistently across defaults/template/config source
- preserve `EDITOR` and `PAGER` environment overrides after default-profile fallback

## Why it is not split right now
This work fixes one user-visible first-run behavior surface that spans init, defaults, and editor-entry flow. Splitting these changes would create temporary inconsistent states (for example: startup default depth differs from F10 template depth). No related PRs.

## What could break
- existing tests or workflows that implicitly relied on old default `TREEDEPTH=1`
- first-run profile loading path if fallback template load fails unexpectedly on unusual tmp-file constraints
- edge cases around profile edit/save detection for first-run staged temp files

## Validation
- `source .venv/bin/activate`
- `pytest -q tests/test_archive_exit_ui.py`
