### PR TITLE
fix(split): preserve file-window shape across Tab and F8

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -116,6 +116,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **BUG-5: F8 + SMALLWINDOWSKIP=0 Tab Can Force Inactive Panel into Wrong Focus**
 *   **Description**: With `SMALLWINDOWSKIP=0`, when cursor is in the small file window on one panel, `Tab` to the other panel can show that inactive panel as file-focused/zoomed unexpectedly; tabbing back restores prior tree/small state.
+*   **Extension (manual, 2026-05-23)**: With `SMALLWINDOWSKIP=1`, splitting from file view (`Enter` then `F8`) could leave the inactive panel shown as tree/small until `Tab`, instead of immediately preserving file-view shape.
 *   **Repro (manual)**:
     *   `F10` config, set `SMALLWINDOWSKIP=0`.
     *   Enter split mode (`F8`), enter small file window in one panel.
@@ -128,10 +129,13 @@ Ordering policy (for all editors, including AI editors):
     *   `docs/SPECIFICATION.md` §5.2 **Freeze/Resume Rule**
 *   **Impact**: Breaks trust in split focus separation and can trigger wrong-context commands.
 *   **Remediation**: Harden switch-time state transfer so focus/view state is restored from panel-owned snapshots only; forbid cross-panel focus inheritance during `Tab` unless explicitly commanded by the active panel.
-*   **Tests/Gates**: Add/maintain deterministic regression for `SMALLWINDOWSKIP=0` split/tab focus retention in `tests/test_panel_isolation.py`.
-*   **Regression notes (manual, 2026-05-21)**:
-    *   With `SMALLWINDOWSKIP=0`, `Tab` can still show the inactive panel in zoomed file-window focus until tabbing back.
-*   **Status**: Reopened (regression confirmed).
+*   **Tests/Gates**:
+    *   `tests/test_panel_isolation.py::test_split_tab_from_small_file_does_not_expand_inactive_panel`
+    *   `tests/test_panel_isolation.py::test_split_from_big_file_keeps_inactive_panel_in_file_view`
+*   **Regression notes (manual)**:
+    *   2026-05-21: With `SMALLWINDOWSKIP=0`, `Tab` could show the inactive panel in zoomed file-window focus until tabbing back.
+    *   2026-05-23: With `SMALLWINDOWSKIP=1`, split from file view could keep inactive panel in tree/small until `Tab` flipped it to file view.
+*   **Status**: Fixed.
 
 ### **BUG-6: Dir Display Mode Resets After Context Switch (`^F`/Future `1..4`)**
 *   **Description**: Setting a directory display mode while focused in dir/tree context can be lost after entering file/small-window context and returning to dir/tree context.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,7 @@ Ordering policy (for all editors, including AI editors):
 *   All new/updated split-isolation tests pass locally and in PR full-QA CI evidence.
 *   Linked split-panel bugs (`BUG-2`, `BUG-3`, `BUG-4`, `BUG-5`) are either fixed or have explicit blocker notes tied to this work.
 *   **Outcome:** Completed. Ownership map + boundary invariants/assertions are in place; split dotfile ownership migration remains follow-on work.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Completed.
 
 ### **Task 2: Remove Dead-History Comments + Add Anti-History Comment Gate**
 *   **Goal:** Remove comments that describe removed code/history and prevent their reintroduction.
@@ -515,6 +515,7 @@ Ordering policy (for all editors, including AI editors):
 ### **Task 46: Enforce Footer/F1 Context-Parity Contract (gettext-ready)**
 *   **Goal:** Ensure F1 help is concise, context-specific, and complete for each footer/help variant, with no missing commands.
 *   **Rationale:** Footer and F1 are the primary in-app guidance surfaces; they must match exactly while keeping F1 brief and pushing detail to manpage/USAGE.
+*   **Related Bugs:** `BUG-9` / `BUG-10` / `BUG-15` / `BUG-14` / `BUG-13` — footer/help/prompt mismatch (discoverability + confidence).
 *   **Scope Lock:** Help contract, coverage matrix, and text-structure readiness only; no command behavior changes in this task.
 *   **Acceptance Criteria:**
 *   For each supported context, every footer command appears in the matching F1 help set with concise wording and no essay-style descriptions.
@@ -538,15 +539,19 @@ Ordering policy (for all editors, including AI editors):
 *   `6` => toggle symlink row rendering (`name` vs `name -> target`) in list rows.
 *   `7` => toggle richer metadata/text-snippet view.
 *   `8` => toggle file-type/summary view.
-*   `9` => toggle brief/full width behavior for the focused panel.
-*   `0` => Git-focused file-info band (status-oriented view) when the current scope is inside a Git worktree.
-*   Number keys are toggle-driven controls: `0..4` select the primary file-info layout while `5..9` toggle additive display behaviors.
-*   Applies to file-display rendering across normal list contexts for the active panel (whether focus is currently on tree/dir window or file window); not active in `F7` preview mode.
+*   `9` => toggle brief/full width behavior for file-window rendering.
+*   `0` => Git-focused file-info band (status-oriented file view) when the current scope is inside a Git worktree.
+*   Number keys are grouped by ownership/scope for the active panel:
+    *   **Panel-wide toggles (dir + file projections):** `` ` `` dotfiles (existing behavior) and `5` size-unit toggle.
+    *   **Context-scoped display modes (`dir` vs `file`):** `1..4` apply to the currently focused context only (dir-focus changes dir display only; file-focus changes file display only).
+    *   **File-window-only toggles:** `6..0` (`6`, `7`, `8`, `9`, `0`) affect file-window rendering only and are silent no-ops when dir/tree focus is active.
+*   Not active in `F7` preview mode.
 *   If a requested mode is unsupported in the active context (for example VFS file mode `4`, or `0` outside a Git worktree), do a silent no-op (no beep).
 *   Git band (`0`) defaults to off, uses cached/non-blocking status refresh, and must not stall list rendering in large repos.
 *   Add `FILE_SIZE_UNITS=binary|human-readable` profile setting (default `binary`) as the seed for `5`.
 *   **Keybinding Policy:** Remove `^F` from runtime behavior and help/manpage docs. This task is the explicit keybinding-change exception referenced by Task 39 scope lock.
 *   **UX/Help Policy:** Footer stays concise (`1..0 FileInfo`); full key semantics live in F1 help/manpage.
+*   **Spec/Docs Sync Policy:** When delivered, update `docs/SPECIFICATION.md` and `etc/ytree.1.md` (and regenerated `docs/USAGE.md`) with the same grouped ownership contract.
 *   - [ ] **Status:** Not Started.
 
 ### **Task 48: Add Case-Sensitive Sort Toggle + Profile Default**
@@ -830,7 +835,17 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Future Phase 1: Post-Baseline Configurability Follow-On**
 
-### **Idea FE-1: Explicit Accessibility Mode (Screen-Reader-First Terminal Behavior)**
+### **Idea FE-1: Optional Hidden-Child Restore on Re-Expand (`RESTORE_HIDDEN_CHILD=0|1`)**
+*   **Goal:** Add an opt-in tree-navigation behavior that can restore the previously selected hidden child when a collapsed parent is re-expanded.
+*   **Config Direction (`ytree.conf`):** `RESTORE_HIDDEN_CHILD=0|1` (default `0`).
+*   **Behavior Contract:**
+    *   When `0` (default), keep current deterministic behavior: collapse invalidates child selection and selection remains at the fallback target (typically parent) after re-expand.
+    *   When `1`, re-expand restores the last hidden child only if it still exists and is visible/valid; otherwise use deterministic fallback order (nearest ancestor, next/previous sibling, root visible node).
+    *   Behavior applies to general tree navigation, not only split mode.
+*   **Rationale:** Supports users who prefer sticky child selection after collapse/expand without changing default deterministic semantics.
+*   - [ ] **Status:** Not Started.
+
+### **Idea FE-2: Explicit Accessibility Mode (Screen-Reader-First Terminal Behavior)**
 *   **Goal:** Introduce an opt-in explicit accessibility mode focused on stable, low-noise behavior for screen-reader workflows.
 *   **Research Gate (Required Before Implementation):**
     *   Audit current redraw/cursor-update hotspots (clock, spinner, status-line, dialogs, preview loops) for assistive-tech impact.
@@ -843,7 +858,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Terminal UI is not automatically accessible; explicit mode-level contracts are needed to avoid redraw/cursor noise regressions.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-2: Portable Keyboard Capability Probe + `.ytree` Key Workarounds**
+### **Idea FE-3: Portable Keyboard Capability Probe + `.ytree` Key Workarounds**
 *   **Goal:** Add startup-time terminal key-capability probing and user-configurable key overrides/workarounds in `~/.ytree`.
 *   **Behavior Direction:**
     *   Probe optional key availability once at startup (cache results; no per-keystroke probing overhead).
@@ -852,7 +867,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Improves old-terminal portability while keeping runtime input handling fast.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-3: Keymap Follow-On Work (Post-Baseline)**
+### **Idea FE-4: Keymap Follow-On Work (Post-Baseline)**
 *   **Description:** Follow-up keymap work after baseline keymap support lands (preset profiles, conflict diagnostics, import/export format hardening, and migration notes for existing users).
 *   **Localized keymap profiles:** Add opt-in locale-oriented profiles as separate keymap files (not automatic locale remapping), while keeping the default keymap stable.
 *   **Best-practice guardrails:** Preserve a universal core of stable bindings (function keys/Ctrl/digits/arrows), allow locale mnemonic aliases where safe, and enforce strict collision/unbound-action validation with clear diagnostics.
@@ -860,7 +875,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Future Phase 2: UI/UX Enhancements and Cleanup**
 
-### **Idea FE-4: Configurable VCS Provider for `0` FileInfo Band**
+### **Idea FE-5: Configurable VCS Provider for `0` FileInfo Band**
 *   **Goal:** Keep `0` as one stable VCS info band while allowing users to choose which backend powers it.
 *   **Config Direction (`ytree.conf`):** Add a single-provider selector (for example `VCS_PROVIDER=off|git|hg|svn|fossil|auto`).
 *   **Behavior Contract:**
@@ -870,7 +885,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Preserves key stability and avoids renumbering while keeping a path open for non-Git users.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-5: Typed Filter Modes (`glob` default, `re:`, `fz:`)**
+### **Idea FE-6: Typed Filter Modes (`glob` default, `re:`, `fz:`)**
 *   **Goal:** Extend file filtering with explicit typed terms while preserving today's glob-first behavior and key flow.
 *   **User-Facing Behavior:**
     *   Keep existing glob syntax as default (`*.c`, `*.c,*.h`, `-*.tmp`).
@@ -890,18 +905,18 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Adds regex/fuzzy power in a Unix-style, scriptable format without breaking existing wildcard workflows or adding submenu friction.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-6: Prompt Input Decode Hardening (curses-first, legacy ESC fallback)**
+### **Idea FE-7: Prompt Input Decode Hardening (curses-first, legacy ESC fallback)**
 *   **Goal:** Replace prompt-path manual ESC sequence parsing with curses/terminfo-first decoding, while keeping legacy manual ESC parsing as controlled fallback (or config-gated compatibility mode).
 *   **Rationale:** Reduces xterm-specific assumptions in prompt entry and improves cross-terminal correctness on older UNIX environments.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-7: Input Portability Regression Matrix (`TERM`)**
+### **Idea FE-8: Input Portability Regression Matrix (`TERM`)**
 *   **Goal:** Expand UI regression coverage with a terminal-profile matrix and action-level assertions for keyboard behavior.
 *   **Initial Matrix Target:** `xterm`, `vt100`, `screen`, `tmux`, `linux`.
 *   **Rationale:** Existing UI tests prove behavior well in xterm-like sequences, but matrix runs provide stronger evidence for old/variant terminal compatibility.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-8: Extended `sYsinfo` in Directory-Window Mode**
+### **Idea FE-9: Extended `sYsinfo` in Directory-Window Mode**
 *   **Goal:** Add an on-demand extended stats/system-info surface (`sYsinfo`) for directory-window workflows without replacing the default compact stats panel.
 *   **Rationale:** Advanced disk/system context is useful for planning operations, but should stay opt-in to avoid clutter in normal navigation.
 *   **Keybinding Direction:** Keep context-specific `Y` behavior collision-free: directory-window `Y` may expose `sYsinfo`; file-window `Y` may expose sync workflow entry.
@@ -911,17 +926,17 @@ Ordering policy (for all editors, including AI editors):
 *   Footer/F1/manpage wording explicitly documents context split where `Y` differs by mode.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-9: Implement In-App Configuration Editor (F10)**
+### **Idea FE-10: Implement In-App Configuration Editor (F10)**
 *   **Goal:** Implement a user-friendly configuration editor (activated by `F10`) that supports guided editing for common options in `~/.ytree` (e.g., `CONFIRMQUIT`, colors), while retaining an expert raw-text path.
 *   **Rationale:** Reduces configuration friction for most users without removing power-user flexibility.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-10: Implement Mouse Support**
+### **Idea FE-11: Implement Mouse Support**
 *   **Goal:** Add mouse support for core navigation and selection actions within the terminal (e.g., click to select, double-click to enter, wheel scrolling).
 *   **Rationale:** In capable terminal environments, mouse support can improve speed and ease of use for navigation and selection without changing the keyboard-first design.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-11: Configurable Split Header Path Display (`active` or `both`)**
+### **Idea FE-12: Configurable Split Header Path Display (`active` or `both`)**
 *   **Goal:** Add a user option for split-mode header path display so users can choose active-panel-only path or both-panel paths.
 *   **Rationale:** Active-only header is cleaner by default, while dual-path header can improve orientation for users managing two distant locations.
 *   **Scope Lock:** Header display policy only; no split navigation, selection, or command behavior changes.
@@ -932,7 +947,7 @@ Ordering policy (for all editors, including AI editors):
 *   Footer/F1 help and config docs are updated when option lands.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-12: Prompt Path Entry, Shell-Style Completion, and ncurses-Native Input Editing**
+### **Idea FE-13: Prompt Path Entry, Shell-Style Completion, and ncurses-Native Input Editing**
 *   **Goal:** Replace the current history-biased prompt input with a first-class path-entry workflow that is good enough for deep navigation, destination entry, and command prompts.
 *   **Scope:** This task subsumes the previous separate ideas for shell-style tab completion, deep path jump, and advanced ncurses-native command-line editing.
 *   **Behavior to Deliver:**
@@ -943,7 +958,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Prompt entry should be strong enough that common path-based workflows stay direct: "type path -> complete/adjust -> Enter -> result" without forcing a separate browser/menu detour.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-13: Tagged-Only Results View**
+### **Idea FE-14: Tagged-Only Results View**
 *   **Goal:** Add a view mode that shows only tagged files without altering the tag set itself.
 *   **User-Facing Behavior:**
     *   `F4` toggles **Tagged-Only** view mode.
@@ -953,13 +968,13 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** After tagging, compare, or grep operations, users often want a focused "show me only the files I marked" result view instead of manually navigating through the full list.
 *   - [ ] **Status:** In Progress (tagged-only toggle shipped on `o/O`; broader workflow/key-shape refinements remain).
 
-### **Idea FE-14: Investigate Recursive Tagging vs Existing Showall/Global Workflow**
+### **Idea FE-15: Investigate Recursive Tagging vs Existing Showall/Global Workflow**
 *   **Goal:** Determine whether recursive tagging provides enough real workflow benefit over the current `log dir -> Showall/Global -> tag` path to justify added complexity.
 *   **Rationale:** Recursive tagging may reduce steps in some trees, but can also add command ambiguity and accidental broad-selection risk.
 *   **Investigation Output:** Document concrete user workflows, interaction-depth impact, and safety tradeoffs; propose either (a) no change, or (b) a minimal, default-safe recursive tagging design with clear scope/confirmation semantics.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-15: Richer Compare Result Views**
+### **Idea FE-16: Richer Compare Result Views**
 *   **Goal:** Extend compare workflows so the result can be viewed directly, not just turned into tags on the active side.
 *   **User-Facing Behavior:**
     *   After comparing two directories/trees, users can narrow the result to categories such as **left/source only**, **right/target only**, **newer**, **older**, **size different**, **content different**, or **identical**.
@@ -968,7 +983,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Current compare behavior is useful but blunt. A richer result view makes compare a practical review tool rather than only a tag generator.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-16: Recent-Directory Bookmarks and Pinned Favorites**
+### **Idea FE-17: Recent-Directory Bookmarks and Pinned Favorites**
 *   **Goal:** Add a first-class recent-directory and pinned-favorites picker for fast return to commonly visited locations.
 *   **User-Facing Behavior:**
     *   Show a compact list of recently visited directories together with user-pinned favorites.
@@ -978,7 +993,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Prompt history helps when the user remembers what they typed. A dedicated recent-directory/favorites list helps when the user remembers the place, not the exact command string.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-17: Dual-Preview Split Mode**
+### **Idea FE-18: Dual-Preview Split Mode**
 *   **Goal:** Allow each `F8` split panel to enter and retain its own `F7`-style preview state independently.
 *   **User-Facing Behavior:**
     *   In split mode, each panel can independently enter preview without forcing preview state changes in the other panel.
@@ -994,7 +1009,7 @@ Ordering policy (for all editors, including AI editors):
 *   Focused regression coverage proves per-panel state retention, panel switching, and exit/return behavior.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-18: Directory-Focus Small-File Peek Navigation (`Shift` + Nav Keys)**
+### **Idea FE-19: Directory-Focus Small-File Peek Navigation (`Shift` + Nav Keys)**
 *   **Goal:** In directory focus, allow `Shift+Up/Down/Page/Home/End` to scroll the small file window for the selected directory without switching to full file-window focus.
 *   **Rationale:** This gives a fast "peek and keep tree focus" workflow and mirrors the existing `Shift`-navigation feel used in `F7` preview.
 *   **Scope Lock:** Directory-focus small-file-window navigation only; no new submenu flow, no change to normal unshifted tree navigation, and no change to `F7` preview behavior.
@@ -1007,7 +1022,7 @@ Ordering policy (for all editors, including AI editors):
 *   Add focused regression coverage for shifted small-window navigation bounds/offset behavior and isolation from directory navigation.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-19: Unified `N Create` Entry Point (Capability-Filtered by Backend)**
+### **Idea FE-20: Unified `N Create` Entry Point (Capability-Filtered by Backend)**
 *   **Goal:** Replace the narrow `NewFile` entry point with a single explicit `Create` chooser whose available options are filtered by the active backend and context.
 *   **User-Facing Behavior:**
     *   Where creation is supported, `n`/`N` opens `Create:` with only the actions that are valid for the active backend/context.
@@ -1031,81 +1046,81 @@ Ordering policy (for all editors, including AI editors):
 *   Symlink creation is available natively where supported, with explicit prompts and focused regression coverage for both selected-target and explicit-target flows.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-20: Per-Window Filter State (Split Screen Prerequisite)**
+### **Idea FE-21: Per-Window Filter State (Split Screen Prerequisite)**
 *   Decouple the file filter (`file_spec`) from the `Volume` structure and move it into a new `WindowView` context. This architecture is required to support F8 Split Screen, enabling two independent views of the same volume with different filters (e.g., `*.c` in the left panel versus `*.h` in the right).
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-21: State Preservation on Reload (`^L`)**
+### **Idea FE-22: State Preservation on Reload (`^L`)**
 *   Modify the Refresh command to preserve directory expansion states. Cache open paths prior to the re-scan and restore the previous view structure instead of resetting to the default depth.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-22: Preserve Tree Expansion on Refresh**
+### **Idea FE-23: Preserve Tree Expansion on Refresh**
 *   Modify the Refresh/Rescan logic (`^L`, `F5`) to cache the list of currently expanded directories before reading the disk. After the scan is complete, programmatically re-expand those paths if they still exist.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-23: Scroll Bars**
+### **Idea FE-24: Scroll Bars**
 *   On left border of the file and directory windows to indicate the relative position of the highlighted item in the entire list (configurable to char or line).
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-24: Callback API Constification Cleanup (cppcheck strict mode)**
+### **Idea FE-25: Callback API Constification Cleanup (cppcheck strict mode)**
 *   `cppcheck` suggests const-qualifying callback `user_data`, but doing this correctly likely requires changing callback typedef/API signatures (e.g., `RewriteCallback`) and related call sites. Defer this to a focused API pass to avoid scattered casts and partial churn.
 *   - [ ] **Status:** Not Started.
 
 ### **Future Phase 3: Long-Horizon Experiments**
 
-### **Idea FE-25: Implement VFS Abstraction Layer** (Use the Architect persona here)
+### **Idea FE-26: Implement VFS Abstraction Layer** (Use the Architect persona here)
 *   **Goal:** Replace hardcoded filesystem logic with a driver-based architecture. This allows `ytree` to treat any data source (Local FS, Archive, SSH, SQL) uniformly as a `Volume`.
 *   **Context:** Currently, `log.c` decides between "Disk" and "Archive". We will change this so `log.c` asks a Registry: "Who can handle this path?"
 *   **Follow-on Direction:** Include remote logging backends under this VFS model (FTP/SFTP candidates), with final protocol choice deferred until security and maintenance review.
 
-### **Idea FE-26: Define VFS Interface & Volume Integration** (Use the Architect persona here)
+### **Idea FE-27: Define VFS Interface & Volume Integration** (Use the Architect persona here)
 *   **Goal:** Define the `VFS_Driver` contract (struct of function pointers) and update the `Volume` struct to hold a pointer to its active driver.
 *   **Mechanism:**
     *   Create `include/ytree_vfs.h`.
     *   Define function pointers: `scan`, `stat`, `lstat`, `extract`, `get_path` (for internal addressing).
     *   Update `include/ytree_defs.h` to add `const VFS_Driver *driver` and `void *driver_data` to `struct Volume`.
 
-### **Idea FE-27: Implement VFS Registry** (Use the Architect persona here)
+### **Idea FE-28: Implement VFS Registry** (Use the Architect persona here)
 *   **Goal:** Create the core logic to register drivers and probe paths.
 *   **Mechanism:**
     *   Create `src/fs/vfs.c`.
     *   Implement `VFS_Init()` (registers built-in drivers).
     *   Implement `VFS_Probe(path)` which iterates drivers asking "Can you handle this?" and returns the best match.
 
-### **Idea FE-28: Implement "Local" VFS Driver** (Use the Architect persona here)
+### **Idea FE-29: Implement "Local" VFS Driver** (Use the Architect persona here)
 *   **Goal:** Wrap the existing POSIX `opendir`/`readdir` logic into a `VFS_Driver`.
 *   **Mechanism:**
     *   Create `src/fs/drv_local.c`.
     *   Move logic from `src/fs/tree_read.c` into the driver's `.scan` method.
     *   Ensure it populates `DirEntry` structures exactly as before.
 
-### **Idea FE-29: Implement "Archive" VFS Driver** (Use the Architect persona here)
+### **Idea FE-30: Implement "Archive" VFS Driver** (Use the Architect persona here)
 *   **Goal:** Wrap the existing `libarchive` logic into a `VFS_Driver`.
 *   **Mechanism:**
     *   Create `src/fs/drv_archive.c`.
     *   Move logic from `src/fs/archive_read.c` and `src/fs/archive_write.c` into the driver.
     *   Implement `.extract` to handle the temporary file creation for viewing/copying.
 
-### **Idea FE-30: Switch `LogDisk` to VFS** (Use the Architect persona here)
+### **Idea FE-31: Switch `LogDisk` to VFS** (Use the Architect persona here)
 *   **Goal:** Update the main entry point to use the new system.
 *   **Mechanism:**
     *   Refactor `src/cmd/log.c`.
     *   Replace the `stat`/`S_ISDIR` check with `VFS_Probe(path)`.
     *   Call `vol->driver->scan()` instead of calling `ReadTree` or `ReadTreeFromArchive` directly.
 
-### **Idea FE-31: Refactor Consumers (Polymorphism)** (Use the Architect persona here)
+### **Idea FE-32: Refactor Consumers (Polymorphism)** (Use the Architect persona here)
 *   **Goal:** Remove `if (mode == ARCHIVE)` from the rest of the codebase.
 *   **Mechanism:**
     *   Update `view.c`, `copy.c`, `execute.c`.
     *   Replace specific calls with `vol->driver->extract(...)` or `vol->driver->stat(...)`.
 
-### **Idea FE-32: Database Browsing and Editing via Virtual Filesystem Drivers**
+### **Idea FE-33: Database Browsing and Editing via Virtual Filesystem Drivers**
 *   **Goal:** After the driver-based VFS abstraction exists, allow ytree to browse supported database formats as navigable virtual filesystems and eventually edit them through driver-defined operations.
 *   **User-Facing Direction:** Treat a database as a structured volume (for example database -> tables -> rows/records or exported views) rather than as one opaque file blob.
 *   **Rationale:** This is a specialized extension of the VFS model, not a core file-manager requirement. Keep it as a future experiment until a clear driver design and real use-case exist.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-33: Implement Recursive Directory Watching**
+### **Idea FE-34: Implement Recursive Directory Watching**
 *   **Goal:** Keep visible tree and file-list state fresh by watching all currently expanded filesystem directories, not only the active cursor directory.
 *   **Rationale:** Without recursive watch coverage, edits in visible sibling/child directories can leave the UI stale until manual refresh.
 *   **Scope Lock:** Filesystem watcher behavior only; no archive-internal recursive watching.
@@ -1121,17 +1136,17 @@ Ordering policy (for all editors, including AI editors):
     *   `ENOSPC` fallback is explicit, stable, and non-fatal.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-34: Implement Shell Script Generator**
+### **Idea FE-35: Implement Shell Script Generator**
 *   **Goal:** Generate a shell script from tagged files using user-defined templates (e.g., `cp %f /backup/%f.bak`), replacing the "Batch" concept.
 *   **Rationale:** Offers complex templating logic that goes beyond simple pipe/xargs, and critically allows the user to review/edit the generated script before execution for safety.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-35: Implement Keyboard Macros (F12 Record/Playback)**
+### **Idea FE-36: Implement Keyboard Macros (F12 Record/Playback)**
 *   **Goal:** Implement keystroke recording and replay. `F12` starts/stops recording command/input sequences for deterministic playback.
 *   **Rationale:** Allows automation of repetitive interaction sequences (for example "Tag, Move, Rename, Repeat") without creating shell command templates.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-36: Enhance Built-In Viewer**
+### **Idea FE-37: Enhance Built-In Viewer**
 *   **Goal:** Evolve ytree's internal viewer from a basic fallback inspector into a more capable built-in viewing tool for normal terminal workflows.
 *   **Builds On:** Current-delivery viewer work such as `Add Configurable Bypass for External Viewers` and `Standardize Internal Viewer Layout`.
 *   **Candidate Scope:**
@@ -1144,12 +1159,12 @@ Ordering policy (for all editors, including AI editors):
 *   - [ ] **Status:** Not Started.
 
 
-### **Idea FE-37: Terminal-Independent TUI Runtime (ncurses-Decoupling Investigation)**
+### **Idea FE-38: Terminal-Independent TUI Runtime (ncurses-Decoupling Investigation)**
 *   **Goal:** Investigate a runtime path where ytree's TUI is not tightly coupled to ncurses.
 *   **Rationale:** This is a platform/input architecture effort intended to evaluate whether backend decoupling can reduce current control-key handling constraints (including limitations around mappings like `^M`) while preserving ytree interaction semantics.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-38: Implement "Safe Delete" (Trash Can)**
+### **Idea FE-39: Implement "Safe Delete" (Trash Can)**
 *   **Goal:** Add optional trash-backed delete where the active filesystem/backend supports it.
 *   **Config:** Add a `ytree.conf` switch for trash-delete with default `1` (enabled).
 *   **Fallback:** If trash-delete is disabled or unsupported for the active backend, use permanent delete with explicit confirmation.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -175,6 +175,8 @@ Switching panels via `Tab` must restore the exact state held when that panel las
 *   **Compare Tagging Rule:** Compare workflows may report difference counts, but they do not implicitly mutate per-file tag state; tags change only through explicit tagging actions.
 *   **Filter (Filespec):** Independent search/filter strings.
 *   **Window/Mode Context:** Directory/File/Showall-style panel-local focus context.
+*   **File-Window Shape Context:** In split mode, each panel owns its own file-window shape (`tree`, `small file`, `big file`). `Tab` and `F8` transitions must restore that panel-local shape exactly on reactivation.
+*   **No Transient Fallback Rule:** Reactivating a panel must not briefly render a different shape (for example tree-first then file, or small-first then big) before correcting.
 
 ### 5.3 Shared Tree Topology Contract
 The split panels share one logged tree topology contract for a given logged volume:

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -312,13 +312,14 @@ Use this when wrapping up a PROMPT_TEMPLATE-driven mission and returning the rep
     *   Manually exercise the changed behavior.
 2.  **Maintainer -> Architect/AI:** If manual checks find issues, report failures; architect dispatches a new developer/auditor unit and repeats the loop until manual checks are green.
 3.  **Architect/AI:** Clean stale task artifacts from the finished mission (prompt/report/temp workflow files).
+    *   Required before final commit: remove stale handoff artifacts from repo root (for example `<id>.txt`, `<id>.*.txt`, and any consumed prompt/report files) unless the maintainer explicitly asks to keep them.
 4.  **Architect/AI:** Run quick local checks only (build + targeted smoke/tests for touched scope).
 5.  **Architect/AI:** Stage intended changes only (exclude unrelated local edits and workflow artifacts).
 6.  **Architect/AI:** Suggest a Conventional Commit subject and request maintainer commit-message approval.
 7.  **Architect/AI:** Commit, push branch, and open/update a draft PR.
 8.  **Maintainer (GitHub):** Review draft PR scope and evidence.
-9.  **Maintainer (GitHub):** Wait for PR CI full gate; if any checks are red, report failures to architect/AI.
-10. **Architect/AI:** Fix CI failures root-cause-first, push updates, and repeat until required PR full-QA CI (`make qa-all` equivalent) is green.
+9.  **Architect/AI + Maintainer (GitHub):** Monitor PR CI full gate proactively (for example `gh pr checks <pr-number> --watch`). Do not wait passively for a separate reminder when checks change state.
+10. **Architect/AI:** If any checks are red, triage failing jobs immediately, fix CI failures root-cause-first, push updates, and repeat until required PR full-QA CI (`make qa-all` equivalent) is green.
 11. **Maintainer (GitHub):** Merge PR to `main` after checks are green and review is satisfied.
 12. **Maintainer (GitHub):** Delete remote branch:
     *   `git push origin --delete <branch>`

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -378,10 +378,12 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
     (*dir_entry_ptr)->cursor_pos = file_cursor;
     ctx->focused_window = FOCUS_FILE;
     ctx->active->saved_focus = FOCUS_FILE;
+    ctx->active->saved_big_file_view = FALSE;
   } else {
     (*dir_entry_ptr)->cursor_pos = -1;
     ctx->focused_window = FOCUS_TREE;
     ctx->active->saved_focus = FOCUS_TREE;
+    ctx->active->saved_big_file_view = FALSE;
   }
 
   ctx->active->file_dir_entry = *dir_entry_ptr;

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -258,6 +258,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   /* ADDED INSTRUCTION: Focus Unification */
   ctx->focused_window = FOCUS_FILE;
   ctx->active->saved_focus = FOCUS_FILE;
+  ctx->active->saved_big_file_view =
+      (dir_entry->big_window || dir_entry->global_flag || dir_entry->tagged_flag);
   if (tracked_file_dir == dir_entry) {
     dir_entry->start_file = ctx->active->start_file;
     dir_entry->cursor_pos = ctx->active->file_cursor_pos;
@@ -660,6 +662,7 @@ file_window_done:
 
   if (!switched_panel) {
     owner_panel->saved_focus = FOCUS_TREE;
+    owner_panel->saved_big_file_view = FALSE;
   }
   if (!volume_changed) {
     owner_panel->file_dir_entry = dir_entry;
@@ -677,6 +680,7 @@ file_window_done:
     owner_panel->file_dir_entry = NULL;
     owner_panel->start_file = 0;
     owner_panel->file_cursor_pos = 0;
+    owner_panel->saved_big_file_view = FALSE;
   }
 
   DEBUG_LOG("DEBUG: HandleFileWindow EXITING with %s",

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -572,6 +572,8 @@ BOOL handle_file_window_split_switch_action(
         active_selected_dir[PATH_LENGTH] = '\0';
       }
     }
+    owner_panel->saved_big_file_view =
+        (dir_entry->big_window || dir_entry->global_flag || dir_entry->tagged_flag);
 
     if (!ctx->is_split_screen) {
       owner_panel->file_dir_entry = dir_entry;
@@ -634,6 +636,7 @@ BOOL handle_file_window_split_switch_action(
         ctx->right->file_cursor_pos = dir_entry->cursor_pos;
         ctx->right->file_dir_entry = dir_entry;
         ctx->right->saved_focus = ctx->left->saved_focus;
+        ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
         PanelTags_Copy(ctx->right, ctx->left);
         FreeFileEntryList(ctx->right);
       }
@@ -669,6 +672,9 @@ BOOL handle_file_window_split_switch_action(
       owner_panel->file_cursor_pos = dir_entry->cursor_pos;
       CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
       ctx->active->saved_focus = FOCUS_FILE;
+      ctx->active->saved_big_file_view =
+          (dir_entry->big_window || dir_entry->global_flag ||
+           dir_entry->tagged_flag);
       *switched_panel_ptr = TRUE;
       SwitchToSmallFileWindow(ctx);
 
@@ -688,6 +694,9 @@ BOOL handle_file_window_split_switch_action(
     owner_panel->file_cursor_pos = dir_entry->cursor_pos;
     CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
     ctx->active->saved_focus = FOCUS_FILE;
+    ctx->active->saved_big_file_view =
+        (dir_entry->big_window || dir_entry->global_flag ||
+         dir_entry->tagged_flag);
     *switched_panel_ptr = TRUE;
     SwitchToSmallFileWindow(ctx);
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1164,7 +1164,9 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
       dir_entry->global_flag = FALSE;
       dir_entry->global_all_volumes = FALSE;
       dir_entry->tagged_flag = FALSE;
-      if (!restore_saved_file_window)
+      if (restore_saved_file_window)
+        dir_entry->big_window = TRUE;
+      else
         dir_entry->big_window = ctx->bypass_small_window;
       if (p->file_dir_entry == dir_entry) {
         dir_entry->start_file = p->start_file;
@@ -1449,6 +1451,9 @@ static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry
   panel->file_dir_entry = dir_entry;
   panel->start_file = dir_entry->start_file;
   panel->file_cursor_pos = dir_entry->cursor_pos;
+  if (!dir_entry->global_flag && !dir_entry->tagged_flag) {
+    dir_entry->big_window = panel->saved_big_file_view;
+  }
   if (dir_entry->start_file < 0)
     dir_entry->start_file = 0;
   if (dir_entry->cursor_pos < 0 && dir_entry->total_files > 0)

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -424,6 +424,8 @@ void UnmapF2Window(ViewContext *ctx) {
 
 void RefreshWindow(WINDOW *win) { wnoutrefresh(win); }
 
+static BOOL IsPanelSavedBigFileMode(const YtreePanel *panel);
+
 static int FindPanelDirIndexByEntry(const YtreePanel *panel,
                                     const DirEntry *target) {
   int i;
@@ -598,7 +600,7 @@ void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
       render_cursor = 0;
     }
 
-    if (panel->saved_focus == FOCUS_FILE && panel->pan_big_file_window) {
+    if (IsPanelSavedBigFileMode(panel) && panel->pan_big_file_window) {
       DEBUG_LOG("RenderInactivePanel:file path='%s' start=%d cursor=%d count=%u",
                 panel->file_selection_dir_path[0] ? panel->file_selection_dir_path
                                                    : "<none>",
@@ -643,6 +645,13 @@ static BOOL IsActivePanelBigFileMode(const ViewContext *ctx,
 
   return (dir_entry->big_window || dir_entry->global_flag ||
           dir_entry->tagged_flag);
+}
+
+static BOOL IsPanelSavedBigFileMode(const YtreePanel *panel) {
+  if (!panel)
+    return FALSE;
+
+  return (panel->saved_focus == FOCUS_FILE && panel->saved_big_file_view);
 }
 
 static void DrawSplitSeparatorRow(ViewContext *ctx, BOOL left_big,
@@ -786,14 +795,20 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
 
       left_big_mode = (ctx->active == ctx->left)
                           ? active_big_mode
-                          : (ctx->left->saved_focus == FOCUS_FILE);
+                          : IsPanelSavedBigFileMode(ctx->left);
       right_big_mode = (ctx->active == ctx->right)
                            ? active_big_mode
-                           : (ctx->right->saved_focus == FOCUS_FILE);
+                           : IsPanelSavedBigFileMode(ctx->right);
 
-      ctx->active->pan_file_window = active_big_mode
-                                         ? ctx->active->pan_big_file_window
-                                         : ctx->active->pan_small_file_window;
+      ctx->left->pan_file_window =
+          left_big_mode ? ctx->left->pan_big_file_window
+                        : ctx->left->pan_small_file_window;
+      ctx->right->pan_file_window =
+          right_big_mode ? ctx->right->pan_big_file_window
+                         : ctx->right->pan_small_file_window;
+      ctx->active->pan_file_window =
+          active_big_mode ? ctx->active->pan_big_file_window
+                          : ctx->active->pan_small_file_window;
       ctx->ctx_file_window = ctx->active->pan_file_window;
 
       DrawSplitSeparatorRow(ctx, left_big_mode, right_big_mode);

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -190,6 +190,85 @@ def test_split_from_file_keeps_file_focus_on_tab(tmp_path, ytree_binary):
     tui.quit()
 
 
+def test_split_tab_from_small_file_does_not_expand_inactive_panel(tmp_path, ytree_binary):
+    root = tmp_path / "split_tab_small_file_inactive_shape"
+    root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nSMALLWINDOWSKIP=0\n", encoding="utf-8")
+    left = root / "left"
+    right = root / "right"
+    left.mkdir()
+    right.mkdir()
+    for idx in range(5):
+        (left / f"left{idx}.txt").write_text("left\n", encoding="utf-8")
+        (right / f"right{idx}.txt").write_text("right\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+
+        # Baseline: small-window file content is below the split separator.
+        before_tab = tui.get_screen_dump()
+        before_idx = next(
+            (idx for idx, line in enumerate(before_tab) if "left0.txt" in line), -1
+        )
+        assert before_idx >= 0, _screen_text(tui)
+        assert before_idx > 10, _screen_text(tui)
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        after_tab = tui.get_screen_dump()
+        after_idx = next(
+            (idx for idx, line in enumerate(after_tab) if "left0.txt" in line), -1
+        )
+        assert after_idx >= 0, _screen_text(tui)
+
+        # BUG-5: inactive panel must keep tree+small layout, not expand to big file.
+        assert after_idx > 10, (
+            "Tab from small file view expanded the inactive panel to big file mode "
+            "(file rows jumped into the top/tree area).\n"
+            f"{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_split_from_big_file_keeps_inactive_panel_in_file_view(tmp_path, ytree_binary):
+    root = tmp_path / "split_from_big_file_inactive_file_view"
+    root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nSMALLWINDOWSKIP=1\n", encoding="utf-8")
+    left = root / "left"
+    right = root / "right"
+    left.mkdir()
+    right.mkdir()
+    for idx in range(3):
+        (left / f"left{idx}.txt").write_text("left\n", encoding="utf-8")
+        (right / f"right{idx}.txt").write_text("right\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke(Keys.F8, wait=0.5)
+        lines = tui.get_screen_dump()
+        split_col = _detect_split_column(lines)
+        assert split_col is not None, _screen_text(tui)
+
+        right_top = [line[split_col + 1 :] for line in lines[2:12]]
+        assert any("left0.txt" in segment for segment in right_top), (
+            "Splitting from big file view must keep inactive panel in file view.\n"
+            f"{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_split_same_directory_file_tags_are_panel_local(tmp_path, ytree_binary):
     root = tmp_path / "split_same_dir_panel_local_tags"
     root.mkdir()


### PR DESCRIPTION
## Summary
- fix split focus/view-state regressions by preserving panel-local file-window shape (`tree`/`small`/`big`) across `F8` and `Tab` transitions
- cover both confirmed paths:
  - `SMALLWINDOWSKIP=0`: inactive panel must not expand to big-file shape on `Tab`
  - `SMALLWINDOWSKIP=1`: split from file view must keep inactive panel in file view immediately
- update canonical docs:
  - `docs/SPECIFICATION.md` with explicit split shape persistence + no transient fallback rule
  - `docs/BUGS.md` status/evidence updates for this defect family
  - `docs/ai/WORKFLOW.md` stale-artifact cleanup and proactive CI monitoring guidance

## Root cause
Split/Tab rendering and restore logic treated `saved_focus == FOCUS_FILE` as sufficient for big-file rendering and did not consistently preserve/copy panel-local big/small shape state during split handoff. That allowed inactive-side shape drift and transient/fallback displays.

## Validation
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k split_tab_from_small_file_does_not_expand_inactive_panel -q`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k split_from_big_file_keeps_inactive_panel_in_file_view -q`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k 'split_tab_from_small_file_does_not_expand_inactive_panel or split_from_big_file_keeps_inactive_panel_in_file_view or split_from_file_keeps_file_focus_on_tab or f8_release_volume_keeps_small_window_and_tab_safe' -q`
