### PR TITLE
fix(relay): require staged prompt artifacts before developer dispatch

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -42,24 +42,6 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Define and enforce a context-valid option matrix for `Write`, expose only valid options in each mode, and keep prompt/help text explicit and non-jargon (including destination examples such as file output and printer-command output). Keep `SPECIFICATION`, `F1` help, and manpage/USAGE text synchronized with the same destination semantics.
 *   **Status**: Confirmed.
 
-### **BUG-5: `F10` Hard-Fails When `~/.ytree` Is Missing**
-*   **Description**: If `~/.ytree` does not exist, pressing `F10` fails with an edit error instead of letting users proceed with configuration editing.
-*   **Impact**: Creates avoidable first-run friction in a common workflow and forces users to discover `--init` before they can use in-app config editing.
-*   **Remediation**: On `F10` with missing `~/.ytree`, open an editable default config buffer immediately and create `~/.ytree` only if the user saves; if they exit without saving, do not create the file.
-*   **Status**: Confirmed.
-
-### **BUG-6: `SMALLWINDOWSKIP=0` Is Ignored**
-*   **Description**: Setting `SMALLWINDOWSKIP=0` does not re-enable the small window; runtime still behaves as if small-window skipping is active.
-*   **Impact**: Breaks configuration trust and blocks users from restoring a primary layout element through documented config.
-*   **Remediation**: Ensure `SMALLWINDOWSKIP` is parsed/applied correctly so `0` reliably enables the small window and `1` skips it across relevant contexts.
-*   **Status**: Confirmed.
-
-### **BUG-7: `F10` Save Does Not Reload Configuration in-Session**
-*   **Description**: Editing and saving configuration via `F10` does not update active runtime behavior until ytree is quit and restarted.
-*   **Impact**: Violates expected interactive-config workflow and adds avoidable friction after in-app edits.
-*   **Remediation**: Live-apply is preferred: reload and apply safe settings immediately after `F10` save. For settings that are not safe to rebind mid-session, show a concise explicit notice that restart is required.
-*   **Status**: Confirmed.
-
 ### **BUG-8: Copy/Move Cancel (`Esc`) Can Leave Footer Blank**
 *   **Description**: In `Copy`/`Move` flows, canceling with `Esc` can leave footer/help lines blank instead of restoring the normal context footer.
 *   **Impact**: Hides command discoverability immediately after a canceled mutation flow and makes the UI look partially broken.

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -84,3 +84,12 @@ Important guardrails:
 - Status updates must be facts-first: report what was completed (with evidence handle) before stating next action.
 - If uncertain, ask before choosing behavior-changing options.
 - If anything is ambiguous, ask me to clarify instead of guessing.
+
+Operator UX contract (mandatory):
+- First line of every update MUST be exactly one of:
+  - `ACTION NEEDED (maintainer): none`
+  - `ACTION NEEDED (maintainer): reply "<exact text>"`
+- If `ACTION NEEDED` is `none`, keep the rest of the update to at most five concise lines.
+- If `ACTION NEEDED` is not `none`, print that line before any other content.
+- Do not ask the maintainer to extract machine/runtime internals from logs; provide exact values directly.
+- On completion, proactively emit final delivery package (summary, verification evidence, commit-ready status, and exact approval text when needed) without waiting for maintainer prodding.

--- a/docs/ai/RELAY_PROMPT_TEMPLATE.md
+++ b/docs/ai/RELAY_PROMPT_TEMPLATE.md
@@ -66,6 +66,10 @@ Prompt/report artifact rules:
   - Heartbeat-only updates are liveness pings and MUST include elapsed runtime + current executing action.
   - Do not emit “will do X” updates unless the prior event already emitted “did X” evidence for the previous action.
 - Runtime event labels should prefer explicit completion facts (`worker_command_started`, `worker_command_completed`, `worker_command_failed`, `unit_completed`, `unit_failed`, `retry_scheduled`, `workflow_completed`, `workflow_failed`).
+- Before requesting maintainer approval to dispatch `developer_run`, you MUST stage both relay prompt artifacts for this run_id:
+  - `scripts/relay-prompts.sh stage --run-id <run_id> --developer <developer_prompt_source> --auditor <auditor_prompt_source>`
+  - Then verify with `scripts/relay-prompts.sh verify --run-id <run_id>`
+- Do not claim dispatch/start for `developer_run` without runtime evidence (`unit_queued`, `lease_acquired`, or `worker_command_started`) and its `history_seq`.
 
 Stall/escalation policy:
 - If a unit exceeds timeout or misses heartbeat, watchdog MUST emit a stall event.
@@ -120,4 +124,17 @@ Response format to maintainer:
   Model: <selected model>
   Reasoning level: <selected level>
   Handoff line: <next-role>: Execute $WORK_KIND $TASK from handle <handoff-handle> exactly as written.
+
+Non-negotiable operator UX contract:
+- First line of every update MUST be exactly one of:
+  - `ACTION NEEDED (maintainer): none`
+  - `ACTION NEEDED (maintainer): reply "<exact text>"`
+- If `ACTION NEEDED` is not `none`, emit that line before any other content.
+- If `ACTION NEEDED` is `none`, keep update body to at most five concise lines.
+- On run start/resume, provide exactly one copy-paste command line for runtime launch:
+  - `scripts/relay-run.sh --run-id <run_id> --idempotency-key <idempotency_key> --activity-timeout 900 --retry-limit 2`
+- If prompt artifacts are required, provide exactly one copy-paste command line for staging+verify:
+  - `scripts/relay-prompts.sh stage --run-id <run_id> --developer <developer_prompt_source> --auditor <auditor_prompt_source>;scripts/relay-prompts.sh verify --run-id <run_id>`
+- Do not require maintainer to query runtime internals (run_id lookup, idempotency lookup, history parsing); architect must provide exact values.
+- On `workflow_completed`, immediately emit final delivery package without maintainer prodding: summary, pass/fail, commit-ready status, commit-message approval line (or `none`), PR/CI status, and cleanup commands.
 ```

--- a/docs/ai/RELAY_QUICKSTART.md
+++ b/docs/ai/RELAY_QUICKSTART.md
@@ -1,0 +1,89 @@
+# Relay Quickstart (Minimal)
+
+## One-time (or after relay config/unit changes)
+
+```bash
+cd ~/ytree
+scripts/setup_relay_runtime.sh
+```
+
+## Each working session
+
+```bash
+cd ~/ytree
+scripts/relay-workers.sh start
+```
+
+## Prompt source (AI chat/IDE)
+
+- Non-trivial work: `docs/ai/RELAY_PROMPT_TEMPLATE.md`
+- Single quick unit: `docs/ai/PROMPT_TEMPLATE.md`
+
+In IDE, open a fresh AI thread and paste the task-customized template.
+Do not run prompt text in bash.
+
+## Start a durable run
+
+```bash
+cd ~/ytree
+scripts/relay-run.sh --run-id <run_id> --idempotency-key <idempotency_key> --activity-timeout 900 --retry-limit 2
+```
+
+Expected output:
+
+- `RUN STARTED: <run_id>` (or `RUN RESUMED: <run_id>`)
+- `PROMPT ARTIFACTS READY: <run_id>` **or** `PROMPT ARTIFACTS PENDING: <run_id>`
+
+If prompt artifacts are pending, stage them:
+
+```bash
+cd ~/ytree
+scripts/relay-prompts.sh stage --run-id <run_id> --developer <developer_prompt_source> --auditor <auditor_prompt_source>
+scripts/relay-prompts.sh verify --run-id <run_id>
+```
+
+## Optional monitoring (single terminal)
+
+```bash
+cd ~/ytree
+scripts/relay-monitor.sh --run <run_id> --view quiet
+```
+
+Other views:
+
+```bash
+scripts/relay-monitor.sh --run <run_id> --view normal
+scripts/relay-monitor.sh --run <run_id> --view verbose
+```
+
+- `quiet` = status + `ACTION NEEDED` only
+- `normal` = key transitions
+- `verbose` = full stream (includes heartbeats)
+
+Stop monitor with `Ctrl+C`.
+
+## What to look for in AI updates
+
+Every update should include exactly one explicit line:
+
+- `ACTION NEEDED (maintainer): none`
+- or `ACTION NEEDED (maintainer): reply "<exact text>"`
+
+(“maintainer” means you.)
+
+## Finish / shutdown
+
+```bash
+cd ~/ytree
+scripts/relay-workers.sh stop
+```
+
+## Numbered flow
+
+1. Run setup once: `scripts/setup_relay_runtime.sh`
+2. Start workers for the session: `scripts/relay-workers.sh start`
+3. Paste task prompt in IDE (not bash)
+4. Run the exact `scripts/relay-run.sh ...` line
+5. If pending, run `scripts/relay-prompts.sh stage ...` then `verify`
+6. Optional monitor: `scripts/relay-monitor.sh --run <run_id> --view quiet`
+7. When done: `scripts/relay-workers.sh stop`

--- a/docs/ai/RELAY_RUNBOOK.md
+++ b/docs/ai/RELAY_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Relay Runbook (Single-Terminal)
 
-Use this runbook for autonomous architect -> developer -> auditor relay execution without tmux or multi-terminal monitoring.
+Use this runbook for autonomous architect -> developer -> auditor relay execution in a single terminal.
 
 ## Quickstart
 
@@ -26,6 +26,14 @@ scripts/relay-run.sh --run-id <run_id> --idempotency-key <idempotency_key> --act
 On success, the script prints one explicit line:
 
 - `RUN STARTED: <run_id>` (or `RUN RESUMED: <run_id>`)
+
+If prompt artifacts are still pending, stage them immediately:
+
+```bash
+cd ~/ytree
+scripts/relay-prompts.sh stage --run-id <run_id> --developer <developer_prompt_source> --auditor <auditor_prompt_source>
+scripts/relay-prompts.sh verify --run-id <run_id>
+```
 
 ## Monitor one run (optional)
 

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -269,7 +269,13 @@ scripts/relay-run.sh --run-id <run_id> --idempotency-key <idempotency_key> --act
 scripts/relay-monitor.sh --run <run_id> --view quiet
 ```
 
-The run wrapper auto-loads relay env and prints `RUN STARTED: <run_id>` (or `RUN RESUMED: <run_id>`).
+The run wrapper auto-loads relay env and prints `RUN STARTED: <run_id>` (or `RUN RESUMED: <run_id>`), then reports whether prompt artifacts are ready or pending.
+If pending, stage them with:
+
+```bash
+scripts/relay-prompts.sh stage --run-id <run_id> --developer <developer_prompt_source> --auditor <auditor_prompt_source>
+scripts/relay-prompts.sh verify --run-id <run_id>
+```
 
 Manual fallback (direct runtime invocation): load relay env first so runtime preflight reads the configured worker commands:
 
@@ -307,6 +313,7 @@ watch -n 5 'python3 scripts/relay_runtime.py dashboard --verbose --limit 20'
 2.  Architect starts exactly one durable run with stable `run_id` + idempotency key.
 3.  Unit lifecycle is fixed and durable: `architect_handoff -> developer_run -> auditor_run -> architect_validation`.
 4.  Architect emits exactly one runnable developer unit at a time (never multiple units in-flight for the same run unless explicitly designed).
+    *   Before requesting maintainer approval to dispatch `developer_run`, architect MUST stage and verify relay prompt artifacts for the run id.
 5.  Every unit definition must include:
     *   strict scope lock,
     *   acceptance criteria,

--- a/scripts/relay-monitor.sh
+++ b/scripts/relay-monitor.sh
@@ -19,6 +19,7 @@ RUN_ID=""
 INTERVAL=3
 LIMIT=20
 FOLLOW=1
+AUTO_SELECT_RUN=0
 
 usage() {
   cat <<'USAGE'
@@ -84,20 +85,50 @@ fi
 cd "$REPO_ROOT"
 
 if [[ -z "$RUN_ID" ]]; then
-  RUN_ID="$(python3 - <<'PY'
-import os, sqlite3
-path = os.path.expanduser(os.environ.get('RELAY_DB', '~/.local/state/ytree/relay.db'))
+  AUTO_SELECT_RUN=1
+fi
+
+resolve_run_id() {
+  python3 - <<'PY'
+import os
+import sqlite3
+
+path = os.path.expanduser(os.environ.get("RELAY_DB", "~/.local/state/ytree/relay.db"))
 conn = sqlite3.connect(path)
-row = conn.execute('SELECT run_id FROM runs ORDER BY updated_at DESC LIMIT 1').fetchone()
-print(row[0] if row else '')
+row = conn.execute(
+    "SELECT run_id FROM runs WHERE status = 'running' ORDER BY updated_at DESC LIMIT 1"
+).fetchone()
+if row:
+    print(row[0])
+else:
+    fallback = conn.execute("SELECT run_id FROM runs ORDER BY updated_at DESC LIMIT 1").fetchone()
+    print(fallback[0] if fallback else "")
 PY
-)"
+}
+
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID="$(resolve_run_id)"
 fi
 
 if [[ -z "$RUN_ID" ]]; then
   echo "No relay runs found." >&2
   exit 1
 fi
+
+if [[ "$AUTO_SELECT_RUN" -eq 1 ]]; then
+  echo "Auto-selecting run_id=$RUN_ID" >&2
+fi
+
+refresh_auto_selected_run() {
+  if [[ "$AUTO_SELECT_RUN" -ne 1 ]]; then
+    return
+  fi
+  local selected
+  selected="$(resolve_run_id)"
+  if [[ -n "$selected" ]]; then
+    RUN_ID="$selected"
+  fi
+}
 
 render_once() {
   local history
@@ -172,11 +203,13 @@ PY
 }
 
 if [[ "$FOLLOW" -eq 0 ]]; then
+  refresh_auto_selected_run
   render_once
   exit $?
 fi
 
 while true; do
+  refresh_auto_selected_run
   clear
   render_once || true
   sleep "$INTERVAL"

--- a/scripts/relay-prompts.sh
+++ b/scripts/relay-prompts.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Stage/verify relay prompt artifacts for a run_id.
+#
+# Usage:
+#   scripts/relay-prompts.sh stage --run-id <id> --developer <path> --auditor <path>
+#   scripts/relay-prompts.sh verify --run-id <id>
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+MODE=""
+RUN_ID=""
+DEVELOPER_SRC=""
+AUDITOR_SRC=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/relay-prompts.sh stage --run-id <id> --developer <path> --auditor <path>
+  scripts/relay-prompts.sh verify --run-id <id>
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+MODE="${1:-}"
+shift
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)
+      RUN_ID="${2:-}"
+      shift 2
+      ;;
+    --developer)
+      DEVELOPER_SRC="${2:-}"
+      shift 2
+      ;;
+    --auditor)
+      AUDITOR_SRC="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -f "$HOME/.config/ytree/relay.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$HOME/.config/ytree/relay.env"
+  set +a
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "ERROR: --run-id is required" >&2
+  exit 2
+fi
+
+PROMPT_DIR="${RELAY_PROMPT_DIR:-$HOME/.config/ytree/relay-prompts}"
+mkdir -p "$PROMPT_DIR"
+DEVELOPER_DST="$PROMPT_DIR/${RUN_ID}_developer_run_developer.txt"
+AUDITOR_DST="$PROMPT_DIR/${RUN_ID}_auditor_run_code_auditor.txt"
+
+cd "$REPO_ROOT"
+
+case "$MODE" in
+  stage)
+    if [[ -z "$DEVELOPER_SRC" || -z "$AUDITOR_SRC" ]]; then
+      echo "ERROR: stage requires --developer and --auditor" >&2
+      exit 2
+    fi
+    if [[ ! -f "$DEVELOPER_SRC" ]]; then
+      echo "ERROR: developer prompt source not found: $DEVELOPER_SRC" >&2
+      exit 1
+    fi
+    if [[ ! -f "$AUDITOR_SRC" ]]; then
+      echo "ERROR: auditor prompt source not found: $AUDITOR_SRC" >&2
+      exit 1
+    fi
+    cp "$DEVELOPER_SRC" "$DEVELOPER_DST"
+    cp "$AUDITOR_SRC" "$AUDITOR_DST"
+    echo "PROMPT STAGED: $DEVELOPER_DST"
+    echo "PROMPT STAGED: $AUDITOR_DST"
+    echo "PROMPT READY: $RUN_ID"
+    ;;
+  verify)
+    missing=0
+    if [[ -f "$DEVELOPER_DST" ]]; then
+      echo "PROMPT FOUND: $DEVELOPER_DST"
+    else
+      echo "PROMPT MISSING: $DEVELOPER_DST"
+      missing=1
+    fi
+    if [[ -f "$AUDITOR_DST" ]]; then
+      echo "PROMPT FOUND: $AUDITOR_DST"
+    else
+      echo "PROMPT MISSING: $AUDITOR_DST"
+      missing=1
+    fi
+    if [[ "$missing" -eq 0 ]]; then
+      echo "PROMPT READY: $RUN_ID"
+    else
+      exit 1
+    fi
+    ;;
+  *)
+    echo "ERROR: mode must be stage or verify" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/relay-run.sh
+++ b/scripts/relay-run.sh
@@ -54,4 +54,14 @@ if [[ -n "$run_id" ]]; then
   else
     echo "RUN RESUMED: $run_id"
   fi
+
+  prompt_dir="${RELAY_PROMPT_DIR:-$HOME/.config/ytree/relay-prompts}"
+  developer_prompt="$prompt_dir/${run_id}_developer_run_developer.txt"
+  auditor_prompt="$prompt_dir/${run_id}_auditor_run_code_auditor.txt"
+  if [[ -f "$developer_prompt" && -f "$auditor_prompt" ]]; then
+    echo "PROMPT ARTIFACTS READY: $run_id"
+  else
+    echo "PROMPT ARTIFACTS PENDING: $run_id"
+    echo "NEXT: scripts/relay-prompts.sh stage --run-id $run_id --developer <developer_prompt_source> --auditor <auditor_prompt_source>"
+  fi
 fi

--- a/scripts/relay_runtime.py
+++ b/scripts/relay_runtime.py
@@ -52,6 +52,9 @@ _NOOP_PLACEHOLDER_COMMANDS: set[tuple[str, ...]] = {
 }
 
 _REPORT_HANDLE_PATTERN = re.compile(r"(?:^|\s)report_handle=([^\s;]+)")
+_MISSING_PROMPT_FILE_PATTERN = re.compile(
+    r"missing prompt file(?:[:\s]+)(?P<path>[^\s;]+)", re.IGNORECASE
+)
 DEFAULT_MAINTAINER_HEARTBEAT_SECONDS = max(
     30, int(os.environ.get("RELAY_MAINTAINER_HEARTBEAT_SECONDS", "300"))
 )
@@ -400,7 +403,7 @@ class TemporalRelayStore:
                             status = UNIT_STATUS_SUCCEEDED
                             attempt = 1
                         elif unit_id == "developer_run":
-                            status = UNIT_STATUS_QUEUED
+                            status = UNIT_STATUS_BLOCKED
                             attempt = 0
                         else:
                             status = UNIT_STATUS_BLOCKED
@@ -451,9 +454,15 @@ class TemporalRelayStore:
                                 "run_id": run_id,
                                 "unit_id": "developer_run",
                                 "role": ROLE_DEVELOPER,
-                                "event_type": "unit_queued",
-                                "status": UNIT_STATUS_QUEUED,
-                                "message": "developer unit queued",
+                                "event_type": "unit_blocked",
+                                "status": UNIT_STATUS_BLOCKED,
+                                "message": "developer unit blocked pending prompt artifacts",
+                                "metadata": {
+                                    "prompt_files": [
+                                        str(_expected_prompt_files(run_id)[0]),
+                                        str(_expected_prompt_files(run_id)[1]),
+                                    ]
+                                },
                                 "ts": stamp,
                             },
                         ]
@@ -468,6 +477,60 @@ class TemporalRelayStore:
         events: list[dict[str, Any]] = []
         lease: Lease | None = None
         with self._conn() as conn:
+            if role == ROLE_DEVELOPER:
+                blocked = conn.execute(
+                    """
+                    SELECT u.run_id, u.unit_id
+                    FROM units u
+                    INNER JOIN runs r ON r.run_id = u.run_id
+                    WHERE u.role = ?
+                      AND u.status = ?
+                      AND r.status = ?
+                    ORDER BY u.updated_at ASC
+                    """,
+                    (ROLE_DEVELOPER, UNIT_STATUS_BLOCKED, RUN_STATUS_RUNNING),
+                ).fetchall()
+                for row in blocked:
+                    run_id = str(row["run_id"])
+                    if not _developer_prompts_ready(run_id):
+                        continue
+                    updated = conn.execute(
+                        """
+                        UPDATE units
+                        SET status = ?, retry_not_before = ?, updated_at = ?
+                        WHERE run_id = ?
+                          AND unit_id = ?
+                          AND status = ?
+                        """,
+                        (
+                            UNIT_STATUS_QUEUED,
+                            stamp,
+                            stamp,
+                            run_id,
+                            str(row["unit_id"]),
+                            UNIT_STATUS_BLOCKED,
+                        ),
+                    )
+                    if updated.rowcount == 1:
+                        developer_prompt, auditor_prompt = _expected_prompt_files(run_id)
+                        events.append(
+                            {
+                                "run_id": run_id,
+                                "unit_id": "developer_run",
+                                "role": ROLE_DEVELOPER,
+                                "event_type": "unit_queued",
+                                "status": UNIT_STATUS_QUEUED,
+                                "message": "developer unit queued after prompt artifacts detected",
+                                "metadata": {
+                                    "prompt_files": [
+                                        str(developer_prompt),
+                                        str(auditor_prompt),
+                                    ]
+                                },
+                                "ts": stamp,
+                            }
+                        )
+
             candidate = conn.execute(
                 """
                 SELECT u.*, r.activity_timeout_seconds, r.lease_ttl_seconds
@@ -483,90 +546,204 @@ class TemporalRelayStore:
                 (role, UNIT_STATUS_QUEUED, UNIT_STATUS_RETRYABLE, stamp, RUN_STATUS_RUNNING),
             ).fetchone()
             if not candidate:
-                return None
+                if events:
+                    self._record_events(conn, events)
+                lease = None
+            else:
+                lease_version = int(candidate["lease_version"])
+                lease_token = lease_version + 1
+                lease_expires_at = stamp + int(candidate["lease_ttl_seconds"])
+                updated = conn.execute(
+                    """
+                    UPDATE units
+                    SET status = ?,
+                        attempt = attempt + 1,
+                        lease_owner = ?,
+                        lease_token = ?,
+                        lease_version = ?,
+                        lease_expires_at = ?,
+                        heartbeat_at = ?,
+                        updated_at = ?
+                    WHERE run_id = ?
+                      AND unit_id = ?
+                      AND lease_version = ?
+                      AND status IN (?, ?)
+                    """,
+                    (
+                        UNIT_STATUS_RUNNING,
+                        lease_owner,
+                        lease_token,
+                        lease_token,
+                        lease_expires_at,
+                        stamp,
+                        stamp,
+                        candidate["run_id"],
+                        candidate["unit_id"],
+                        lease_version,
+                        UNIT_STATUS_QUEUED,
+                        UNIT_STATUS_RETRYABLE,
+                    ),
+                )
+                if updated.rowcount != 1:
+                    if events:
+                        self._record_events(conn, events)
+                    lease = None
+                else:
+                    refreshed = conn.execute(
+                        """
+                        SELECT u.*, r.activity_timeout_seconds
+                        FROM units u
+                        INNER JOIN runs r ON r.run_id = u.run_id
+                        WHERE u.run_id = ? AND u.unit_id = ?
+                        """,
+                        (candidate["run_id"], candidate["unit_id"]),
+                    ).fetchone()
+                    if not refreshed:
+                        if events:
+                            self._record_events(conn, events)
+                        lease = None
+                    else:
+                        lease = Lease(
+                            run_id=str(refreshed["run_id"]),
+                            unit_id=str(refreshed["unit_id"]),
+                            role=str(refreshed["role"]),
+                            lease_owner=str(refreshed["lease_owner"]),
+                            lease_token=int(refreshed["lease_token"]),
+                            lease_version=int(refreshed["lease_version"]),
+                            lease_expires_at=float(refreshed["lease_expires_at"]),
+                            heartbeat_at=float(refreshed["heartbeat_at"]),
+                            attempt=int(refreshed["attempt"]),
+                            max_attempts=int(refreshed["max_attempts"]),
+                            activity_timeout_seconds=int(refreshed["activity_timeout_seconds"]),
+                        )
+                        events.append(
+                            {
+                                "run_id": lease.run_id,
+                                "unit_id": lease.unit_id,
+                                "role": lease.role,
+                                "event_type": "lease_acquired",
+                                "status": UNIT_STATUS_RUNNING,
+                                "message": "worker acquired lease",
+                                "metadata": {
+                                    "lease_owner": lease_owner,
+                                    "lease_token": lease.lease_token,
+                                    "attempt": lease.attempt,
+                                },
+                                "ts": stamp,
+                            }
+                        )
+                        self._record_events(conn, events)
 
-            lease_version = int(candidate["lease_version"])
-            lease_token = lease_version + 1
-            lease_expires_at = stamp + int(candidate["lease_ttl_seconds"])
-            updated = conn.execute(
+        if events:
+            self._emit_events(events)
+        return lease
+
+    def defer_unit_waiting_for_prompt(
+        self,
+        lease: Lease,
+        *,
+        message: str,
+        missing_prompt_file: str | None,
+        now: float | None = None,
+    ) -> str:
+        stamp = now if now is not None else time.time()
+        events: list[dict[str, Any]] = []
+        final_status = UNIT_STATUS_QUEUED
+        with self._conn() as conn:
+            unit = conn.execute(
+                "SELECT * FROM units WHERE run_id = ? AND unit_id = ?",
+                (lease.run_id, lease.unit_id),
+            ).fetchone()
+            if not unit:
+                raise RuntimeError("unit not found")
+            if (
+                unit["status"] != UNIT_STATUS_RUNNING
+                or unit["lease_owner"] != lease.lease_owner
+                or unit["lease_token"] != lease.lease_token
+            ):
+                events.append(
+                    {
+                        "run_id": lease.run_id,
+                        "unit_id": lease.unit_id,
+                        "role": lease.role,
+                        "event_type": "unit_defer_rejected",
+                        "status": "error",
+                        "message": "defer rejected due to lease mismatch",
+                        "metadata": {"lease_owner": lease.lease_owner, "lease_token": lease.lease_token},
+                        "ts": stamp,
+                    }
+                )
+                self._record_events(conn, events)
+                self._emit_events(events)
+                return "rejected"
+
+            run_row = conn.execute(
+                "SELECT retry_backoff_seconds FROM runs WHERE run_id = ?",
+                (lease.run_id,),
+            ).fetchone()
+            backoff = int(run_row["retry_backoff_seconds"]) if run_row else 10
+            retry_at = stamp + max(2, backoff)
+            next_attempt = max(0, int(unit["attempt"]) - 1)
+            conn.execute(
                 """
                 UPDATE units
                 SET status = ?,
-                    attempt = attempt + 1,
-                    lease_owner = ?,
-                    lease_token = ?,
-                    lease_version = ?,
-                    lease_expires_at = ?,
-                    heartbeat_at = ?,
+                    attempt = ?,
+                    retry_not_before = ?,
+                    lease_owner = NULL,
+                    lease_token = NULL,
+                    lease_expires_at = NULL,
+                    heartbeat_at = NULL,
+                    last_error = ?,
                     updated_at = ?
-                WHERE run_id = ?
-                  AND unit_id = ?
-                  AND lease_version = ?
-                  AND status IN (?, ?)
+                WHERE run_id = ? AND unit_id = ?
                 """,
                 (
-                    UNIT_STATUS_RUNNING,
-                    lease_owner,
-                    lease_token,
-                    lease_token,
-                    lease_expires_at,
-                    stamp,
-                    stamp,
-                    candidate["run_id"],
-                    candidate["unit_id"],
-                    lease_version,
                     UNIT_STATUS_QUEUED,
-                    UNIT_STATUS_RETRYABLE,
+                    next_attempt,
+                    retry_at,
+                    message,
+                    stamp,
+                    lease.run_id,
+                    lease.unit_id,
                 ),
             )
-            if updated.rowcount != 1:
-                return None
-
-            refreshed = conn.execute(
-                """
-                SELECT u.*, r.activity_timeout_seconds
-                FROM units u
-                INNER JOIN runs r ON r.run_id = u.run_id
-                WHERE u.run_id = ? AND u.unit_id = ?
-                """,
-                (candidate["run_id"], candidate["unit_id"]),
-            ).fetchone()
-            if not refreshed:
-                return None
-
-            lease = Lease(
-                run_id=str(refreshed["run_id"]),
-                unit_id=str(refreshed["unit_id"]),
-                role=str(refreshed["role"]),
-                lease_owner=str(refreshed["lease_owner"]),
-                lease_token=int(refreshed["lease_token"]),
-                lease_version=int(refreshed["lease_version"]),
-                lease_expires_at=float(refreshed["lease_expires_at"]),
-                heartbeat_at=float(refreshed["heartbeat_at"]),
-                attempt=int(refreshed["attempt"]),
-                max_attempts=int(refreshed["max_attempts"]),
-                activity_timeout_seconds=int(refreshed["activity_timeout_seconds"]),
-            )
+            metadata: dict[str, Any] = {
+                "retry_not_before": _utc_iso(retry_at),
+            }
+            if missing_prompt_file:
+                metadata["missing_prompt_file"] = missing_prompt_file
             events.append(
                 {
                     "run_id": lease.run_id,
                     "unit_id": lease.unit_id,
                     "role": lease.role,
-                    "event_type": "lease_acquired",
-                    "status": UNIT_STATUS_RUNNING,
-                    "message": "worker acquired lease",
-                    "metadata": {
-                        "lease_owner": lease_owner,
-                        "lease_token": lease.lease_token,
-                        "attempt": lease.attempt,
-                    },
+                    "event_type": "unit_waiting_for_prompt",
+                    "status": UNIT_STATUS_QUEUED,
+                    "message": "worker deferred unit until prompt artifacts are available",
+                    "metadata": metadata,
+                    "ts": stamp,
+                }
+            )
+            maintainer_message = "prompt artifacts missing for developer unit"
+            if missing_prompt_file:
+                maintainer_message = f"{maintainer_message}: {missing_prompt_file}"
+            events.append(
+                {
+                    "run_id": lease.run_id,
+                    "unit_id": lease.unit_id,
+                    "role": ROLE_ARCHITECT,
+                    "event_type": "maintainer_update_required",
+                    "status": UNIT_STATUS_QUEUED,
+                    "message": maintainer_message,
+                    "metadata": metadata,
                     "ts": stamp,
                 }
             )
             self._record_events(conn, events)
 
         self._emit_events(events)
-        return lease
+        return final_status
 
     def renew_heartbeat(self, lease: Lease, *, now: float | None = None) -> bool:
         stamp = now if now is not None else time.time()
@@ -1103,6 +1280,66 @@ class TemporalRelayStore:
                             }
                         )
 
+            blocked_developer_units = conn.execute(
+                """
+                SELECT u.run_id, u.unit_id
+                FROM units u
+                INNER JOIN runs r ON r.run_id = u.run_id
+                WHERE u.status = ?
+                  AND u.role = ?
+                  AND r.status = ?
+                ORDER BY u.updated_at ASC
+                """,
+                (UNIT_STATUS_BLOCKED, ROLE_DEVELOPER, RUN_STATUS_RUNNING),
+            ).fetchall()
+            for blocked_row in blocked_developer_units:
+                run_id = str(blocked_row["run_id"])
+                unit_id = str(blocked_row["unit_id"])
+                if _developer_prompts_ready(run_id):
+                    continue
+                reminder_row = conn.execute(
+                    """
+                    SELECT MAX(ts_epoch) AS ts_epoch
+                    FROM temporal_history
+                    WHERE run_id = ?
+                      AND unit_id = ?
+                      AND event_type = ?
+                    """,
+                    (run_id, unit_id, "maintainer_update_required"),
+                ).fetchone()
+                last_reminder_epoch = (
+                    float(reminder_row["ts_epoch"])
+                    if reminder_row and reminder_row["ts_epoch"] is not None
+                    else None
+                )
+                reminder_due = (
+                    last_reminder_epoch is None
+                    or (stamp - last_reminder_epoch) >= float(maintainer_interval)
+                )
+                if not reminder_due:
+                    continue
+                developer_prompt, auditor_prompt = _expected_prompt_files(run_id)
+                events.append(
+                    {
+                        "run_id": run_id,
+                        "unit_id": unit_id,
+                        "role": ROLE_ARCHITECT,
+                        "event_type": "maintainer_update_required",
+                        "status": UNIT_STATUS_BLOCKED,
+                        "message": (
+                            "ACTION NEEDED (maintainer): ask architect to stage relay prompt artifacts "
+                            f"for run_id {run_id}"
+                        ),
+                        "metadata": {
+                            "missing_prompt_files": [
+                                str(developer_prompt),
+                                str(auditor_prompt),
+                            ]
+                        },
+                        "ts": stamp,
+                    }
+                )
+
             if events:
                 self._record_events(conn, events)
 
@@ -1188,6 +1425,21 @@ class RelayWorker:
 
     def complete(self, lease: Lease, *, success: bool, message: str, now: float | None = None) -> str:
         return self.store.complete_unit(lease, success=success, message=message, now=now)
+
+    def defer_waiting_for_prompt(
+        self,
+        lease: Lease,
+        *,
+        message: str,
+        missing_prompt_file: str | None,
+        now: float | None = None,
+    ) -> str:
+        return self.store.defer_unit_waiting_for_prompt(
+            lease,
+            message=message,
+            missing_prompt_file=missing_prompt_file,
+            now=now,
+        )
 
     def run_once(
         self,
@@ -1331,6 +1583,33 @@ def _extract_report_handle(command_output: str) -> str | None:
     if not matches:
         return None
     return matches[-1]
+
+
+def _extract_missing_prompt_file(command_output: str) -> str | None:
+    match = _MISSING_PROMPT_FILE_PATTERN.search(command_output or "")
+    if not match:
+        return None
+    return match.group("path")
+
+
+def _relay_prompt_dir() -> Path:
+    configured = os.environ.get("RELAY_PROMPT_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".config" / "ytree" / "relay-prompts"
+
+
+def _expected_prompt_files(run_id: str) -> tuple[Path, Path]:
+    prompt_dir = _relay_prompt_dir()
+    return (
+        prompt_dir / f"{run_id}_developer_run_developer.txt",
+        prompt_dir / f"{run_id}_auditor_run_code_auditor.txt",
+    )
+
+
+def _developer_prompts_ready(run_id: str) -> bool:
+    developer_prompt, auditor_prompt = _expected_prompt_files(run_id)
+    return developer_prompt.is_file() and auditor_prompt.is_file()
 
 
 def _summarize_worker_output(command_output: str, *, limit: int = 240) -> str:
@@ -1512,6 +1791,29 @@ def _run_worker_loop(
             command=parsed_command,
             heartbeat_interval=heartbeat_interval,
         )
+        missing_prompt_file = _extract_missing_prompt_file(message) if not success else None
+        if missing_prompt_file:
+            store.event_log.append(
+                run_id=lease.run_id,
+                unit_id=lease.unit_id,
+                role=lease.role,
+                event_type="worker_command_deferred",
+                status=UNIT_STATUS_RUNNING,
+                message="worker command deferred until prompt artifacts are present",
+                metadata={
+                    "missing_prompt_file": missing_prompt_file,
+                    "lease_owner": lease.lease_owner,
+                    "lease_token": lease.lease_token,
+                },
+            )
+            worker.defer_waiting_for_prompt(
+                lease,
+                message=message,
+                missing_prompt_file=missing_prompt_file,
+            )
+            if once:
+                return 0
+            continue
         if not success and _is_policy_block_failure(message):
             store.event_log.append(
                 run_id=lease.run_id,

--- a/scripts/setup_relay_runtime.sh
+++ b/scripts/setup_relay_runtime.sh
@@ -143,4 +143,12 @@ else
 fi
 
 echo "[setup-relay] Complete."
-echo "[setup-relay] Next: use scripts/relay-run.sh to start runs and scripts/relay-monitor.sh to monitor one run in a single terminal."
+if [[ "$NO_START" -eq 0 ]]; then
+  echo "[setup-relay] 1) workers: running"
+else
+  echo "[setup-relay] 1) workers: run scripts/relay-workers.sh start"
+fi
+echo "[setup-relay] 2) IDE: paste a task-customized relay prompt template"
+echo "[setup-relay] 3) run: scripts/relay-run.sh --run-id <run_id> --idempotency-key <idempotency_key> --activity-timeout 900 --retry-limit 2"
+echo "[setup-relay] 4) if pending prompts: scripts/relay-prompts.sh stage --run-id <run_id> --developer <developer_prompt_source> --auditor <auditor_prompt_source>;scripts/relay-prompts.sh verify --run-id <run_id>"
+echo "[setup-relay] 5) optional monitor: scripts/relay-monitor.sh --view quiet"

--- a/tests/test_relay_runtime.py
+++ b/tests/test_relay_runtime.py
@@ -19,12 +19,22 @@ RUNTIME_SPEC.loader.exec_module(relay)
 def _new_store(tmp_path: Path) -> tuple[relay.TemporalRelayStore, relay.AppendOnlyEventLog, Path, Path]:
     db_path = tmp_path / "relay.db"
     log_path = tmp_path / "relay-events.jsonl"
+    prompt_dir = tmp_path / "relay-prompts"
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["RELAY_PROMPT_DIR"] = str(prompt_dir)
     event_log = relay.AppendOnlyEventLog(log_path)
     store = relay.TemporalRelayStore(db_path, event_log)
     return store, event_log, db_path, log_path
 
 
+def _stage_prompt_artifacts(run_id: str) -> None:
+    prompt_dir = Path(os.environ["RELAY_PROMPT_DIR"])
+    (prompt_dir / f"{run_id}_developer_run_developer.txt").write_text("developer prompt\n", encoding="utf-8")
+    (prompt_dir / f"{run_id}_auditor_run_code_auditor.txt").write_text("auditor prompt\n", encoding="utf-8")
+
+
 def _start_run(store: relay.TemporalRelayStore, run_id: str, now: float = 1000.0) -> None:
+    _stage_prompt_artifacts(run_id)
     store.start_or_resume_run(
         run_id=run_id,
         idempotency_key=f"idem-{run_id}",
@@ -44,6 +54,7 @@ def _start_run_custom_lease(
     heartbeat_late_seconds: int,
     heartbeat_stale_seconds: int,
 ) -> None:
+    _stage_prompt_artifacts(run_id)
     store.start_or_resume_run(
         run_id=run_id,
         idempotency_key=f"idem-{run_id}",
@@ -66,6 +77,7 @@ def _start_run_custom_retry(
     max_attempts: int,
     backoff_seconds: int = 0,
 ) -> None:
+    _stage_prompt_artifacts(run_id)
     store.start_or_resume_run(
         run_id=run_id,
         idempotency_key=f"idem-{run_id}",
@@ -307,6 +319,7 @@ def test_event_log_is_append_only_and_dashboard_low_noise(tmp_path: Path) -> Non
 
 def test_end_to_end_cycle_completes_durably(tmp_path: Path) -> None:
     store, event_log, db_path, log_path = _new_store(tmp_path)
+    _stage_prompt_artifacts("run-e2e")
     run_id, state = store.start_or_resume_run(
         run_id="run-e2e",
         idempotency_key="idem-run-e2e",
@@ -446,6 +459,7 @@ def test_worker_policy_block_retryable_failure_does_not_prompt_maintainer(tmp_pa
 
 def test_worker_timeout_failure_is_retryable_without_maintainer_prompt(tmp_path: Path) -> None:
     store, event_log, _db_path, _log_path = _new_store(tmp_path)
+    _stage_prompt_artifacts("run-timeout-retry")
     store.start_or_resume_run(
         run_id="run-timeout-retry",
         idempotency_key="idem-run-timeout-retry",


### PR DESCRIPTION
## Summary
- harden relay runtime so developer unit stays blocked until prompt artifacts exist
- add explicit prompt staging/verification helper script for run-scoped artifacts
- tighten run/start docs and prompt template to enforce artifact staging before dispatch
- add runtime + watchdog behavior to emit explicit maintainer update instead of silent blocked state

## Validation
- source .venv/bin/activate
- pytest tests/test_relay_runtime.py tests/test_relay_systemd.py tests/test_project_ai_config_guard.py -q
