### PR TITLE
chore(qa): add deep QA runner script and record sanitize repro note

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -44,6 +44,9 @@ Ordering policy (for all editors, including AI editors):
 
 ### **BUG-8: Copy/Move Cancel (`Esc`) Can Leave Footer Blank**
 *   **Description**: In `Copy`/`Move` flows, canceling with `Esc` can leave footer/help lines blank instead of restoring the normal context footer.
+*   **Findings**:
+    *   Deterministic repro under sanitizer gate (`make qa-sanitize`) on 2026-05-16: `tests/test_display_layout.py::test_dir_copy_to_missing_destination_prompts_create_and_no_restores_footer` fails with `AssertionError: Header/path row disappeared after canceling create prompt`.
+    *   The failing path is directory copy to a missing destination where the create-directory prompt is canceled with `No`.
 *   **Impact**: Hides command discoverability immediately after a canceled mutation flow and makes the UI look partially broken.
 *   **Remediation**: On all `Copy`/`Move` cancel/exit paths (`Esc` and equivalent cancel keys), restore footer/help ownership deterministically to the active view context and force a full footer redraw before accepting the next command.
 *   **Related**: `BUG-25` (footer restore consistency during input flows), `ROADMAP` Task 36 (footer/F1 context parity).
@@ -65,7 +68,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **BUG-11: Modal Severity Messages Render as Error-Red**
 *   **Description**: Centered modal messages can render with error-red styling even when the message severity is informational or warning-level, instead of using severity-specific visual treatment.
-*   **Findings**: Mmodal messages can render with error-red styling even when the message severity is informational or warning-level, instead of using severity-specific visual treatment.
+*   **Findings**: Modal messages can render with error-red styling even when the message severity is informational or warning-level, instead of using severity-specific visual treatment.
 *   **Impact**: Blurs severity intent, increases operator confusion, and conflicts with documented message tiers and configurable color expectations.
 *   **Remediation**: Perform a full user-message surface audit (modal/footer/status paths), identify all message-producing callsites and severity-routing logic, and enforce a single severity-aware rendering contract. Ensure modal severity maps to `INFO_COLOR`, `WARN_COLOR`, and `ERR_COLOR` from `ytree.conf`, then add focused regression tests that prove correct severity-to-color routing (including config-driven overrides and safe defaults).
 *   **Related**: `docs/SPECIFICATION.md` section 6.2 modal severity tiers; `ROADMAP` Task 76 (full modal taxonomy/color audit); `etc/ytree.conf` `[COLORS]` keys `INFO_COLOR`, `WARN_COLOR`, `ERR_COLOR`.

--- a/scripts/qa-deep.sh
+++ b/scripts/qa-deep.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+ROOT="${1:-$HOME/ytree}"
+LOG_DIR="${2:-$ROOT/logs}"
+STAMP="$(date +%F_%H-%M-%S)"
+LOG_FILE="$LOG_DIR/overnight_qa_timed_$STAMP.txt"
+
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+fmt_duration() {
+  local s="$1"
+  printf '%02dh:%02dm:%02ds' $((s/3600)) $(((s%3600)/60)) $((s%60))
+}
+
+step_names=()
+step_secs=()
+step_rcs=()
+step_warns=()
+step_errs=()
+
+run_step() {
+  local name="$1"
+  shift
+  local tmp
+  tmp="$(mktemp)"
+  local t0 t1 dt rc warns errs
+
+  echo
+  echo "============================================================"
+  echo "STEP: $name"
+  echo "START: $(date)"
+  echo "============================================================"
+
+  t0=$(date +%s)
+
+  (
+    cd "$ROOT" || exit 2
+    source .venv/bin/activate
+    make clean
+    "$@"
+  ) 2>&1 | tee "$tmp"
+  rc=${PIPESTATUS[0]}
+
+  t1=$(date +%s)
+  dt=$((t1 - t0))
+
+  # Heuristic counts (for triage; manual review still needed)
+  warns=$(grep -Eic '\bwarning(s)?\b' "$tmp" || true)
+  errs=$(grep -Eic '\berror(s)?\b|AddressSanitizer|UndefinedBehaviorSanitizer|runtime error|ERROR SUMMARY' "$tmp" || true)
+
+  echo "END: $(date)"
+  echo "EXIT CODE: $rc"
+  echo "DURATION: $(fmt_duration "$dt")"
+  echo "WARNINGS (heuristic): $warns"
+  echo "ERRORS   (heuristic): $errs"
+
+  step_names+=("$name")
+  step_secs+=("$dt")
+  step_rcs+=("$rc")
+  step_warns+=("$warns")
+  step_errs+=("$errs")
+
+  rm -f "$tmp"
+  return 0
+}
+
+overall_start=$(date +%s)
+echo "Overnight timed QA started: $(date)"
+echo "Repo: $ROOT"
+echo "Log:  $LOG_FILE"
+
+run_step "qa-sanitize"        make qa-sanitize
+run_step "qa-valgrind-full"   make qa-valgrind-full
+run_step "qa-pytest-coverage" make qa-pytest-coverage
+
+overall_end=$(date +%s)
+overall_dt=$((overall_end - overall_start))
+
+echo
+echo "==================== FINAL SUMMARY ===================="
+fail=0
+total_warns=0
+total_errs=0
+
+for i in "${!step_names[@]}"; do
+  n="${step_names[$i]}"
+  s="${step_secs[$i]}"
+  r="${step_rcs[$i]}"
+  w="${step_warns[$i]}"
+  e="${step_errs[$i]}"
+  total_warns=$((total_warns + w))
+  total_errs=$((total_errs + e))
+  [[ "$r" -ne 0 ]] && fail=1
+
+  printf '%-20s rc=%-3s time=%-10s warns=%-5s errs=%-5s\n' \
+    "$n" "$r" "$(fmt_duration "$s")" "$w" "$e"
+done
+
+echo "-------------------------------------------------------"
+echo "TOTAL TIME: $(fmt_duration "$overall_dt")"
+echo "TOTAL WARNINGS (heuristic): $total_warns"
+echo "TOTAL ERRORS   (heuristic): $total_errs"
+
+if [[ $fail -eq 0 ]]; then
+  echo "RESULT: PASS (all exit codes 0)"
+  exit 0
+else
+  echo "RESULT: FAIL (one or more steps returned non-zero)"
+  exit 1
+fi


### PR DESCRIPTION
Adds a deep QA helper script (`scripts/qa-deep.sh`) that runs three deeper checks in sequence (`qa-sanitize`, `qa-valgrind-full`, `qa-pytest-coverage`) and logs output/timing for later review.  
Also updates `docs/BUGS.md` (BUG-8 findings) to record a reproducible sanitizer-gate failure for the “copy to missing destination, cancel create prompt” footer/header redraw case.