### PR TITLE
fix: modal severity colors and update workflow QA-gate docs

### DIFF
--- a/.ai/codex.md
+++ b/.ai/codex.md
@@ -42,5 +42,5 @@ Codex-specific behavior for this repository.
 ## Mandatory Audit Cadence
 
 - Use focused build/test checks during normal implementation.
-- Run full `make qa-all` only before merge to `main` or when the maintainer explicitly requests it.
-- Treat this as a required pre-merge gate, not a per-iteration requirement.
+- Use PR full-QA CI (`make qa-all` equivalent) as the required pre-merge gate before merging to `main`.
+- Run local full `make qa-all` only when the maintainer explicitly requests it or when extra local confidence is needed.

--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -93,7 +93,7 @@ These instructions apply to all AI agents used in this repository.
 9. You MUST amend (`git commit --amend --no-edit`) for all follow-up corrections to the same task. You MUST NOT create trivial sequential bugfix commits. Use a new commit only when the correction is materially distinct.
 10. Treat user instructions as authoritative on goals, not automatically on exact wording, labels, keybindings, menu structure, or UX details. If a requested detail does not follow convention, established Ytree patterns, or best practices, say so explicitly and recommend the better option before implementing it.
 11. For every bug fix, follow strict red-green: write/adjust a regression test first and demonstrate it fails on current code before changing implementation; then implement the architectural fix and re-run to green. A test added only after the fix is not sufficient evidence.
-12. Focused-first audit cadence is mandatory: use targeted build/test checks during implementation; reserve full-project `make qa-all` for pre-merge into `main` or explicit maintainer request.
+12. Focused-first audit cadence is mandatory: use targeted build/test checks during implementation; rely on PR full-QA CI (`make qa-all` equivalent) as the required pre-merge gate, and run local `make qa-all` only on explicit maintainer request or when extra local confidence is needed.
 13. UX economy gate is mandatory for interactive flows: common path MUST be `key -> Enter -> result` with at most one submenu. Any flow requiring more than one submenu must include explicit justification and an equivalent fast path.
 14. QA remediation gate is mandatory: fix root causes, do not patch around failing checks. Do not change tests solely to force a pass unless the test is demonstrably wrong against spec. Do not add local suppressions/skips/xfails as a shortcut; if a temporary suppression is the only safe short-term option, discuss with the user first and get explicit approval.
 15. Documentation signal-to-noise is mandatory: add or update guidance only in the most relevant canonical location for that audience; avoid duplicating AI/process notes across unrelated docs or sections unless uniquely necessary in that local context.
@@ -107,7 +107,7 @@ These instructions apply to all AI agents used in this repository.
     - Before first push, run a quick local gate (build plus targeted smoke/tests).
     - Open a draft PR early; red is allowed while iterating.
     - While PR is red, prefix draft title with `WIP:` and do not request reviewers.
-    - Before merge to `main`, require full local audit gates (`make qa-all` and required audit loop) unless the maintainer explicitly waives.
+    - Before merge to `main`, require green PR full-QA CI gate (`make qa-all` equivalent) and required audit-loop evidence; local `make qa-all` is optional unless the maintainer explicitly requests it.
     - Convert draft PR to ready only after posting full QA evidence in a PR comment.
     - Before merge, require green PR checks and reviewer signoff.
 23. Change-description durability is mandatory: commit subjects and PR titles/summaries MUST describe the concrete behavior/problem being changed, and MUST NOT rely on volatile tracker IDs alone (for example `BUG-14`, `TASK-7`) as the primary description.
@@ -125,7 +125,7 @@ These instructions apply to all AI agents used in this repository.
 - Always activate the venv before pytest: `source .venv/bin/activate`.
 - Run audit targets (`make qa-all`, `make qa-*`) with host permissions from the start when those targets are explicitly requested.
 - Run relevant tests with `pytest ...`.
-- For feature-sized/major/PR work, run focused checks during development; run the full audit loop from `docs/AUDIT.md` before merge to `main` or when explicitly requested by the maintainer.
+- For feature-sized/major/PR work, run focused checks during development; before merge to `main`, require green PR full-QA CI evidence from `docs/AUDIT.md` and run local full-loop commands only when explicitly requested by the maintainer.
 - Do not claim completion without terminal verification.
 
 ## Primary References

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Testing quick reference (Codex):
 - Full suite command: `pytest`
 - Always run pytest with host permissions from the start (no sandbox-first run), because PTY-based tests require unrestricted PTY allocation.
 - Run audit targets (`make qa-all`, `make qa-*`) with host permissions from the start (no sandbox-first run), because toolchain steps can require unrestricted environment access.
+- Pre-merge quality gate is PR full-QA CI (`make qa-all` equivalent). Local `make qa-all` is optional unless maintainer-requested.
 
 MCP health check (Codex):
 - Diagnose MCP startup/config drift: `make mcp-doctor`

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -5,7 +5,7 @@ This document defines the mandatory quality process for the Ytree modernization 
 
 ## 1.1 Cadence
 - Use focused checks during feature-sized change or PR iteration.
-- Run the full audit loop before merge to `main` (or when explicitly requested by the maintainer).
+- Before merge to `main`, require green PR full-QA CI (`make qa-all` equivalent). Local full audit loop is optional unless explicitly requested by the maintainer.
 - For feature-sized changes, include explicit `make qa-module-boundaries` evidence (controller allowlists + growth budgets) in the verification notes.
 - Always run the merge/release gate before merge/release.
 - Do not run the full gate after every prompt-level micro-edit unless risk justifies it.
@@ -17,14 +17,15 @@ The project uses six QA layers with increasing depth and cost:
 | Layer | Command | What it checks | When to run |
 |---|---|---|---|
 | CI Gate | `git push` (automatic) | Draft-PR baseline confidence checks (`qa-code-quality` + `qa-fileops-integrity`, coverage pytest gate, fuzz gate) | Every push to `main` and every PR update targeting `main` (automatic) |
-| Local QA | `make qa-all` | clang-tidy, cppcheck, scan-build, Valgrind smoke (`--version`), full `pytest`, unsafe API guard, gitleaks, module-boundary guard, ai-config guard, fuzz guard | Before every PR or feature merge |
+| PR Full QA CI (required) | `.github/workflows/full-qa.yml` (`make qa-all`) | clang-tidy, cppcheck, scan-build, Valgrind smoke (`--version`), full `pytest`, unsafe API guard, gitleaks, module-boundary guard, ai-config guard, fuzz guard | Must be green before merge to `main` |
 | Fileops Integrity Gate | `make qa-fileops-integrity` | Deterministic file/archive mutation integrity + security regression checks (copy/move/delete/rename/archive rewrite, cancel/failure safeguards, shell/tempfile hardening contracts) | Before merge and when touching file/archive mutation flows |
 | Sanitizer QA | `make qa-sanitize` | Main ytree build + `pytest` under AddressSanitizer/UndefinedBehaviorSanitizer | Before release, after memory/UB-sensitive changes, or when triaging suspicious crashes |
 | Deep Audit | `make qa-valgrind-full` | Automated interactive Valgrind Memcheck session (leak, uninit, FD, use-after-free checks) | Before release, after major refactoring, or periodically |
 | Manual Feature Audit | `make qa-valgrind-interactive` | You manually drive ytree under Valgrind to exercise new feature code paths | After adding a major new feature |
 
 - **CI Gate** runs automatically on push via GitHub Actions. No developer action needed.
-- **Local QA** (`make qa-all`) is the standard pre-merge gate. Avoid running it on every iteration unless explicitly requested.
+- **PR Full QA CI** (`.github/workflows/full-qa.yml`, `make qa-all` equivalent) is the standard pre-merge gate.
+- **Local QA** (`make qa-all`) is optional for faster local confidence and maintainer-requested deep preflight; avoid running it on every iteration by default.
 - **Fileops Integrity Gate** (`make qa-fileops-integrity`) is the dedicated regression wall for mutation integrity/security contracts; run it before merge and whenever file/archive mutation code or prompts change.
 - **Deep Audit** (`make qa-valgrind-full`) is on-demand. It drives a scripted interactive ytree session under Valgrind and takes ~2-3 minutes. Run it:
   - Before tagging a release
@@ -54,7 +55,7 @@ Scope is strict: QA/check/test organization and efficiency only. Non-QA workflow
 - Before first push, run a quick local gate (`make`, plus targeted smoke/tests for touched scope).
 - Open a draft PR early; draft PR checks may be red while iterating.
 - Do not request review while draft checks are red.
-- Before merge to `main`, run full local audit gates (`make qa-all` + required loop evidence from this document), unless the maintainer explicitly waives.
+- Before merge to `main`, require green PR full-QA CI (`make qa-all` equivalent) plus required loop evidence from this document; local full audit reruns are optional unless the maintainer explicitly requests them.
 - Before merge, require green PR checks and reviewer signoff.
 
 ### Required Gate Tiers
@@ -63,7 +64,7 @@ Scope is strict: QA/check/test organization and efficiency only. Non-QA workflow
 |---|---|---|---|---|
 | Tier A (local fast iteration) | Developer | During implementation before first push and between risky edits | `make`; targeted pytest for touched scope; targeted guards (`qa-unsafe-apis`, `qa-fileops-integrity`) when relevant | Keep iteration fast; avoid full-suite duplication unless local risk demands it |
 | Tier B (draft PR baseline CI) | CI + PR author | Every push while PR is draft | `ci-baseline` (`qa-code-quality` + `qa-fileops-integrity` + `qa-pytest-coverage` + `qa-fuzz`) | Provide baseline branch-protection signal (includes coverage by design); do not duplicate Tier C full local gate content |
-| Tier C (pre-merge full gate) | PR author | Before merge to `main` (or earlier only when explicitly requested) | `make qa-all-log` evidence (`qa-clang`, `qa-cppcheck`, `qa-scan`, `qa-valgrind`, `qa-pytest`, `qa-unsafe-apis`, `qa-gitleaks`, `qa-module-boundaries`, `qa-ai-config`, `qa-fuzz`) plus explicit `qa-fileops-integrity` evidence when mutation workflows changed | Consolidate full local quality signal at merge boundary; avoid repeating full gates during routine iteration |
+| Tier C (pre-merge full gate) | CI + PR author | Before merge to `main` (or earlier only when explicitly requested) | Green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent); optional local `make qa-all-log` evidence when maintainer-requested; plus explicit `qa-fileops-integrity` evidence when mutation workflows changed | Use CI as canonical full-gate signal; avoid duplicate local full-gate reruns during routine iteration |
 | Tier D (merge/release gate) | Maintainer + reviewer | Before merge and before release/tag cut | Branch-protection checks green; reviewer signoff; `qa-sanitize`; `qa-valgrind-full` for release-risk changes; `qa-valgrind-interactive` after major feature flows | Reserve deepest runtime checks for merge/release assurance to avoid slowing every draft iteration |
 
 ### branch-protection and PR State Criteria (Mandatory)

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -65,11 +65,10 @@ Ordering policy (for all editors, including AI editors):
 
 ### **BUG-11: Modal Severity Messages Render as Error-Red**
 *   **Description**: Centered modal messages can render with error-red styling even when the message severity is informational or warning-level, instead of using severity-specific visual treatment.
-*   **Findings**:
-    *   Directory compare completion summary dialogs (counts + tagged-match summary) can render in error-red despite being non-error informational results.
+*   **Findings**: Mmodal messages can render with error-red styling even when the message severity is informational or warning-level, instead of using severity-specific visual treatment.
 *   **Impact**: Blurs severity intent, increases operator confusion, and conflicts with documented message tiers and configurable color expectations.
 *   **Remediation**: Perform a full user-message surface audit (modal/footer/status paths), identify all message-producing callsites and severity-routing logic, and enforce a single severity-aware rendering contract. Ensure modal severity maps to `INFO_COLOR`, `WARN_COLOR`, and `ERR_COLOR` from `ytree.conf`, then add focused regression tests that prove correct severity-to-color routing (including config-driven overrides and safe defaults).
-*   **Related**: `docs/SPECIFICATION.md` section 6.2 modal severity tiers; `etc/ytree.conf` `[COLORS]` keys `INFO_COLOR`, `WARN_COLOR`, `ERR_COLOR`.
+*   **Related**: `docs/SPECIFICATION.md` section 6.2 modal severity tiers; `ROADMAP` Task 76 (full modal taxonomy/color audit); `etc/ytree.conf` `[COLORS]` keys `INFO_COLOR`, `WARN_COLOR`, `ERR_COLOR`.
 *   **Status**: Confirmed.
 
 ### **BUG-12: Copy/Move/PathCopy Rename Prompt Missing Explicit `AS:` Label**

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -209,17 +209,17 @@ For direct `pytest` CLI usage, test naming conventions, infrastructure details, 
 Use **[AUDIT.md](AUDIT.md)** as the single source of truth.
 
 - During implementation, run focused checks first (`make` + targeted tests for touched scope).
-- Run the full audit loop before merge to `main` (or earlier only when explicitly requested).
+- Before merge to `main`, require green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent). Local full audit loop is optional unless explicitly requested.
 - Use the canonical tool order from `AUDIT.md`: `clang-tidy`, `cppcheck`, `scan-build`, `valgrind`, then `pytest` for regression verification.
 
 ### Local QA Commands
 
 - Normal development build: `make`
-- Full local QA gate (pre-merge / on explicit request): `make qa-all` (includes `pytest`, unsafe C API guard, module-boundary guard, and fuzz smoke)
-- Full local QA gate with captured log (pre-merge / on explicit request): `make qa-all-log` (writes `qa-all.log` in repo root; override with `QA_LOG=/path/to/file`)
+- Full local QA gate (optional unless maintainer-requested): `make qa-all` (includes `pytest`, unsafe C API guard, module-boundary guard, and fuzz smoke)
+- Full local QA gate with captured log (optional unless maintainer-requested): `make qa-all-log` (writes `qa-all.log` in repo root; override with `QA_LOG=/path/to/file`)
 - Optional strict mode: `make QA_ON_BUILD=1` (runs `qa-all` after build)
 - GitHub baseline CI (`.github/workflows/ci.yml`) runs `make ci-baseline` on PRs to `main` and pushes to `main`.
-- GitHub PR full QA CI (`.github/workflows/full-qa.yml`) runs `make qa-all` on PRs to `main`.
+- GitHub PR full QA CI (`.github/workflows/full-qa.yml`) runs `make qa-all` on PRs to `main` and is the required full pre-merge gate.
 - GitHub PR sanitizer gate in `.github/workflows/full-qa.yml` runs only on manual dispatch or when PR label `qa-sanitize` is present.
 - GitHub nightly deep Valgrind CI (`.github/workflows/nightly-deep-valgrind.yml`) runs `make qa-valgrind-full` on schedule (and manual dispatch).
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -8,6 +8,8 @@ Ytree performs standard file operations (rename, move, copy, delete) through nor
 
 This is the same trust model you should use for any file manager: do not assume zero risk, verify behavior, keep backups, and, at first, try it out in a non-critical directory.
 
+For detailed safeguards, limits, and verification pointers, see [`TRUST.md`](TRUST.md).
+
 ### How is AI used in this project?
 
 AI is used as an implementation assistant, not as an autonomous authority.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,6 +154,19 @@ Ordering policy (for all editors, including AI editors):
 *   A focused regression test (or existing footer/help test extension) verifies archive footer/action parity.
 *   - [ ] **Status:** Not Started.
 
+### **Task 76: Modal Dialog Severity Taxonomy + Full Existing-Modal Color Audit**
+*   **Goal:** Classify every existing modal/dialog surface as `severity` (`info`/`warn`/`error`) or `neutral interaction`, then enforce color routing contracts for each class.
+*   **Rationale:** Current and future modal trust depends on deterministic visual semantics: severity-bearing messages must use severity colors, while interaction dialogs must remain neutral and consistent.
+*   **Scope Lock:** Modal/dialog color taxonomy, routing, and configuration surface only; no keybinding/flow-depth redesign.
+*   **Acceptance Criteria:**
+*   Define and document a modal taxonomy contract in `docs/SPECIFICATION.md` (severity vs neutral interaction classes).
+*   Audit all existing modal/dialog producers and assign each to one class with explicit rationale.
+*   Severity-class modals must route through `INFO_COLOR`, `WARN_COLOR`, or `ERR_COLOR` (via mapped runtime color pairs) with focused regression coverage.
+*   Neutral-class dialogs (for example selection/picker/help/history/volume interaction surfaces) must not use severity colors; they must use dedicated neutral palette keys.
+*   Any neutral dialog surface without a dedicated configurable color key in `ytree.conf` must receive one, with deterministic defaults and synchronized docs/help/manpage text.
+*   Add regression coverage that prevents severity/neutral cross-contamination (severity modal rendered neutral or neutral dialog rendered as warn/error).
+*   - [ ] **Status:** Not Started.
+
 ### **Task 7: Path Message Formatting Audit (`//` Artifact Prevention)**
 *   **Goal:** Audit user-facing message/path rendering and eliminate accidental double-slash artifacts in status/error/footer output.
 *   **Rationale:** Message correctness is a trust surface; inconsistent path rendering invites avoidable bug reports and operator confusion.

--- a/docs/ai/CODE_QUALITY.md
+++ b/docs/ai/CODE_QUALITY.md
@@ -31,7 +31,7 @@ Then report/implement only approved P0-P1 issues.
 Keep these repo guardrails active in every change:
 
 1. Conventional commit-msg hook policy enforcement.
-2. Mandatory focused verification in development; full `make qa-all` at pre-merge gate.
+2. Mandatory focused verification in development; green PR full-QA CI (`make qa-all` equivalent) at pre-merge gate.
 3. QA remediation gate: fix root cause, do not patch around failures.
 4. Module ownership gate: keep business logic out of controllers when separable.
 5. UX economy gate for interactive paths.

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -101,11 +101,11 @@ Validation:
 - Before first push, run a quick local gate (build plus targeted smoke/tests).
 - Run targeted tests as needed.
 - Do not run `make qa-all` during routine iteration unless explicitly requested.
-- Before merge to `main`, or when maintainer explicitly requests it, run:
-  - `source .venv/bin/activate`
-  - `make qa-all`
+- Before merge to `main`, require green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent).
+- Run local `make qa-all` only when maintainer explicitly requests it or when extra local confidence is needed.
 
 Commit and PR flow:
+- See `docs/ai/WORKFLOW.md` section **3.1.8** for the practical finish flow (AI instructions + maintainer GitHub/local steps).
 - Use Conventional Commits.
 - Commit subject and PR title/summary must describe the concrete behavior/problem; do not rely on volatile tracker IDs alone.
 - For follow-up corrections to the same intent, prefer:

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -277,7 +277,7 @@ make qa-fuzz
     *   `watchdog_stall_retry_terminal`: stale heartbeat/timeout must emit `stall_detected`, then bounded retry/reassign, then terminal escalation on retry exhaustion.
     *   `maintainer_pause_gate=true_blocker_decision|commit_message_approval`: pause gate allows maintainer interruption only for those two reasons.
     *   Runtime event naming should prefer explicit completion semantics (`worker_command_started`, `worker_command_completed`, `worker_command_failed`, `unit_completed`, `unit_failed`) so maintainers can distinguish done-vs-next without prompt interpretation.
-5.  Before merge to `main`, architect MUST ensure fresh full-gate evidence (`make qa-all`) for accepted branch state.
+5.  Before merge to `main`, architect MUST ensure green PR full-QA CI evidence (`make qa-all` equivalent) for accepted branch state.
 6.  If accepted:
     *   commit only code/doc files (no relay/runtime artifacts),
     *   use maintainer-approved commit message describing durable behavior (no task numbering),
@@ -291,12 +291,39 @@ make qa-fuzz
 
 #### 3.1.7 Completion Gate, Merge, and Manual Fallback
 
-1.  When preparing merge to `main`, require green full project gate (`make qa-all`).
+1.  When preparing merge to `main`, require green PR full-QA CI gate (`make qa-all` equivalent).
 2.  Integrate branch to `main` using fast-forward only.
 3.  For any bug or task, mark final status (Fixed/Completed) in the commit that is fast-forwarded to main; before that, status must stay non-final (Confirmed/In Progress).
 4.  Delete temporary feature branch locally and on remote after merge.
 5.  Verify workflow artifacts are not committed.
 6.  Manual mode is default: one-unit-at-a-time architect -> developer -> auditor handoff.
+
+#### 3.1.8 Practical Prompt-Template Finish Flow (Consecutive Role Order)
+
+Use this when wrapping up a PROMPT_TEMPLATE-driven mission and returning the repo to a stable post-merge state.
+
+1.  **Maintainer (local):** Run manual verification of the latest change first. Typical flow:
+    *   `clear; make clean; sudo make uninstall; make; sudo make install`
+    *   `ytree ~`
+    *   Manually exercise the changed behavior.
+2.  **Maintainer -> Architect/AI:** If manual checks find issues, report failures; architect dispatches a new developer/auditor unit and repeats the loop until manual checks are green.
+3.  **Architect/AI:** Clean stale task artifacts from the finished mission (prompt/report/temp workflow files).
+4.  **Architect/AI:** Run quick local checks only (build + targeted smoke/tests for touched scope).
+5.  **Architect/AI:** Stage intended changes only (exclude unrelated local edits and workflow artifacts).
+6.  **Architect/AI:** Suggest a Conventional Commit subject and request maintainer commit-message approval.
+7.  **Architect/AI:** Commit, push branch, and open/update a draft PR.
+8.  **Maintainer (GitHub):** Review draft PR scope and evidence.
+9.  **Maintainer (GitHub):** Wait for PR CI full gate; if any checks are red, report failures to architect/AI.
+10. **Architect/AI:** Fix CI failures root-cause-first, push updates, and repeat until required PR full-QA CI (`make qa-all` equivalent) is green.
+11. **Maintainer (GitHub):** Merge PR to `main` after checks are green and review is satisfied.
+12. **Maintainer (GitHub):** Delete remote branch:
+    *   `git push origin --delete <branch>`
+13. **Maintainer (local):** Sync local `main` to remote:
+    *   `git checkout main`
+    *   `git fetch origin`
+    *   `git pull --ff-only`
+14. **Maintainer (local):** Delete local feature branch:
+    *   `git branch -d <branch>` (use `-D` only when needed)
 
 ## 4. Debugging Procedures
 
@@ -320,7 +347,7 @@ Follow **[../AUDIT.md](../AUDIT.md)** as the canonical process.
 Cadence:
 - Treat auditing as a continuous process during implementation, not an end-only step.
 - Use focused build/test checks during each feature-sized change or PR iteration.
-- Run full `make qa-all` only before merge to `main` or when the maintainer explicitly requests it.
+- Use PR full-QA CI (`make qa-all` equivalent) as the required pre-merge full gate; run local `make qa-all` only when the maintainer explicitly requests it or when extra local confidence is needed.
 - Run the merge gate before merging.
 - Do not run the full loop after every single prompt-level edit unless risk justifies it.
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -12,7 +12,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==47.0.0
+cryptography==48.0.0
     # via google-auth
 google-ai-generativelanguage==0.6.15
     # via google-generativeai
@@ -21,20 +21,20 @@ google-api-core[grpc]==2.30.3
     #   google-ai-generativelanguage
     #   google-api-python-client
     #   google-generativeai
-google-api-python-client==2.194.0
+google-api-python-client==2.196.0
     # via google-generativeai
-google-auth==2.49.2
+google-auth==2.53.0
     # via
     #   google-ai-generativelanguage
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
     #   google-generativeai
-google-auth-httplib2==0.3.1
+google-auth-httplib2==0.4.0
     # via google-api-python-client
 google-generativeai==0.8.6
-    # via -r requirements.in
-googleapis-common-protos==1.74.0
+    # via -r scripts/requirements.in
+googleapis-common-protos==1.75.0
     # via
     #   google-api-core
     #   grpcio-status
@@ -48,7 +48,7 @@ httplib2==0.31.2
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.13
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -57,12 +57,12 @@ nexus-rpc==1.4.0
 packaging==26.2
     # via pytest
 pexpect==4.9.0
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 pluggy==1.6.0
     # via pytest
 prompt-toolkit==3.0.52
-    # via -r requirements.in
-proto-plus==1.27.2
+    # via -r scripts/requirements.in
+proto-plus==1.28.0
     # via
     #   google-ai-generativelanguage
     #   google-api-core
@@ -83,22 +83,22 @@ pyasn1-modules==0.4.2
     # via google-auth
 pycparser==3.0
     # via cffi
-pydantic==2.13.3
+pydantic==2.13.4
     # via google-generativeai
-pydantic-core==2.46.3
+pydantic-core==2.46.4
     # via pydantic
 pygments==2.20.0
     # via pytest
 pyparsing==3.3.2
     # via httplib2
 pyte==0.8.2
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 pytest==9.0.3
-    # via -r requirements.in
-requests==2.33.1
+    # via -r scripts/requirements.in
+requests==2.34.2
     # via google-api-core
-temporalio==1.27.0
-    # via -r requirements.in
+temporalio==1.27.2
+    # via -r scripts/requirements.in
 tqdm==4.67.3
     # via google-generativeai
 types-protobuf==6.32.1.20260221
@@ -118,7 +118,7 @@ uritemplate==4.2.0
     # via google-api-python-client
 urllib3==2.7.0
     # via requests
-wcwidth==0.6.0
+wcwidth==0.7.0
     # via
     #   prompt-toolkit
     #   pyte

--- a/src/ui/error.c
+++ b/src/ui/error.c
@@ -9,8 +9,15 @@
 
 #include <stdarg.h>
 
-static void MapErrorWindow(ViewContext *ctx, char *header);
-static void MapNoticeWindow(ViewContext *ctx, char *header);
+typedef enum ModalSeverity {
+  MODAL_SEVERITY_INFO = 0,
+  MODAL_SEVERITY_WARNING,
+  MODAL_SEVERITY_ERROR
+} ModalSeverity;
+
+static short ModalSeverityColorPair(ModalSeverity severity);
+static void MapModalWindow(ViewContext *ctx, char *header, char *prompt,
+                           ModalSeverity severity);
 static void UnmapErrorWindow(ViewContext *ctx);
 static void PrintErrorLine(ViewContext *ctx, int y, char *str);
 static void DisplayMessage(ViewContext *ctx, char *msg);
@@ -87,7 +94,8 @@ int UI_Message(ViewContext *ctx, const char *fmt, ...) {
     return 0;
   }
 
-  MapErrorWindow(ctx, "E R R O R");
+  MapModalWindow(ctx, "I N F O", "             PRESS ENTER              ",
+                 MODAL_SEVERITY_INFO);
   return PrintMessage(ctx, buffer);
 }
 
@@ -104,7 +112,8 @@ int UI_Notice(ViewContext *ctx, const char *fmt, ...) {
     return 0;
   }
 
-  MapNoticeWindow(ctx, "N O T I C E");
+  MapModalWindow(ctx, "N O T I C E", "             PLEASE WAIT              ",
+                 MODAL_SEVERITY_INFO);
   DisplayMessage(ctx, buffer);
   RefreshWindow(ctx->ctx_error_window);
   doupdate();
@@ -124,7 +133,8 @@ int UI_Warning(ViewContext *ctx, const char *fmt, ...) {
     return 0;
   }
 
-  MapErrorWindow(ctx, "W A R N I N G");
+  MapModalWindow(ctx, "W A R N I N G", "             PRESS ENTER              ",
+                 MODAL_SEVERITY_WARNING);
   return PrintMessage(ctx, buffer);
 }
 
@@ -139,7 +149,8 @@ void AboutBox(ViewContext *ctx) {
 #endif
                  VERSION, VERSIONDATE);
 
-  MapErrorWindow(ctx, "ABOUT");
+  MapModalWindow(ctx, "ABOUT", "             PRESS ENTER              ",
+                 MODAL_SEVERITY_INFO);
   (void)PrintMessage(ctx, version);
 }
 
@@ -158,37 +169,32 @@ int UI_Error(ViewContext *ctx, const char *module, int line, const char *fmt,
     return -1;
   }
 
-  MapErrorWindow(ctx, "INTERNAL ERROR");
+  MapModalWindow(ctx, "INTERNAL ERROR", "             PRESS ENTER              ",
+                 MODAL_SEVERITY_ERROR);
   (void)snprintf(final_buffer, sizeof(final_buffer),
                  "%s*In Module \"%s\"*Line %d", msg_buffer, module, line);
   return PrintMessage(ctx, final_buffer);
 }
 
-static void MapErrorWindow(ViewContext *ctx, char *header) {
-  werase(ctx->ctx_error_window);
-  wattron(ctx->ctx_error_window, COLOR_PAIR(CPAIR_WINERR) | A_ALTCHARSET);
-
-  /* Box frame with ACS */
-  wborder(ctx->ctx_error_window, 0, 0, 0, 0, 0, 0, 0, 0);
-
-  mvwhline(ctx->ctx_error_window, ERROR_WINDOW_HEIGHT - 3, 1, ACS_HLINE,
-           ERROR_WINDOW_WIDTH - 2);
-  mvwaddch(ctx->ctx_error_window, ERROR_WINDOW_HEIGHT - 3, 0, ACS_LTEE);
-  mvwaddch(ctx->ctx_error_window, ERROR_WINDOW_HEIGHT - 3,
-           ERROR_WINDOW_WIDTH - 1, ACS_RTEE);
-  wattroff(ctx->ctx_error_window, A_ALTCHARSET);
-  wattrset(ctx->ctx_error_window, A_NORMAL);
-
-  wattrset(ctx->ctx_error_window, A_REVERSE | A_BLINK);
-  MvWAddStr(ctx->ctx_error_window, ERROR_WINDOW_HEIGHT - 2, 1,
-            "             PRESS ENTER              ");
-  wattrset(ctx->ctx_error_window, A_NORMAL);
-  PrintErrorLine(ctx, 1, header);
+static short ModalSeverityColorPair(ModalSeverity severity) {
+  switch (severity) {
+    case MODAL_SEVERITY_INFO:
+      return CPAIR_INFO;
+    case MODAL_SEVERITY_WARNING:
+      return CPAIR_WARN;
+    case MODAL_SEVERITY_ERROR:
+    default:
+      return CPAIR_ERR;
+  }
 }
 
-static void MapNoticeWindow(ViewContext *ctx, char *header) {
+static void MapModalWindow(ViewContext *ctx, char *header, char *prompt,
+                           ModalSeverity severity) {
+  short color_pair = ModalSeverityColorPair(severity);
+
+  WbkgdSet(ctx, ctx->ctx_error_window, COLOR_PAIR(color_pair));
   werase(ctx->ctx_error_window);
-  wattron(ctx->ctx_error_window, COLOR_PAIR(CPAIR_WINERR) | A_ALTCHARSET);
+  wattron(ctx->ctx_error_window, COLOR_PAIR(color_pair) | A_ALTCHARSET);
 
   /* Box frame with ACS */
   wborder(ctx->ctx_error_window, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -202,8 +208,7 @@ static void MapNoticeWindow(ViewContext *ctx, char *header) {
   wattrset(ctx->ctx_error_window, A_NORMAL);
 
   wattrset(ctx->ctx_error_window, A_REVERSE | A_BLINK);
-  MvWAddStr(ctx->ctx_error_window, ERROR_WINDOW_HEIGHT - 2, 1,
-            "             PLEASE WAIT              ");
+  MvWAddStr(ctx->ctx_error_window, ERROR_WINDOW_HEIGHT - 2, 1, prompt);
   wattrset(ctx->ctx_error_window, A_NORMAL);
   PrintErrorLine(ctx, 1, header);
 }

--- a/tests/test_modal_severity_contract.py
+++ b/tests/test_modal_severity_contract.py
@@ -1,0 +1,71 @@
+from helpers_source import extract_function_block as _extract_function_block
+from helpers_source import read_repo_source as _read_source
+
+
+def test_modal_message_severity_routes_info_warn_error_pairs():
+    error_source = _read_source("src/ui/error.c")
+
+    assert "static short ModalSeverityColorPair(" in error_source, (
+        "Modal rendering must route severity through one centralized color-tier mapper."
+    )
+    assert "CPAIR_INFO" in error_source, "Info-tier modal color must be wired."
+    assert "CPAIR_WARN" in error_source, "Warning-tier modal color must be wired."
+    assert "CPAIR_ERR" in error_source, "Error-tier modal color must be wired."
+
+    ui_message_block = _extract_function_block(error_source, "int UI_Message(")
+    ui_warning_block = _extract_function_block(error_source, "int UI_Warning(")
+    ui_error_block = _extract_function_block(error_source, "int UI_Error(")
+
+    assert "MODAL_SEVERITY_INFO" in ui_message_block, (
+        "UI_Message must route through informational modal severity."
+    )
+    assert "MODAL_SEVERITY_WARNING" in ui_warning_block, (
+        "UI_Warning must route through warning modal severity."
+    )
+    assert "MODAL_SEVERITY_ERROR" in ui_error_block, (
+        "UI_Error must route through error modal severity."
+    )
+
+
+def test_directory_compare_completion_uses_informational_modal_path():
+    compare_source = _read_source("src/ui/dir_compare.c")
+
+    flat_compare_block = _extract_function_block(
+        compare_source, "void DirCompare_RunInternalDirectory("
+    )
+    logged_tree_block = _extract_function_block(
+        compare_source, "void DirCompare_RunInternalLoggedTree("
+    )
+
+    assert "Directory compare complete." in flat_compare_block
+    assert "UI_Message(" in flat_compare_block, (
+        "Directory compare completion summary should use the informational modal path."
+    )
+
+    assert "Logged-tree compare complete." in logged_tree_block
+    assert "UI_Message(" in logged_tree_block, (
+        "Logged-tree completion summary should use the informational modal path."
+    )
+
+
+def test_modal_window_background_rebinds_per_severity_tier():
+    error_source = _read_source("src/ui/error.c")
+    map_modal_block = _extract_function_block(
+        error_source,
+        "static void MapModalWindow(ViewContext *ctx, char *header, char *prompt,\n"
+        "                           ModalSeverity severity) {",
+    )
+
+    assert "WbkgdSet(ctx, ctx->ctx_error_window, COLOR_PAIR(color_pair));" in map_modal_block, (
+        "Modal rendering must rebind the error window background to the mapped "
+        "severity tier before drawing."
+    )
+
+    background_rebind = map_modal_block.find(
+        "WbkgdSet(ctx, ctx->ctx_error_window, COLOR_PAIR(color_pair));"
+    )
+    erase_call = map_modal_block.find("werase(ctx->ctx_error_window);")
+    assert background_rebind >= 0 and erase_call > background_rebind, (
+        "Modal background must be rebound before clearing so refreshed content "
+        "uses the selected severity tier."
+    )


### PR DESCRIPTION
## Summary
- fix BUG-11 modal dialog severity coloring so info/warn/error render through severity-tier mappings
- add regression coverage for modal severity routing and background rebinding
- publish maintainer carry-over local edits (`docs/BUGS.md`, `docs/FAQ.md`, `scripts/requirements.txt`)
- document workflow policy updates for PR-CI full gate + prompt-template finish flow

## Commits
1. `fix(ui): apply severity-tier colors for modal dialogs`
2. `chore(repo): publish maintainer carry-over edits`
3. `docs(workflow): update QA-gate policy and prompt-template finish flow`

## Validation
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_modal_severity_contract.py -q`
- `source .venv/bin/activate && pytest tests/test_compare_actions.py -k "compare_prompt_labels_and_result_text or compare_flow_cancel_is_safe_and_footer_remains_clean" -q`

## Notes
- Full gate is expected from PR CI (`full-qa.yml`).
