### PR TITLE
fix(split): keep split dot visibility and focus state panel-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **Ytree: a File Manager for Unix-like Systems**
+# **Ytree: A File Manager for Unix-like Systems**
 
 **Ytree** is a keyboard-first file manager for Linux and BSD with fast multi-volume logging and navigation.
 

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -95,7 +95,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Regression notes (manual, 2026-05-21)**:
     *   In split mode, active-panel dotfile toggles still influence inactive-panel behavior after `Tab` transitions.
     *   Toggling in active file window can still perturb inactive tree presentation.
-*   **Status**: Reopened (regression confirmed).
+*   **Status**: Fixed.
 
 ### **BUG-4: F8 Dotfiles Toggle Causes Inactive Selection Jitter**
 *   **Description**: In split mode, toggling dotfiles in one panel can make the inactive panel’s selected directory move away and then return (transient cursor/selection drift).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -35,7 +35,7 @@ Creating a new file manager from scratch would have resulted in a loss of identi
 
 ### Why is this not written in Rust?
 
-The primary objective of this phase was the architectural cleanup and restoration of the existing C codebase.
+The primary objective of this phase was architectural cleanup and feature completion in the existing C codebase.
 
 Switching languages immediately would constitute a total rewrite rather than a modernization. However, now that the architecture has been simplified, legacy dependencies removed, and the project stabilized, a port to a modern memory-safe language like Rust is a possibility for a future version.
 
@@ -49,11 +49,11 @@ Ytree only needs fast, reliable text/line-box terminal UI for file and VFS brows
 
 ### Why modernize Ytree when UnixTree already exists?
 
-While both projects aim to provide a file manager inspired by [XTree&trade;](https://www.xtreefanpage.org/x10dirja.htm), they represent architectural solutions for different eras.
+While both projects aim to provide a file manager inspired by [XTree&trade;](https://www.xtreefanpage.org/x10dirja.htm), they represent solutions for different eras.
 
-`UnixTree` was designed for a time of fragmented, incompatible commercial Unix systems. To guarantee portability, it had to be a self-contained monolith, bundling and maintaining its own internal libraries.
+`UnixTree` was built for a time when Unix systems were far more inconsistent. To stay portable, it evolved a project-specific internal ecosystem (`libecurses`, `libtcap`, custom term files, and related adaptations). That approach made sense then, but those methods are less common in mainstream Unix development today and can increase long-term maintenance, audit, and packaging effort.
 
-The goal of modernizing Ytree is to create a tool native to the *current* landscape of open-source operating systems. By discarding the custom frameworks required in the past and leveraging standard system libraries, Ytree becomes a lean, POSIX-compliant utility that fits naturally into modern distributions, easier to package, audit, and maintain.
+The goal of modernizing Ytree is to build for today’s open-source Unix systems. By using common libraries (`ncurses`, `libarchive`, `readline`) and keeping modules focused, Ytree becomes a lean, POSIX-compliant utility that is easier for new maintainers to understand, test, extend, audit, and package.
 
 ### How do the architectures compare?
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,7 +150,10 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Allows the developer to maintain a simple local text-based workflow during heavy development, while ensuring that all tracking data can be synchronized to the public web interface when the project goes live.
 *   - [ ] **Status:** Not Started.
 
-### **Task 14: Config Source-of-Truth + Generation/Verification Gate**
+### **Task 14: Configuration Integrity and Persistence**
+*   **Goal:** Group configuration-source governance and config/history persistence hardening under one umbrella with ordered subtask delivery.
+
+#### **Task 14.1: Config Source-of-Truth + Generation/Verification Gate**
 *   **Goal:** Enforce one canonical editable default profile source and make generated artifacts deterministic and verifiable.
 *   **Source-of-Truth Policy:** `etc/ytree.conf` is the only human-edited default profile source; `src/core/default_profile_template.h` is generated-only and consumed by `--init`.
 *   **Mechanism:** Add a reproducible generator path (`etc/ytree.conf` -> `src/core/default_profile_template.h`) and a QA/CI check that fails when generated output is stale or hand-edited.
@@ -159,6 +162,22 @@ Ordering policy (for all editors, including AI editors):
 *   A single documented command regenerates the header deterministically.
 *   `make qa-all` (or dedicated gate) fails on source/generated drift.
 *   **Files to Modify:** `Makefile`, `scripts/*` (new/updated generator + verifier), `src/core/default_profile_template.h`, and contributor/docs references as needed.
+*   - [ ] **Status:** Not Started.
+
+#### **Task 14.2: Config/History Robustness Gate (Strict Parse, Validation, Atomic Persistence)**
+*   **Goal:** Harden config/history reliability and corruption resistance without changing user-facing feature semantics.
+*   **Scope:**
+*   Strict parse rules for config/history input.
+*   Value validation (type/range/enum/path sanity) with explicit diagnostics.
+*   Atomic write path for persisted files.
+*   **Mechanism (mandatory):**
+*   Writes must use `temp file -> fsync -> atomic rename` for config/history persistence paths.
+*   Parser must reject malformed lines deterministically and report actionable errors.
+*   Invalid values must not partially apply; fallback behavior must be explicit and logged/notified.
+*   **Acceptance Criteria:**
+*   Corrupted or malformed config/history input does not crash runtime and does not leave partial in-memory state.
+*   Persistence writes are crash-safe and do not produce truncated/half-written files.
+*   Regression tests cover malformed input, invalid value ranges, interrupted-write simulation, and recovery behavior.
 *   - [ ] **Status:** Not Started.
 
 ---
@@ -284,7 +303,10 @@ Ordering policy (for all editors, including AI editors):
 *   Add focused regression coverage for progress-state selection (indeterminate vs measurable) and completion/error transitions.
 *   - [ ] **Status:** Not Started.
 
-### **Task 24: Unify Stats + Main-Pane Frame Redraw Contract**
+### **Task 24: Redraw Coherence**
+*   **Goal:** Ensure all related redraw-synchronization work ships under one coherent umbrella with deterministic scope boundaries.
+
+#### **Task 24.1: Unify Stats + Main-Pane Frame Redraw Contract**
 *   **Goal:** Eliminate intermittent split-brain rendering where stats and main panes update on different redraw lifecycles.
 *   **Rationale:** UI trust depends on one coherent frame; partial redraw divergence creates stale/corrupted mixed states.
 *   **Scope Lock:** Rendering/invalidation pipeline and regression coverage only; no command/keybinding semantics changes.
@@ -293,6 +315,16 @@ Ordering policy (for all editors, including AI editors):
 *   Resize, mode-switch, and recoverable-error paths trigger deterministic full-surface invalidation and redraw.
 *   No persistent mixed state where stats is fresh while main panes are stale (or vice versa) after redraw-triggering actions.
 *   Add focused regression coverage for redraw coherence across resize/mode toggles and representative recovery paths.
+*   - [ ] **Status:** Not Started.
+
+#### **Task 24.2: Footer-Aware Redraw Synchronization Contract**
+*   **Goal:** Footer/help/prompt surfaces must participate in the same redraw contract as stats/path/dir/file panes.
+*   **Rationale:** Partial redraw of guidance surfaces creates trust loss even when content panes are correct.
+*   **Scope Lock:** Redraw ordering and invalidation only; no keybinding or command behavior changes.
+*   **Acceptance Criteria:**
+*   Footer/help/prompt are rendered from the same frame snapshot as content panes.
+*   Resize and mode transitions must not leave footer/help stale relative to active context.
+*   Focused regression coverage proves synchronized redraw across normal, split, and overlay transitions.
 *   - [ ] **Status:** Not Started.
 
 ### **Task 25: Clarify Internal `^V` Navigation for File vs Hit Traversal**
@@ -491,7 +523,28 @@ Ordering policy (for all editors, including AI editors):
     *   Reassemble the command string (prefix + completed token) before returning.
 *   - [ ] **Status:** Not Started.
 
-### **Task 43: Implement Responsive Adaptive Footer**
+### **Task 43: Responsive Adaptive Footer**
+*   **Goal:** Group footer auto-fit layout and width-tier behavior under one umbrella with explicit subtask sequencing.
+
+#### **Task 43.1: Footer Auto-Fit Line Layout (No Hardcoded Per-Line Bindings)**
+*   **Goal:** Footer command hints must auto-fit available width instead of relying on fixed hardcoded keybinding placement per line.
+*   **Rationale:** Improves discoverability and prevents truncation/clipping across terminal sizes without changing command behavior.
+*   **Scope:**
+    *   Build footer lines from the active command set at render time.
+    *   Pack/wrap hints by available columns (`COLS`) with stable ordering.
+    *   Keep two-line footer budget unless constrained terminal fallback requires compact mode.
+*   **Scope Lock (mandatory):**
+    *   No keybinding changes.
+    *   No command behavior changes.
+    *   No prompt/help semantic changes.
+*   **Acceptance Criteria:**
+    *   Footer content fits width deterministically at common sizes (80, 100, 120, 160 cols).
+    *   No clipped mid-token hints in supported sizes.
+    *   F1 remains visible in compact and standard footer variants.
+    *   Existing footer/F1 parity checks remain green.
+*   - [ ] **Status:** Not Started.
+
+#### **Task 43.2: Implement Responsive Adaptive Footer**
 *   **Goal:** Make the two-line command footer dynamic based on terminal width.
     *   **Compact (constrained dimensions):** Show all currently available actions as bound-key hints only (minimal/no labels), and always keep `(F1)` visible for full help.
     *   **Standard (80-120 cols):** Show the standard set (current behavior).
@@ -573,15 +626,26 @@ Ordering policy (for all editors, including AI editors):
     *   **Portability:** Guard everything with `#ifdef __linux__`. On other systems, these functions act as empty stubs.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 50: Refactor Input Loop for Event Handling**
-*   **Task:** Modify `key_engine.c` to support non-blocking input handling.
-*   **Logic:**
-    *   Currently, `Getch()` blocks indefinitely waiting for a key.
-    *   **New Logic:** Use `select()` or `poll()` to wait on **two** file descriptors:
-        1.  `STDIN_FILENO` (The keyboard).
-        2.  `Watcher_GetFD()` (The inotify handle).
-    *   If the Watcher FD triggers, call `Watcher_CheckEvents()`. If it confirms a change, set a global flag `refresh_needed = TRUE`.
-    *   If STDIN triggers, proceed to `wgetch()`.
+### **Task 50: Input Loop Determinism and Event Handling**
+*   **Goal:** Group event-priority policy and multiplexing implementation under one umbrella to reduce recurring input-loop regressions.
+
+#### **Task 50.1: Input Loop Determinism and Event-Priority Contract**
+*   **Goal:** Make key handling deterministic across ESC sequences, resize events, watcher events, and prompt/overlay contexts.
+*   **Rationale:** Recurring regressions originate from event-order ambiguity, not raw key decoding alone.
+*   **Scope Lock:** Input/event ordering, dispatch priority, and regression coverage only; no keybinding changes.
+*   **Acceptance Criteria:**
+*   Event-priority order is explicit and enforced for: resize, watcher refresh, ESC-sequence normalization, and key dispatch.
+*   Prompt/overlay contexts must consume input according to innermost-active-context rules before base-mode dispatch.
+*   No double-processing or dropped-event regressions on rapid resize + key + watcher activity.
+*   Focused regression matrix covers ESC timing, resize storms, watcher bursts, and split/overlay transitions.
+*   - [ ] **Status:** Not Started.
+
+#### **Task 50.2: Non-Blocking FD Multiplexing Implementation**
+*   **Task:** Implement/maintain non-blocking input multiplexing (`select`/`poll`) for keyboard + watcher FDs as the concrete mechanism under Task 50.
+*   **Scope Lock:** Mechanism-level implementation only.
+*   **Acceptance Criteria:**
+*   Multiplex loop behavior conforms to Task 50 event-priority contract.
+*   Regression coverage confirms no blocking/starvation under mixed input/event load.
 *   - [ ] **Status:** Not Started.
 
 #### **Task 51: Implement Live Refresh Logic**
@@ -654,9 +718,41 @@ Ordering policy (for all editors, including AI editors):
 *   **Deliverables:** findings inventory with severity, owner, disposition (fix now vs tracked debt), and explicit residual-risk notes.
 *   - [ ] **Status:** Not Started.
 
-#### **Task 61: Expand Security Guard Coverage to Block Reintroduction**
+#### **Task 61: Runtime Execution Security Guardrail**
+*   **Goal:** Group runtime execution security hardening and guard expansion under one umbrella with mandatory staged completion.
+
+##### **Task 61.1: Expand Security Guard Coverage to Block Reintroduction**
 *   **Goal:** Ensure banned/legacy security-sensitive APIs and patterns are explicitly rejected by automated guard scripts.
 *   **Mechanism:** Extend guard checks for legacy unsafe escaping/runtime paths and other approved denylisted APIs/patterns.
+*   - [ ] **Status:** Not Started.
+
+##### **Task 61.2: Standardize Runtime Process Launch Hardening (`fork` + `execvp` + `waitpid`)**
+*   **Goal:** Make runtime command execution deterministic and secure by using one mandatory process-launch path in app runtime code.
+*   **Policy (mandatory):** Runtime launches **must** use `fork()` -> `execvp()` -> `waitpid()` only.
+*   **Non-Goal:** This task **must not** introduce `posix_spawn()`.
+*   **Rationale:** Remove mixed execution behavior (`system()`/`popen()` vs direct child-process execution), reduce shell-injection surface, and stabilize terminal restore behavior.
+
+*   **Scope:**
+    *   Add one shared launcher module for runtime child-process execution.
+    *   Migrate existing runtime call sites that currently use `system()`/`popen()` (including `system.c`, `print_ops.c`, `ctrl_file_ops.c`, and equivalent runtime paths).
+    *   Preserve existing UX flow: ytree remains active, launched command completes, control returns to ytree, curses state is restored.
+
+*   **Implementation Rules (mandatory):**
+    *   Parent process remains ytree; ytree **must not** replace itself.
+    *   Child process **must** execute target via `execvp()`.
+    *   Parent **must** reap child via `waitpid()` using an `EINTR`-safe wait loop.
+    *   No new runtime `system()` or `popen()` usage is permitted.
+    *   Any temporary migration shim/wrapper **must** be removed before task closure (see Task 78).
+
+*   **Acceptance Criteria:**
+    *   All runtime command-launch paths use the shared `fork`/`execvp`/`waitpid` implementation.
+    *   Zero runtime `system()`/`popen()` call sites remain in production runtime paths.
+    *   Regression coverage proves:
+        *   launched command runs and exits correctly,
+        *   ytree returns to interactive control after command completion,
+        *   terminal/curses state is restored correctly after command return.
+    *   QA guard fails CI if new runtime `system()`/`popen()` usage is introduced.
+    *   Shim cleanup is complete per Task 78.
 *   - [ ] **Status:** Not Started.
 
 #### **Task 62: Security Regression Gate in CI + Merge Workflow**
@@ -795,6 +891,19 @@ Ordering policy (for all editors, including AI editors):
 ## **Phase 8: Final Polish (Post-Alpha, Pre-v3.0.0)**
 *This phase focuses on release polish. Security, module-boundary, and quality gates remain continuous from earlier phases and are not deferred to this phase.*
 
+### **Task 78: Remove Temporary Compatibility Shims (Global Cleanup Gate)**
+*   **Goal:** Eliminate temporary compatibility shims introduced during staged migrations and prevent shim accumulation as permanent architecture debt.
+*   **Scope:** Applies to all migration tasks, including process-launch hardening and overlay/submode state unification.
+*   **Policy (mandatory):**
+    *   Temporary compatibility shims **must** be tagged at introduction with owner task ID and removal condition.
+    *   Temporary compatibility shims **must** be removed when migration acceptance criteria are met.
+    *   No temporary compatibility shim **may** remain in production paths after task completion.
+*   **Acceptance Criteria:**
+    *   A tracked shim inventory exists (file, symbol, owner task, removal condition).
+    *   All shims owned by completed tasks are removed.
+    *   CI/QA gate fails if orphaned/expired shim markers exist.
+*   - [ ] **Status:** Not Started.
+
 ### **Task 73: UI/UX Snappiness Polish (Targeted Optimization)**
 *   **Goal:** Improve perceived responsiveness in high-frequency flows using profiling-driven optimizations.
 *   **Rationale:** Premature optimization is avoided; final polish applies targeted improvements where bottlenecks are measured.
@@ -826,6 +935,42 @@ Ordering policy (for all editors, including AI editors):
 
 ## **Beta: Stabilization and Performance**
 *This phase follows alpha delivery phases and precedes wishlist work. Place stabilization tasks here: bug fixes, regressions, reliability, and performance. Defer non-essential feature work to wishlist phases.*
+
+### **Task 77: Stabilize and Unify Overlay/Submode State Model (Compatibility-First)**
+*   **Goal:** Make overlay/submode behavior deterministic by moving to one unified state model while preserving current user-visible behavior.
+*   **Why now (Beta):** Split/mode/node state is explicit and stable, but overlay/submode behavior is still distributed across flags/controller paths.
+*   **Precondition:** Current bug queue and planned current-delivery tasks are completed and green.
+
+*   **Scope:**
+    *   Add explicit enum-based `overlay_state` and `submode_state` fields to the authoritative runtime context.
+    *   Unify state handling for:
+        *   active overlay/context (normal/help/config/app-menu/autoview/fullview/diff/hexedit/destination-chooser),
+        *   command submode (regular/tag/alt),
+        *   overlay return/cancel chain behavior.
+    *   Use compatibility-first migration with temporary adapters while preserving behavior parity.
+    *   Migrate incrementally by context path; one-shot rewrite is out of scope.
+
+*   **Scope Lock (mandatory):**
+    *   No keybinding changes.
+    *   No command-surface changes.
+    *   No UX wording changes except correctness fixes required for parity.
+    *   No new features.
+
+*   **Post-migration Cleanup (mandatory):**
+    *   Temporary compatibility shims **must** be removed once migration acceptance criteria are met.
+    *   No compatibility shim may remain as permanent architecture.
+    *   Shim cleanup is mandatory per Task 78 before closure.
+
+*   **Acceptance Criteria:**
+    *   One authoritative overlay/submode state path exists in runtime logic.
+    *   Overlay entry/exit/cancel behavior is parity-validated for help, config, app menu, autoview, fullview, diff, hexedit, and destination chooser.
+    *   Split behavior (`F8`/`Tab`) and active/inactive panel isolation remain unchanged.
+    *   Existing split-panel/state-transition regression suites remain green.
+    *   New regression coverage exists for overlay/submode transitions and cancel-chain restoration.
+    *   Legacy overlay/submode flag/controller dispatch paths are removed from production paths.
+    *   Zero compatibility shims remain for overlay/submode dispatch in production paths.
+    *   `docs/ARCHITECTURE.md` is updated to document the unified model and migration endpoint.
+*   - [ ] **Status:** Not Started.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # NAME
 
-ytree - A File Manager for UNIX-like systems
+ytree - a file manager for Unix-like systems
 
 # SYNOPSIS
 

--- a/etc/ytree.1.md
+++ b/etc/ytree.1.md
@@ -8,7 +8,7 @@ date: "January 2026"
 
 # NAME
 
-ytree - A File Manager for UNIX-like systems
+ytree - a file manager for Unix-like systems
 
 # SYNOPSIS
 

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -785,6 +785,7 @@ typedef struct {
   unsigned int max_visual_linkname_len;
   unsigned int max_visual_userview_len;
   BOOL reverse_sort;
+  BOOL hide_dot_files;
 } YtreePanel;
 
 typedef struct _history {

--- a/include/ytree_ui.h
+++ b/include/ytree_ui.h
@@ -103,6 +103,11 @@ extern DirEntry *GetSelectedDirEntry(ViewContext *ctx, struct Volume *vol);
 extern DirEntry *GetPanelDirEntry(YtreePanel *p);
 extern void BuildDirEntryList(ViewContext *ctx, struct Volume *vol,
                               int *index_ptr);
+extern BOOL PanelDirIsVisible(const YtreePanel *panel, const DirEntry *dir_entry);
+extern int PanelFindNextVisibleDirIndex(const YtreePanel *panel, int start_idx,
+                                        int direction);
+extern int PanelFindFirstVisibleDirIndex(const YtreePanel *panel);
+extern int PanelFindLastVisibleDirIndex(const YtreePanel *panel);
 extern void FreeDirEntryList(ViewContext *ctx);
 extern void FreeVolumeCache(struct Volume *vol);
 extern DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p,

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -365,6 +365,7 @@ void InitView(ViewContext *ctx) {
   ctx->left->file_cursor_pos = 0;
   ctx->left->file_dir_entry = NULL;
   ctx->left->saved_big_file_view = FALSE;
+  ctx->left->hide_dot_files = FALSE;
 
   ctx->right = (YtreePanel *)calloc(1, sizeof(YtreePanel));
   if (ctx->right == NULL) {
@@ -379,6 +380,7 @@ void InitView(ViewContext *ctx) {
   ctx->right->file_cursor_pos = 0;
   ctx->right->file_dir_entry = NULL;
   ctx->right->saved_big_file_view = FALSE;
+  ctx->right->hide_dot_files = FALSE;
 
   ctx->active = ctx->left;
 
@@ -884,6 +886,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
   ctx->hide_dot_files =
       (strtol(CoreInitGetProfileValue(ctx, "HIDEDOTFILES"), NULL, 0)) ? TRUE
                                                                        : FALSE;
+  ctx->left->hide_dot_files = ctx->hide_dot_files;
+  ctx->right->hide_dot_files = ctx->hide_dot_files;
   ctx->animation_method =
       strtol(CoreInitGetProfileValue(ctx, "ANIMATION"), NULL, 0);
   ctx->initial_directory = (char *)CoreInitGetProfileValue(ctx, "INITIALDIR");

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -32,6 +32,7 @@ typedef struct {
   const DirEntry *file_dir_entry;
   ViewFocus saved_focus;
   BOOL saved_big_file_view;
+  BOOL hide_dot_files;
   char file_selection_name[PATH_LENGTH + 1];
   char file_selection_dir_path[PATH_LENGTH + 1];
 } FilePanelIsolationSnapshot;
@@ -48,6 +49,7 @@ static void CaptureFilePanelIsolationSnapshot(
   snapshot->file_dir_entry = panel->file_dir_entry;
   snapshot->saved_focus = panel->saved_focus;
   snapshot->saved_big_file_view = panel->saved_big_file_view;
+  snapshot->hide_dot_files = panel->hide_dot_files;
   (void)snprintf(snapshot->file_selection_name,
                  sizeof(snapshot->file_selection_name), "%s",
                  panel->file_selection_name);
@@ -67,6 +69,7 @@ static void AssertFilePanelIsolationSnapshotUnchanged(
   assert(panel->file_dir_entry == snapshot->file_dir_entry);
   assert(panel->saved_focus == snapshot->saved_focus);
   assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
+  assert(panel->hide_dot_files == snapshot->hide_dot_files);
   assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
   assert(strcmp(panel->file_selection_dir_path,
                 snapshot->file_selection_dir_path) == 0);
@@ -595,6 +598,7 @@ BOOL handle_file_window_split_switch_action(
       ctx->left->start_file = ctx->right->start_file;
       ctx->left->file_cursor_pos = ctx->right->file_cursor_pos;
       ctx->left->file_dir_entry = ctx->right->file_dir_entry;
+      ctx->left->hide_dot_files = ctx->right->hide_dot_files;
       (void)snprintf(ctx->left->file_selection_name,
                      sizeof(ctx->left->file_selection_name), "%s",
                      ctx->right->file_selection_name);
@@ -635,6 +639,7 @@ BOOL handle_file_window_split_switch_action(
         ctx->right->start_file = dir_entry->start_file;
         ctx->right->file_cursor_pos = dir_entry->cursor_pos;
         ctx->right->file_dir_entry = dir_entry;
+        ctx->right->hide_dot_files = ctx->left->hide_dot_files;
         ctx->right->saved_focus = ctx->left->saved_focus;
         ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
         PanelTags_Copy(ctx->right, ctx->left);
@@ -644,6 +649,7 @@ BOOL handle_file_window_split_switch_action(
       FreeFileEntryList(ctx->right);
       ctx->active = ctx->left;
     }
+    ctx->hide_dot_files = ctx->active->hide_dot_files;
 
     DebugLogFileSplitState("FileAction:split:after", ctx);
 
@@ -683,6 +689,7 @@ BOOL handle_file_window_split_switch_action(
       } else {
         ctx->active = ctx->left;
       }
+      ctx->hide_dot_files = ctx->active->hide_dot_files;
       ctx->focused_window = ctx->active->saved_focus;
       *loop_action_ptr = ACTION_ESCAPE;
       AssertFilePanelIsolationSnapshotUnchanged(target_panel,
@@ -705,6 +712,7 @@ BOOL handle_file_window_split_switch_action(
     } else {
       ctx->active = ctx->left;
     }
+    ctx->hide_dot_files = ctx->active->hide_dot_files;
     ctx->focused_window = ctx->active->saved_focus;
     *loop_action_ptr = ACTION_ESCAPE;
 #endif

--- a/src/ui/dir_list.c
+++ b/src/ui/dir_list.c
@@ -15,12 +15,6 @@ static void ReadDirList(ViewContext *ctx, DirEntry *dir_entry,
   static unsigned long indent = 0L;
 
   for (de_ptr = dir_entry; de_ptr; de_ptr = de_ptr->next) {
-    /* Check visibility. */
-    if (ctx->hide_dot_files && de_ptr->name[0] == '.') {
-      if (de_ptr != vol->vol_stats.tree)
-        continue;
-    }
-
     /* Bounds Checking & Dynamic Reallocation */
     if (*index_ptr >= (int)vol->dir_entry_list_capacity) {
       size_t new_capacity = vol->dir_entry_list_capacity * 2;
@@ -88,6 +82,71 @@ void BuildDirEntryList(ViewContext *ctx, struct Volume *vol, int *index_ptr) {
 #endif
 }
 
+BOOL PanelDirIsVisible(const YtreePanel *panel, const DirEntry *dir_entry) {
+  const DirEntry *ancestor;
+
+  if (!panel || !panel->vol || !dir_entry)
+    return FALSE;
+
+  if (!panel->hide_dot_files)
+    return TRUE;
+
+  if (dir_entry == panel->vol->vol_stats.tree)
+    return TRUE;
+
+  if (dir_entry->name[0] == '.')
+    return FALSE;
+
+  for (ancestor = dir_entry->up_tree;
+       ancestor && ancestor != panel->vol->vol_stats.tree;
+       ancestor = ancestor->up_tree) {
+    if (ancestor->name[0] == '.')
+      return FALSE;
+  }
+
+  return TRUE;
+}
+
+int PanelFindNextVisibleDirIndex(const YtreePanel *panel, int start_idx,
+                                 int direction) {
+  int idx;
+  int total_dirs;
+
+  if (!panel || !panel->vol || !panel->vol->dir_entry_list)
+    return -1;
+
+  total_dirs = panel->vol->total_dirs;
+  if (total_dirs <= 0)
+    return -1;
+
+  if (direction == 0)
+    direction = 1;
+  direction = (direction > 0) ? 1 : -1;
+
+  if (start_idx < 0)
+    start_idx = (direction > 0) ? 0 : total_dirs - 1;
+  if (start_idx >= total_dirs)
+    start_idx = (direction > 0) ? total_dirs - 1 : 0;
+
+  for (idx = start_idx; idx >= 0 && idx < total_dirs; idx += direction) {
+    const DirEntry *candidate = panel->vol->dir_entry_list[idx].dir_entry;
+    if (PanelDirIsVisible(panel, candidate))
+      return idx;
+  }
+
+  return -1;
+}
+
+int PanelFindFirstVisibleDirIndex(const YtreePanel *panel) {
+  return PanelFindNextVisibleDirIndex(panel, 0, 1);
+}
+
+int PanelFindLastVisibleDirIndex(const YtreePanel *panel) {
+  if (!panel || !panel->vol)
+    return -1;
+  return PanelFindNextVisibleDirIndex(panel, panel->vol->total_dirs - 1, -1);
+}
+
 /*
  * Frees the memory allocated for the dir_entry_list array of a volume.
  */
@@ -126,7 +185,11 @@ DirEntry *GetPanelDirEntry(YtreePanel *p) {
     if (idx >= p->vol->total_dirs)
       idx = p->vol->total_dirs - 1;
 
-    return p->vol->dir_entry_list[idx].dir_entry;
+    idx = PanelFindNextVisibleDirIndex(p, idx, 1);
+    if (idx < 0)
+      idx = PanelFindNextVisibleDirIndex(p, p->disp_begin_pos + p->cursor_pos, -1);
+    if (idx >= 0)
+      return p->vol->dir_entry_list[idx].dir_entry;
   }
   /* Fallback to root if list is empty/invalid */
   return p->vol->vol_stats.tree;
@@ -149,7 +212,14 @@ DirEntry *GetSelectedDirEntry(ViewContext *ctx, struct Volume *vol) {
     if (idx >= vol->total_dirs)
       idx = vol->total_dirs - 1;
 
-    return vol->dir_entry_list[idx].dir_entry;
+    idx = PanelFindNextVisibleDirIndex(ctx->active, idx, 1);
+    if (idx < 0)
+      idx = PanelFindNextVisibleDirIndex(ctx->active,
+                                         ctx->active->disp_begin_pos +
+                                             ctx->active->cursor_pos,
+                                         -1);
+    if (idx >= 0)
+      return vol->dir_entry_list[idx].dir_entry;
   }
   /* Fallback to root if list is empty/invalid */
   return vol->vol_stats.tree;

--- a/src/ui/dir_nav.c
+++ b/src/ui/dir_nav.c
@@ -8,11 +8,73 @@
 #include "ytree_fs.h"
 #include "ytree_ui.h"
 
+static void PositionPanelAtIndex(YtreePanel *p, int target_idx, int height) {
+  if (!p || !p->vol || p->vol->total_dirs <= 0)
+    return;
+
+  if (height < 1)
+    height = 1;
+
+  if (target_idx < 0)
+    target_idx = 0;
+  if (target_idx >= p->vol->total_dirs)
+    target_idx = p->vol->total_dirs - 1;
+
+  if (target_idx < p->disp_begin_pos) {
+    p->disp_begin_pos = target_idx;
+    p->cursor_pos = 0;
+    return;
+  }
+
+  if (target_idx >= p->disp_begin_pos + height) {
+    p->disp_begin_pos = target_idx - height + 1;
+    if (p->disp_begin_pos < 0)
+      p->disp_begin_pos = 0;
+    p->cursor_pos = target_idx - p->disp_begin_pos;
+    return;
+  }
+
+  p->cursor_pos = target_idx - p->disp_begin_pos;
+}
+
+static BOOL SyncPanelToVisibleSelection(const ViewContext *ctx, YtreePanel *p,
+                                        int direction_hint) {
+  int total_dirs;
+  int idx;
+  int visible_idx;
+
+  if (!ctx || !p || !p->vol || !p->vol->dir_entry_list)
+    return FALSE;
+
+  total_dirs = p->vol->total_dirs;
+  if (total_dirs <= 0)
+    return FALSE;
+
+  idx = p->disp_begin_pos + p->cursor_pos;
+  if (idx < 0)
+    idx = 0;
+  if (idx >= total_dirs)
+    idx = total_dirs - 1;
+
+  visible_idx = PanelFindNextVisibleDirIndex(p, idx, direction_hint);
+  if (visible_idx < 0)
+    visible_idx = PanelFindNextVisibleDirIndex(p, idx, -direction_hint);
+  if (visible_idx < 0)
+    visible_idx = PanelFindFirstVisibleDirIndex(p);
+  if (visible_idx < 0)
+    return FALSE;
+
+  PositionPanelAtIndex(p, visible_idx, ctx->layout.dir_win_height);
+  return TRUE;
+}
+
 void DirNav_Movedown(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
   const Statistic *s = &p->vol->vol_stats;
 
   Nav_MoveDown(&p->cursor_pos, &p->disp_begin_pos, p->vol->total_dirs,
                ctx->layout.dir_win_height, 1);
+  if (!SyncPanelToVisibleSelection(ctx, p, 1))
+    return;
 
   *dir_entry =
       p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
@@ -51,6 +113,8 @@ void DirNav_Moveup(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
   const Statistic *s = &p->vol->vol_stats;
 
   Nav_MoveUp(&p->cursor_pos, &p->disp_begin_pos);
+  if (!SyncPanelToVisibleSelection(ctx, p, -1))
+    return;
 
   *dir_entry =
       p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
@@ -85,6 +149,8 @@ void DirNav_Movenpage(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
 
   Nav_PageDown(&p->cursor_pos, &p->disp_begin_pos, p->vol->total_dirs,
                ctx->layout.dir_win_height);
+  if (!SyncPanelToVisibleSelection(ctx, p, 1))
+    return;
 
   *dir_entry =
       p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
@@ -118,6 +184,8 @@ void DirNav_Moveppage(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
   const Statistic *s = &p->vol->vol_stats;
 
   Nav_PageUp(&p->cursor_pos, &p->disp_begin_pos, ctx->layout.dir_win_height);
+  if (!SyncPanelToVisibleSelection(ctx, p, -1))
+    return;
 
   *dir_entry =
       p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
@@ -152,6 +220,13 @@ void DirNav_MoveEnd(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
 
   Nav_End(&p->cursor_pos, &p->disp_begin_pos, p->vol->total_dirs,
           ctx->layout.dir_win_height);
+  {
+    int idx = PanelFindLastVisibleDirIndex(p);
+    if (idx >= 0)
+      PositionPanelAtIndex(p, idx, ctx->layout.dir_win_height);
+  }
+  if (!SyncPanelToVisibleSelection(ctx, p, -1))
+    return;
 
   *dir_entry =
       p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
@@ -187,6 +262,13 @@ void DirNav_MoveHome(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
   const Statistic *s = &p->vol->vol_stats;
 
   Nav_Home(&p->cursor_pos, &p->disp_begin_pos);
+  {
+    int idx = PanelFindFirstVisibleDirIndex(p);
+    if (idx >= 0)
+      PositionPanelAtIndex(p, idx, ctx->layout.dir_win_height);
+  }
+  if (!SyncPanelToVisibleSelection(ctx, p, 1))
+    return;
 
   *dir_entry =
       p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -46,6 +46,7 @@ typedef struct {
   const DirEntry *file_dir_entry;
   ViewFocus saved_focus;
   BOOL saved_big_file_view;
+  BOOL hide_dot_files;
   char file_selection_name[PATH_LENGTH + 1];
   char file_selection_dir_path[PATH_LENGTH + 1];
 } PanelIsolationSnapshot;
@@ -62,6 +63,7 @@ static void CapturePanelIsolationSnapshot(const YtreePanel *panel,
   snapshot->file_dir_entry = panel->file_dir_entry;
   snapshot->saved_focus = panel->saved_focus;
   snapshot->saved_big_file_view = panel->saved_big_file_view;
+  snapshot->hide_dot_files = panel->hide_dot_files;
   (void)snprintf(snapshot->file_selection_name,
                  sizeof(snapshot->file_selection_name), "%s",
                  panel->file_selection_name);
@@ -81,6 +83,7 @@ static void AssertPanelIsolationSnapshotUnchanged(
   assert(panel->file_dir_entry == snapshot->file_dir_entry);
   assert(panel->saved_focus == snapshot->saved_focus);
   assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
+  assert(panel->hide_dot_files == snapshot->hide_dot_files);
   assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
   assert(strcmp(panel->file_selection_dir_path,
                 snapshot->file_selection_dir_path) == 0);
@@ -95,6 +98,7 @@ static void AssertPanelIsolationFileStateUnchanged(
   assert(panel->file_dir_entry == snapshot->file_dir_entry);
   assert(panel->saved_focus == snapshot->saved_focus);
   assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
+  assert(panel->hide_dot_files == snapshot->hide_dot_files);
   assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
   assert(strcmp(panel->file_selection_dir_path,
                 snapshot->file_selection_dir_path) == 0);
@@ -571,6 +575,7 @@ static int CountPathSnapshot(const PathList *list) {
 
 static void PositionPanelAtIndex(YtreePanel *panel, int idx) {
   int height;
+  int visible_idx;
 
   if (!panel)
     return;
@@ -580,6 +585,18 @@ static void PositionPanelAtIndex(YtreePanel *panel, int idx) {
     panel->cursor_pos = 0;
     return;
   }
+
+  visible_idx = PanelFindNextVisibleDirIndex(panel, idx, 1);
+  if (visible_idx < 0)
+    visible_idx = PanelFindNextVisibleDirIndex(panel, idx, -1);
+  if (visible_idx < 0)
+    visible_idx = PanelFindFirstVisibleDirIndex(panel);
+  if (visible_idx < 0) {
+    panel->disp_begin_pos = 0;
+    panel->cursor_pos = 0;
+    return;
+  }
+  idx = visible_idx;
 
   height = (panel->pan_dir_window) ? getmaxy(panel->pan_dir_window) : 1;
   if (height < 1)
@@ -637,6 +654,11 @@ BOOL DirOps_SelectVisibleDirAndRefresh(ViewContext *ctx, YtreePanel *panel,
     return FALSE;
   if (!panel->vol->dir_entry_list || panel->vol->total_dirs <= 0)
     return FALSE;
+
+  while (target && !PanelDirIsVisible(panel, target))
+    target = target->up_tree;
+  if (!target)
+    target = panel->vol->vol_stats.tree;
 
   idx = FindDirIndex(panel->vol, target);
   if (idx < 0)
@@ -1233,6 +1255,7 @@ void SyncActivePanelWindows(ViewContext *ctx) {
   ctx->ctx_small_file_window = ctx->active->pan_small_file_window;
   ctx->ctx_big_file_window = ctx->active->pan_big_file_window;
   ctx->ctx_file_window = ctx->active->pan_file_window;
+  ctx->hide_dot_files = ctx->active->hide_dot_files;
 }
 
 DirEntry *ResolveActiveDirEntry(ViewContext *ctx, const Statistic *s) {
@@ -1532,6 +1555,7 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
       int preserved_file_cursor = ctx->left->file_cursor_pos;
       DirEntry *preserved_file_dir_entry = ctx->left->file_dir_entry;
       BOOL preserved_big_file_view = ctx->left->saved_big_file_view;
+      BOOL preserved_hide_dot_files = ctx->left->hide_dot_files;
       ViewFocus preserved_saved_focus = ctx->left->saved_focus;
       char preserved_file_selection_name[PATH_LENGTH + 1];
       char preserved_file_selection_dir_path[PATH_LENGTH + 1];
@@ -1562,12 +1586,14 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
                      sizeof(ctx->left->file_selection_dir_path), "%s",
                      ctx->right->file_selection_dir_path);
       ctx->left->saved_big_file_view = ctx->right->saved_big_file_view;
+      ctx->left->hide_dot_files = ctx->right->hide_dot_files;
       ctx->left->saved_focus = ctx->right->saved_focus;
       if (preserve_left_file_state) {
         ctx->left->start_file = preserved_start_file;
         ctx->left->file_cursor_pos = preserved_file_cursor;
         ctx->left->file_dir_entry = preserved_file_dir_entry;
         ctx->left->saved_big_file_view = preserved_big_file_view;
+        ctx->left->hide_dot_files = preserved_hide_dot_files;
         ctx->left->saved_focus = preserved_saved_focus;
         (void)snprintf(ctx->left->file_selection_name,
                        sizeof(ctx->left->file_selection_name), "%s",
@@ -1596,6 +1622,7 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
         ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
         ctx->right->file_dir_entry = ctx->left->file_dir_entry;
         ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
+        ctx->right->hide_dot_files = ctx->left->hide_dot_files;
         ctx->right->saved_focus = FOCUS_TREE;
         FreeFileEntryList(ctx->right);
       }
@@ -1605,6 +1632,7 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
     }
 
     ctx->focused_window = ctx->active->saved_focus;
+    ctx->hide_dot_files = ctx->active->hide_dot_files;
     RefreshView(ctx, *dir_entry_ptr);
     DebugLogSplitState("DirPanelAction:split:after", ctx);
     *need_dsp_help_ptr = TRUE;
@@ -2044,8 +2072,9 @@ void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
     target = s->tree;
   }
 
-  /* 2. Toggle State and Recalculate Stats */
-  ctx->hide_dot_files = !ctx->hide_dot_files;
+  /* 2. Toggle active-panel state and synchronize context view filter. */
+  p->hide_dot_files = !p->hide_dot_files;
+  ctx->hide_dot_files = p->hide_dot_files;
   RecalculateSysStats(ctx, s);
 
   /* 3. Rebuild the linear list of visible directories */
@@ -2055,7 +2084,8 @@ void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
   DirEntry *search = target;
   while (search != NULL && found_idx == -1) {
     for (i = 0; i < p->vol->total_dirs; i++) {
-      if (p->vol->dir_entry_list[i].dir_entry == search) {
+      if (p->vol->dir_entry_list[i].dir_entry == search &&
+          PanelDirIsVisible(p, search)) {
         found_idx = i;
         break;
       }

--- a/src/ui/dir_tags.c
+++ b/src/ui/dir_tags.c
@@ -14,7 +14,7 @@ void HandleTagDir(ViewContext *ctx, DirEntry *dir_entry, BOOL value,
   FileEntry *fe_ptr;
   for (fe_ptr = dir_entry->file; fe_ptr; fe_ptr = fe_ptr->next) {
     /* Skip hidden dotfiles if the option is enabled */
-    if (ctx->hide_dot_files && fe_ptr->name[0] == '.')
+    if (p->hide_dot_files && fe_ptr->name[0] == '.')
       continue;
 
     if ((fe_ptr->matching) && (fe_ptr->tagged != value)) {
@@ -51,7 +51,7 @@ void HandleTagAllDirs(ViewContext *ctx, struct Volume *vol, DirEntry *dir_entry,
     for (fe_ptr = vol->dir_entry_list[i].dir_entry->file; fe_ptr;
          fe_ptr = fe_ptr->next) {
       /* Skip hidden dotfiles if the option is enabled */
-      if (ctx->hide_dot_files && fe_ptr->name[0] == '.')
+      if (p->hide_dot_files && fe_ptr->name[0] == '.')
         continue;
 
       if ((fe_ptr->matching) && (fe_ptr->tagged != value)) {
@@ -87,7 +87,7 @@ static void HandleInvertDirTags(ViewContext *ctx, DirEntry *dir_entry,
   FileEntry *fe_ptr;
 
   for (fe_ptr = dir_entry->file; fe_ptr; fe_ptr = fe_ptr->next) {
-    if (ctx->hide_dot_files && fe_ptr->name[0] == '.')
+    if (p->hide_dot_files && fe_ptr->name[0] == '.')
       continue;
 
     if (!fe_ptr->matching)

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -465,6 +465,7 @@ static int FindPanelDirIndexByPath(const YtreePanel *panel, const char *path) {
 
 static void PositionPanelAtDirIndex(YtreePanel *panel, int idx) {
   int height;
+  int visible_idx;
 
   if (!panel || !panel->vol || !panel->vol->dir_entry_list ||
       panel->vol->total_dirs <= 0)
@@ -474,6 +475,15 @@ static void PositionPanelAtDirIndex(YtreePanel *panel, int idx) {
     idx = 0;
   if (idx >= panel->vol->total_dirs)
     idx = panel->vol->total_dirs - 1;
+
+  visible_idx = PanelFindNextVisibleDirIndex(panel, idx, 1);
+  if (visible_idx < 0)
+    visible_idx = PanelFindNextVisibleDirIndex(panel, idx, -1);
+  if (visible_idx < 0)
+    visible_idx = PanelFindFirstVisibleDirIndex(panel);
+  if (visible_idx < 0)
+    return;
+  idx = visible_idx;
 
   height = panel->pan_dir_window ? getmaxy(panel->pan_dir_window) : 1;
   if (height < 1)
@@ -489,13 +499,12 @@ static void PositionPanelAtDirIndex(YtreePanel *panel, int idx) {
       if (panel->disp_begin_pos < 0)
         panel->disp_begin_pos = 0;
       panel->cursor_pos = idx - panel->disp_begin_pos;
-      if (panel->cursor_pos < 0)
-        panel->cursor_pos = 0;
     }
   }
 }
 
 static DirEntry *ResolvePanelFileAnchor(const YtreePanel *panel) {
+  const DirEntry *anchor = NULL;
   int anchor_idx = -1;
 
   if (!panel || !panel->vol || panel->saved_focus != FOCUS_FILE)
@@ -507,6 +516,15 @@ static DirEntry *ResolvePanelFileAnchor(const YtreePanel *panel) {
   if (anchor_idx < 0 && panel->file_dir_entry) {
     anchor_idx = FindPanelDirIndexByEntry(panel, panel->file_dir_entry);
   }
+  if (anchor_idx < 0)
+    return NULL;
+
+  anchor = panel->vol->dir_entry_list[anchor_idx].dir_entry;
+  while (anchor && !PanelDirIsVisible(panel, anchor))
+    anchor = anchor->up_tree;
+  if (!anchor)
+    return NULL;
+  anchor_idx = FindPanelDirIndexByEntry(panel, anchor);
   if (anchor_idx < 0)
     return NULL;
 
@@ -550,13 +568,20 @@ void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
   }
 
   {
-    int idx = begin + cursor;
     int render_start = panel->start_file;
     int render_cursor = 0;
+    int idx;
     const DirEntry *de = NULL;
 
+    idx = begin + cursor;
+    idx = PanelFindNextVisibleDirIndex(panel, idx, 1);
+    if (idx < 0)
+      idx = PanelFindNextVisibleDirIndex(panel, begin + cursor, -1);
     if (idx < 0 || idx >= total)
       return;
+    PositionPanelAtDirIndex(panel, idx);
+    begin = panel->disp_begin_pos;
+    cursor = panel->cursor_pos;
 
     de = panel->vol->dir_entry_list[idx].dir_entry;
     if (!de)
@@ -616,7 +641,10 @@ void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
     }
 
     if (panel->pan_dir_window) {
-      DisplayTree(ctx, panel->vol, panel->pan_dir_window, begin, begin + cursor,
+      int tree_hilight = begin + cursor;
+      if (panel->saved_focus == FOCUS_FILE)
+        tree_hilight = -1;
+      DisplayTree(ctx, panel->vol, panel->pan_dir_window, begin, tree_hilight,
                   FALSE);
       wnoutrefresh(panel->pan_dir_window);
     }
@@ -627,7 +655,10 @@ void RenderInactivePanel(ViewContext *ctx, YtreePanel *panel) {
         werase(panel->pan_file_window);
         wnoutrefresh(panel->pan_file_window);
       } else {
-        DisplayFiles(ctx, panel, de, render_start, -1, 0,
+        int file_hilight = -1;
+        if (panel->saved_focus == FOCUS_FILE && panel->file_count > 0)
+          file_hilight = render_start + render_cursor;
+        DisplayFiles(ctx, panel, de, render_start, file_hilight, 0,
                      panel->pan_file_window);
         wnoutrefresh(panel->pan_file_window);
       }

--- a/src/ui/file_list.c
+++ b/src/ui/file_list.c
@@ -33,7 +33,7 @@ static void ReadFileList(ViewContext *ctx, YtreePanel *panel, BOOL tagged_only,
     if (fe_ptr->matching && (!tagged_only || fe_ptr->tagged)) {
       /* Ensure hidden dot files are skipped unless option is disabled.
          This applies to both FS mode and Archive mode. */
-      if (ctx->hide_dot_files && fe_ptr->name[0] == '.')
+      if (panel->hide_dot_files && fe_ptr->name[0] == '.')
         continue;
 
       /* Bounds check */
@@ -74,7 +74,7 @@ static void ReadGlobalFileListInternal(ViewContext *ctx, YtreePanel *panel,
   DirEntry *de_ptr;
 
   for (de_ptr = dir_entry; de_ptr; de_ptr = de_ptr->next) {
-    if (ctx->hide_dot_files && de_ptr->name[0] == '.')
+    if (panel->hide_dot_files && de_ptr->name[0] == '.')
       continue;
     if (de_ptr->sub_tree)
       ReadGlobalFileListInternal(ctx, panel, tagged_only, de_ptr->sub_tree);

--- a/src/ui/render_dir.c
+++ b/src/ui/render_dir.c
@@ -8,6 +8,22 @@
 #include "ytree_cmd.h"
 #include "ytree_ui.h"
 
+static const YtreePanel *ResolveDirRenderPanel(const ViewContext *ctx,
+                                               const struct Volume *vol,
+                                               const WINDOW *win) {
+  if (!ctx || !vol || !win)
+    return NULL;
+
+  if (ctx->left && ctx->left->vol == vol && ctx->left->pan_dir_window == win)
+    return ctx->left;
+  if (ctx->right && ctx->right->vol == vol && ctx->right->pan_dir_window == win)
+    return ctx->right;
+  if (ctx->active && ctx->active->vol == vol && ctx->ctx_dir_window == win)
+    return ctx->active;
+
+  return NULL;
+}
+
 /*
  * SetDirMode
  * Sets the display mode for directory entries.
@@ -273,7 +289,9 @@ void PrintDirEntry(ViewContext *ctx, struct Volume *vol, WINDOW *win,
 void DisplayTree(ViewContext *ctx, struct Volume *vol, WINDOW *win,
                  int start_entry_no, int hilight_no, BOOL is_active) {
   int i, y;
+  int list_idx;
   int height;
+  const YtreePanel *panel;
 
   if (!ctx || !vol || !win)
     return;
@@ -295,16 +313,29 @@ void DisplayTree(ViewContext *ctx, struct Volume *vol, WINDOW *win,
     box(win, 0, 0);
   }
 
-  for (i = 0; i < height; i++) {
-    if (start_entry_no + i >= vol->total_dirs)
+  panel = ResolveDirRenderPanel(ctx, vol, win);
+  list_idx = start_entry_no;
+
+  if (list_idx < 0)
+    list_idx = 0;
+
+  for (i = 0; i < height && list_idx < vol->total_dirs; i++) {
+    while (list_idx < vol->total_dirs) {
+      const DirEntry *candidate = vol->dir_entry_list[list_idx].dir_entry;
+      if (!panel || PanelDirIsVisible(panel, candidate))
+        break;
+      list_idx++;
+    }
+    if (list_idx >= vol->total_dirs)
       break;
 
-    if (start_entry_no + i != hilight_no)
-      PrintDirEntry(ctx, vol, win, start_entry_no + i, i, FALSE, is_active);
+    if (list_idx != hilight_no)
+      PrintDirEntry(ctx, vol, win, list_idx, i, FALSE, is_active);
     else
       y = i;
+    list_idx++;
   }
 
   if (y >= 0)
-    PrintDirEntry(ctx, vol, win, start_entry_no + y, y, TRUE, is_active);
+    PrintDirEntry(ctx, vol, win, hilight_no, y, TRUE, is_active);
 }

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -1712,7 +1712,7 @@ def test_bug_f_eight_dotfiles_toggle_keeps_inactive_selection_identity(
     root = tmp_path / "bug_f_eight_dotfiles_inactive_identity"
     root.mkdir()
     (root / ".ytree").write_text(
-        "[GLOBAL]\nTREEDEPTH=1\nHIDEDOTFILES=1\n",
+        "[GLOBAL]\nTREEDEPTH=3\nHIDEDOTFILES=1\n",
         encoding="utf-8",
     )
 
@@ -1777,6 +1777,125 @@ def test_bug_f_eight_dotfiles_toggle_keeps_inactive_selection_identity(
 
         tui.send_keystroke("`", wait=0.5)
         _assert_right_panel_opens_tail_dir(tui, "dotfiles hidden")
+    finally:
+        tui.quit()
+
+
+def test_bug_f_eight_dotfiles_toggle_is_panel_local_visibility(
+    tmp_path, ytree_binary
+):
+    """
+    BUG-3 regression:
+    In split mode, dotfile visibility toggled on the active panel must not leak
+    into the inactive panel's file view.
+    """
+    root = tmp_path / "bug_f_eight_dotfiles_panel_local_visibility"
+    root.mkdir()
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=3\nHIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    active_dir = root / "active_dir"
+    active_dir.mkdir()
+    tail_dir = root / "zzz_tail"
+    tail_dir.mkdir()
+    hidden_parent = root / ".split_hidden_dir"
+    hidden_parent.mkdir()
+    (hidden_parent / "visible_child").mkdir()
+
+    (active_dir / "active_visible.txt").write_text("visible\n", encoding="utf-8")
+    (active_dir / ".active_hidden.txt").write_text("hidden\n", encoding="utf-8")
+    (tail_dir / "tail_visible.txt").write_text("visible\n", encoding="utf-8")
+    (tail_dir / ".tail_hidden.txt").write_text("hidden\n", encoding="utf-8")
+
+    def _active_path_contains(tui, marker):
+        screen = _screen_text(tui)
+        header = screen.splitlines()[0] if screen else ""
+        return marker in header
+
+    def _select_dir_by_marker(tui, marker):
+        for _ in range(40):
+            if _active_path_contains(tui, marker):
+                return
+            tui.send_keystroke(Keys.DOWN, wait=0.2)
+        raise AssertionError(
+            f"Could not select '{marker}' in tree view.\n{_screen_text(tui)}"
+        )
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.9)
+    try:
+        _select_dir_by_marker(tui, "active_dir")
+        tui.send_keystroke(Keys.F8, wait=0.4)
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        if "hex invert j compare" in _footer_text(tui):
+            tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(tui, "Expected right panel tree mode after split.")
+        _select_dir_by_marker(tui, "zzz_tail")
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(
+            tui, "Expected left panel tree mode before active toggle."
+        )
+
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        baseline_screen = _screen_text(tui)
+        assert "active_visible.txt" in baseline_screen, baseline_screen
+        assert ".active_hidden.txt" not in baseline_screen, baseline_screen
+
+        tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(
+            tui, "Expected left panel tree mode before split tree assertion."
+        )
+        left_tree_screen = _screen_text(tui)
+        assert ".split_hidden_dir" not in left_tree_screen, left_tree_screen
+        assert "visible_child" not in left_tree_screen, left_tree_screen
+
+        tui.send_keystroke("`", wait=0.5)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        toggled_screen = _screen_text(tui)
+        assert ".active_hidden.txt" in toggled_screen, toggled_screen
+        tui.send_keystroke(Keys.ESC, wait=0.3)
+        _assert_dir_mode_footer(
+            tui, "Expected left panel tree mode after active toggle."
+        )
+        left_tree_toggled = _screen_text(tui)
+        assert ".split_hidden_dir" in left_tree_toggled, left_tree_toggled
+
+        tui.send_keystroke(Keys.HOME, wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.RIGHT, wait=0.4)
+        left_tree_expanded = _screen_text(tui)
+        assert "visible_child" in left_tree_expanded, left_tree_expanded
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(tui, "Expected right panel tree mode after Tab.")
+        left_seg, right_seg, screen = _split_segments_for_file(
+            tui, ".split_hidden_dir"
+        )
+        assert ".split_hidden_dir" in left_seg, screen
+        assert ".split_hidden_dir" not in right_seg, screen
+        assert "visible_child" not in right_seg, screen
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(
+            tui, "Expected left panel tree mode before hiding expanded subtree."
+        )
+        tui.send_keystroke("`", wait=0.5)
+        hidden_again_screen = _screen_text(tui)
+        assert ".split_hidden_dir" not in hidden_again_screen, hidden_again_screen
+        assert "visible_child" not in hidden_again_screen, hidden_again_screen
+
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        _assert_dir_mode_footer(
+            tui, "Expected right panel tree mode after second Tab."
+        )
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        right_screen = _screen_text(tui)
+        assert "tail_visible.txt" in right_screen, right_screen
+        assert ".tail_hidden.txt" not in right_screen, right_screen
     finally:
         tui.quit()
 


### PR DESCRIPTION
## Validation
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k "dotfiles_toggle_keeps_inactive_selection_identity or dotfiles_toggle_is_panel_local_visibility" -q`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k "inactive_panel_stays_file_focused_after_tab_away or split_from_big_file_keeps_inactive_panel_in_file_view or split_tab_from_small_file_does_not_expand_inactive_panel" -q`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k "bug_f_eight" -q`
