### PR TITLE
docs(ai): codify autonomous loop triggers and status wording

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -106,11 +106,13 @@ These instructions apply to all AI agents used in this repository.
 22. Hybrid PR quality workflow is mandatory:
     - Before first push, run a quick local gate (build plus targeted smoke/tests).
     - Open a draft PR early; red is allowed while iterating.
-    - While PR is red, prefix draft title with `WIP:` and do not request reviewers.
+    - Keep a durable PR title even while checks are red; do not use temporary `WIP:` title prefixes.
+    - While PR is red, keep the PR in draft and do not request reviewers.
     - Before merge to `main`, require green PR full-QA CI gate (`make qa-all` equivalent) and required audit-loop evidence; local `make qa-all` is optional unless the maintainer explicitly requests it.
     - Convert draft PR to ready only after posting full QA evidence in a PR comment.
     - Before merge, require green PR checks and reviewer signoff.
 23. Change-description durability is mandatory: commit subjects and PR titles/summaries MUST describe the concrete behavior/problem being changed, and MUST NOT rely on volatile tracker IDs alone (for example `BUG-14`, `TASK-7`) as the primary description.
+24. Agentic-loop autonomy and clarity are mandatory: worker completion notifications/events must trigger automatic loop progression without maintainer echo/re-send of worker completion text; maintainer-facing status wording must use only `active`, `completed`, or `blocked` and must not use ambiguous runtime labels such as `awaiting instruction`.
 
 ## Source Comment Contract
 

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -38,6 +38,7 @@ Relay autonomy policy tokens (required):
 Subagent autonomy rules (required):
 - Do not wait for maintainer nudges about agent state.
 - Treat any subagent completion notification as an immediate trigger.
+- Treat worker completion events/notifications as authoritative loop triggers; do not require or wait for the maintainer to resend worker completion lines.
 - On completion, immediately:
   1) read the report file,
   2) run required validation/checks,
@@ -46,6 +47,7 @@ Subagent autonomy rules (required):
   5) post a maintainer update.
 - Poll/wait on active agents proactively until they reach terminal status.
 - Never leave completed agents open unless explicitly instructed.
+- Status wording gate for maintainer-facing updates: use only `active`, `completed`, or `blocked`; do not relay ambiguous runtime phrasing such as `awaiting instruction`.
 Branch/process setup:
 1) Sync local main with GitHub main:
    - git checkout main
@@ -126,6 +128,7 @@ Update format to maintainer:
   3) `REPRO` (only when maintainer-run repro is needed)
   4) `EVIDENCE` (only new/changed file handles or command results)
 - Keep updates concise and facts-first.
+- Use unambiguous agent-state wording only (`active`, `completed`, `blocked`).
 - Do not emit `Model:` or `Reasoning level:` banners.
 - Do not ask the maintainer to extract internals from logs; provide concrete values directly.
 

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -268,6 +268,7 @@ make qa-fuzz
     *   if worker creation is policy-blocked, retry once with a reduced subagent-safe prompt profile (minimal technical payload only) and do not pause maintainer for that recoverable path.
 3.  Relay execution remains autonomous end-to-end; maintainer interruption is reserved strictly for `true_blocker_decision` and `commit_message_approval`.
     *   Workers must not be stopped/paused for routine process gating; stop/cancel is only for explicit maintainer stop requests or terminal failure recovery.
+    *   Worker completion events/notifications are authoritative loop triggers; the architect must proceed automatically and must not require maintainer echo/re-send of worker completion text.
     *   When maintainer input is required, architect MUST emit exactly one standalone line:
         `ACTION NEEDED (maintainer): reply "<exact text to send>"`.
     *   When no maintainer input is required, architect MUST emit:
@@ -277,6 +278,7 @@ make qa-fuzz
     *   `watchdog_stall_retry_terminal`: stale heartbeat/timeout must emit `stall_detected`, then bounded retry/reassign, then terminal escalation on retry exhaustion.
     *   `maintainer_pause_gate=true_blocker_decision|commit_message_approval`: pause gate allows maintainer interruption only for those two reasons.
     *   Runtime event naming should prefer explicit completion semantics (`worker_command_started`, `worker_command_completed`, `worker_command_failed`, `unit_completed`, `unit_failed`) so maintainers can distinguish done-vs-next without prompt interpretation.
+    *   Maintainer-facing status wording should be constrained to `active`, `completed`, or `blocked`; avoid ambiguous runtime labels (for example `awaiting instruction`) in relay updates.
 5.  Before merge to `main`, architect MUST ensure green PR full-QA CI evidence (`make qa-all` equivalent) for accepted branch state.
 6.  If accepted:
     *   commit only code/doc files (no relay/runtime artifacts),


### PR DESCRIPTION
## Summary
- codify that worker completion notifications/events are authoritative loop triggers
- require autonomous progression without maintainer echo/re-send of worker completion text
- constrain maintainer-facing status wording to `active`, `completed`, or `blocked`
- explicitly ban ambiguous runtime wording such as `awaiting instruction` in relay updates

## Verification
- documentation-only change (no runtime code changes)
