### PR TITLE
ci(github): tolerate pr size label permission limits

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   size-signal:
@@ -50,8 +51,11 @@ jobs:
                   description: label.description,
                 });
               } catch (error) {
-                if (error.status !== 422) {
+                if (error.status !== 422 && error.status !== 403) {
                   throw error;
+                }
+                if (error.status === 403) {
+                  core.warning(`Skipping label creation (${label.name}): ${error.message}`);
                 }
               }
             }
@@ -67,18 +71,28 @@ jobs:
                     name: existing,
                   });
                 } catch (error) {
-                  if (error.status !== 404) {
+                  if (error.status !== 404 && error.status !== 403) {
                     throw error;
+                  }
+                  if (error.status === 403) {
+                    core.warning(`Skipping size label removal (${existing}): ${error.message}`);
                   }
                 }
               }
             }
 
             if (!existingLabels.includes(labelName)) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number,
-                labels: [labelName],
-              });
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number,
+                  labels: [labelName],
+                });
+              } catch (error) {
+                if (error.status !== 403) {
+                  throw error;
+                }
+                core.warning(`Skipping size label add (${labelName}): ${error.message}`);
+              }
             }


### PR DESCRIPTION
## Summary
Make the PR size label workflow resilient when GitHub token permissions block issue label writes.

## Changes
- add `pull-requests: write` permission to the workflow
- treat `403 Resource not accessible by integration` as non-fatal for label create/remove/add
- keep behavior unchanged when permissions are available

## Why
`pull_request_target` runs from `main`; when label writes are restricted, the size-label job failed and blocked unrelated PRs.
