### PR TITLE
fix(split): enforce deterministic inactive split-panel fallback

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -112,7 +112,7 @@ These instructions apply to all AI agents used in this repository.
     - Convert draft PR to ready only after posting full QA evidence in a PR comment.
     - Before merge, require green PR checks and reviewer signoff.
 23. Change-description durability is mandatory: commit subjects and PR titles/summaries MUST describe the concrete behavior/problem being changed, and MUST NOT rely on volatile tracker IDs alone (for example `BUG-14`, `TASK-7`) as the primary description.
-24. Agentic-loop autonomy and clarity are mandatory: worker completion notifications/events must trigger automatic loop progression without maintainer echo/re-send of worker completion text; maintainer-facing status wording must use only `active`, `completed`, or `blocked` and must not use ambiguous runtime labels such as `awaiting instruction`.
+24. Agentic-loop autonomy and clarity are mandatory: proactively poll/wait `active` workers to terminal `completed`/`blocked`; worker completion notifications/events are immediate triggers that must progress the loop without maintainer echo/re-send of worker completion text; on completion immediately read the completion report, run required validation checks, close the completed worker agent, proceed to the next planned step, and post a delta-only maintainer update; maintainer-facing status wording must use only `active`, `completed`, or `blocked` and must not use ambiguous runtime labels such as `awaiting instruction`.
 
 ## Source Comment Contract
 

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -268,7 +268,9 @@ make qa-fuzz
     *   if worker creation is policy-blocked, retry once with a reduced subagent-safe prompt profile (minimal technical payload only) and do not pause maintainer for that recoverable path.
 3.  Relay execution remains autonomous end-to-end; maintainer interruption is reserved strictly for `true_blocker_decision` and `commit_message_approval`.
     *   Workers must not be stopped/paused for routine process gating; stop/cancel is only for explicit maintainer stop requests or terminal failure recovery.
-    *   Worker completion events/notifications are authoritative loop triggers; the architect must proceed automatically and must not require maintainer echo/re-send of worker completion text.
+    *   Architect MUST proactively poll/wait all `active` workers until each transitions to `completed` or `blocked`; do not idle passively or wait for maintainer echo/re-send.
+    *   Worker completion events/notifications are authoritative immediate loop triggers; the architect MUST start completion handling as soon as the completion event is observed.
+    *   On each worker completion event, architect MUST immediately: read the completion report, run required validation checks, close the completed worker agent, proceed to the next step, and post a delta-only maintainer update using only `active|completed|blocked` status wording.
     *   When maintainer input is required, architect MUST emit exactly one standalone line:
         `ACTION NEEDED (maintainer): reply "<exact text to send>"`.
     *   When no maintainer input is required, architect MUST emit:

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -30,6 +30,12 @@ static void CaptureInactiveFallback(ViewContext *ctx, YtreePanel *p,
                                     YtreePanel **inactive_out,
                                     DirEntry **inactive_fallback_out);
 static void ReanchorPanelToDir(YtreePanel *panel, const DirEntry *target);
+typedef struct {
+  YtreePanel *panel;
+  char selected_path[PATH_LENGTH + 1];
+  char next_sibling_path[PATH_LENGTH + 1];
+  char prev_sibling_path[PATH_LENGTH + 1];
+} InactiveFallbackSnapshot;
 
 #ifndef NDEBUG
 typedef struct {
@@ -359,6 +365,23 @@ static DirEntry *FindDirByPath(const struct Volume *vol, const char *path) {
   return FindDirByPathInSubTree(vol->vol_stats.tree, path);
 }
 
+static DirEntry *FindVisibleDirByPath(const struct Volume *vol,
+                                      const char *path) {
+  DirEntry *candidate;
+
+  if (!vol || !path || !*path)
+    return NULL;
+
+  candidate = FindDirByPath(vol, path);
+  if (!candidate)
+    return NULL;
+
+  if (FindDirIndex(vol, candidate) < 0)
+    return NULL;
+
+  return candidate;
+}
+
 DirEntry *DirOps_FindDirEntryByPath(const ViewContext *ctx,
                                     const char *dir_path) {
   if (!ctx || !ctx->active || !ctx->active->vol || !dir_path ||
@@ -640,6 +663,112 @@ BOOL DirOps_SelectVisibleDirAndRefresh(ViewContext *ctx, YtreePanel *panel,
   return TRUE;
 }
 
+static DirEntry *GetPanelSelectedDir(const YtreePanel *panel) {
+  DirEntry *selected = NULL;
+
+  if (!panel || !panel->vol)
+    return NULL;
+
+  if (panel->vol->total_dirs > 0 && panel->vol->dir_entry_list) {
+    int idx = panel->disp_begin_pos + panel->cursor_pos;
+    if (idx < 0)
+      idx = 0;
+    if (idx >= panel->vol->total_dirs)
+      idx = panel->vol->total_dirs - 1;
+    selected = panel->vol->dir_entry_list[idx].dir_entry;
+  }
+
+  if (!selected && panel->file_selection_dir_path[0] != '\0')
+    selected = FindDirByPath(panel->vol, panel->file_selection_dir_path);
+  if (!selected)
+    selected = panel->file_dir_entry;
+  if (!selected)
+    selected = panel->vol->vol_stats.tree;
+
+  return selected;
+}
+
+static void CaptureInactiveFallbackSnapshot(ViewContext *ctx, YtreePanel *p,
+                                            InactiveFallbackSnapshot *snapshot) {
+  YtreePanel *inactive;
+  DirEntry *selected;
+
+  if (!snapshot)
+    return;
+
+  snapshot->panel = NULL;
+  snapshot->selected_path[0] = '\0';
+  snapshot->next_sibling_path[0] = '\0';
+  snapshot->prev_sibling_path[0] = '\0';
+
+  if (!ctx || !p || !ctx->is_split_screen)
+    return;
+
+  inactive = (p == ctx->left) ? ctx->right : ctx->left;
+  if (!inactive || inactive->vol != p->vol)
+    return;
+
+  selected = GetPanelSelectedDir(inactive);
+  if (!selected)
+    return;
+
+  snapshot->panel = inactive;
+  GetPath(selected, snapshot->selected_path);
+  snapshot->selected_path[PATH_LENGTH] = '\0';
+  if (selected->next) {
+    GetPath(selected->next, snapshot->next_sibling_path);
+    snapshot->next_sibling_path[PATH_LENGTH] = '\0';
+  }
+  if (selected->prev) {
+    GetPath(selected->prev, snapshot->prev_sibling_path);
+    snapshot->prev_sibling_path[PATH_LENGTH] = '\0';
+  }
+}
+
+static const DirEntry *ResolveInactiveFallbackTarget(
+    const InactiveFallbackSnapshot *snapshot) {
+  const struct Volume *vol;
+  DirEntry *target;
+  char root_path[PATH_LENGTH + 1];
+
+  if (!snapshot || !snapshot->panel || !snapshot->panel->vol)
+    return NULL;
+  vol = snapshot->panel->vol;
+
+  target = FindVisibleDirByPath(vol, snapshot->selected_path);
+  if (target)
+    return target;
+
+  root_path[0] = '\0';
+  if (vol->vol_stats.tree) {
+    GetPath(vol->vol_stats.tree, root_path);
+    root_path[PATH_LENGTH] = '\0';
+  }
+
+  target = FindDirByPathOrAncestor(vol, snapshot->selected_path);
+  while (target) {
+    char target_path[PATH_LENGTH + 1];
+
+    GetPath(target, target_path);
+    target_path[PATH_LENGTH] = '\0';
+    if (FindDirIndex(vol, target) >= 0 &&
+        (root_path[0] == '\0' || strcmp(target_path, root_path) != 0)) {
+      return target;
+    }
+    target = target->up_tree;
+  }
+
+  target = FindVisibleDirByPath(vol, snapshot->next_sibling_path);
+  if (target)
+    return target;
+
+  target = FindVisibleDirByPath(vol, snapshot->prev_sibling_path);
+  if (target)
+    return target;
+
+  return vol->vol_stats.tree;
+}
+
 static void CaptureInactiveFallback(ViewContext *ctx, YtreePanel *p,
                                     const DirEntry *dir_entry,
                                     YtreePanel **inactive_out,
@@ -659,22 +788,7 @@ static void CaptureInactiveFallback(ViewContext *ctx, YtreePanel *p,
   if (!inactive || inactive->vol != p->vol)
     return;
 
-  if (inactive->vol->total_dirs > 0) {
-    int inactive_idx = inactive->disp_begin_pos + inactive->cursor_pos;
-    if (inactive_idx < 0)
-      inactive_idx = 0;
-    if (inactive_idx >= inactive->vol->total_dirs)
-      inactive_idx = inactive->vol->total_dirs - 1;
-    inactive_de = inactive->vol->dir_entry_list[inactive_idx].dir_entry;
-  }
-  if (!inactive_de && inactive->file_selection_dir_path[0] != '\0') {
-    inactive_de = FindDirByPath(inactive->vol, inactive->file_selection_dir_path);
-  }
-  if (!inactive_de)
-    inactive_de = inactive->file_dir_entry;
-  if (!inactive_de) {
-    inactive_de = inactive->vol->vol_stats.tree;
-  }
+  inactive_de = GetPanelSelectedDir(inactive);
 
   inactive_fallback = inactive_de;
   if (dir_entry != NULL) {
@@ -927,6 +1041,10 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
 }
 
 DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
+  InactiveFallbackSnapshot inactive_snapshot;
+
+  CaptureInactiveFallbackSnapshot(ctx, ctx->active, &inactive_snapshot);
+
   if (!DeleteDirectory(ctx, dir_entry, UI_ChoiceResolver)) {
     if (ctx->active->disp_begin_pos + ctx->active->cursor_pos > 0) {
       if (ctx->active->cursor_pos > 0)
@@ -937,6 +1055,12 @@ DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   }
 
   BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
+  if (inactive_snapshot.panel && inactive_snapshot.panel->vol == ctx->active->vol) {
+    const DirEntry *inactive_target =
+        ResolveInactiveFallbackTarget(&inactive_snapshot);
+    ReanchorPanelToDir(inactive_snapshot.panel, inactive_target);
+    BuildFileEntryList(ctx, inactive_snapshot.panel);
+  }
   dir_entry = ctx->active->vol
                   ->dir_entry_list[ctx->active->disp_begin_pos +
                                    ctx->active->cursor_pos]

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -1374,6 +1374,116 @@ def test_f8_inactive_selection_moves_to_parent_on_mirrored_collapse(tmp_path, yt
     tui.quit()
 
 
+def test_f8_inactive_selection_delete_falls_to_next_visible_sibling(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "f8_mirrored_delete_sibling_fallback"
+    root.mkdir()
+
+    before_dir = root / "aaa_before_dir"
+    target_dir = root / "bbb_target_dir"
+    after_dir = root / "ccc_after_dir"
+    before_dir.mkdir()
+    target_dir.mkdir()
+    after_dir.mkdir()
+    (before_dir / "before_marker.txt").write_text("before\n", encoding="utf-8")
+    (target_dir / "target_marker.txt").write_text("target\n", encoding="utf-8")
+    (after_dir / "after_marker.txt").write_text("after\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(1.0)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(
+            tui, "Expected right panel tree mode before mirrored delete."
+        )
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.child.send(Keys.DELETE)
+        tui.child.expect(r"(Delete this directory|PRUNE)", timeout=2.0)
+        tui.child.send("Y")
+        tui.send_keystroke("", wait=0.9)
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        _assert_dir_mode_footer(
+            tui, "Expected right panel tree mode after mirrored delete."
+        )
+        tui.send_keystroke(Keys.ENTER, wait=0.6)
+
+        screen = _screen_text(tui)
+        header = screen.splitlines()[0] if screen else ""
+        assert "ccc_after_dir" in header and "bbb_target_dir" not in header, (
+            "Deleting the inactive-selected directory should fall forward to the "
+            "next visible sibling before root.\n"
+            f"{screen}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_f8_inactive_selection_delete_falls_to_visible_ancestor(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "f8_mirrored_delete_ancestor_fallback"
+    root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
+
+    grand_dir = root / "grand_dir"
+    deleted_ancestor = grand_dir / "ancestor_to_delete"
+    selected_dir = deleted_ancestor / "selected_leaf"
+    grand_dir.mkdir()
+    deleted_ancestor.mkdir()
+    selected_dir.mkdir()
+    (grand_dir / "grand_marker.txt").write_text("grand\n", encoding="utf-8")
+    (selected_dir / "selected_marker.txt").write_text("selected\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(1.0)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke(Keys.RIGHT, wait=0.5)
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke(Keys.RIGHT, wait=0.5)
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(
+            tui, "Expected right panel tree mode before ancestor delete."
+        )
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.child.send(Keys.DELETE)
+        tui.child.expect(r"(Delete this directory|PRUNE)", timeout=2.0)
+        tui.child.send("Y")
+        tui.send_keystroke("", wait=1.0)
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        _assert_dir_mode_footer(
+            tui, "Expected right panel tree mode after ancestor delete."
+        )
+        tui.send_keystroke(Keys.ENTER, wait=0.6)
+
+        screen = _screen_text(tui)
+        assert "grand_marker.txt" in screen, (
+            "Deleting an ancestor of the inactive selection should fall back to the "
+            "nearest surviving visible ancestor.\n"
+            f"{screen}"
+        )
+        assert "selected_marker.txt" not in screen, (
+            "Inactive panel still entered the deleted subtree after ancestor delete.\n"
+            f"{screen}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_bug_f_eight_mirrored_inactive_selection_identity_stable(tmp_path, ytree_binary):
     """
     BUG-36 regression:
@@ -1439,6 +1549,77 @@ def test_bug_f_eight_mirrored_inactive_selection_identity_stable(tmp_path, ytree
         )
 
     tui.quit()
+
+
+def test_bug_f_eight_mkdir_additions_keep_inactive_selection_identity(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "bug_f_eight_mkdir_add_identity"
+    root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nTREEDEPTH=1\n", encoding="utf-8")
+
+    active_branch = root / "active_branch"
+    tail_dir = root / "zzz_tail"
+    active_branch.mkdir()
+    tail_dir.mkdir()
+    (active_branch / "branch_file.txt").write_text("branch\n", encoding="utf-8")
+    (active_branch / "child_existing").mkdir()
+    (tail_dir / "tail_file.txt").write_text("tail\n", encoding="utf-8")
+
+    def _active_path_contains(tui, marker):
+        screen = _screen_text(tui)
+        header = screen.splitlines()[0] if screen else ""
+        return marker in header
+
+    def _select_dir_by_marker(tui, marker):
+        for _ in range(40):
+            if _active_path_contains(tui, marker):
+                return
+            tui.send_keystroke(Keys.DOWN, wait=0.2)
+        raise AssertionError(
+            f"Could not select '{marker}' in tree view.\n{_screen_text(tui)}"
+        )
+
+    def _assert_right_panel_opens_tail_dir(tui, label):
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(tui, f"{label}: expected right panel tree mode.")
+        tui.send_keystroke(Keys.ENTER, wait=0.5)
+        screen = _screen_text(tui)
+        header = screen.splitlines()[0] if screen else ""
+        assert "zzz_tail" in header and "active_branch" not in header, (
+            f"{label}: inactive selection drifted away from zzz_tail.\n{screen}"
+        )
+        tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(tui, f"{label}: expected right panel to return to tree mode.")
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.9)
+    try:
+        _select_dir_by_marker(tui, "active_branch")
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(tui, "Expected right panel tree mode after split.")
+        _select_dir_by_marker(tui, "zzz_tail")
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(tui, "Expected left panel tree mode before mkdir flow.")
+
+        _assert_right_panel_opens_tail_dir(tui, "baseline")
+
+        tui.send_keystroke(Keys.HOME, wait=0.3)
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("aaa_root_insert" + Keys.ENTER, wait=0.8)
+        _assert_right_panel_opens_tail_dir(tui, "after sibling add")
+
+        _select_dir_by_marker(tui, "active_branch")
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("aaa_child_insert" + Keys.ENTER, wait=0.8)
+        _assert_right_panel_opens_tail_dir(tui, "after ancestor-branch add")
+    finally:
+        tui.quit()
 
 
 def test_bug_f_eight_dotfiles_toggle_keeps_inactive_selection_identity(


### PR DESCRIPTION
## Summary
- enforce deterministic inactive-panel fallback behavior for mirrored split-tree updates
- add focused regressions for mirrored collapse, delete invalidation, and non-invalidating add flows
- harden AI workflow autonomy rules to require immediate worker-completion handling with proactive polling

## Changes
- `src/ui/dir_ops.c`
  - preserve inactive selection identity by path where still valid
  - resolve invalidated inactive selection with deterministic order: nearest visible ancestor, next sibling, previous sibling, root
- `tests/test_panel_isolation.py`
  - add mirrored delete fallback regression coverage
  - add mirrored add non-invalidation regression coverage
- `docs/ai/WORKFLOW.md`, `.ai/shared.md`
  - require proactive polling/waiting of active workers
  - require immediate completion handling sequence (read report, validate, close worker, proceed, update maintainer)

## Verification
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k "mirrored or inactive_selection or dotfiles_toggle"`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py`
- `make clean && make`
