### PR TITLE
fix(split): preserve inactive panel selection on dotfiles toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **ytree - The Unix File Logger**
+# **Ytree - The Unix File Logger**
 
 **Ytree** is a keyboard-first file manager for Linux and BSD with fast multi-volume logging and navigation.
 
@@ -20,7 +20,7 @@ Born from the lineage of [XTree&trade;](https://www.xtreefanpage.org/lowres/x10d
 
 Many file managers today function as "browsers"—they look at one directory at a time and rely on the OS to fetch files on demand. `Ytree` is different: it is a **Logger**. It scans ("logs") entire drive hierarchies into memory. This treats the filesystem as a database, allowing you to **Show All** files in a flat view, filter across thousands of subdirectories instantly, and perform bulk operations on tagged files regardless of their location.
 
-This v3.0 project focuses on feature completeness for Unix power users, including split-screen and integrated autoview. The move to a modular C99/POSIX architecture is a practical side effect of delivering those capabilities safely and maintainably.
+Forked in October 2025 from [Ytree](https://www.han.de/~werner/ytree.html) v2.10, created by Werner Bregulla and others. This v3.0 project focuses on feature completeness for Unix power users, including split-screen and integrated autoview. The move to a modular C99/POSIX architecture is a practical side effect of delivering those capabilities safely and maintainably.
 
 ## Development Methodology
 

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -1,4 +1,4 @@
-# Contributors to ytree
+# Contributors to Ytree
 
 **Original Development**
 
@@ -24,4 +24,4 @@ Originally developed by [Werner Bregulla](https://www.han.de/~werner/ytree.html)
 
 **v3.0 Modernization**
 
-* **Rob Kam** - Modernized and enhanced the project after decades of dormancy, making extensive use of LLMs for code generation and debugging.
+* **Rob Kam** - Forked in October 2025 from Ytree v2.10. Modernized and enhanced the project after decades of dormancy, making extensive use of LLMs for code generation and debugging.

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -24,7 +24,6 @@ Ordering policy (for all editors, including AI editors):
 *   **Related**: `ROADMAP` Task 33 (split selection semantics/regression coverage).
 *   **Status**: Fixed.
 
-
 ### **BUG-3: F8 Dotfiles Toggle Leaks Across Panels**
 *   **Description**: In `F8` split mode, toggling dotfiles visibility (`` ` `` do/undo) in the active panel can apply the same visibility change to the inactive panel.
 *   **Repro (manual)**:
@@ -41,6 +40,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Tests/Gates**: Must have deterministic panel-isolation regression coverage under `tests/test_panel_isolation.py`; gate via `pytest` split-isolation subset and PR full-QA CI.
 *   **Status**: Confirmed.
 *   **Ownership-map disposition**: **Blocker documented.** Dotfile visibility is classified as non-transfer split state, but `hide_dot_files` is still session-global (`ViewContext`) and needs a dedicated ownership migration before this bug can close.
+*   **Status**: Fixed.
 
 ### **BUG-4: F8 Dotfiles Toggle Causes Inactive Selection Jitter**
 *   **Description**: In split mode, toggling dotfiles in one panel can make the inactive panel’s selected directory move away and then return (transient cursor/selection drift).
@@ -59,6 +59,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Tests/Gates**: Add deterministic regression asserting no inactive selection movement on non-invalidating dotfile toggles.
 *   **Status**: Confirmed.
 *   **Ownership-map disposition**: **Blocker documented.** Split transfer/switch paths now have boundary invariants and debug cross-panel assertions, but this bug remains coupled to the unresolved dotfile ownership model noted above.
+*   **Status**: Confirmed.
 
 ### **BUG-5: F8 + SMALLWINDOWSKIP=0 Tab Can Force Inactive Panel into Wrong Focus**
 *   **Description**: With `SMALLWINDOWSKIP=0`, when cursor is in the small file window on one panel, `Tab` to the other panel can show that inactive panel as file-focused/zoomed unexpectedly; tabbing back restores prior tree/small state.

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1849,14 +1849,50 @@ HandleDirWindowLogAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
 
 void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
   DirEntry *target;
+  YtreePanel *inactive = NULL;
   int i, found_idx = -1;
   int win_height;
   const Statistic *s;
+  char inactive_anchor_path[PATH_LENGTH + 1];
+  BOOL has_inactive_anchor_path = FALSE;
 
-  if (!p || !p->vol)
+  if (!ctx || !p || !p->vol)
     return;
 
   s = &p->vol->vol_stats;
+  inactive_anchor_path[0] = '\0';
+
+  if (ctx->is_split_screen && ctx->left && ctx->right) {
+    if (p == ctx->left)
+      inactive = ctx->right;
+    else if (p == ctx->right)
+      inactive = ctx->left;
+  }
+
+  if (inactive && inactive->vol == p->vol && inactive->vol->dir_entry_list &&
+      inactive->vol->total_dirs > 0) {
+    int inactive_idx = inactive->disp_begin_pos + inactive->cursor_pos;
+    const DirEntry *inactive_anchor = NULL;
+
+    if (inactive->saved_focus == FOCUS_FILE &&
+        inactive->file_selection_dir_path[0] != '\0') {
+      (void)snprintf(inactive_anchor_path, sizeof(inactive_anchor_path), "%s",
+                     inactive->file_selection_dir_path);
+      has_inactive_anchor_path = TRUE;
+    } else {
+      if (inactive_idx < 0)
+        inactive_idx = 0;
+      if (inactive_idx >= inactive->vol->total_dirs)
+        inactive_idx = inactive->vol->total_dirs - 1;
+      inactive_anchor =
+          inactive->vol->dir_entry_list[inactive_idx].dir_entry;
+      if (inactive_anchor) {
+        GetPath((DirEntry *)inactive_anchor, inactive_anchor_path);
+        inactive_anchor_path[PATH_LENGTH] = '\0';
+        has_inactive_anchor_path = TRUE;
+      }
+    }
+  }
 
   /* Suspend clock to prevent signal handler interrupt corrupting UI during
    * rebuild */
@@ -1934,6 +1970,15 @@ void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
     p->cursor_pos = (p->vol->total_dirs > 0)
                         ? (p->vol->total_dirs - 1 - p->disp_begin_pos)
                         : 0;
+  }
+
+  if (inactive && inactive->vol == p->vol && has_inactive_anchor_path) {
+    const DirEntry *inactive_target =
+        FindDirByPath(p->vol, inactive_anchor_path);
+    if (!inactive_target) {
+      inactive_target = FindDirByPathOrAncestor(p->vol, inactive_anchor_path);
+    }
+    ReanchorPanelToDir(inactive, inactive_target);
   }
 
   /* Refresh Directory Tree */

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -1441,6 +1441,86 @@ def test_bug_f_eight_mirrored_inactive_selection_identity_stable(tmp_path, ytree
     tui.quit()
 
 
+def test_bug_f_eight_dotfiles_toggle_keeps_inactive_selection_identity(
+    tmp_path, ytree_binary
+):
+    """
+    BUG-4 regression:
+    In split mode, toggling dotfiles from the active panel must not re-index
+    the inactive panel selection when the selected directory remains valid.
+    """
+    root = tmp_path / "bug_f_eight_dotfiles_inactive_identity"
+    root.mkdir()
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=1\nHIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    (root / ".dot_insert").mkdir()
+    (root / "active_dir").mkdir()
+    anchor_dir = root / "anchor_dir"
+    anchor_dir.mkdir()
+    tail_dir = root / "zzz_tail"
+    tail_dir.mkdir()
+
+    (anchor_dir / "anchor_file.txt").write_text("anchor\n", encoding="utf-8")
+    (tail_dir / "tail_file.txt").write_text("tail\n", encoding="utf-8")
+
+    def _active_path_contains(tui, marker):
+        screen = _screen_text(tui)
+        header = screen.splitlines()[0] if screen else ""
+        return marker in header
+
+    def _select_dir_by_marker(tui, marker):
+        for _ in range(40):
+            if _active_path_contains(tui, marker):
+                return
+            tui.send_keystroke(Keys.DOWN, wait=0.2)
+        raise AssertionError(
+            f"Could not select '{marker}' in tree view.\n{_screen_text(tui)}"
+        )
+
+    def _assert_right_panel_opens_tail_dir(tui, label):
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(tui, f"{label}: expected right panel tree mode.")
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        screen = _screen_text(tui)
+        assert "tail_file.txt" in screen, (
+            f"{label}: inactive selection drifted away from zzz_tail.\n{screen}"
+        )
+        assert "anchor_file.txt" not in screen, (
+            f"{label}: inactive panel entered anchor_dir after dotfiles toggle.\n{screen}"
+        )
+        tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(tui, f"{label}: expected right panel to return to tree mode.")
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.9)
+    try:
+        _select_dir_by_marker(tui, "active_dir")
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        if "hex invert j compare" in _footer_text(tui):
+            tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(tui, "Expected right panel tree mode after split.")
+        _select_dir_by_marker(tui, "zzz_tail")
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(tui, "Expected left panel tree mode before toggle.")
+
+        _assert_right_panel_opens_tail_dir(tui, "baseline")
+
+        tui.send_keystroke("`", wait=0.5)
+        _assert_right_panel_opens_tail_dir(tui, "dotfiles shown")
+
+        tui.send_keystroke("`", wait=0.5)
+        _assert_right_panel_opens_tail_dir(tui, "dotfiles hidden")
+    finally:
+        tui.quit()
+
+
 def test_bug_f_eight_source_selection_survives_destination_tree_prep(
     tmp_path, ytree_binary
 ):


### PR DESCRIPTION
## Summary
- fix split-mode jitter where toggling dotfiles in the active panel could transiently move inactive-panel selection
- preserve inactive panel anchor by stable path across shared dir-list rebuilds
- add deterministic regression coverage for inactive selection identity across dotfiles do/undo

## Changes
- `src/ui/dir_ops.c`
  - capture inactive panel anchor path before dotfiles toggle rebuild
  - restore inactive selection via `FindDirByPath`, then deterministic ancestor fallback
- `tests/test_panel_isolation.py`
  - add `test_bug_f_eight_dotfiles_toggle_keeps_inactive_selection_identity`

## Validation
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py::test_bug_f_eight_dotfiles_toggle_keeps_inactive_selection_identity -q`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k "dotfiles" -q`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -q`
- `make clean && make`

## Notes
- Includes existing local doc edits present in working tree per maintainer instruction to stage all files.