### PR TITLE
docs(readme): remove stale infra directory entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ ytree/
 ├── tests/               pytest/pexpect test suite
 ├── scripts/             helper scripts (build, relay, tooling)
 ├── docs/                user, developer, and process documentation
-├── infra/               service and infrastructure templates
 ├── etc/                 manpage source and related assets
 ├── build/               build artifacts
 ├── obj/                 object files


### PR DESCRIPTION
Remove outdated `infra/` tree entry from README.

The `infra/` directory no longer exists in the repository, so this keeps the tree listing accurate.
