### PR TITLE
fix(split): keep per-volume file-window state stable during volume cycling

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -18,7 +18,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Regression notes (manual, 2026-05-21)**:
     *   `F10` can fail with `Can't edit "/home/rob/.ytree"` after volume-cycle transitions, then succeeds again after cycling back.
     *   With `SMALLWINDOWSKIP=0`, cycling away and back from a zoomed file window can return the same location in small-window non-zoom state.
-*   **Status**: Reopened (regression confirmed).
+*   **Status**: Fixed.
 
 ### **BUG-2: F8 Same-Volume Destination Navigation Can Lose Source Selection/Tagged Set**
 *   **Description**: In `F8` split mode on the same volume, navigating the destination side (including creating/changing directories during copy/move preparation) can cause the original source file selection/tagged set to disappear or be replaced by the destination-context file list.
@@ -64,7 +64,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Impact**: Indicates unstable cross-panel state restoration and increases risk of wrong-target operations after state churn.
 *   **Remediation**: Re-anchor inactive selection strictly by stable directory identity/path during mirror updates; never re-resolve by transient index unless deterministic fallback is required.
 *   **Tests/Gates**: Add deterministic regression asserting no inactive selection movement on non-invalidating dotfile toggles.
-*   **Status**: Fixed (manually re-verified 2026-05-21).
+*   **Status**: Fixed.
 
 ### **BUG-5: F8 + SMALLWINDOWSKIP=0 Tab Can Force Inactive Panel into Wrong Focus**
 *   **Description**: With `SMALLWINDOWSKIP=0`, when cursor is in the small file window on one panel, `Tab` to the other panel can show that inactive panel as file-focused/zoomed unexpectedly; tabbing back restores prior tree/small state.
@@ -85,7 +85,20 @@ Ordering policy (for all editors, including AI editors):
     *   With `SMALLWINDOWSKIP=0`, `Tab` can still show the inactive panel in zoomed file-window focus until tabbing back.
 *   **Status**: Reopened (regression confirmed).
 
-### **BUG-6: F7 Preview Over-Restricts Command Availability**
+### **BUG-6: Dir Display Mode Resets After Context Switch (`^F`/Future `1..4`)**
+*   **Description**: Setting a directory display mode while focused in dir/tree context can be lost after entering file/small-window context and returning to dir/tree context.
+*   **Repro (manual)**:
+    *   In dir/tree focus, press `^F` to cycle to a non-default dir display mode (for example Owner/Times).
+    *   Enter file/small-window focus.
+    *   Return to dir/tree focus.
+*   **Expected**: Dir display mode remains as last set in dir context until explicitly changed.
+*   **Actual**: Dir display mode reverts/reset unexpectedly.
+*   **Impact**: Breaks context-local view-state persistence and makes display-mode controls feel unreliable.
+*   **Remediation**: Persist dir-context display mode independently across focus/context transitions, and preserve it when file-context display mode changes.
+*   **Related**: `ROADMAP` Task 47 (`1..0 FileInfo` ownership contract).
+*   **Status**: Confirmed.
+
+### **BUG-7: F7 Preview Over-Restricts Command Availability**
 *   **Description**: `F7` mode is currently incomplete for inspect-and-act workflows. Too many common file actions are disabled, so users must leave preview to continue work.
 *   **Expected Behavior**:
     *   `F7` should allow a practical command subset for in-context file work (for example attributes/copy/delete/edit/filter/compare/move/new-date/open/print/rename/tag/untag/view/execute/quit paths as applicable).
@@ -97,57 +110,57 @@ Ordering policy (for all editors, including AI editors):
 *   **Related**: Existing regression intent for `F8`-in-`F7` state safety should remain preserved and extended to `Tab`.
 *   **Status**: Confirmed.
 
-### **BUG-7: `Write` Offers/Describes Actions That Are Not Context-Valid**
+### **BUG-8: `Write` Offers/Describes Actions That Are Not Context-Valid**
 *   **Description**: `Write` format/options/prompt/help are not consistently aligned with context (`dir`/`file`/`archive`/`tagged`) and can imply workflows that are unavailable or misleading in the active mode.
 *   **Impact**: Reduces discoverability and trust, and creates avoidable trial-and-error in critical output/export flows.
 *   **Remediation**: Define and enforce a context-valid option matrix for `Write`, expose only valid options in each mode, and keep prompt/help text explicit and non-jargon (including destination examples such as file output and printer-command output). Keep `SPECIFICATION`, `F1` help, and manpage/USAGE text synchronized with the same destination semantics.
 *   **Status**: Confirmed.
 
-### **BUG-8: Copy/Move Cancel (`Esc`) Can Leave Footer Blank**
+### **BUG-9: Copy/Move Cancel (`Esc`) Can Leave Footer Blank**
 *   **Description**: In `Copy`/`Move` flows, canceling with `Esc` can leave footer/help lines blank instead of restoring the normal context footer.
 *   **Findings**:
     *   Deterministic repro under sanitizer gate (`make qa-sanitize`) on 2026-05-16: `tests/test_display_layout.py::test_dir_copy_to_missing_destination_prompts_create_and_no_restores_footer` fails with `AssertionError: Header/path row disappeared after canceling create prompt`.
     *   The failing path is directory copy to a missing destination where the create-directory prompt is canceled with `No`.
 *   **Impact**: Hides command discoverability immediately after a canceled mutation flow and makes the UI look partially broken.
 *   **Remediation**: On all `Copy`/`Move` cancel/exit paths (`Esc` and equivalent cancel keys), restore footer/help ownership deterministically to the active view context and force a full footer redraw before accepting the next command.
-*   **Related**: `BUG-23` (footer restore consistency during input flows), `ROADMAP` Task 46 (footer/F1 context parity).
+*   **Related**: `BUG-24` (footer restore consistency during input flows), `ROADMAP` Task 46 (footer/F1 context parity).
 *   **Status**: Confirmed.
 
-### **BUG-9: Prompt Footer/F1 Parity Can Hide Available Prompt Actions**
+### **BUG-10: Prompt Footer/F1 Parity Can Hide Available Prompt Actions**
 *   **Description**: In prompt-driven workflows, footer/F1 coverage can omit active prompt actions and semantics (for example completion/browse controls and compare/archive prompt meanings), leaving available behavior under-discoverable.
 *   **Impact**: Creates hidden-feature workflow confusion and high-friction issue reports during routine operations.
 *   **Remediation**: Enforce a prompt-context parity contract: footer shows currently available prompt actions; F1 may add concise semantics/examples for those same actions, but must not advertise unavailable actions.
-*   **Related**: `ROADMAP` Task 46 (footer/F1 context parity), `BUG-12` (archive unavailable-action messaging), `BUG-7` (prompt/help context mismatch).
+*   **Related**: `ROADMAP` Task 46 (footer/F1 context parity), `BUG-13` (archive unavailable-action messaging), `BUG-8` (prompt/help context mismatch).
 *   **Status**: Confirmed.
 
-### **BUG-10: Progress Spinner Can Overwrite Footer/Prompt Help Surfaces**
+### **BUG-11: Progress Spinner Can Overwrite Footer/Prompt Help Surfaces**
 *   **Description**: During long-running operations, spinner/progress rendering can overwrite footer/prompt help text instead of using a non-obtrusive status area.
 *   **Impact**: Hides available actions and makes active workflows look unstable or hung.
 *   **Remediation**: Preserve footer/prompt/F1 ownership during progress updates. Render progress in a dedicated non-obtrusive status surface, and degrade to a compact indicator when space is constrained rather than overwriting help text.
 *   **Related**: `ROADMAP` Task 23 (progress indicators), `ROADMAP` Task 46 (footer/F1 parity contract).
 *   **Status**: Confirmed.
 
-### **BUG-11: Copy/Move/PathCopy Rename Prompt Missing Explicit `AS:` Label**
+### **BUG-12: Copy/Move/PathCopy Rename Prompt Missing Explicit `AS:` Label**
 *   **Description**: The first rename-target prompt in `Copy`, `Move`, and `PathCopy` can appear as `COPY: <source> <edited_target>` (and equivalents) without explicit `AS:` labeling, making source vs new-name intent ambiguous.
 *   **Impact**: Increases wrong-target risk and slows high-frequency copy/move workflows because users must infer prompt semantics from field behavior.
 *   **Remediation**: Make rename intent explicit in prompt text for all three flows (for example `COPY: <source> AS: <target>`), keep one-flow interaction depth, and keep destination-dir prompt behavior unchanged. Add focused regression coverage for prompt text/flow parity in `Copy`, `Move`, and `PathCopy`. Keep `F1` help, manpage/USAGE text, and specification wording synchronized with final prompt contract.
 *   **Related**: `ROADMAP` Task 45 (prompt/help clarity).
 *   **Status**: Confirmed.
 
-### **BUG-12: Archive Unavailable-Action Message Reports Wrong Shortcut**
+### **BUG-13: Archive Unavailable-Action Message Reports Wrong Shortcut**
 *   **Description**: In archive mode, triggering `^W` can show an error message for a different shortcut (`^P is not available in archive mode`).
 *   **Impact**: Misleading feedback increases operator confusion and undermines trust in key/action hints.
 *   **Remediation**: Ensure unavailable-action messaging reports the actual attempted action/shortcut in archive context.
 *   **Status**: Confirmed.
 
-### **BUG-13: Single-Empty-Directory Archive Can Collapse Tree Rendering**
+### **BUG-14: Single-Empty-Directory Archive Can Collapse Tree Rendering**
 *   **Description**: In archive mode, when the archive contains only one empty directory, ytree can skip normal tree-node rendering and show that directory identity as appended archive-name/path text instead.
 *   **Impact**: Obscures archive structure and creates high-friction navigation confusion in a common edge case.
 *   **Remediation**: Keep archive tree rendering consistent in this edge case: render a proper directory node in the tree and keep archive identity separate from child directory labels.
-*   **Related**: `BUG-12` (name-text rendering contamination), `ROADMAP` Task 16 (path/message formatting hygiene).
+*   **Related**: `BUG-13` (name-text rendering contamination), `ROADMAP` Task 16 (path/message formatting hygiene).
 *   **Status**: Confirmed.
 
-### **BUG-14: File-View Focus Leak After Parent Jump (`\\`)**
+### **BUG-15: File-View Focus Leak After Parent Jump (`\\`)**
 *   **Description**: After entering parent-directory context from file view using `\\`, navigation keys affect the directory pane before explicit mode switch.
 *   **Findings**:
     *   Arrow keys can change adjacent directory selection while the user is still in file view.
@@ -156,68 +169,68 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Keep navigation scope in the file list after `\\` parent jump and require explicit `Enter` transition before directory-pane navigation is allowed.
 *   **Status**: Confirmed.
 
-### **BUG-15: Zoom/Split State Corruption After Parent/View Toggles**
+### **BUG-16: Zoom/Split State Corruption After Parent/View Toggles**
 *   **Description**: After a sequence involving show-all, repeated view-mode toggles, parent jump (`\\`), and another view toggle, the UI exits the expected zoomed state and shows an empty small pane.
 *   **Findings**:
     *   Layout unexpectedly switches back to tree + small window.
     *   Small window can become empty instead of preserving the current context.
 *   **Impact**: Breaks predictable navigation flow and increases risk of accidental context loss.
 *   **Remediation**: Preserve active zoom/view state across parent-jump and view-toggle transitions; prevent empty-pane state in this flow.
-*   **Related**: `BUG-14` (same focus/state-transition family).
+*   **Related**: `BUG-15` (same focus/state-transition family).
 *   **Status**: Confirmed.
 
-### **BUG-16: Long Lines Wrap Instead of Truncate in List Views**
+### **BUG-17: Long Lines Wrap Instead of Truncate in List Views**
 *   **Description**: Long entries wrap to additional rows instead of truncating in single-row list rendering contexts (reported in `^f` small-window flow and dir/tree list views).
 *   **Impact**: Breaks scanability, corrupts row alignment, and causes ambiguous cursor context in navigation-heavy views.
 *   **Remediation**: Enforce truncate/clipping semantics for list-row rendering in these views and add regression tests that fail on wrapping behavior.
 *   **Status**: Confirmed.
 
-### **BUG-17: Intermittent Showall/Global Filter Can Hide Matching Files**
+### **BUG-18: Intermittent Showall/Global Filter Can Hide Matching Files**
 *   **Description**: In intermittent edge-case `Showall/Global` + filter combinations, directories can show no files even when matching files exist.
 *   **Impact**: Breaks trust in filter correctness and can make users miss valid results.
 *   **Remediation**: Capture a minimal deterministic repro and add regression coverage; verify file-list build/count/filter logic remains consistent in `Showall/Global` contexts with active filters.
 *   **Status**: Confirmed.
 
-### **BUG-18: Directory Copy Prompt Does Not Clearly State Recursive Behavior**
+### **BUG-19: Directory Copy Prompt Does Not Clearly State Recursive Behavior**
 *   **Description**: Directory copy flow prompt text is not explicit enough that directory copy is recursive, so users cannot reliably predict whether descendants are included.
 *   **Impact**: Creates avoidable trust/friction issues in backup-style workflows and increases accidental over-copy concern.
 *   **Remediation**: Make directory-copy prompts/confirmation text explicit about recursive behavior and resulting destination semantics before execution.
 *   **Status**: Confirmed.
 
-### **BUG-19: Directory Copy Can Appear Successful While Producing No Effective Update**
+### **BUG-20: Directory Copy Can Appear Successful While Producing No Effective Update**
 *   **Description**: In some destination states (for example existing target or edge-case destination handling), directory-copy flow can look like it executed successfully while leaving destination contents unchanged or unclear to the user.
 *   **Impact**: High wrong-assurance risk for repeat backup workflows where users expect an update on each run.
 *   **Remediation**: Report explicit copy outcome (`updated`, `skipped`, `destination exists`, or error) and never leave no-op outcomes ambiguous. Add regression coverage for existing-destination and missing-parent edge paths.
 *   **Status**: Confirmed.
 
-### **BUG-20: Archive Mutations Do Not Show Immediate Results in Archive View**
+### **BUG-21: Archive Mutations Do Not Show Immediate Results in Archive View**
 *   **Description**: In archive mode, mutating actions (for example `rename`, `mkdir`, and copy-in flows) can succeed but the current archive listing does not reflect the change immediately.
 *   **Impact**: Creates false-failure perception and high-friction workflow confusion because users may repeat operations that already succeeded.
 *   **Remediation**: After any successful archive mutation, update the archive view in-place so users immediately see the effect in the same archive context, with no manual refresh/re-entry/relog required. Preserve cursor/selection when possible.
-*   **Related**: `BUG-19` (copy outcome clarity).
+*   **Related**: `BUG-20` (copy outcome clarity).
 *   **Status**: Confirmed.
 
-### **BUG-21: Attributes Name Truncation Can Hide File Identity**
+### **BUG-22: Attributes Name Truncation Can Hide File Identity**
 *   **Description**: In attributes/stat contexts, long file names can be truncated using a tail-only style (for example `...fy_xml_integrity.sh`) that hides too much distinguishing information and makes similarly named files harder to differentiate at a glance.
 *   **Impact**: Increases wrong-target risk during metadata workflows and slows navigation in dense directories with similar filenames.
 *   **Remediation**: Apply an identity-preserving truncation policy for filename-bearing attribute surfaces: keep static deterministic text (no marquee/auto-scroll), prefer `prefix…suffix` for plain filenames, and use suffix-focused clipping only where path-tail context is explicitly higher-value.
-*   **Related**: `BUG-16` (no-wrap/truncate contract), `ROADMAP` Task 21 (manual file-column width controls).
+*   **Related**: `BUG-17` (no-wrap/truncate contract), `ROADMAP` Task 21 (manual file-column width controls).
 *   **Status**: Confirmed.
 
-### **BUG-22: Internal Preview Down-Scroll Can Pass EOF and Repeat Last Page**
+### **BUG-23: Internal Preview Down-Scroll Can Pass EOF and Repeat Last Page**
 *   **Description**: In internal preview paths (`F7` preview and internal `^V` tagged viewer), down-scroll/page-down can continue past EOF and keep redisplaying the last page. Up-scroll behavior does not show this defect. External viewer mode stops correctly at EOF.
 *   **Impact**: Produces misleading navigation state and inconsistent behavior between internal and external viewing paths.
 *   **Remediation**: Clamp downward preview offsets at the last valid page in shared internal preview rendering paths so bottom-of-file is a hard stop.
 *   **Related**: `F7` preview and internal `^V` tagged viewer should be treated as one defect family.
 *   **Status**: Confirmed.
 
-### **BUG-23: `/` Jump Replaces Footer Help with Prompt UI**
+### **BUG-24: `/` Jump Replaces Footer Help with Prompt UI**
 *   **Description**: Pressing `/` currently switches footer content to a `Jump to:` prompt UI instead of keeping the normal footer help text visible while incremental jump runs.
 *   **Impact**: Breaks the expected inline jump flow and creates avoidable UI churn during frequent navigation.
 *   **Remediation**: Keep footer help text unchanged during `/` incremental jump and apply immediate selection movement as characters are typed (for example `/y` jumps to the first matching entry) without footer prompt takeover.
 *   **Status**: Confirmed.
 
-### **BUG-24: Recursive Scan Interrupt Responsiveness**
+### **BUG-25: Recursive Scan Interrupt Responsiveness**
 *   **Description**: Interrupting a recursive expansion (`*`) via `ESC` is supported but requires multiple keypresses (Prompt Y/N).
 *   **Impact**: Users cannot instantly halt accidental large-branch scans.
 *   **Remediation**: Evaluate if `ESC` during `ReadTree` should immediately halt the scan once instead of prompting, given that partial results are preserved.
@@ -225,7 +238,7 @@ Ordering policy (for all editors, including AI editors):
 
 ## **Correctness, Consistency, and Naming Defects (Priority Ordered)**
 
-### **BUG-25: Configuration Template Drift (`VI_KEYS`)**
+### **BUG-26: Configuration Template Drift (`VI_KEYS`)**
 *   **Description**: Discrepancy in default visibility and documentation for `VI_KEYS`.
 *   **Findings**:
     *   `default_profile_template.h` uses `VI_KEYS=0`.
@@ -235,7 +248,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Ensure the `ytree --init` generation path strictly matches the `etc/ytree.conf` provided in the distribution.
 *   **Status**: Confirmed.
 
-### **BUG-26: VI Mode Key Ambiguity and Collisions**
+### **BUG-27: VI Mode Key Ambiguity and Collisions**
 *   **Description**: When `VI_KEYS=1` is enabled, lowercase navigation keys (`h/j/k/l`) collide with primary command keys without clear UI signaling.
 *   **Findings**:
     *   `j` maps to both `ACTION_MOVE_DOWN` (via `VI_KEY_DOWN`) and historically to `ACTION_LOG_VOLUME` (though currently `l/L` is the log volume key, older documentation/muscle memory remains confused).
@@ -244,14 +257,14 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Audit all `VI_KEY` remappings in `key_engine.c` and ensure the footer help lines (`display.c`) dynamically update to show the uppercase variants when `VI_KEYS=1`.
 *   **Status**: Confirmed.
 
-### **BUG-27: Incremental Search Legacy Mapping (`F12`)**
+### **BUG-28: Incremental Search Legacy Mapping (`F12`)**
 *   **Description**: `F12` is used as an alias for `/` (Incremental Search/Jump), but its presence is inconsistent in help strings and documentation.
 *   **Impact**: Confuses users about "hidden" keys.
 *   **Remediation**: Explicitly document `F12` as a legacy alias or deprecate it in favor of standard `/`.
 *   **Parity Principle:** Treat this as a documentation-parity defect class: no active keybinding may exist in runtime without consistent footer, `F1`, and manpage/USAGE coverage.
 *   **Status**: Confirmed.
 
-### **BUG-28: Misleading Tree Expansion Action Names**
+### **BUG-29: Misleading Tree Expansion Action Names**
 *   **Description**: The internal `YtreeAction` names for tree expansion are swapped relative to their behavior and documentation.
 *   **Findings**:
     *   `+` key maps to `ACTION_TREE_EXPAND_ALL`, but only expands **one level**.
@@ -262,7 +275,7 @@ Ordering policy (for all editors, including AI editors):
     *   Rename `ACTION_ASTERISK` -> `ACTION_TREE_EXPAND_RECURSIVE`.
 *   **Status**: Confirmed.
 
-### **BUG-29: Intermittent Split-Brain Redraw Between Stats Box and Main Panes**
+### **BUG-30: Intermittent Split-Brain Redraw Between Stats Box and Main Panes**
 *   **Description**: Intermittently, the stats box redraw state can diverge from the main UI surfaces (`path`, `dir`, and `file` windows), leaving one surface fresh while the other appears stale/corrupted.
 *   **Impact**: Creates a visibly broken UI state and undermines trust in navigation context during active workflows.
 *   **Remediation**: Unify frame redraw ownership so stats and main panes are rendered from one layout snapshot in one update cycle, and force full-surface invalidation/redraw on resize/recovery/error paths.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,7 @@ Ordering policy (for all editors, including AI editors):
 *   All new/updated split-isolation tests pass locally and in PR full-QA CI evidence.
 *   Linked split-panel bugs (`BUG-2`, `BUG-3`, `BUG-4`, `BUG-5`) are either fixed or have explicit blocker notes tied to this work.
 *   **Outcome:** Completed. Ownership map + boundary invariants/assertions are in place; split dotfile ownership migration remains follow-on work.
-*   - [x] **Status:** Completed.
+*   - [ ] **Status:** Not Started.
 
 ### **Task 2: Remove Dead-History Comments + Add Anti-History Comment Gate**
 *   **Goal:** Remove comments that describe removed code/history and prevent their reintroduction.
@@ -515,6 +515,7 @@ Ordering policy (for all editors, including AI editors):
 ### **Task 46: Enforce Footer/F1 Context-Parity Contract (gettext-ready)**
 *   **Goal:** Ensure F1 help is concise, context-specific, and complete for each footer/help variant, with no missing commands.
 *   **Rationale:** Footer and F1 are the primary in-app guidance surfaces; they must match exactly while keeping F1 brief and pushing detail to manpage/USAGE.
+*   **Related Bugs:** `BUG-9` / `BUG-10` / `BUG-15` / `BUG-14` / `BUG-13` — footer/help/prompt mismatch (discoverability + confidence).
 *   **Scope Lock:** Help contract, coverage matrix, and text-structure readiness only; no command behavior changes in this task.
 *   **Acceptance Criteria:**
 *   For each supported context, every footer command appears in the matching F1 help set with concise wording and no essay-style descriptions.
@@ -538,15 +539,19 @@ Ordering policy (for all editors, including AI editors):
 *   `6` => toggle symlink row rendering (`name` vs `name -> target`) in list rows.
 *   `7` => toggle richer metadata/text-snippet view.
 *   `8` => toggle file-type/summary view.
-*   `9` => toggle brief/full width behavior for the focused panel.
-*   `0` => Git-focused file-info band (status-oriented view) when the current scope is inside a Git worktree.
-*   Number keys are toggle-driven controls: `0..4` select the primary file-info layout while `5..9` toggle additive display behaviors.
-*   Applies to file-display rendering across normal list contexts for the active panel (whether focus is currently on tree/dir window or file window); not active in `F7` preview mode.
+*   `9` => toggle brief/full width behavior for file-window rendering.
+*   `0` => Git-focused file-info band (status-oriented file view) when the current scope is inside a Git worktree.
+*   Number keys are grouped by ownership/scope for the active panel:
+    *   **Panel-wide toggles (dir + file projections):** `` ` `` dotfiles (existing behavior) and `5` size-unit toggle.
+    *   **Context-scoped display modes (`dir` vs `file`):** `1..4` apply to the currently focused context only (dir-focus changes dir display only; file-focus changes file display only).
+    *   **File-window-only toggles:** `6..0` (`6`, `7`, `8`, `9`, `0`) affect file-window rendering only and are silent no-ops when dir/tree focus is active.
+*   Not active in `F7` preview mode.
 *   If a requested mode is unsupported in the active context (for example VFS file mode `4`, or `0` outside a Git worktree), do a silent no-op (no beep).
 *   Git band (`0`) defaults to off, uses cached/non-blocking status refresh, and must not stall list rendering in large repos.
 *   Add `FILE_SIZE_UNITS=binary|human-readable` profile setting (default `binary`) as the seed for `5`.
 *   **Keybinding Policy:** Remove `^F` from runtime behavior and help/manpage docs. This task is the explicit keybinding-change exception referenced by Task 39 scope lock.
 *   **UX/Help Policy:** Footer stays concise (`1..0 FileInfo`); full key semantics live in F1 help/manpage.
+*   **Spec/Docs Sync Policy:** When delivered, update `docs/SPECIFICATION.md` and `etc/ytree.1.md` (and regenerated `docs/USAGE.md`) with the same grouped ownership contract.
 *   - [ ] **Status:** Not Started.
 
 ### **Task 48: Add Case-Sensitive Sort Toggle + Profile Default**
@@ -830,7 +835,17 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Future Phase 1: Post-Baseline Configurability Follow-On**
 
-### **Idea FE-1: Explicit Accessibility Mode (Screen-Reader-First Terminal Behavior)**
+### **Idea FE-1: Optional Hidden-Child Restore on Re-Expand (`RESTORE_HIDDEN_CHILD=0|1`)**
+*   **Goal:** Add an opt-in tree-navigation behavior that can restore the previously selected hidden child when a collapsed parent is re-expanded.
+*   **Config Direction (`ytree.conf`):** `RESTORE_HIDDEN_CHILD=0|1` (default `0`).
+*   **Behavior Contract:**
+    *   When `0` (default), keep current deterministic behavior: collapse invalidates child selection and selection remains at the fallback target (typically parent) after re-expand.
+    *   When `1`, re-expand restores the last hidden child only if it still exists and is visible/valid; otherwise use deterministic fallback order (nearest ancestor, next/previous sibling, root visible node).
+    *   Behavior applies to general tree navigation, not only split mode.
+*   **Rationale:** Supports users who prefer sticky child selection after collapse/expand without changing default deterministic semantics.
+*   - [ ] **Status:** Not Started.
+
+### **Idea FE-2: Explicit Accessibility Mode (Screen-Reader-First Terminal Behavior)**
 *   **Goal:** Introduce an opt-in explicit accessibility mode focused on stable, low-noise behavior for screen-reader workflows.
 *   **Research Gate (Required Before Implementation):**
     *   Audit current redraw/cursor-update hotspots (clock, spinner, status-line, dialogs, preview loops) for assistive-tech impact.
@@ -843,7 +858,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Terminal UI is not automatically accessible; explicit mode-level contracts are needed to avoid redraw/cursor noise regressions.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-2: Portable Keyboard Capability Probe + `.ytree` Key Workarounds**
+### **Idea FE-3: Portable Keyboard Capability Probe + `.ytree` Key Workarounds**
 *   **Goal:** Add startup-time terminal key-capability probing and user-configurable key overrides/workarounds in `~/.ytree`.
 *   **Behavior Direction:**
     *   Probe optional key availability once at startup (cache results; no per-keystroke probing overhead).
@@ -852,7 +867,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Improves old-terminal portability while keeping runtime input handling fast.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-3: Keymap Follow-On Work (Post-Baseline)**
+### **Idea FE-4: Keymap Follow-On Work (Post-Baseline)**
 *   **Description:** Follow-up keymap work after baseline keymap support lands (preset profiles, conflict diagnostics, import/export format hardening, and migration notes for existing users).
 *   **Localized keymap profiles:** Add opt-in locale-oriented profiles as separate keymap files (not automatic locale remapping), while keeping the default keymap stable.
 *   **Best-practice guardrails:** Preserve a universal core of stable bindings (function keys/Ctrl/digits/arrows), allow locale mnemonic aliases where safe, and enforce strict collision/unbound-action validation with clear diagnostics.
@@ -860,7 +875,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Future Phase 2: UI/UX Enhancements and Cleanup**
 
-### **Idea FE-4: Configurable VCS Provider for `0` FileInfo Band**
+### **Idea FE-5: Configurable VCS Provider for `0` FileInfo Band**
 *   **Goal:** Keep `0` as one stable VCS info band while allowing users to choose which backend powers it.
 *   **Config Direction (`ytree.conf`):** Add a single-provider selector (for example `VCS_PROVIDER=off|git|hg|svn|fossil|auto`).
 *   **Behavior Contract:**
@@ -870,7 +885,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Preserves key stability and avoids renumbering while keeping a path open for non-Git users.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-5: Typed Filter Modes (`glob` default, `re:`, `fz:`)**
+### **Idea FE-6: Typed Filter Modes (`glob` default, `re:`, `fz:`)**
 *   **Goal:** Extend file filtering with explicit typed terms while preserving today's glob-first behavior and key flow.
 *   **User-Facing Behavior:**
     *   Keep existing glob syntax as default (`*.c`, `*.c,*.h`, `-*.tmp`).
@@ -890,18 +905,18 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Adds regex/fuzzy power in a Unix-style, scriptable format without breaking existing wildcard workflows or adding submenu friction.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-6: Prompt Input Decode Hardening (curses-first, legacy ESC fallback)**
+### **Idea FE-7: Prompt Input Decode Hardening (curses-first, legacy ESC fallback)**
 *   **Goal:** Replace prompt-path manual ESC sequence parsing with curses/terminfo-first decoding, while keeping legacy manual ESC parsing as controlled fallback (or config-gated compatibility mode).
 *   **Rationale:** Reduces xterm-specific assumptions in prompt entry and improves cross-terminal correctness on older UNIX environments.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-7: Input Portability Regression Matrix (`TERM`)**
+### **Idea FE-8: Input Portability Regression Matrix (`TERM`)**
 *   **Goal:** Expand UI regression coverage with a terminal-profile matrix and action-level assertions for keyboard behavior.
 *   **Initial Matrix Target:** `xterm`, `vt100`, `screen`, `tmux`, `linux`.
 *   **Rationale:** Existing UI tests prove behavior well in xterm-like sequences, but matrix runs provide stronger evidence for old/variant terminal compatibility.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-8: Extended `sYsinfo` in Directory-Window Mode**
+### **Idea FE-9: Extended `sYsinfo` in Directory-Window Mode**
 *   **Goal:** Add an on-demand extended stats/system-info surface (`sYsinfo`) for directory-window workflows without replacing the default compact stats panel.
 *   **Rationale:** Advanced disk/system context is useful for planning operations, but should stay opt-in to avoid clutter in normal navigation.
 *   **Keybinding Direction:** Keep context-specific `Y` behavior collision-free: directory-window `Y` may expose `sYsinfo`; file-window `Y` may expose sync workflow entry.
@@ -911,17 +926,17 @@ Ordering policy (for all editors, including AI editors):
 *   Footer/F1/manpage wording explicitly documents context split where `Y` differs by mode.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-9: Implement In-App Configuration Editor (F10)**
+### **Idea FE-10: Implement In-App Configuration Editor (F10)**
 *   **Goal:** Implement a user-friendly configuration editor (activated by `F10`) that supports guided editing for common options in `~/.ytree` (e.g., `CONFIRMQUIT`, colors), while retaining an expert raw-text path.
 *   **Rationale:** Reduces configuration friction for most users without removing power-user flexibility.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-10: Implement Mouse Support**
+### **Idea FE-11: Implement Mouse Support**
 *   **Goal:** Add mouse support for core navigation and selection actions within the terminal (e.g., click to select, double-click to enter, wheel scrolling).
 *   **Rationale:** In capable terminal environments, mouse support can improve speed and ease of use for navigation and selection without changing the keyboard-first design.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-11: Configurable Split Header Path Display (`active` or `both`)**
+### **Idea FE-12: Configurable Split Header Path Display (`active` or `both`)**
 *   **Goal:** Add a user option for split-mode header path display so users can choose active-panel-only path or both-panel paths.
 *   **Rationale:** Active-only header is cleaner by default, while dual-path header can improve orientation for users managing two distant locations.
 *   **Scope Lock:** Header display policy only; no split navigation, selection, or command behavior changes.
@@ -932,7 +947,7 @@ Ordering policy (for all editors, including AI editors):
 *   Footer/F1 help and config docs are updated when option lands.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-12: Prompt Path Entry, Shell-Style Completion, and ncurses-Native Input Editing**
+### **Idea FE-13: Prompt Path Entry, Shell-Style Completion, and ncurses-Native Input Editing**
 *   **Goal:** Replace the current history-biased prompt input with a first-class path-entry workflow that is good enough for deep navigation, destination entry, and command prompts.
 *   **Scope:** This task subsumes the previous separate ideas for shell-style tab completion, deep path jump, and advanced ncurses-native command-line editing.
 *   **Behavior to Deliver:**
@@ -943,7 +958,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Prompt entry should be strong enough that common path-based workflows stay direct: "type path -> complete/adjust -> Enter -> result" without forcing a separate browser/menu detour.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-13: Tagged-Only Results View**
+### **Idea FE-14: Tagged-Only Results View**
 *   **Goal:** Add a view mode that shows only tagged files without altering the tag set itself.
 *   **User-Facing Behavior:**
     *   `F4` toggles **Tagged-Only** view mode.
@@ -953,13 +968,13 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** After tagging, compare, or grep operations, users often want a focused "show me only the files I marked" result view instead of manually navigating through the full list.
 *   - [ ] **Status:** In Progress (tagged-only toggle shipped on `o/O`; broader workflow/key-shape refinements remain).
 
-### **Idea FE-14: Investigate Recursive Tagging vs Existing Showall/Global Workflow**
+### **Idea FE-15: Investigate Recursive Tagging vs Existing Showall/Global Workflow**
 *   **Goal:** Determine whether recursive tagging provides enough real workflow benefit over the current `log dir -> Showall/Global -> tag` path to justify added complexity.
 *   **Rationale:** Recursive tagging may reduce steps in some trees, but can also add command ambiguity and accidental broad-selection risk.
 *   **Investigation Output:** Document concrete user workflows, interaction-depth impact, and safety tradeoffs; propose either (a) no change, or (b) a minimal, default-safe recursive tagging design with clear scope/confirmation semantics.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-15: Richer Compare Result Views**
+### **Idea FE-16: Richer Compare Result Views**
 *   **Goal:** Extend compare workflows so the result can be viewed directly, not just turned into tags on the active side.
 *   **User-Facing Behavior:**
     *   After comparing two directories/trees, users can narrow the result to categories such as **left/source only**, **right/target only**, **newer**, **older**, **size different**, **content different**, or **identical**.
@@ -968,7 +983,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Current compare behavior is useful but blunt. A richer result view makes compare a practical review tool rather than only a tag generator.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-16: Recent-Directory Bookmarks and Pinned Favorites**
+### **Idea FE-17: Recent-Directory Bookmarks and Pinned Favorites**
 *   **Goal:** Add a first-class recent-directory and pinned-favorites picker for fast return to commonly visited locations.
 *   **User-Facing Behavior:**
     *   Show a compact list of recently visited directories together with user-pinned favorites.
@@ -978,7 +993,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Prompt history helps when the user remembers what they typed. A dedicated recent-directory/favorites list helps when the user remembers the place, not the exact command string.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-17: Dual-Preview Split Mode**
+### **Idea FE-18: Dual-Preview Split Mode**
 *   **Goal:** Allow each `F8` split panel to enter and retain its own `F7`-style preview state independently.
 *   **User-Facing Behavior:**
     *   In split mode, each panel can independently enter preview without forcing preview state changes in the other panel.
@@ -994,7 +1009,7 @@ Ordering policy (for all editors, including AI editors):
 *   Focused regression coverage proves per-panel state retention, panel switching, and exit/return behavior.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-18: Directory-Focus Small-File Peek Navigation (`Shift` + Nav Keys)**
+### **Idea FE-19: Directory-Focus Small-File Peek Navigation (`Shift` + Nav Keys)**
 *   **Goal:** In directory focus, allow `Shift+Up/Down/Page/Home/End` to scroll the small file window for the selected directory without switching to full file-window focus.
 *   **Rationale:** This gives a fast "peek and keep tree focus" workflow and mirrors the existing `Shift`-navigation feel used in `F7` preview.
 *   **Scope Lock:** Directory-focus small-file-window navigation only; no new submenu flow, no change to normal unshifted tree navigation, and no change to `F7` preview behavior.
@@ -1007,7 +1022,7 @@ Ordering policy (for all editors, including AI editors):
 *   Add focused regression coverage for shifted small-window navigation bounds/offset behavior and isolation from directory navigation.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-19: Unified `N Create` Entry Point (Capability-Filtered by Backend)**
+### **Idea FE-20: Unified `N Create` Entry Point (Capability-Filtered by Backend)**
 *   **Goal:** Replace the narrow `NewFile` entry point with a single explicit `Create` chooser whose available options are filtered by the active backend and context.
 *   **User-Facing Behavior:**
     *   Where creation is supported, `n`/`N` opens `Create:` with only the actions that are valid for the active backend/context.
@@ -1031,81 +1046,81 @@ Ordering policy (for all editors, including AI editors):
 *   Symlink creation is available natively where supported, with explicit prompts and focused regression coverage for both selected-target and explicit-target flows.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-20: Per-Window Filter State (Split Screen Prerequisite)**
+### **Idea FE-21: Per-Window Filter State (Split Screen Prerequisite)**
 *   Decouple the file filter (`file_spec`) from the `Volume` structure and move it into a new `WindowView` context. This architecture is required to support F8 Split Screen, enabling two independent views of the same volume with different filters (e.g., `*.c` in the left panel versus `*.h` in the right).
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-21: State Preservation on Reload (`^L`)**
+### **Idea FE-22: State Preservation on Reload (`^L`)**
 *   Modify the Refresh command to preserve directory expansion states. Cache open paths prior to the re-scan and restore the previous view structure instead of resetting to the default depth.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-22: Preserve Tree Expansion on Refresh**
+### **Idea FE-23: Preserve Tree Expansion on Refresh**
 *   Modify the Refresh/Rescan logic (`^L`, `F5`) to cache the list of currently expanded directories before reading the disk. After the scan is complete, programmatically re-expand those paths if they still exist.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-23: Scroll Bars**
+### **Idea FE-24: Scroll Bars**
 *   On left border of the file and directory windows to indicate the relative position of the highlighted item in the entire list (configurable to char or line).
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-24: Callback API Constification Cleanup (cppcheck strict mode)**
+### **Idea FE-25: Callback API Constification Cleanup (cppcheck strict mode)**
 *   `cppcheck` suggests const-qualifying callback `user_data`, but doing this correctly likely requires changing callback typedef/API signatures (e.g., `RewriteCallback`) and related call sites. Defer this to a focused API pass to avoid scattered casts and partial churn.
 *   - [ ] **Status:** Not Started.
 
 ### **Future Phase 3: Long-Horizon Experiments**
 
-### **Idea FE-25: Implement VFS Abstraction Layer** (Use the Architect persona here)
+### **Idea FE-26: Implement VFS Abstraction Layer** (Use the Architect persona here)
 *   **Goal:** Replace hardcoded filesystem logic with a driver-based architecture. This allows `ytree` to treat any data source (Local FS, Archive, SSH, SQL) uniformly as a `Volume`.
 *   **Context:** Currently, `log.c` decides between "Disk" and "Archive". We will change this so `log.c` asks a Registry: "Who can handle this path?"
 *   **Follow-on Direction:** Include remote logging backends under this VFS model (FTP/SFTP candidates), with final protocol choice deferred until security and maintenance review.
 
-### **Idea FE-26: Define VFS Interface & Volume Integration** (Use the Architect persona here)
+### **Idea FE-27: Define VFS Interface & Volume Integration** (Use the Architect persona here)
 *   **Goal:** Define the `VFS_Driver` contract (struct of function pointers) and update the `Volume` struct to hold a pointer to its active driver.
 *   **Mechanism:**
     *   Create `include/ytree_vfs.h`.
     *   Define function pointers: `scan`, `stat`, `lstat`, `extract`, `get_path` (for internal addressing).
     *   Update `include/ytree_defs.h` to add `const VFS_Driver *driver` and `void *driver_data` to `struct Volume`.
 
-### **Idea FE-27: Implement VFS Registry** (Use the Architect persona here)
+### **Idea FE-28: Implement VFS Registry** (Use the Architect persona here)
 *   **Goal:** Create the core logic to register drivers and probe paths.
 *   **Mechanism:**
     *   Create `src/fs/vfs.c`.
     *   Implement `VFS_Init()` (registers built-in drivers).
     *   Implement `VFS_Probe(path)` which iterates drivers asking "Can you handle this?" and returns the best match.
 
-### **Idea FE-28: Implement "Local" VFS Driver** (Use the Architect persona here)
+### **Idea FE-29: Implement "Local" VFS Driver** (Use the Architect persona here)
 *   **Goal:** Wrap the existing POSIX `opendir`/`readdir` logic into a `VFS_Driver`.
 *   **Mechanism:**
     *   Create `src/fs/drv_local.c`.
     *   Move logic from `src/fs/tree_read.c` into the driver's `.scan` method.
     *   Ensure it populates `DirEntry` structures exactly as before.
 
-### **Idea FE-29: Implement "Archive" VFS Driver** (Use the Architect persona here)
+### **Idea FE-30: Implement "Archive" VFS Driver** (Use the Architect persona here)
 *   **Goal:** Wrap the existing `libarchive` logic into a `VFS_Driver`.
 *   **Mechanism:**
     *   Create `src/fs/drv_archive.c`.
     *   Move logic from `src/fs/archive_read.c` and `src/fs/archive_write.c` into the driver.
     *   Implement `.extract` to handle the temporary file creation for viewing/copying.
 
-### **Idea FE-30: Switch `LogDisk` to VFS** (Use the Architect persona here)
+### **Idea FE-31: Switch `LogDisk` to VFS** (Use the Architect persona here)
 *   **Goal:** Update the main entry point to use the new system.
 *   **Mechanism:**
     *   Refactor `src/cmd/log.c`.
     *   Replace the `stat`/`S_ISDIR` check with `VFS_Probe(path)`.
     *   Call `vol->driver->scan()` instead of calling `ReadTree` or `ReadTreeFromArchive` directly.
 
-### **Idea FE-31: Refactor Consumers (Polymorphism)** (Use the Architect persona here)
+### **Idea FE-32: Refactor Consumers (Polymorphism)** (Use the Architect persona here)
 *   **Goal:** Remove `if (mode == ARCHIVE)` from the rest of the codebase.
 *   **Mechanism:**
     *   Update `view.c`, `copy.c`, `execute.c`.
     *   Replace specific calls with `vol->driver->extract(...)` or `vol->driver->stat(...)`.
 
-### **Idea FE-32: Database Browsing and Editing via Virtual Filesystem Drivers**
+### **Idea FE-33: Database Browsing and Editing via Virtual Filesystem Drivers**
 *   **Goal:** After the driver-based VFS abstraction exists, allow ytree to browse supported database formats as navigable virtual filesystems and eventually edit them through driver-defined operations.
 *   **User-Facing Direction:** Treat a database as a structured volume (for example database -> tables -> rows/records or exported views) rather than as one opaque file blob.
 *   **Rationale:** This is a specialized extension of the VFS model, not a core file-manager requirement. Keep it as a future experiment until a clear driver design and real use-case exist.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-33: Implement Recursive Directory Watching**
+### **Idea FE-34: Implement Recursive Directory Watching**
 *   **Goal:** Keep visible tree and file-list state fresh by watching all currently expanded filesystem directories, not only the active cursor directory.
 *   **Rationale:** Without recursive watch coverage, edits in visible sibling/child directories can leave the UI stale until manual refresh.
 *   **Scope Lock:** Filesystem watcher behavior only; no archive-internal recursive watching.
@@ -1121,17 +1136,17 @@ Ordering policy (for all editors, including AI editors):
     *   `ENOSPC` fallback is explicit, stable, and non-fatal.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-34: Implement Shell Script Generator**
+### **Idea FE-35: Implement Shell Script Generator**
 *   **Goal:** Generate a shell script from tagged files using user-defined templates (e.g., `cp %f /backup/%f.bak`), replacing the "Batch" concept.
 *   **Rationale:** Offers complex templating logic that goes beyond simple pipe/xargs, and critically allows the user to review/edit the generated script before execution for safety.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-35: Implement Keyboard Macros (F12 Record/Playback)**
+### **Idea FE-36: Implement Keyboard Macros (F12 Record/Playback)**
 *   **Goal:** Implement keystroke recording and replay. `F12` starts/stops recording command/input sequences for deterministic playback.
 *   **Rationale:** Allows automation of repetitive interaction sequences (for example "Tag, Move, Rename, Repeat") without creating shell command templates.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-36: Enhance Built-In Viewer**
+### **Idea FE-37: Enhance Built-In Viewer**
 *   **Goal:** Evolve ytree's internal viewer from a basic fallback inspector into a more capable built-in viewing tool for normal terminal workflows.
 *   **Builds On:** Current-delivery viewer work such as `Add Configurable Bypass for External Viewers` and `Standardize Internal Viewer Layout`.
 *   **Candidate Scope:**
@@ -1144,12 +1159,12 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 
-### **Idea FE-37: Terminal-Independent TUI Runtime (ncurses-Decoupling Investigation)**
+### **Idea FE-38: Terminal-Independent TUI Runtime (ncurses-Decoupling Investigation)**
 *   **Goal:** Investigate a runtime path where ytree's TUI is not tightly coupled to ncurses.
 *   **Rationale:** This is a platform/input architecture effort intended to evaluate whether backend decoupling can reduce current control-key handling constraints (including limitations around mappings like `^M`) while preserving ytree interaction semantics.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-38: Implement "Safe Delete" (Trash Can)**
+### **Idea FE-39: Implement "Safe Delete" (Trash Can)**
 *   **Goal:** Add optional trash-backed delete where the active filesystem/backend supports it.
 *   **Config:** Add a `ytree.conf` switch for trash-delete with default `1` (enabled).
 *   **Fallback:** If trash-delete is disabled or unsupported for the active backend, use permanent delete with explicit confirmation.

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -730,6 +730,7 @@ typedef struct _panel_volume_file_state {
   int volume_id;
   int saved_file_start;
   int saved_file_cursor;
+  BOOL saved_big_file_view;
   char saved_file_dir_path[PATH_LENGTH + 1];
   char saved_file_selection_name[PATH_LENGTH + 1];
   char saved_file_selection_dir_path[PATH_LENGTH + 1];

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -46,12 +46,15 @@ static void SavePanelFileSelection(YtreePanel *panel) {
   state = GetPanelVolumeFileState(panel, panel->vol->id);
   state->saved_file_start = panel->start_file;
   state->saved_file_cursor = panel->file_cursor_pos;
+  state->saved_big_file_view = FALSE;
 
   state->saved_file_dir_path[0] = '\0';
   if (panel->file_dir_entry != NULL) {
     GetPath(panel->file_dir_entry, state->saved_file_dir_path);
     state->saved_file_dir_path[PATH_LENGTH] = '\0';
+    state->saved_big_file_view = panel->file_dir_entry->big_window;
   }
+  panel->saved_big_file_view = state->saved_big_file_view;
 
   (void)snprintf(state->saved_file_selection_name,
                  sizeof(state->saved_file_selection_name), "%s",
@@ -117,6 +120,7 @@ static void RestorePanelFileSelection(YtreePanel *panel) {
   panel->file_selection_name[0] = '\0';
   panel->file_selection_dir_path[0] = '\0';
   panel->file_dir_entry = NULL;
+  panel->saved_big_file_view = FALSE;
   if (!state)
     return;
 
@@ -135,7 +139,10 @@ static void RestorePanelFileSelection(YtreePanel *panel) {
   if (state->saved_file_dir_path[0] != '\0') {
     resolved_file_dir = FindSavedDirInVolume(vol, state->saved_file_dir_path);
     panel->file_dir_entry = resolved_file_dir;
+    if (resolved_file_dir)
+      resolved_file_dir->big_window = state->saved_big_file_view;
   }
+  panel->saved_big_file_view = state->saved_big_file_view;
 }
 
 static void SavePanelTreeSelection(YtreePanel *panel) {
@@ -208,17 +215,6 @@ static void Log_Progress(ViewContext *ctx, const void *data) {
     if (ctx->hook_refresh_ui)
       ctx->hook_refresh_ui();
   }
-}
-
-/* Helper function to clear big_window flag recursively */
-static void RecursiveClearBigWindow(DirEntry *d) {
-  if (!d)
-    return;
-  d->big_window = FALSE;
-  if (d->sub_tree)
-    RecursiveClearBigWindow(d->sub_tree);
-  if (d->next)
-    RecursiveClearBigWindow(d->next);
 }
 
 /*
@@ -642,8 +638,6 @@ int CycleLoadedVolume(ViewContext *ctx, YtreePanel *panel, int direction) {
     /* Use LogDisk to attempt the switch.
      * LogDisk handles validation, cleanup if inaccessible, and UI updates. */
     if (LogDisk(ctx, panel, target_path) == 0) {
-      /* Force UI reset to standard split view on cycle */
-      RecursiveClearBigWindow(panel->vol->vol_stats.tree);
       if (ctx->hook_recreate_windows)
         ctx->hook_recreate_windows(ctx);
       if (ctx->hook_clock_handler)

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1154,10 +1154,14 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
     if (dir_entry->log_flag) {
       dir_entry->log_flag = FALSE;
     } else {
+      BOOL restore_saved_file_window =
+          (p->saved_focus == FOCUS_FILE && p->saved_big_file_view &&
+           p->file_dir_entry == dir_entry);
       dir_entry->global_flag = FALSE;
       dir_entry->global_all_volumes = FALSE;
       dir_entry->tagged_flag = FALSE;
-      dir_entry->big_window = ctx->bypass_small_window;
+      if (!restore_saved_file_window)
+        dir_entry->big_window = ctx->bypass_small_window;
       if (p->file_dir_entry == dir_entry) {
         dir_entry->start_file = p->start_file;
         dir_entry->cursor_pos = p->file_cursor_pos;


### PR DESCRIPTION
## Summary
- preserve per-volume file-window state across volume cycling in split workflows
- stop clearing per-directory `big_window` state during cycle transitions
- persist/restore saved big-file-window state with each panel+volume snapshot
- include maintainer-edited tracker updates in `docs/ROADMAP.md` and `docs/BUGS.md`

## Validation
- `make clean && make`
- `pytest -q tests/test_panel_isolation.py -k "volume_cycle and (window_mode or leak_state or split_file_selection_preserves_panel_local_volume_cycle_state)"`
- `pytest -q tests/test_panel_isolation.py`

## Notes
- draft PR opened early; full-QA CI gate remains required before merge
