### PR TITLE
chore(relay): standardize autonomous runtime start and monitoring

### DIFF
--- a/docs/ai/GOVERNANCE.md
+++ b/docs/ai/GOVERNANCE.md
@@ -51,6 +51,7 @@ For common governance edits, use these canonical targets:
 Prompt templates live in `docs/ai/` and are maintained as copy/paste entrypoints:
 - `PROMPT_TEMPLATE.md`: single quick developer unit only; includes a hard redirect to relay if scope is broader.
 - `RELAY_PROMPT_TEMPLATE.md`: architect-supervised relay workflow for non-trivial, multi-unit missions.
+- `RELAY_RUNBOOK.md`: single-terminal operator runbook for starting and monitoring durable relay runs.
 - Both templates enforce facts-first relay visibility updates (completed evidence before planned next action).
 
 When template behavior or routing rules change, update both the template file and `docs/ai/WORKFLOW.md`.

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -13,7 +13,7 @@ Work item:
 Scope gate (mandatory):
 - This prompt is for exactly one quick developer unit (single focused fix/change).
 - If the request is broader than a single quick developer unit, STOP and reply exactly:
-  "No — this is more than a single quick development task. Use RELAY_PROMPT_TEMPLATE.md for this."
+  "No — this is more than a single quick development task. Use RELAY_PROMPT_TEMPLATE.md for this, and use RELAY_RUNBOOK.md for runtime execution/monitoring."
 
 ## Subagent-safe prompt profile (required)
 

--- a/docs/ai/RELAY_PROMPT_TEMPLATE.md
+++ b/docs/ai/RELAY_PROMPT_TEMPLATE.md
@@ -5,6 +5,8 @@ For one quick, focused change, use **[PROMPT_TEMPLATE.md](PROMPT_TEMPLATE.md)** 
 
 Edit only the first four lines to match the tracked work item exactly, then copy/paste the full prompt as-is.
 
+Operator prerequisite: run the single-terminal startup/monitoring flow in **[RELAY_RUNBOOK.md](RELAY_RUNBOOK.md)** so this prompt is attached to durable relay runtime state.
+
 ```text
 $WORK_DOC=docs/ROADMAP.md or docs/BUGS.md
 $WORK_KIND=task or bug
@@ -45,6 +47,8 @@ Execution model (auto-relay runtime):
 7) Correct semantic-index drift and context drift before each validation/commit.
 8) Run final completion gate from workflow and report final status.
 9) Architect updates $WORK_DOC
+10) After starting the durable run, print exactly one explicit line:
+    `RUN STARTED: <run_id>`
 
 Prompt/report artifact rules:
 - Use run_id + unit_id + event seq in all status updates; include handles only when new/changed.
@@ -104,10 +108,15 @@ Response format to maintainer:
 - Concise operational status only.
 - Include completed state + current next action only.
 - Include handles only when they changed or are newly created.
+- For any required maintainer decision/approval, include one standalone explicit line:
+  - `ACTION NEEDED (maintainer): reply "<exact text to send>"`
+  - Example: `ACTION NEEDED (maintainer): reply "approve checks for BUG-11.2"`
+- If no maintainer input is required, include:
+  - `ACTION NEEDED (maintainer): none`
 - Use delta-only updates: include only net-new state, next action, and new/changed handles unless maintainer asks for a full recap.
 - Include `Latest relay event` in each update with direction + unit + handle.
 - Do not repeat full historical handle inventories unless the maintainer explicitly requests a full recap.
-- Include mandatory handoff block for every relay:
+- Include handoff block for relay role-to-role traceability only (maintainer does not need to copy/paste this):
   Model: <selected model>
   Reasoning level: <selected level>
   Handoff line: <next-role>: Execute $WORK_KIND $TASK from handle <handoff-handle> exactly as written.

--- a/docs/ai/RELAY_RUNBOOK.md
+++ b/docs/ai/RELAY_RUNBOOK.md
@@ -1,0 +1,62 @@
+# Relay Runbook (Single-Terminal)
+
+Use this runbook for autonomous architect -> developer -> auditor relay execution without tmux or multi-terminal monitoring.
+
+## Quickstart
+
+```bash
+cd ~/ytree
+scripts/setup_relay_runtime.sh
+```
+
+Then, for each session:
+
+```bash
+cd ~/ytree
+scripts/relay-workers.sh start
+```
+
+## Start a run
+
+```bash
+cd ~/ytree
+scripts/relay-run.sh --run-id <run_id> --idempotency-key <idempotency_key> --activity-timeout 900 --retry-limit 2
+```
+
+On success, the script prints one explicit line:
+
+- `RUN STARTED: <run_id>` (or `RUN RESUMED: <run_id>`)
+
+## Monitor one run (optional)
+
+```bash
+cd ~/ytree
+scripts/relay-monitor.sh --run <run_id> --view quiet
+```
+
+Detail levels:
+- `quiet`: status + `ACTION NEEDED (maintainer)` only
+- `normal`: key transitions (heartbeat noise filtered)
+- `verbose`: full event stream including heartbeats
+
+Convenience:
+- omit `--run` to monitor the latest run in durable relay state.
+
+## Maintainer action line contract
+
+When the architect needs your input, updates must include exactly one explicit line:
+
+- `ACTION NEEDED (maintainer): reply "<exact short text>"`
+
+If no input is required:
+
+- `ACTION NEEDED (maintainer): none`
+
+In relay messages, **maintainer** means you (operator/user).
+
+## Stop workers when done
+
+```bash
+cd ~/ytree
+scripts/relay-workers.sh stop
+```

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -163,6 +163,7 @@ Prompt templates:
 Before starting the loop, ensure the auto-relay runtime is configured for every client role (`architect`, `developer`, `code_auditor`) and that systemd worker services are available:
 - Run `scripts/setup_relay_runtime.sh` once per machine/user (or again only after relay config/unit changes).
 - On each new WSL start, run `scripts/relay-workers.sh health`; if unhealthy, run `scripts/relay-workers.sh start`.
+- For single-terminal operations (start + monitor), use **[RELAY_RUNBOOK.md](RELAY_RUNBOOK.md)**.
 
 ##### 3.1.0.1 MCP Config Bootstrap (Recommended)
 
@@ -197,6 +198,7 @@ make mcp-doctor
 make mcp-doctor FIX=1
 
 # Optional: refresh pinned helper-script requirements
+source .venv/bin/activate
 pip-compile --upgrade -o scripts/requirements.txt scripts/requirements.in
 ```
 
@@ -260,7 +262,16 @@ Before every `start-run`, confirm worker commands are configured in `~/.config/y
 - `RELAY_DEVELOPER_CMD=...`
 - `RELAY_CODE_AUDITOR_CMD=...`
 
-When invoking `scripts/relay_runtime.py start-run` directly, load relay env first so runtime preflight reads the configured worker commands:
+Preferred operator entrypoints:
+
+```bash
+scripts/relay-run.sh --run-id <run_id> --idempotency-key <idempotency_key> --activity-timeout 900 --retry-limit 2
+scripts/relay-monitor.sh --run <run_id> --view quiet
+```
+
+The run wrapper auto-loads relay env and prints `RUN STARTED: <run_id>` (or `RUN RESUMED: <run_id>`).
+
+Manual fallback (direct runtime invocation): load relay env first so runtime preflight reads the configured worker commands:
 
 ```bash
 set -a
@@ -269,7 +280,7 @@ set +a
 python3 scripts/relay_runtime.py start-run ...
 ```
 
-For live monitoring, use verbose dashboard output so heartbeat events are visible:
+Manual fallback live monitoring:
 
 ```bash
 watch -n 5 'python3 scripts/relay_runtime.py dashboard --verbose --limit 20'
@@ -343,6 +354,10 @@ watch -n 5 'python3 scripts/relay_runtime.py dashboard --verbose --limit 20'
     *   terminal fail when retry budget is exhausted (no silent stop states),
     *   if worker creation is policy-blocked, retry once with a reduced subagent-safe prompt profile (minimal technical payload only) and do not pause maintainer for that recoverable path.
 3.  Relay execution remains autonomous end-to-end; maintainer interruption is reserved strictly for `true_blocker_decision` and `commit_message_approval`.
+    *   When maintainer input is required, architect MUST emit exactly one standalone line:
+        `ACTION NEEDED (maintainer): reply "<exact text to send>"`.
+    *   When no maintainer input is required, architect MUST emit:
+        `ACTION NEEDED (maintainer): none`.
 4.  Canonical relay autonomy policy tokens (required in docs + guards):
     *   `policy_block_retry_once`: policy-blocked worker prompt failure is auto-retried once with reduced prompt profile and no maintainer interruption.
     *   `watchdog_stall_retry_terminal`: stale heartbeat/timeout must emit `stall_detected`, then bounded retry/reassign, then terminal escalation on retry exhaustion.

--- a/infra/systemd/ytree-relay-code-auditor.service
+++ b/infra/systemd/ytree-relay-code-auditor.service
@@ -2,6 +2,8 @@
 Description=ytree durable relay code_auditor worker
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=30
 
 [Service]
 Type=simple
@@ -14,8 +16,6 @@ Environment=RELAY_CODE_AUDITOR_CMD=/usr/bin/true
 ExecStart=/usr/bin/env bash -lc 'source .venv/bin/activate && exec python3 scripts/relay_runtime.py worker --role code_auditor --poll-seconds 2 --heartbeat-interval 10'
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=120
-StartLimitBurst=30
 TimeoutStopSec=15
 KillSignal=SIGTERM
 NoNewPrivileges=yes

--- a/infra/systemd/ytree-relay-developer.service
+++ b/infra/systemd/ytree-relay-developer.service
@@ -2,6 +2,8 @@
 Description=ytree durable relay developer worker
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=30
 
 [Service]
 Type=simple
@@ -14,8 +16,6 @@ Environment=RELAY_DEVELOPER_CMD=/usr/bin/true
 ExecStart=/usr/bin/env bash -lc 'source .venv/bin/activate && exec python3 scripts/relay_runtime.py worker --role developer --poll-seconds 2 --heartbeat-interval 10'
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=120
-StartLimitBurst=30
 TimeoutStopSec=15
 KillSignal=SIGTERM
 NoNewPrivileges=yes

--- a/infra/systemd/ytree-relay-watchdog.service
+++ b/infra/systemd/ytree-relay-watchdog.service
@@ -2,6 +2,8 @@
 Description=ytree durable relay watchdog
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=30
 
 [Service]
 Type=simple
@@ -13,8 +15,6 @@ Environment=RELAY_EVENT_LOG=%h/.local/state/ytree/relay-events.jsonl
 ExecStart=/usr/bin/env bash -lc 'source .venv/bin/activate && exec python3 scripts/relay_runtime.py watchdog --poll-seconds 5'
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=120
-StartLimitBurst=30
 TimeoutStopSec=15
 KillSignal=SIGTERM
 NoNewPrivileges=yes

--- a/scripts/relay-monitor.sh
+++ b/scripts/relay-monitor.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Single-terminal relay monitor with selectable detail level.
+#
+# Views:
+#   quiet   -> latest state + action-needed line only
+#   normal  -> key transitions (filters heartbeat noise)
+#   verbose -> full event stream including heartbeats
+#
+# Usage:
+#   scripts/relay-monitor.sh --view quiet
+#   scripts/relay-monitor.sh --run <run_id> --view normal
+#   scripts/relay-monitor.sh --run <run_id> --view verbose --once
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+VIEW="normal"
+RUN_ID=""
+INTERVAL=3
+LIMIT=20
+FOLLOW=1
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/relay-monitor.sh [--run <run_id>] [--view quiet|normal|verbose] [--interval <seconds>] [--limit <n>] [--once]
+
+Defaults:
+  --run       latest run in relay DB
+  --view      normal
+  --interval  3
+  --limit     20
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run)
+      RUN_ID="${2:-}"
+      shift 2
+      ;;
+    --view)
+      VIEW="${2:-}"
+      shift 2
+      ;;
+    --interval)
+      INTERVAL="${2:-}"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="${2:-}"
+      shift 2
+      ;;
+    --once)
+      FOLLOW=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$VIEW" in
+  quiet|normal|verbose) ;;
+  *)
+    echo "ERROR: --view must be one of quiet|normal|verbose" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -f "$HOME/.config/ytree/relay.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$HOME/.config/ytree/relay.env"
+  set +a
+fi
+
+cd "$REPO_ROOT"
+
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID="$(python3 - <<'PY'
+import os, sqlite3
+path = os.path.expanduser(os.environ.get('RELAY_DB', '~/.local/state/ytree/relay.db'))
+conn = sqlite3.connect(path)
+row = conn.execute('SELECT run_id FROM runs ORDER BY updated_at DESC LIMIT 1').fetchone()
+print(row[0] if row else '')
+PY
+)"
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "No relay runs found." >&2
+  exit 1
+fi
+
+render_once() {
+  local history
+  if ! history="$(python3 scripts/relay_runtime.py history --run-id "$RUN_ID" 2>/dev/null)"; then
+    echo "ERROR: could not read history for run_id=$RUN_ID" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$history" | python3 -c "$(cat <<'PY'
+import json
+import sys
+
+run_id, view, limit_s = sys.argv[1:4]
+limit = int(limit_s)
+lines = [ln.strip() for ln in sys.stdin if ln.strip()]
+rows = []
+for ln in lines:
+    try:
+        rows.append(json.loads(ln))
+    except json.JSONDecodeError:
+        pass
+
+print(f"RUN: {run_id}")
+if not rows:
+    print("STATE: no events yet")
+    print("ACTION NEEDED (maintainer): none")
+    sys.exit(0)
+
+last = rows[-1]
+seq = last.get('history_seq', '-')
+event = last.get('event_type', '-')
+status = last.get('status', '-')
+unit = last.get('unit_id', '-')
+ts = last.get('ts_utc_iso', '-')
+print(f"LATEST: seq={seq} event={event} status={status} unit={unit} at={ts}")
+
+action = "none"
+if last.get('event_type') not in ('workflow_completed', 'workflow_failed'):
+    for row in reversed(rows):
+        msg = str(row.get('message', ''))
+        msg_l = msg.lower()
+        event_type = str(row.get('event_type', ''))
+        if event_type == 'maintainer_update_required':
+            action = msg or "maintainer update required"
+            break
+        if 'maintainer' in msg_l and any(tok in msg_l for tok in ('reply', 'approve', 'confirm', 'decision', 'required')):
+            action = msg
+            break
+print(f"ACTION NEEDED (maintainer): {action}")
+
+if view == 'quiet':
+    sys.exit(0)
+
+if view == 'normal':
+    interesting = [r for r in rows if r.get('event_type') != 'heartbeat']
+else:
+    interesting = rows
+
+print("")
+print("RECENT EVENTS:")
+for row in interesting[-limit:]:
+    print(
+        f"- seq={row.get('history_seq', '-')} "
+        f"event={row.get('event_type', '-')} "
+        f"role={row.get('role', '-')} "
+        f"unit={row.get('unit_id', '-')} "
+        f"status={row.get('status', '-')} "
+        f"msg={row.get('message', '')}"
+    )
+PY
+)" "$RUN_ID" "$VIEW" "$LIMIT"
+}
+
+if [[ "$FOLLOW" -eq 0 ]]; then
+  render_once
+  exit $?
+fi
+
+while true; do
+  clear
+  render_once || true
+  sleep "$INTERVAL"
+done

--- a/scripts/relay-run.sh
+++ b/scripts/relay-run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Start or resume a durable relay run with env preflight loaded automatically.
+#
+# Usage examples:
+#   scripts/relay-run.sh --run-id my-run --idempotency-key my-run
+#   scripts/relay-run.sh --run-id my-run --idempotency-key my-run --activity-timeout 900
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/relay-run.sh --run-id <id> --idempotency-key <key> [options]
+
+Options (pass-through to relay_runtime.py start-run):
+  --retry-limit <n>
+  --retry-backoff <seconds>
+  --activity-timeout <seconds>
+  --lease-ttl <seconds>
+  --heartbeat-late <seconds>
+  --heartbeat-stale <seconds>
+USAGE
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -f "$HOME/.config/ytree/relay.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$HOME/.config/ytree/relay.env"
+  set +a
+fi
+
+cd "$REPO_ROOT"
+
+output="$(python3 scripts/relay_runtime.py start-run "$@")"
+printf '%s\n' "$output"
+
+run_id="$(sed -n 's/^run_id=\([^ ]*\) state=.*/\1/p' <<<"$output" | tail -n1)"
+state="$(sed -n 's/^run_id=[^ ]* state=\(.*\)$/\1/p' <<<"$output" | tail -n1)"
+
+if [[ -n "$run_id" ]]; then
+  if [[ "$state" == "started" ]]; then
+    echo "RUN STARTED: $run_id"
+  else
+    echo "RUN RESUMED: $run_id"
+  fi
+fi

--- a/scripts/setup_relay_runtime.sh
+++ b/scripts/setup_relay_runtime.sh
@@ -143,3 +143,4 @@ else
 fi
 
 echo "[setup-relay] Complete."
+echo "[setup-relay] Next: use scripts/relay-run.sh to start runs and scripts/relay-monitor.sh to monitor one run in a single terminal."


### PR DESCRIPTION
## Summary
- add single-terminal relay operator runbook (`docs/ai/RELAY_RUNBOOK.md`)
- add wrapper scripts for durable runtime startup and run-scoped monitoring:
  - `scripts/relay-run.sh`
  - `scripts/relay-monitor.sh`
- update relay prompt/workflow docs to require explicit maintainer action lines and `RUN STARTED` output
- fix systemd unit templates so `StartLimit*` keys live under `[Unit]` instead of `[Service]`
- update setup output to point operators at the new single-terminal wrappers

## Validation
- `bash -n scripts/relay-run.sh scripts/relay-monitor.sh scripts/setup_relay_runtime.sh`
- `scripts/relay-run.sh --help`
- `scripts/relay-monitor.sh --help`
- `scripts/relay-monitor.sh --run run-bug-eleven-modal-severity-20260510T221024Z --view quiet --once`

## Notes
- this change removes the need for tmux/multi-terminal relay monitoring in default operations.
