### PR TITLE
fix(split): enforce panel ownership guardrails

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,6 +137,17 @@ The Split-Screen architecture treats each panel as an independent instance of a 
 *   **State Persistence (Tab-Switch):** The `Tab` key is the bridge. Switching panels restores the exact state held when that panel last had focus.
 *   **Panel vs. Volume Rule:** Sharing a `Volume` only shares logged tree topology and file payload cache. It never shares panel-local tags, file-window anchors, cursor identity, or focus/mode state.
 
+#### 4.2.1 Split-Panel Ownership Map (Task 1 Guardrail)
+Split-transfer/switch code must classify each field before copying or restoring:
+
+| State Class | Owned By | Examples | Forbidden Cross-Panel Behavior |
+|---|---|---|---|
+| **Panel-Local** | `YtreePanel` | `cursor_pos`, `disp_begin_pos`, `start_file`, `file_cursor_pos`, `file_dir_entry`, `saved_focus`, `saved_big_file_view`, `file_selection_name`, `file_selection_dir_path`, `tagged_paths` | Active-only commands must not mutate the inactive panel's values. |
+| **Shared-Topology** | `Volume` (possibly referenced by both panels) | `vol_stats.tree`, `dir_entry_list`, directory expansion/logging topology | Panel code may mirror topology visibility updates, but must re-anchor each panel by identity/path and must not infer panel-local selection by shared index. |
+| **Global-Only** | `ViewContext` session scope | `is_split_screen`, `focused_window`, layout windows, session options (for example current global dotfile setting) | Global toggles must not be treated as panel-local transfer state; split hand-off code must not use them to overwrite inactive panel-local snapshots. |
+
+Boundary implementations in `src/ui/dir_ops.c` and `src/ui/ctrl_file_ops.c` reference this map in invariant comments and debug assertions.
+
 ### 4.3 Inter-Panel Operations (The Directional Rule)
 *   **Targeting:** Copy and Move operations occur directionally: **Source (Active Panel) to Destination (Inactive Panel)**.
 *   **Read-Only Bridge:** The active panel reads the path of the inactive panel to set a default destination without altering the inactive panel's state.

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -23,6 +23,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Enforce source-vs-destination state isolation in split mode so destination-side `mkdir`/`cd` and tree navigation cannot mutate source selection/tag state. Preserve source tagged/selection state by stable file identity across destination context changes, and apply deterministic fallback only when a selected source entry truly no longer exists.
 *   **Related**: `ROADMAP` Task 33 (split selection semantics/regression coverage).
 *   **Status**: Confirmed.
+*   **Task 1 Disposition (Split Ownership Map + Guardrail Gate)**: **Fixed path under guardrail.** Split transfer/switch boundaries now carry ownership invariants plus debug assertions; regression coverage is enforced in `tests/test_panel_isolation.py` (`split_from_file_keeps_inactive_file_selection_independent`, `split_tab_back_preserves_selected_file_index`, and related active-only mutation tests).
 
 
 ### **BUG-3: F8 Dotfiles Toggle Leaks Across Panels**
@@ -40,6 +41,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Move dotfile-visibility ownership to panel-local split state and keep shared-tree updates limited to topology-only mirroring. Add split regression coverage for active-side dotfile toggles with inactive-panel state snapshots.
 *   **Tests/Gates**: Must have deterministic panel-isolation regression coverage under `tests/test_panel_isolation.py`; gate via `pytest` split-isolation subset and PR full-QA CI.
 *   **Status**: Confirmed.
+*   **Task 1 Disposition (Split Ownership Map + Guardrail Gate)**: **Blocker documented.** Ownership map classifies dotfile visibility as non-transfer state for split boundaries, but `hide_dot_files` is still session-global (`ViewContext`) and requires a dedicated ownership migration before BUG-3 can be closed.
 
 ### **BUG-4: F8 Dotfiles Toggle Causes Inactive Selection Jitter**
 *   **Description**: In split mode, toggling dotfiles in one panel can make the inactive panel’s selected directory move away and then return (transient cursor/selection drift).
@@ -57,6 +59,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Re-anchor inactive selection strictly by stable directory identity/path during mirror updates; never re-resolve by transient index unless deterministic fallback is required.
 *   **Tests/Gates**: Add deterministic regression asserting no inactive selection movement on non-invalidating dotfile toggles.
 *   **Status**: Confirmed.
+*   **Task 1 Disposition (Split Ownership Map + Guardrail Gate)**: **Blocker documented.** Task 1 adds boundary invariants and debug cross-panel assertions for split transfer/switch paths, but BUG-4 remains coupled to the unresolved dotfile ownership model noted in BUG-3.
 
 ### **BUG-5: F8 + SMALLWINDOWSKIP=0 Tab Can Force Inactive Panel into Wrong Focus**
 *   **Description**: With `SMALLWINDOWSKIP=0`, when cursor is in the small file window on one panel, `Tab` to the other panel can show that inactive panel as file-focused/zoomed unexpectedly; tabbing back restores prior tree/small state.
@@ -74,6 +77,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Harden switch-time state transfer so focus/view state is restored from panel-owned snapshots only; forbid cross-panel focus inheritance during `Tab` unless explicitly commanded by the active panel.
 *   **Tests/Gates**: Add/maintain deterministic regression for `SMALLWINDOWSKIP=0` split/tab focus retention in `tests/test_panel_isolation.py`.
 *   **Status**: Confirmed.
+*   **Task 1 Disposition (Split Ownership Map + Guardrail Gate)**: **Fixed path under guardrail.** Split `Tab` switch and split-toggle boundaries now include explicit ownership invariants and debug assertions that forbid inactive-panel focus/file-anchor mutation from active-side mode transitions.
 
 ### **BUG-6: F7 Preview Over-Restricts Command Availability**
 *   **Description**: `F7` mode is currently incomplete for inspect-and-act workflows. Too many common file actions are disabled, so users must leave preview to continue work.

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -653,7 +653,7 @@ BOOL handle_file_window_split_switch_action(
     DebugLogFileSplitState("FileAction:switch:before", ctx);
 #ifndef NDEBUG
     {
-      YtreePanel *target_panel =
+      const YtreePanel *target_panel =
           (ctx->active == ctx->left) ? ctx->right : ctx->left;
       FilePanelIsolationSnapshot target_panel_snapshot;
 

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -9,6 +9,8 @@
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
 #include "ytree_ui.h"
+#include <assert.h>
+#include <string.h>
 #include <utime.h>
 
 static void ResetPreviewAfterNavigation(
@@ -20,6 +22,56 @@ static void ResetPreviewAfterNavigation(
   if (update_preview)
     update_preview(ctx, dir_entry);
 }
+
+#ifndef NDEBUG
+typedef struct {
+  int cursor_pos;
+  int disp_begin_pos;
+  int start_file;
+  int file_cursor_pos;
+  const DirEntry *file_dir_entry;
+  ViewFocus saved_focus;
+  BOOL saved_big_file_view;
+  char file_selection_name[PATH_LENGTH + 1];
+  char file_selection_dir_path[PATH_LENGTH + 1];
+} FilePanelIsolationSnapshot;
+
+static void CaptureFilePanelIsolationSnapshot(
+    const YtreePanel *panel, FilePanelIsolationSnapshot *snapshot) {
+  if (!panel || !snapshot)
+    return;
+
+  snapshot->cursor_pos = panel->cursor_pos;
+  snapshot->disp_begin_pos = panel->disp_begin_pos;
+  snapshot->start_file = panel->start_file;
+  snapshot->file_cursor_pos = panel->file_cursor_pos;
+  snapshot->file_dir_entry = panel->file_dir_entry;
+  snapshot->saved_focus = panel->saved_focus;
+  snapshot->saved_big_file_view = panel->saved_big_file_view;
+  (void)snprintf(snapshot->file_selection_name,
+                 sizeof(snapshot->file_selection_name), "%s",
+                 panel->file_selection_name);
+  (void)snprintf(snapshot->file_selection_dir_path,
+                 sizeof(snapshot->file_selection_dir_path), "%s",
+                 panel->file_selection_dir_path);
+}
+
+static void AssertFilePanelIsolationSnapshotUnchanged(
+    const YtreePanel *panel, const FilePanelIsolationSnapshot *snapshot) {
+  assert(panel != NULL);
+  assert(snapshot != NULL);
+  assert(panel->cursor_pos == snapshot->cursor_pos);
+  assert(panel->disp_begin_pos == snapshot->disp_begin_pos);
+  assert(panel->start_file == snapshot->start_file);
+  assert(panel->file_cursor_pos == snapshot->file_cursor_pos);
+  assert(panel->file_dir_entry == snapshot->file_dir_entry);
+  assert(panel->saved_focus == snapshot->saved_focus);
+  assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
+  assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
+  assert(strcmp(panel->file_selection_dir_path,
+                snapshot->file_selection_dir_path) == 0);
+}
+#endif
 
 /* =========================================================================
  * Shared UI Helpers for Post-Action Refresh, Sync, and Render
@@ -529,6 +581,12 @@ BOOL handle_file_window_split_switch_action(
     CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
 
     if (ctx->is_split_screen && ctx->active == ctx->right) {
+      /*
+       * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
+       * Shared-topology tree linkage may move with the active panel when
+       * unsplitting, but file identity anchors remain panel-local and must be
+       * transferred by explicit name/path snapshots, never by row index.
+       */
       ctx->left->vol = ctx->right->vol;
       ctx->left->cursor_pos = ctx->right->cursor_pos;
       ctx->left->disp_begin_pos = ctx->right->disp_begin_pos;
@@ -551,6 +609,15 @@ BOOL handle_file_window_split_switch_action(
                        sizeof(ctx->left->file_selection_dir_path), "%s",
                        active_selected_dir);
       }
+#ifndef NDEBUG
+      if (active_selected_file) {
+        assert(strcmp(ctx->left->file_selection_name, active_selected_file->name) ==
+               0);
+      }
+      if (active_selected_dir[0] != '\0') {
+        assert(strcmp(ctx->left->file_selection_dir_path, active_selected_dir) == 0);
+      }
+#endif
       PanelTags_Copy(ctx->left, ctx->right);
       ctx->left->saved_focus = ctx->right->saved_focus;
       FreeFileEntryList(ctx->left);
@@ -584,6 +651,38 @@ BOOL handle_file_window_split_switch_action(
     if (!ctx->is_split_screen)
       return TRUE;
     DebugLogFileSplitState("FileAction:switch:before", ctx);
+#ifndef NDEBUG
+    {
+      YtreePanel *target_panel =
+          (ctx->active == ctx->left) ? ctx->right : ctx->left;
+      FilePanelIsolationSnapshot target_panel_snapshot;
+
+      /*
+       * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
+       * Tab from file view may snapshot the active panel before hand-off, but
+       * must not mutate the destination panel before it becomes active.
+       */
+      CaptureFilePanelIsolationSnapshot(target_panel, &target_panel_snapshot);
+
+      owner_panel->file_dir_entry = dir_entry;
+      owner_panel->start_file = dir_entry->start_file;
+      owner_panel->file_cursor_pos = dir_entry->cursor_pos;
+      CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
+      ctx->active->saved_focus = FOCUS_FILE;
+      *switched_panel_ptr = TRUE;
+      SwitchToSmallFileWindow(ctx);
+
+      if (ctx->active == ctx->left) {
+        ctx->active = ctx->right;
+      } else {
+        ctx->active = ctx->left;
+      }
+      ctx->focused_window = ctx->active->saved_focus;
+      *loop_action_ptr = ACTION_ESCAPE;
+      AssertFilePanelIsolationSnapshotUnchanged(target_panel,
+                                                &target_panel_snapshot);
+    }
+#else
     owner_panel->file_dir_entry = dir_entry;
     owner_panel->start_file = dir_entry->start_file;
     owner_panel->file_cursor_pos = dir_entry->cursor_pos;
@@ -599,6 +698,7 @@ BOOL handle_file_window_split_switch_action(
     }
     ctx->focused_window = ctx->active->saved_focus;
     *loop_action_ptr = ACTION_ESCAPE;
+#endif
     DebugLogFileSplitState("FileAction:switch:after", ctx);
     return TRUE;
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1479,7 +1479,7 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
     DebugLogSplitState("DirPanelAction:switch:before", ctx);
 #ifndef NDEBUG
     {
-      YtreePanel *previous_active = ctx->active;
+      const YtreePanel *previous_active = ctx->active;
       PanelIsolationSnapshot previous_active_snapshot;
 
       /*

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -10,6 +10,7 @@
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
 #include "ytree_ui.h"
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -29,6 +30,70 @@ static void CaptureInactiveFallback(ViewContext *ctx, YtreePanel *p,
                                     YtreePanel **inactive_out,
                                     DirEntry **inactive_fallback_out);
 static void ReanchorPanelToDir(YtreePanel *panel, const DirEntry *target);
+
+#ifndef NDEBUG
+typedef struct {
+  int cursor_pos;
+  int disp_begin_pos;
+  int start_file;
+  int file_cursor_pos;
+  const DirEntry *file_dir_entry;
+  ViewFocus saved_focus;
+  BOOL saved_big_file_view;
+  char file_selection_name[PATH_LENGTH + 1];
+  char file_selection_dir_path[PATH_LENGTH + 1];
+} PanelIsolationSnapshot;
+
+static void CapturePanelIsolationSnapshot(const YtreePanel *panel,
+                                          PanelIsolationSnapshot *snapshot) {
+  if (!panel || !snapshot)
+    return;
+
+  snapshot->cursor_pos = panel->cursor_pos;
+  snapshot->disp_begin_pos = panel->disp_begin_pos;
+  snapshot->start_file = panel->start_file;
+  snapshot->file_cursor_pos = panel->file_cursor_pos;
+  snapshot->file_dir_entry = panel->file_dir_entry;
+  snapshot->saved_focus = panel->saved_focus;
+  snapshot->saved_big_file_view = panel->saved_big_file_view;
+  (void)snprintf(snapshot->file_selection_name,
+                 sizeof(snapshot->file_selection_name), "%s",
+                 panel->file_selection_name);
+  (void)snprintf(snapshot->file_selection_dir_path,
+                 sizeof(snapshot->file_selection_dir_path), "%s",
+                 panel->file_selection_dir_path);
+}
+
+static void AssertPanelIsolationSnapshotUnchanged(
+    const YtreePanel *panel, const PanelIsolationSnapshot *snapshot) {
+  assert(panel != NULL);
+  assert(snapshot != NULL);
+  assert(panel->cursor_pos == snapshot->cursor_pos);
+  assert(panel->disp_begin_pos == snapshot->disp_begin_pos);
+  assert(panel->start_file == snapshot->start_file);
+  assert(panel->file_cursor_pos == snapshot->file_cursor_pos);
+  assert(panel->file_dir_entry == snapshot->file_dir_entry);
+  assert(panel->saved_focus == snapshot->saved_focus);
+  assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
+  assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
+  assert(strcmp(panel->file_selection_dir_path,
+                snapshot->file_selection_dir_path) == 0);
+}
+
+static void AssertPanelIsolationFileStateUnchanged(
+    const YtreePanel *panel, const PanelIsolationSnapshot *snapshot) {
+  assert(panel != NULL);
+  assert(snapshot != NULL);
+  assert(panel->start_file == snapshot->start_file);
+  assert(panel->file_cursor_pos == snapshot->file_cursor_pos);
+  assert(panel->file_dir_entry == snapshot->file_dir_entry);
+  assert(panel->saved_focus == snapshot->saved_focus);
+  assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
+  assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
+  assert(strcmp(panel->file_selection_dir_path,
+                snapshot->file_selection_dir_path) == 0);
+}
+#endif
 
 static BOOL DirBelongsToVolume(const struct Volume *vol, const DirEntry *target) {
   int i;
@@ -1135,6 +1200,12 @@ static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry
   if (!ctx || !dir_entry || !panel)
     return dir_entry;
 
+  /*
+   * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
+   * This restore path may rebuild shared topology visibility, but it must
+   * resolve file anchors from panel-local identity (`file_selection_*` /
+   * `start_file` / `file_cursor_pos`) and never from the other panel's index.
+   */
   if (panel->saved_focus != FOCUS_FILE)
     return dir_entry;
 
@@ -1311,6 +1382,12 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
     DebugLogSplitState("DirPanelAction:split:before", ctx);
     if (ctx->is_split_screen && ctx->active == ctx->right && ctx->left &&
         ctx->right) {
+      /*
+       * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
+       * - Shared-topology fields (`vol`, tree cursor window) may be mirrored.
+       * - Panel-local file/focus anchors must stay panel-owned; when unsplitting
+       *   from right while left is file-focused, left file anchor/focus wins.
+       */
       BOOL preserve_left_file_state =
           (ctx->left->saved_focus == FOCUS_FILE &&
            ctx->right->saved_focus != FOCUS_FILE);
@@ -1318,8 +1395,12 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
       int preserved_file_cursor = ctx->left->file_cursor_pos;
       DirEntry *preserved_file_dir_entry = ctx->left->file_dir_entry;
       BOOL preserved_big_file_view = ctx->left->saved_big_file_view;
+      ViewFocus preserved_saved_focus = ctx->left->saved_focus;
       char preserved_file_selection_name[PATH_LENGTH + 1];
       char preserved_file_selection_dir_path[PATH_LENGTH + 1];
+#ifndef NDEBUG
+      PanelIsolationSnapshot preserved_left_snapshot;
+#endif
 
       (void)snprintf(preserved_file_selection_name,
                      sizeof(preserved_file_selection_name), "%s",
@@ -1327,6 +1408,9 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
       (void)snprintf(preserved_file_selection_dir_path,
                      sizeof(preserved_file_selection_dir_path), "%s",
                      ctx->left->file_selection_dir_path);
+#ifndef NDEBUG
+      CapturePanelIsolationSnapshot(ctx->left, &preserved_left_snapshot);
+#endif
 
       ctx->left->vol = ctx->right->vol;
       ctx->left->cursor_pos = ctx->right->cursor_pos;
@@ -1347,12 +1431,17 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
         ctx->left->file_cursor_pos = preserved_file_cursor;
         ctx->left->file_dir_entry = preserved_file_dir_entry;
         ctx->left->saved_big_file_view = preserved_big_file_view;
+        ctx->left->saved_focus = preserved_saved_focus;
         (void)snprintf(ctx->left->file_selection_name,
                        sizeof(ctx->left->file_selection_name), "%s",
                        preserved_file_selection_name);
         (void)snprintf(ctx->left->file_selection_dir_path,
                        sizeof(ctx->left->file_selection_dir_path), "%s",
                        preserved_file_selection_dir_path);
+#ifndef NDEBUG
+        AssertPanelIsolationFileStateUnchanged(ctx->left,
+                                               &preserved_left_snapshot);
+#endif
       }
       FreeFileEntryList(ctx->left);
       ctx->active->vol = ctx->left->vol;
@@ -1388,7 +1477,83 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
     if (!ctx->is_split_screen)
       return DIR_WINDOW_DISPATCH_HANDLED;
     DebugLogSplitState("DirPanelAction:switch:before", ctx);
+#ifndef NDEBUG
+    {
+      YtreePanel *previous_active = ctx->active;
+      PanelIsolationSnapshot previous_active_snapshot;
 
+      /*
+       * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
+       * Tab switch may change `ctx->active`/focused window only. The panel
+       * becoming inactive must keep its panel-local snapshot unchanged.
+       */
+      CapturePanelIsolationSnapshot(previous_active, &previous_active_snapshot);
+
+      if (ctx->active == ctx->left) {
+        ctx->active = ctx->right;
+      } else {
+        ctx->active = ctx->left;
+      }
+
+      ctx->focused_window = ctx->active->saved_focus;
+      *s_ptr = &ctx->active->vol->vol_stats;
+      PanelTags_ApplyToTree(ctx, ctx->active);
+      DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",
+                ctx->active->saved_focus);
+
+      if (ctx->active->vol->total_dirs > 0) {
+        if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
+            ctx->active->vol->total_dirs) {
+          ctx->active->cursor_pos =
+              ctx->active->vol->total_dirs - 1 - ctx->active->disp_begin_pos;
+        }
+        *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
+      } else {
+        *dir_entry_ptr = (*s_ptr)->tree;
+      }
+
+      if (*dir_entry_ptr) {
+        char switch_path[PATH_LENGTH + 1];
+        GetPath(*dir_entry_ptr, switch_path);
+        switch_path[PATH_LENGTH] = '\0';
+        DEBUG_LOG("DirPanelAction:switch:resolved_dir='%s'", switch_path);
+      } else {
+        DEBUG_LOG("DirPanelAction:switch:resolved_dir=<null>");
+      }
+
+      DEBUG_LOG("ACTION_SWITCH_PANEL: active panel is now %s with "
+                "cursor_pos=%d, dir_entry=%s",
+                ctx->active == ctx->left ? "LEFT" : "RIGHT",
+                ctx->active->cursor_pos,
+                *dir_entry_ptr ? (*dir_entry_ptr)->name : "NULL");
+
+      SyncActivePanelWindows(ctx);
+      DEBUG_LOG("DirPanelAction:switch:after_sync_windows");
+      *dir_entry_ptr =
+          RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
+      if (!*dir_entry_ptr && *s_ptr) {
+        *dir_entry_ptr = (*s_ptr)->tree;
+        DEBUG_LOG("DirPanelAction:switch:restore returned null; fallback tree");
+      }
+      if (*dir_entry_ptr) {
+        DEBUG_LOG("DirPanelAction:switch:before_refresh dir='%s'",
+                  (*dir_entry_ptr)->name ? (*dir_entry_ptr)->name : "<nullname>");
+        RefreshView(ctx, *dir_entry_ptr);
+        DEBUG_LOG("DirPanelAction:switch:after_refresh");
+      } else {
+        DEBUG_LOG("DirPanelAction:switch:skip_refresh dir_entry null");
+        return DIR_WINDOW_DISPATCH_HANDLED;
+      }
+      *need_dsp_help_ptr = TRUE;
+      if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
+          PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
+        *unput_char_ptr = CR;
+      }
+
+      AssertPanelIsolationSnapshotUnchanged(previous_active,
+                                            &previous_active_snapshot);
+    }
+#else
     if (ctx->active == ctx->left) {
       ctx->active = ctx->right;
     } else {
@@ -1448,6 +1613,7 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
         PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
       *unput_char_ptr = CR;
     }
+#endif
     DebugLogSplitState("DirPanelAction:switch:after", ctx);
     return DIR_WINDOW_DISPATCH_CONTINUE;
 


### PR DESCRIPTION
## Summary
- document a split-panel ownership map (panel-local vs shared-topology vs global-only)
- record split-isolation disposition notes in `docs/BUGS.md` using durable behavior descriptions
- add invariant comments and debug assertions in split toggle/switch boundary paths
- preserve panel-local focus/file-anchor snapshots across F8/Tab hand-offs

## Verification
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k 'active_mode_toggles_do_not_mutate_inactive_file_state or split_panels_keep_independent_file_focus_states or mirrored_inactive_selection_identity_stable or inactive_panel_stays_file_focused_after_tab_away or split_from_file_keeps_inactive_file_selection_independent or split_tab_back_preserves_selected_file_index or inactive_dir_focus_survives_tab_away_and_back' -q`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k 'test_source_tagged_selection_survives_destination_prep' -q`

## Notes
- Dotfile-visibility leakage/jitter remains open by design in this PR because dotfile visibility is still session-global and needs dedicated ownership migration.