### PR TITLE
fix(split): restore focus behavior across tree refresh and delete flows

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -42,7 +42,7 @@ Ordering policy (for all editors, including AI editors):
     *   In this flow, source selection/tag identity stayed unchanged (render/refresh defect, not BUG-2 selection-loss itself).
 *   **Impact**: Degrades trust and usability in high-frequency split copy/move workflows.
 *   **Remediation**: Audit split redraw ownership/order around `Tab` transition and destination-prep mode switches; enforce deterministic repaint sequencing for active/inactive surfaces.
-*   **Status**: Confirmed.
+*   **Status**: Fixed.
 
 ### **BUG-2.5: Volume Switch Can Lose Per-Volume File Context (`SMALLWINDOWSKIP=1`)**
 *   **Description**: With `SMALLWINDOWSKIP=1`, switching between logged volumes can lose previously selected deep file context and return to parent tree location instead.

--- a/src/fs/tree_utils.c
+++ b/src/fs/tree_utils.c
@@ -174,10 +174,9 @@ static void ScanAndSaveState(DirEntry *dir, PathList **expanded,
   if (!dir)
     return;
 
-  /* If directory is scanned (has sub_tree or marked scanned) and NOT root */
-  /* Note: We check !not_scanned. Root is always scanned effectively. */
-  /* We save state if it has a sub_tree (meaning it was expanded) */
-  if (dir->sub_tree) {
+  /* Save only currently expanded directories. Collapsed nodes can still keep
+   * stale sub_tree pointers in memory and must not be restored as expanded. */
+  if (dir->sub_tree && !dir->not_scanned) {
     GetPath(dir, path);
     AddPathToList(expanded, path);
   }
@@ -190,7 +189,11 @@ static void ScanAndSaveState(DirEntry *dir, PathList **expanded,
     }
   }
 
-  /* Recurse into subdirectories */
+  /* Recurse only through expanded nodes so collapsed descendants stay
+   * collapsed across refreshes. */
+  if (dir->not_scanned)
+    return;
+
   for (sub = dir->sub_tree; sub; sub = sub->next) {
     ScanAndSaveState(sub, expanded, tagged);
   }

--- a/src/ui/dir_nav.c
+++ b/src/ui/dir_nav.c
@@ -8,6 +8,8 @@
 #include "ytree_fs.h"
 #include "ytree_ui.h"
 
+static int FindVisibleBackwardNoWrap(const YtreePanel *p, int start_idx);
+
 static void PositionPanelAtIndex(YtreePanel *p, int target_idx, int height) {
   if (!p || !p->vol || p->vol->total_dirs <= 0)
     return;
@@ -19,6 +21,20 @@ static void PositionPanelAtIndex(YtreePanel *p, int target_idx, int height) {
     target_idx = 0;
   if (target_idx >= p->vol->total_dirs)
     target_idx = p->vol->total_dirs - 1;
+
+  if (p->hide_dot_files) {
+    int start_idx = target_idx;
+    int i;
+    for (i = 1; i < height; i++) {
+      int prev_idx = FindVisibleBackwardNoWrap(p, start_idx - 1);
+      if (prev_idx < 0)
+        break;
+      start_idx = prev_idx;
+    }
+    p->disp_begin_pos = start_idx;
+    p->cursor_pos = target_idx - p->disp_begin_pos;
+    return;
+  }
 
   if (target_idx < p->disp_begin_pos) {
     p->disp_begin_pos = target_idx;
@@ -68,11 +84,90 @@ static BOOL SyncPanelToVisibleSelection(const ViewContext *ctx, YtreePanel *p,
   return TRUE;
 }
 
+static int FindVisibleBackwardNoWrap(const YtreePanel *p, int start_idx) {
+  int idx;
+
+  if (!p || !p->vol || !p->vol->dir_entry_list || start_idx < 0)
+    return -1;
+
+  for (idx = start_idx; idx >= 0; idx--) {
+    const DirEntry *candidate = p->vol->dir_entry_list[idx].dir_entry;
+    if (PanelDirIsVisible(p, candidate))
+      return idx;
+  }
+  return -1;
+}
+
+static int GetCurrentVisiblePanelIndex(const YtreePanel *p) {
+  int total_dirs;
+  int idx;
+  const DirEntry *current;
+
+  if (!p || !p->vol || !p->vol->dir_entry_list)
+    return -1;
+
+  total_dirs = p->vol->total_dirs;
+  if (total_dirs <= 0)
+    return -1;
+
+  idx = p->disp_begin_pos + p->cursor_pos;
+  if (idx < 0)
+    idx = 0;
+  if (idx >= total_dirs)
+    idx = total_dirs - 1;
+
+  current = p->vol->dir_entry_list[idx].dir_entry;
+  if (PanelDirIsVisible(p, current))
+    return idx;
+
+  idx = PanelFindNextVisibleDirIndex(p, idx, 1);
+  if (idx < 0)
+    idx = PanelFindNextVisibleDirIndex(p, p->disp_begin_pos + p->cursor_pos, -1);
+  if (idx < 0)
+    idx = PanelFindFirstVisibleDirIndex(p);
+  return idx;
+}
+
+static BOOL MoveVisibleSelection(const ViewContext *ctx, YtreePanel *p,
+                                 int direction, int steps) {
+  int idx;
+  int i;
+  int total_dirs;
+
+  if (!ctx || !p)
+    return FALSE;
+  if (steps < 1)
+    steps = 1;
+  if (direction == 0)
+    direction = 1;
+  direction = (direction > 0) ? 1 : -1;
+
+  idx = GetCurrentVisiblePanelIndex(p);
+  if (idx < 0)
+    return FALSE;
+  total_dirs = p->vol ? p->vol->total_dirs : 0;
+  if (total_dirs <= 0)
+    return FALSE;
+
+  for (i = 0; i < steps; i++) {
+    int candidate_start = idx + direction;
+    if (candidate_start < 0 || candidate_start >= total_dirs)
+      break;
+    int next_idx = PanelFindNextVisibleDirIndex(p, candidate_start, direction);
+    if (next_idx < 0)
+      break;
+    idx = next_idx;
+  }
+
+  PositionPanelAtIndex(p, idx, ctx->layout.dir_win_height);
+  return TRUE;
+}
+
 void DirNav_Movedown(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
   const Statistic *s = &p->vol->vol_stats;
 
-  Nav_MoveDown(&p->cursor_pos, &p->disp_begin_pos, p->vol->total_dirs,
-               ctx->layout.dir_win_height, 1);
+  if (!MoveVisibleSelection(ctx, p, 1, 1))
+    return;
   if (!SyncPanelToVisibleSelection(ctx, p, 1))
     return;
 
@@ -112,7 +207,8 @@ void DirNav_Movedown(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
 void DirNav_Moveup(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
   const Statistic *s = &p->vol->vol_stats;
 
-  Nav_MoveUp(&p->cursor_pos, &p->disp_begin_pos);
+  if (!MoveVisibleSelection(ctx, p, -1, 1))
+    return;
   if (!SyncPanelToVisibleSelection(ctx, p, -1))
     return;
 
@@ -147,8 +243,8 @@ void DirNav_Moveup(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
 void DirNav_Movenpage(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
   const Statistic *s = &p->vol->vol_stats;
 
-  Nav_PageDown(&p->cursor_pos, &p->disp_begin_pos, p->vol->total_dirs,
-               ctx->layout.dir_win_height);
+  if (!MoveVisibleSelection(ctx, p, 1, ctx->layout.dir_win_height))
+    return;
   if (!SyncPanelToVisibleSelection(ctx, p, 1))
     return;
 
@@ -183,7 +279,8 @@ void DirNav_Movenpage(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
 void DirNav_Moveppage(ViewContext *ctx, DirEntry **dir_entry, YtreePanel *p) {
   const Statistic *s = &p->vol->vol_stats;
 
-  Nav_PageUp(&p->cursor_pos, &p->disp_begin_pos, ctx->layout.dir_win_height);
+  if (!MoveVisibleSelection(ctx, p, -1, ctx->layout.dir_win_height))
+    return;
   if (!SyncPanelToVisibleSelection(ctx, p, -1))
     return;
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -72,23 +72,6 @@ static void CapturePanelIsolationSnapshot(const YtreePanel *panel,
                  panel->file_selection_dir_path);
 }
 
-static void AssertPanelIsolationSnapshotUnchanged(
-    const YtreePanel *panel, const PanelIsolationSnapshot *snapshot) {
-  assert(panel != NULL);
-  assert(snapshot != NULL);
-  assert(panel->cursor_pos == snapshot->cursor_pos);
-  assert(panel->disp_begin_pos == snapshot->disp_begin_pos);
-  assert(panel->start_file == snapshot->start_file);
-  assert(panel->file_cursor_pos == snapshot->file_cursor_pos);
-  assert(panel->file_dir_entry == snapshot->file_dir_entry);
-  assert(panel->saved_focus == snapshot->saved_focus);
-  assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
-  assert(panel->hide_dot_files == snapshot->hide_dot_files);
-  assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
-  assert(strcmp(panel->file_selection_dir_path,
-                snapshot->file_selection_dir_path) == 0);
-}
-
 static void AssertPanelIsolationFileStateUnchanged(
     const YtreePanel *panel, const PanelIsolationSnapshot *snapshot) {
   assert(panel != NULL);
@@ -552,6 +535,25 @@ static void CapturePanelTaggedSnapshot(const YtreePanel *panel,
   }
 }
 
+static void CaptureCollapsedTreeState(DirEntry *dir, PathList **collapsed) {
+  DirEntry *sub;
+
+  if (!dir || !collapsed)
+    return;
+
+  if (dir->sub_tree && dir->not_scanned) {
+    char path[PATH_LENGTH + 1];
+    GetPath(dir, path);
+    path[PATH_LENGTH] = '\0';
+    AddPathSnapshot(collapsed, path);
+    return;
+  }
+
+  for (sub = dir->sub_tree; sub; sub = sub->next) {
+    CaptureCollapsedTreeState(sub, collapsed);
+  }
+}
+
 static void RestoreTaggedSnapshot(ViewContext *ctx, struct Volume *vol,
                                   PathList *tagged) {
   PathList *expanded = NULL;
@@ -571,6 +573,20 @@ static int CountPathSnapshot(const PathList *list) {
     count++;
 
   return count;
+}
+
+static int FindVisibleBackwardNoWrap(const YtreePanel *panel, int start_idx) {
+  int idx;
+
+  if (!panel || !panel->vol || !panel->vol->dir_entry_list || start_idx < 0)
+    return -1;
+
+  for (idx = start_idx; idx >= 0; idx--) {
+    const DirEntry *candidate = panel->vol->dir_entry_list[idx].dir_entry;
+    if (PanelDirIsVisible(panel, candidate))
+      return idx;
+  }
+  return -1;
 }
 
 static void PositionPanelAtIndex(YtreePanel *panel, int idx) {
@@ -601,6 +617,20 @@ static void PositionPanelAtIndex(YtreePanel *panel, int idx) {
   height = (panel->pan_dir_window) ? getmaxy(panel->pan_dir_window) : 1;
   if (height < 1)
     height = 1;
+
+  if (panel->hide_dot_files) {
+    int start_idx = idx;
+    int i;
+    for (i = 1; i < height; i++) {
+      int prev_idx = FindVisibleBackwardNoWrap(panel, start_idx - 1);
+      if (prev_idx < 0)
+        break;
+      start_idx = prev_idx;
+    }
+    panel->disp_begin_pos = start_idx;
+    panel->cursor_pos = idx - panel->disp_begin_pos;
+    return;
+  }
 
   if (idx >= panel->disp_begin_pos && idx < panel->disp_begin_pos + height) {
     panel->cursor_pos = idx - panel->disp_begin_pos;
@@ -1068,24 +1098,45 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
 
 DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   InactiveFallbackSnapshot inactive_snapshot;
+  int target_idx;
 
   CaptureInactiveFallbackSnapshot(ctx, ctx->active, &inactive_snapshot);
+  target_idx = ctx->active->disp_begin_pos + ctx->active->cursor_pos;
 
   if (!DeleteDirectory(ctx, dir_entry, UI_ChoiceResolver)) {
-    if (ctx->active->disp_begin_pos + ctx->active->cursor_pos > 0) {
-      if (ctx->active->cursor_pos > 0)
-        ctx->active->cursor_pos--;
-      else
-        ctx->active->disp_begin_pos--;
-    }
+    if (target_idx > 0)
+      target_idx--;
   }
 
   BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
+  if (ctx->active->vol && ctx->active->vol->dir_entry_list &&
+      ctx->active->vol->total_dirs > 0) {
+    int visible_idx = PanelFindNextVisibleDirIndex(ctx->active, target_idx, -1);
+    if (visible_idx < 0)
+      visible_idx = PanelFindNextVisibleDirIndex(ctx->active, target_idx, 1);
+    if (visible_idx < 0)
+      visible_idx = PanelFindFirstVisibleDirIndex(ctx->active);
+    if (visible_idx >= 0)
+      target_idx = visible_idx;
+    PositionPanelAtIndex(ctx->active, target_idx);
+  }
   if (inactive_snapshot.panel && inactive_snapshot.panel->vol == ctx->active->vol) {
     const DirEntry *inactive_target =
         ResolveInactiveFallbackTarget(&inactive_snapshot);
     ReanchorPanelToDir(inactive_snapshot.panel, inactive_target);
     BuildFileEntryList(ctx, inactive_snapshot.panel);
+  }
+  if (!ctx->active || !ctx->active->vol || !ctx->active->vol->dir_entry_list ||
+      ctx->active->vol->total_dirs <= 0) {
+    dir_entry =
+        (ctx->active && ctx->active->vol) ? ctx->active->vol->vol_stats.tree
+                                          : NULL;
+    if (dir_entry) {
+      dir_entry->start_file = 0;
+      dir_entry->cursor_pos = -1;
+      RefreshView(ctx, dir_entry);
+    }
+    return dir_entry;
   }
   dir_entry = ctx->active->vol
                   ->dir_entry_list[ctx->active->disp_begin_pos +
@@ -1715,8 +1766,8 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
         *unput_char_ptr = CR;
       }
 
-      AssertPanelIsolationSnapshotUnchanged(previous_active,
-                                            &previous_active_snapshot);
+      AssertPanelIsolationFileStateUnchanged(previous_active,
+                                             &previous_active_snapshot);
     }
 #else
     if (ctx->active == ctx->left) {
@@ -2208,7 +2259,9 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p, DirEntry *entry) {
 
   if (ctx->view_mode != ARCHIVE_MODE) {
     PathList *expanded = NULL;
+    PathList *collapsed = NULL;
     PathList *tagged = NULL;
+    PathList *collapsed_curr;
     char saved_path[PATH_LENGTH + 1];
     int win_height;
     int dummy_width;
@@ -2218,6 +2271,7 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p, DirEntry *entry) {
     /* 1. Save State */
     GetPath(entry, saved_path);
     SaveTreeState(s->tree, &expanded, &tagged);
+    CaptureCollapsedTreeState(s->tree, &collapsed);
 
     /* 2. Destructive Rescan */
     RescanDir(ctx, entry, strtol(TREEDEPTH, NULL, 0), s, Dir_Progress, ctx);
@@ -2231,8 +2285,18 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p, DirEntry *entry) {
 
     /* 3. Restore State */
     RestoreTreeState(ctx, s->tree, &expanded, tagged, s);
+    for (collapsed_curr = collapsed; collapsed_curr;
+         collapsed_curr = collapsed_curr->next) {
+      DirEntry *collapsed_dir =
+          FindDirByPathInSubTree(s->tree, collapsed_curr->path);
+      if (!collapsed_dir)
+        continue;
+      collapsed_dir->not_scanned = TRUE;
+      collapsed_dir->unlogged_flag = TRUE;
+    }
     PanelTags_Restore(ctx, p);
     FreePathList(expanded);
+    FreePathList(collapsed);
     FreePathList(tagged);
 
     /* 4. Restore Selection */

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -463,6 +463,21 @@ static int FindPanelDirIndexByPath(const YtreePanel *panel, const char *path) {
   return -1;
 }
 
+static int FindVisibleBackwardNoWrap(const YtreePanel *panel, int start_idx) {
+  int idx;
+
+  if (!panel || !panel->vol || !panel->vol->dir_entry_list || start_idx < 0)
+    return -1;
+
+  for (idx = start_idx; idx >= 0; idx--) {
+    const DirEntry *candidate = panel->vol->dir_entry_list[idx].dir_entry;
+    if (PanelDirIsVisible(panel, candidate))
+      return idx;
+  }
+
+  return -1;
+}
+
 static void PositionPanelAtDirIndex(YtreePanel *panel, int idx) {
   int height;
   int visible_idx;
@@ -488,6 +503,20 @@ static void PositionPanelAtDirIndex(YtreePanel *panel, int idx) {
   height = panel->pan_dir_window ? getmaxy(panel->pan_dir_window) : 1;
   if (height < 1)
     height = 1;
+
+  if (panel->hide_dot_files) {
+    int start_idx = idx;
+    int i;
+    for (i = 1; i < height; i++) {
+      int prev_idx = FindVisibleBackwardNoWrap(panel, start_idx - 1);
+      if (prev_idx < 0)
+        break;
+      start_idx = prev_idx;
+    }
+    panel->disp_begin_pos = start_idx;
+    panel->cursor_pos = idx - panel->disp_begin_pos;
+    return;
+  }
 
   if (idx >= panel->disp_begin_pos && idx < panel->disp_begin_pos + height) {
     panel->cursor_pos = idx - panel->disp_begin_pos;

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -225,7 +225,7 @@ def test_split_tab_from_small_file_does_not_expand_inactive_panel(tmp_path, ytre
         )
         assert after_idx >= 0, _screen_text(tui)
 
-        # BUG-5: inactive panel must keep tree+small layout, not expand to big file.
+        # Inactive panel must keep tree+small layout, not expand to big file.
         assert after_idx > 10, (
             "Tab from small file view expanded the inactive panel to big file mode "
             "(file rows jumped into the top/tree area).\n"
@@ -1253,6 +1253,216 @@ def test_navigation_does_not_expand(tmp_path, ytree_binary):
 
     tui.quit()
 
+
+def test_down_from_root_does_not_scroll_hidden_prefix(tmp_path, ytree_binary):
+    """
+    With HIDEDOTFILES=1, DOWN from root must move to the next visible sibling
+    without treating hidden-dot entries as scroll-driving rows.
+    """
+    root = tmp_path / "down_root_hidden_prefix"
+    root.mkdir()
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=1\nHIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    for i in range(40):
+        (root / f".hidden_{i:02d}").mkdir()
+
+    for name in ("go", "gone", "snap", "wikiteam3_utilities"):
+        d = root / name
+        d.mkdir()
+        (d / "child").mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(1.0)
+    try:
+        before = _screen_text(tui)
+        before_lines = before.splitlines()
+        assert len(before_lines) > 2, before
+        assert "mq/" in before_lines[2], before
+
+        tui.send_keystroke(Keys.UP, wait=0.4)
+        after_up = _screen_text(tui)
+        after_up_lines = after_up.splitlines()
+        assert len(after_up_lines) > 2, after_up
+        assert "mq/" in after_up_lines[2], (
+            "UP at top wrapped selection to the bottom.\n"
+            f"Before:\n{before}\n\nAfter UP:\n{after_up}"
+        )
+
+        tui.send_keystroke(Keys.DOWN, wait=0.4)
+        after = _screen_text(tui)
+        after_lines = after.splitlines()
+        assert len(after_lines) > 2, after
+
+        assert "mq/" in after_lines[2], (
+            "DOWN from root scrolled the tree by hidden-dot index distance "
+            "instead of one visible row.\n"
+            f"Before:\n{before}\n\nAfter:\n{after}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_mkdir_preserves_collapsed_children_after_left_enter(
+    tmp_path, ytree_binary
+):
+    """
+    Collapsing root descendants (LEFT then ENTER) must remain collapsed after
+    creating a new sibling directory at root.
+    """
+    root = tmp_path / "mkdir_collapse_preservation"
+    root.mkdir()
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=3\nHIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    for i in range(40):
+        (root / f".hidden_{i:02d}").mkdir()
+
+    for name, child in (
+        ("go", "pkg"),
+        ("gone", "home"),
+        ("snap", "glow"),
+        ("wikiteam3_utilities", "dumps"),
+        ("ytree", "docs"),
+    ):
+        d = root / name
+        d.mkdir()
+        (d / child).mkdir(parents=True)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(1.0)
+    try:
+        tui.send_keystroke(Keys.LEFT, wait=0.3)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+
+        collapsed = _screen_text(tui)
+        assert "go/" in collapsed, collapsed
+        assert "pkg" not in collapsed, collapsed
+
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(
+            tui
+        )
+        tui.send_keystroke("00" + Keys.ENTER, wait=0.8)
+
+        after = _screen_text(tui)
+        assert "go/" in after, after
+        assert "pkg" not in after, (
+            "mkdir at root re-expanded previously collapsed descendants.\n"
+            f"{after}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_split_peer_tree_keeps_root_visible_with_hidden_prefix(
+    tmp_path, ytree_binary
+):
+    """
+    Regression guard:
+    After mkdir + DOWN + split, the peer panel tree must keep root visible at the
+    top when HIDEDOTFILES hides a large hidden-prefix set.
+    """
+    root = tmp_path / "split_peer_root_visible"
+    root.mkdir()
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=3\nHIDEDOTFILES=1\nSMALLWINDOWSKIP=0\n",
+        encoding="utf-8",
+    )
+
+    for i in range(40):
+        (root / f".hidden_{i:02d}").mkdir()
+
+    for name, child in (
+        ("go", "pkg"),
+        ("gone", "home"),
+        ("snap", "glow"),
+        ("wikiteam3_utilities", "dumps"),
+        ("ytree", "docs"),
+    ):
+        d = root / name
+        d.mkdir()
+        (d / child).mkdir(parents=True)
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(1.0)
+    try:
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(
+            tui
+        )
+        tui.send_keystroke("00" + Keys.ENTER, wait=0.7)
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        tui.send_keystroke(Keys.F8, wait=0.5)
+
+        lines = tui.get_screen_dump()
+        split_col = _detect_split_column(lines)
+        assert split_col is not None, _screen_text(tui)
+
+        row = lines[2]
+        right_segment = row[split_col:]
+        assert "mq/" in right_segment, (
+            "Peer panel tree top row lost root after split despite available space.\n"
+            f"{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_delete_first_visible_dir_keeps_visible_selection(
+    tmp_path, ytree_binary
+):
+    """
+    Regression guard:
+    Deleting the first visible (non-dot) child must not leave selection anchored
+    on a hidden-dot sibling, which makes the tree cursor disappear until movement.
+    """
+    root = tmp_path / "delete_first_visible"
+    home = root / "home" / "rob"
+    home.mkdir(parents=True)
+    (home / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=2\nHIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    for name in (".hidden_a", ".hidden_b", ".hidden_c"):
+        (home / name).mkdir()
+    for name in ("00", "zzz"):
+        (home / name).mkdir()
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(home),
+        env_extra={"HOME": str(home)},
+    )
+    time.sleep(1.0)
+    try:
+        tui.send_keystroke(Keys.HOME, wait=0.3)
+        tui.send_keystroke(Keys.DOWN, wait=0.3)
+        before_lines = tui.get_screen_dump()
+        assert _stats_current_dir_contains(before_lines, "00"), (
+            "Precondition failed: DOWN from root should select visible '00'.\n"
+            f"{_screen_text(tui)}"
+        )
+
+        tui.send_keystroke("d", wait=0.3)
+        if tui.wait_for_content("Delete this directory", timeout=0.4):
+            tui.send_keystroke("y", wait=0.8)
+
+        after_lines = tui.get_screen_dump()
+        assert _stats_current_dir_contains(after_lines, "rob"), (
+            "After deleting first visible child, selection left the visible tree "
+            "and anchored to a hidden-dot entry.\n"
+            f"{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_header_path_clearing(dual_panel_sandbox, ytree_binary):
     """BUG 6: Header doesn't clear old long paths when moving to short paths."""
     tui = YtreeTUI(executable=ytree_binary, cwd=str(dual_panel_sandbox))
@@ -1565,7 +1775,7 @@ def test_f8_inactive_selection_delete_falls_to_visible_ancestor(
 
 def test_bug_f_eight_mirrored_inactive_selection_identity_stable(tmp_path, ytree_binary):
     """
-    BUG-36 regression:
+    Regression:
     In mirrored split mode, expanding a sibling branch in the active panel must not
     shift inactive panel selection by row index when the selected directory still
     exists.
@@ -1705,7 +1915,7 @@ def test_bug_f_eight_dotfiles_toggle_keeps_inactive_selection_identity(
     tmp_path, ytree_binary
 ):
     """
-    BUG-4 regression:
+    Regression:
     In split mode, toggling dotfiles from the active panel must not re-index
     the inactive panel selection when the selected directory remains valid.
     """
@@ -1785,7 +1995,7 @@ def test_bug_f_eight_dotfiles_toggle_is_panel_local_visibility(
     tmp_path, ytree_binary
 ):
     """
-    BUG-3 regression:
+    Regression:
     In split mode, dotfile visibility toggled on the active panel must not leak
     into the inactive panel's file view.
     """
@@ -1904,7 +2114,7 @@ def test_bug_f_eight_source_selection_survives_destination_tree_prep(
     tmp_path, ytree_binary
 ):
     """
-    BUG-36 regression:
+    Regression:
     In same-volume split mode, destination-side prep work (newfile + tree
     navigation + mkdir/cd) must not re-index source file selection.
     """
@@ -1979,7 +2189,7 @@ def test_source_selection_survives_destination_tree_prep_home_mkdir(
     tmp_path, ytree_binary
 ):
     """
-    BUG-36 regression:
+    Regression:
     Destination tree HOME+mkdir prep in same-volume split mode must not blank
     the source panel or mutate source tagged/selection identity.
     """
@@ -2600,7 +2810,7 @@ def test_bug2_copy_cancel_then_destination_mkdir_keeps_source_anchor(
     tmp_path, ytree_binary
 ):
     """
-    BUG-2 regression (maintainer manual flow):
+    Regression (maintainer manual flow):
     In source file mode, opening COPY and stepping into destination prompt before
     split destination prep must not mutate source tagged/selection identity.
     """
@@ -2744,7 +2954,7 @@ def test_bug2_copy_cancel_then_destination_mkdir_keeps_source_anchor(
 
 def test_source_tagged_selection_survives_destination_prep(tmp_path, ytree_binary):
     """
-    BUG-36 regression:
+    Regression:
     When split is closed from the right panel, source selection identity must
     stay with the active (right) file instead of restoring a stale left anchor.
     """


### PR DESCRIPTION
## Summary
- prevent top-boundary UP wrap and preserve visible root anchoring in split peer tree
- restore collapsed-state and selection behavior across refresh/delete paths
- fix stale lookup path used during collapsed restore after rescan (ASan UAF path)
- add regression coverage for delete-first-visible selection anchoring

## Verification
- `make clean && make -j4`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -k "down_from_root_does_not_scroll_hidden_prefix or mkdir_preserves_collapsed_children_after_left_enter or split_peer_tree_keeps_root_visible_with_hidden_prefix or delete_first_visible_dir_keeps_visible_selection" -q`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -k split_and_tab_keeps_file_focus -q`
- `source .venv/bin/activate && pytest tests/test_archive_exit_ui.py -k tree_state -q`

