### PR TITLE
fix(volume): preserve panel-local file state across volume cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 > [!IMPORTANT]
 > **STATUS: ALPHA (v3.0.0-alpha)**
-> `ytree` is in active alpha development. Expect rough edges, incomplete behaviour, and occasional regressions. Interfaces, key bindings, and configuration details may change before the first stable release.
+> `ytree` is in active alpha development. It is stable and usable, but expect rough edges, incomplete behaviour, and occasional regressions. Interfaces, key bindings, and configuration details may change before the first stable release.
 >
-> Before opening an issue or suggesting a feature, check [BUGS.md](docs/BUGS.md) and [ROADMAP.md](docs/ROADMAP.md) first, so as not to create a duplicate if it is already listed.
+> Before opening an issue or suggesting a feature, please check [BUGS.md](docs/BUGS.md) and [ROADMAP.md](docs/ROADMAP.md) first, so as not to create a duplicate if it is already listed.
 
 <p align="center">
   <img src="docs/screenshots/split_archive_home.png" alt="Ytree F8 split screen: left panel browsing /home/rob/scripts.tar.gz, right panel showing the ~ tree with scripts inactive and its files in a small window." width="84%">

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -15,15 +15,14 @@ Ordering policy (for all editors, including AI editors):
 *   **Description**: Cycling logged volumes can cause dir/file window mode/state changes in one volume to appear in the other, instead of each volume retaining its own last-used state.
 *   **Impact**: Breaks per-volume navigation predictability and increases wrong-target risk during fast volume switching workflows.
 *   **Remediation**: Preserve and restore per-volume dir/file window state independently when cycling volumes. Add regression coverage for repeated `<`/`>` transitions across volumes with different view states.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-2: F8 Same-Volume Destination Navigation Can Lose Source Selection/Tagged Set**
 *   **Description**: In `F8` split mode on the same volume, navigating the destination side (including creating/changing directories during copy/move preparation) can cause the original source file selection/tagged set to disappear or be replaced by the destination-context file list.
 *   **Impact**: Breaks split-panel isolation and creates high wrong-target risk in copy/move workflows because source intent is lost while preparing destination paths.
 *   **Remediation**: Enforce source-vs-destination state isolation in split mode so destination-side `mkdir`/`cd` and tree navigation cannot mutate source selection/tag state. Preserve source tagged/selection state by stable file identity across destination context changes, and apply deterministic fallback only when a selected source entry truly no longer exists.
 *   **Related**: `ROADMAP` Task 33 (split selection semantics/regression coverage).
-*   **Status**: Confirmed.
-*   **Task 1 Disposition (Split Ownership Map + Guardrail Gate)**: **Fixed path under guardrail.** Split transfer/switch boundaries now carry ownership invariants plus debug assertions; regression coverage is enforced in `tests/test_panel_isolation.py` (`split_from_file_keeps_inactive_file_selection_independent`, `split_tab_back_preserves_selected_file_index`, and related active-only mutation tests).
+*   **Status**: Fixed.
 
 
 ### **BUG-3: F8 Dotfiles Toggle Leaks Across Panels**
@@ -41,7 +40,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Move dotfile-visibility ownership to panel-local split state and keep shared-tree updates limited to topology-only mirroring. Add split regression coverage for active-side dotfile toggles with inactive-panel state snapshots.
 *   **Tests/Gates**: Must have deterministic panel-isolation regression coverage under `tests/test_panel_isolation.py`; gate via `pytest` split-isolation subset and PR full-QA CI.
 *   **Status**: Confirmed.
-*   **Task 1 Disposition (Split Ownership Map + Guardrail Gate)**: **Blocker documented.** Ownership map classifies dotfile visibility as non-transfer state for split boundaries, but `hide_dot_files` is still session-global (`ViewContext`) and requires a dedicated ownership migration before BUG-3 can be closed.
+*   **Ownership-map disposition**: **Blocker documented.** Dotfile visibility is classified as non-transfer split state, but `hide_dot_files` is still session-global (`ViewContext`) and needs a dedicated ownership migration before this bug can close.
 
 ### **BUG-4: F8 Dotfiles Toggle Causes Inactive Selection Jitter**
 *   **Description**: In split mode, toggling dotfiles in one panel can make the inactive panel’s selected directory move away and then return (transient cursor/selection drift).
@@ -59,7 +58,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Re-anchor inactive selection strictly by stable directory identity/path during mirror updates; never re-resolve by transient index unless deterministic fallback is required.
 *   **Tests/Gates**: Add deterministic regression asserting no inactive selection movement on non-invalidating dotfile toggles.
 *   **Status**: Confirmed.
-*   **Task 1 Disposition (Split Ownership Map + Guardrail Gate)**: **Blocker documented.** Task 1 adds boundary invariants and debug cross-panel assertions for split transfer/switch paths, but BUG-4 remains coupled to the unresolved dotfile ownership model noted in BUG-3.
+*   **Ownership-map disposition**: **Blocker documented.** Split transfer/switch paths now have boundary invariants and debug cross-panel assertions, but this bug remains coupled to the unresolved dotfile ownership model noted above.
 
 ### **BUG-5: F8 + SMALLWINDOWSKIP=0 Tab Can Force Inactive Panel into Wrong Focus**
 *   **Description**: With `SMALLWINDOWSKIP=0`, when cursor is in the small file window on one panel, `Tab` to the other panel can show that inactive panel as file-focused/zoomed unexpectedly; tabbing back restores prior tree/small state.
@@ -76,8 +75,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Impact**: Breaks trust in split focus separation and can trigger wrong-context commands.
 *   **Remediation**: Harden switch-time state transfer so focus/view state is restored from panel-owned snapshots only; forbid cross-panel focus inheritance during `Tab` unless explicitly commanded by the active panel.
 *   **Tests/Gates**: Add/maintain deterministic regression for `SMALLWINDOWSKIP=0` split/tab focus retention in `tests/test_panel_isolation.py`.
-*   **Status**: Confirmed.
-*   **Task 1 Disposition (Split Ownership Map + Guardrail Gate)**: **Fixed path under guardrail.** Split `Tab` switch and split-toggle boundaries now include explicit ownership invariants and debug assertions that forbid inactive-panel focus/file-anchor mutation from active-side mode transitions.
+*   **Status**: Fixed.
 
 ### **BUG-6: F7 Preview Over-Restricts Command Availability**
 *   **Description**: `F7` mode is currently incomplete for inspect-and-act workflows. Too many common file actions are disabled, so users must leave preview to continue work.
@@ -157,7 +155,7 @@ Ordering policy (for all editors, including AI editors):
     *   Small window can become empty instead of preserving the current context.
 *   **Impact**: Breaks predictable navigation flow and increases risk of accidental context loss.
 *   **Remediation**: Preserve active zoom/view state across parent-jump and view-toggle transitions; prevent empty-pane state in this flow.
-*   **Related**: File-View Focus Leak After Parent Jump (`\\`) (same focus/state-transition family).
+*   **Related**: `BUG-14` (same focus/state-transition family).
 *   **Status**: Confirmed.
 
 ### **BUG-16: Long Lines Wrap Instead of Truncate in List Views**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,8 +34,9 @@ Ordering policy (for all editors, including AI editors):
 *   Key boundary functions contain invariant comments describing allowed/forbidden state transfer.
 *   Regression coverage fails when inactive-panel state is mutated by active-only commands.
 *   All new/updated split-isolation tests pass locally and in PR full-QA CI evidence.
-*   Linked bugs (`BUG-2`, `BUG-3`, `BUG-4`, `BUG-5`) are either fixed or have explicit blocker notes tied to this task.
-*   - [ ] **Status:** Not Started.
+*   Linked split-panel bugs (`BUG-2`, `BUG-3`, `BUG-4`, `BUG-5`) are either fixed or have explicit blocker notes tied to this work.
+*   **Outcome:** Completed. Ownership map + boundary invariants/assertions are in place; split dotfile ownership migration remains follow-on work.
+*   - [x] **Status:** Completed.
 
 ### **Task 2: Remove Dead-History Comments + Add Anti-History Comment Gate**
 *   **Goal:** Remove comments that describe removed code/history and prevent their reintroduction.

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -726,6 +726,16 @@ typedef struct _PathList {
   struct _PathList *next;
 } PathList;
 
+typedef struct _panel_volume_file_state {
+  int volume_id;
+  int saved_file_start;
+  int saved_file_cursor;
+  char saved_file_dir_path[PATH_LENGTH + 1];
+  char saved_file_selection_name[PATH_LENGTH + 1];
+  char saved_file_selection_dir_path[PATH_LENGTH + 1];
+  struct _panel_volume_file_state *next;
+} PanelVolumeFileState;
+
 typedef struct _ArchiveExpandedEntry {
   char *source_path;
   char *archive_path;
@@ -762,6 +772,7 @@ typedef struct {
   int file_cursor_pos;
   DirEntry *file_dir_entry;
   struct _PathList *tagged_paths;
+  PanelVolumeFileState *volume_file_state;
   char file_selection_name[PATH_LENGTH + 1];
   char file_selection_dir_path[PATH_LENGTH + 1];
   BOOL saved_big_file_view;

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -8,6 +8,136 @@
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
 
+static PanelVolumeFileState *FindPanelVolumeFileState(YtreePanel *panel,
+                                                      int volume_id) {
+  PanelVolumeFileState *state;
+
+  if (!panel)
+    return NULL;
+
+  for (state = panel->volume_file_state; state; state = state->next) {
+    if (state->volume_id == volume_id)
+      return state;
+  }
+  return NULL;
+}
+
+static PanelVolumeFileState *GetPanelVolumeFileState(YtreePanel *panel,
+                                                     int volume_id) {
+  PanelVolumeFileState *state;
+
+  state = FindPanelVolumeFileState(panel, volume_id);
+  if (state)
+    return state;
+
+  state = (PanelVolumeFileState *)xcalloc(1, sizeof(PanelVolumeFileState));
+  state->volume_id = volume_id;
+  state->next = panel->volume_file_state;
+  panel->volume_file_state = state;
+  return state;
+}
+
+static void SavePanelFileSelection(YtreePanel *panel) {
+  PanelVolumeFileState *state;
+
+  if (!panel || !panel->vol)
+    return;
+
+  state = GetPanelVolumeFileState(panel, panel->vol->id);
+  state->saved_file_start = panel->start_file;
+  state->saved_file_cursor = panel->file_cursor_pos;
+
+  state->saved_file_dir_path[0] = '\0';
+  if (panel->file_dir_entry != NULL) {
+    GetPath(panel->file_dir_entry, state->saved_file_dir_path);
+    state->saved_file_dir_path[PATH_LENGTH] = '\0';
+  }
+
+  (void)snprintf(state->saved_file_selection_name,
+                 sizeof(state->saved_file_selection_name), "%s",
+                 panel->file_selection_name);
+  (void)snprintf(state->saved_file_selection_dir_path,
+                 sizeof(state->saved_file_selection_dir_path), "%s",
+                 panel->file_selection_dir_path);
+}
+
+static DirEntry *FindSavedDirInVolume(const struct Volume *vol,
+                                      const char *saved_path) {
+  int i;
+  size_t best_len = 0;
+  DirEntry *best = NULL;
+
+  if (!vol || !saved_path || saved_path[0] == '\0' || !vol->dir_entry_list ||
+      vol->total_dirs <= 0)
+    return NULL;
+
+  for (i = 0; i < vol->total_dirs; i++) {
+    DirEntry *candidate = vol->dir_entry_list[i].dir_entry;
+    char candidate_path[PATH_LENGTH + 1];
+    size_t candidate_len;
+
+    if (!candidate)
+      continue;
+
+    GetPath(candidate, candidate_path);
+    candidate_path[PATH_LENGTH] = '\0';
+
+    if (strcmp(candidate_path, saved_path) == 0)
+      return candidate;
+
+    candidate_len = strlen(candidate_path);
+    if (candidate_len == 0 || candidate_len > strlen(saved_path))
+      continue;
+    if (strncmp(saved_path, candidate_path, candidate_len) != 0)
+      continue;
+    if (saved_path[candidate_len] != '\0' &&
+        saved_path[candidate_len] != FILE_SEPARATOR_CHAR)
+      continue;
+    if (candidate_len > best_len) {
+      best_len = candidate_len;
+      best = candidate;
+    }
+  }
+
+  return best;
+}
+
+static void RestorePanelFileSelection(YtreePanel *panel) {
+  const struct Volume *vol;
+  const PanelVolumeFileState *state;
+  DirEntry *resolved_file_dir = NULL;
+
+  if (!panel || !panel->vol)
+    return;
+
+  vol = panel->vol;
+  state = FindPanelVolumeFileState(panel, vol->id);
+  panel->start_file = 0;
+  panel->file_cursor_pos = 0;
+  panel->file_selection_name[0] = '\0';
+  panel->file_selection_dir_path[0] = '\0';
+  panel->file_dir_entry = NULL;
+  if (!state)
+    return;
+
+  panel->start_file = state->saved_file_start;
+  panel->file_cursor_pos = state->saved_file_cursor;
+  if (panel->start_file < 0)
+    panel->start_file = 0;
+  if (panel->file_cursor_pos < 0)
+    panel->file_cursor_pos = 0;
+  (void)snprintf(panel->file_selection_name, sizeof(panel->file_selection_name),
+                 "%s", state->saved_file_selection_name);
+  (void)snprintf(panel->file_selection_dir_path,
+                 sizeof(panel->file_selection_dir_path), "%s",
+                 state->saved_file_selection_dir_path);
+
+  if (state->saved_file_dir_path[0] != '\0') {
+    resolved_file_dir = FindSavedDirInVolume(vol, state->saved_file_dir_path);
+    panel->file_dir_entry = resolved_file_dir;
+  }
+}
+
 static void SavePanelTreeSelection(YtreePanel *panel) {
   int selected_index;
 
@@ -122,6 +252,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
 
   /* Keep per-volume tree selection before switching away. */
   SavePanelTreeSelection(panel);
+  SavePanelFileSelection(panel);
 
   /* 1. Resolve Path (for UI searching/display purposes) */
   if (realpath(path, resolved_path) == NULL) {
@@ -195,6 +326,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
           ctx->hook_display_menu(ctx);
         if (ctx->hook_build_dir_entry_list)
           ctx->hook_build_dir_entry_list(ctx, panel->vol, &(int){0});
+        RestorePanelFileSelection(panel);
         RestorePanelTreeSelection(ctx, panel);
 
         if (ctx->hook_display_tree)
@@ -302,6 +434,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
         ctx->hook_display_menu(ctx);
       if (ctx->hook_build_dir_entry_list)
         ctx->hook_build_dir_entry_list(ctx, panel->vol, &(int){0});
+      RestorePanelFileSelection(panel);
       RestorePanelTreeSelection(ctx, panel);
 
       if (ctx->hook_display_tree)
@@ -345,6 +478,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
   /* Final Refresh */
   if (ctx->hook_build_dir_entry_list)
     ctx->hook_build_dir_entry_list(ctx, panel->vol, &(int){0});
+  RestorePanelFileSelection(panel);
   if (reload_requested) {
     panel->disp_begin_pos = 0;
     panel->cursor_pos = 0;

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -924,6 +924,227 @@ def test_volume_cycle_restores_prior_directory_selection(tmp_path, ytree_binary)
 
     tui.quit()
 
+
+def test_volume_cycle_leak_state_preserves_per_volume_file_selection(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "volume_cycle_leak_state_file_selection"
+    root.mkdir()
+    vol_a = root / "cycle_state_vol_a"
+    vol_b = root / "cycle_state_vol_b"
+    vol_a.mkdir()
+    vol_b.mkdir()
+
+    for i in range(4):
+        (vol_a / f"a_state_{i}.txt").write_text(f"a{i}\n", encoding="utf-8")
+    for i in range(3):
+        (vol_b / f"b_state_{i}.txt").write_text(f"b{i}\n", encoding="utf-8")
+
+    compare_target = root / "compare_target.txt"
+    compare_target.write_text("target\n", encoding="utf-8")
+    log_path = _configure_filediff_capture(root)
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(root),
+        args=[str(vol_a), str(vol_b)],
+    )
+    time.sleep(1.0)
+
+    def active_volume_name():
+        header = tui.get_screen_dump()[0]
+        for name in ("cycle_state_vol_a", "cycle_state_vol_b"):
+            if name in header:
+                return name
+        return None
+
+    def run_compare_and_read_source():
+        if log_path.exists():
+            log_path.unlink()
+        tui.send_keystroke("J", wait=0.25)
+        assert tui.wait_for_content("COMPARE TARGET:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke(Keys.CTRL_U + str(compare_target) + Keys.ENTER, wait=0.6)
+        if tui.wait_for_content("Hit return to continue", timeout=1.0):
+            tui.send_keystroke(Keys.ENTER, wait=0.3)
+        assert _wait_for_file(log_path, timeout=2.0), "FILEDIFF helper did not run."
+        return log_path.read_text(encoding="utf-8").splitlines()[0]
+
+    for _ in range(8):
+        if active_volume_name() == "cycle_state_vol_a":
+            break
+        tui.send_keystroke(">", wait=0.3)
+    assert active_volume_name() == "cycle_state_vol_a", _screen_text(tui)
+
+    tui.send_keystroke(Keys.ENTER, wait=0.4)
+    assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+    tui.send_keystroke(Keys.DOWN, wait=0.2)
+    tui.send_keystroke(Keys.DOWN, wait=0.2)
+    source_a_expected = run_compare_and_read_source()
+    assert source_a_expected.endswith("a_state_2.txt"), source_a_expected
+
+    tui.send_keystroke(">", wait=0.8)
+    assert active_volume_name() == "cycle_state_vol_b", _screen_text(tui)
+
+    if "hex invert j compare" not in _footer_text(tui):
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+    assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+    tui.send_keystroke(Keys.DOWN, wait=0.2)
+    source_b_expected = run_compare_and_read_source()
+    assert source_b_expected.endswith("b_state_1.txt"), source_b_expected
+
+    tui.send_keystroke("<", wait=0.8)
+    assert active_volume_name() == "cycle_state_vol_a", _screen_text(tui)
+    if "hex invert j compare" not in _footer_text(tui):
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+    assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+    source_a_after_cycle = run_compare_and_read_source()
+    assert source_a_after_cycle == source_a_expected, (
+        "Volume cycling leaked file selection state across volumes (A).\n"
+        f"Expected: {source_a_expected}\n"
+        f"Actual:   {source_a_after_cycle}\n{_screen_text(tui)}"
+    )
+
+    tui.send_keystroke(">", wait=0.8)
+    assert active_volume_name() == "cycle_state_vol_b", _screen_text(tui)
+    if "hex invert j compare" not in _footer_text(tui):
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+    assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+    source_b_after_cycle = run_compare_and_read_source()
+    assert source_b_after_cycle == source_b_expected, (
+        "Volume cycling leaked file selection state across volumes (B).\n"
+        f"Expected: {source_b_expected}\n"
+        f"Actual:   {source_b_after_cycle}\n{_screen_text(tui)}"
+    )
+
+    tui.quit()
+
+
+def test_split_file_selection_preserves_panel_local_volume_cycle_state(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "split_preserves_panel_local_volume_cycle_state"
+    root.mkdir()
+    vol_a = root / "split_cycle_vol_a"
+    vol_b = root / "split_cycle_vol_b"
+    vol_a.mkdir()
+    vol_b.mkdir()
+
+    for i in range(4):
+        (vol_a / f"a_state_{i}.txt").write_text(f"a{i}\n", encoding="utf-8")
+    for i in range(2):
+        (vol_b / f"b_state_{i}.txt").write_text(f"b{i}\n", encoding="utf-8")
+
+    compare_target = root / "compare_target.txt"
+    compare_target.write_text("target\n", encoding="utf-8")
+    log_path = _configure_filediff_capture(root)
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(root),
+        args=[str(vol_a), str(vol_b)],
+    )
+    time.sleep(1.0)
+
+    def active_volume_name():
+        header = tui.get_screen_dump()[0]
+        for name in ("split_cycle_vol_a", "split_cycle_vol_b"):
+            if name in header:
+                return name
+        return None
+
+    def run_compare_and_read_source():
+        if log_path.exists():
+            log_path.unlink()
+        tui.send_keystroke("J", wait=0.25)
+        assert tui.wait_for_content("COMPARE TARGET:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke(Keys.CTRL_U + str(compare_target) + Keys.ENTER, wait=0.6)
+        if tui.wait_for_content("Hit return to continue", timeout=1.0):
+            tui.send_keystroke(Keys.ENTER, wait=0.3)
+        assert _wait_for_file(log_path, timeout=2.0), "FILEDIFF helper did not run."
+        return log_path.read_text(encoding="utf-8").splitlines()[0]
+
+    try:
+        for _ in range(8):
+            if active_volume_name() == "split_cycle_vol_a":
+                break
+            tui.send_keystroke(">", wait=0.3)
+        assert active_volume_name() == "split_cycle_vol_a", _screen_text(tui)
+
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        source_left_expected = run_compare_and_read_source()
+        assert source_left_expected.endswith("a_state_2.txt"), source_left_expected
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        source_right_expected = run_compare_and_read_source()
+        assert source_right_expected.endswith("a_state_3.txt"), source_right_expected
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        source_left_before_cycle = run_compare_and_read_source()
+        assert source_left_before_cycle == source_left_expected, (
+            "Split panel file selections should diverge per panel before cycling.\n"
+            f"Left expected:  {source_left_expected}\n"
+            f"Left observed:  {source_left_before_cycle}\n{_screen_text(tui)}"
+        )
+
+        tui.send_keystroke(">", wait=0.8)
+        assert active_volume_name() == "split_cycle_vol_b", _screen_text(tui)
+        if "hex invert j compare" not in _footer_text(tui):
+            tui.send_keystroke(Keys.ENTER, wait=0.4)
+        tui.send_keystroke("<", wait=0.8)
+        assert active_volume_name() == "split_cycle_vol_a", _screen_text(tui)
+        if "hex invert j compare" not in _footer_text(tui):
+            tui.send_keystroke(Keys.ENTER, wait=0.4)
+        source_left_after_cycle = run_compare_and_read_source()
+        assert source_left_after_cycle == source_left_expected, (
+            "Left split panel lost its own per-volume file selection.\n"
+            f"Expected: {source_left_expected}\n"
+            f"Actual:   {source_left_after_cycle}\n{_screen_text(tui)}"
+        )
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        if "hex invert j compare" not in _footer_text(tui):
+            tui.send_keystroke(Keys.ENTER, wait=0.4)
+        source_right_before_cycle = run_compare_and_read_source()
+        assert source_right_before_cycle == source_right_expected, (
+            "Cycling the left split panel leaked selection into right panel.\n"
+            f"Expected: {source_right_expected}\n"
+            f"Actual:   {source_right_before_cycle}\n{_screen_text(tui)}"
+        )
+
+        tui.send_keystroke(">", wait=0.8)
+        assert active_volume_name() == "split_cycle_vol_b", _screen_text(tui)
+        if "hex invert j compare" not in _footer_text(tui):
+            tui.send_keystroke(Keys.ENTER, wait=0.4)
+        tui.send_keystroke("<", wait=0.8)
+        assert active_volume_name() == "split_cycle_vol_a", _screen_text(tui)
+        if "hex invert j compare" not in _footer_text(tui):
+            tui.send_keystroke(Keys.ENTER, wait=0.4)
+        source_right_after_cycle = run_compare_and_read_source()
+        assert source_right_after_cycle == source_right_expected, (
+            "Right split panel lost its own per-volume file selection.\n"
+            f"Expected: {source_right_expected}\n"
+            f"Actual:   {source_right_after_cycle}\n{_screen_text(tui)}"
+        )
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        if "hex invert j compare" not in _footer_text(tui):
+            tui.send_keystroke(Keys.ENTER, wait=0.4)
+        source_left_after_right_cycle = run_compare_and_read_source()
+        assert source_left_after_right_cycle == source_left_expected, (
+            "Right-panel cycling leaked back into left panel selection.\n"
+            f"Expected: {source_left_expected}\n"
+            f"Actual:   {source_left_after_right_cycle}\n{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_navigation_does_not_expand(tmp_path, ytree_binary):
     """
     BUG 2: Verifies that pressing DOWN arrow merely moves the cursor,


### PR DESCRIPTION
## Summary
- preserve file selection state per panel when cycling between logged volumes
- keep panel-local snapshots out of shared `Volume` model state
- add regression coverage for repeated volume cycling and split-panel isolation

## Validation
- `make -j4`
- `pytest tests/test_panel_isolation.py -k "volume_cycle_leak_state_preserves_per_volume_file_selection or split_file_selection_preserves_panel_local_volume_cycle_state" -q`
- `pytest tests/test_compare_actions.py -k "log_then_cycle_back" -q`
