### PR TITLE
fix(split): stabilize split-state contract

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -36,8 +36,8 @@ These instructions apply to all AI agents used in this repository.
 ## User Notification
 
 - When finishing a long-running mission or when explicitly requesting user review via `notify_user`, you SHOULD trigger a desktop notification on the Windows host.
-- Execute: `/home/rob/ytree/scripts/wsl-notify.sh "Antigravity" "<Context-specific message>"`
-- Example: `/home/rob/ytree/scripts/wsl-notify.sh "Antigravity" "Implementation complete, ready for review."`
+- Execute: `/home/rob/ytree/scripts/wsl-notify.sh "ytree" "<Context-specific message>"`
+- Example: `/home/rob/ytree/scripts/wsl-notify.sh "ytree" "Implementation complete, ready for review."`
 
 ## Persona Skill Auto-Load
 

--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -9,6 +9,8 @@ These instructions apply to all AI agents used in this repository.
 - Codebase language: C (C89/C99, POSIX.1-2008)
 - Testing: Python `pytest` and `pexpect` from the local `.venv`
 - For non-trivial missions, follow the stateless multi-AI workflow in `docs/ai/WORKFLOW.md`: architect plans one task at a time, developer executes one task at a time, with maintainer-approved per-task commits and QA-gated merge/cleanup.
+- For GitHub work, use the GitHub connector as the primary source for PR/issue metadata, comments, reviews, reactions, and check state; use `gh` only when the connector does not expose the needed Actions log/run detail.
+- The GitHub connector is mainly for remote PR/issue review and discussion inside ChatGPT/Codex; use the local checkout for editing and testing.
 
 ## Persona Routing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,14 @@ jobs:
       pull-requests: read
     outputs:
       qa_relevant: ${{ steps.force.outputs.qa_relevant || steps.filter.outputs.qa_relevant }}
+      split_panel_relevant: ${{ steps.force.outputs.split_panel_relevant || steps.filter.outputs.split_panel_relevant }}
     steps:
     - name: Force QA on main pushes
       id: force
       if: github.event_name == 'push'
-      run: echo "qa_relevant=true" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "qa_relevant=true" >> "$GITHUB_OUTPUT"
+        echo "split_panel_relevant=true" >> "$GITHUB_OUTPUT"
 
     - name: Detect PR file changes
       id: filter
@@ -37,6 +40,22 @@ jobs:
             - 'scripts/**'
             - 'Makefile'
             - '.github/workflows/**'
+          split_panel_relevant:
+            - 'docs/ARCHITECTURE.md'
+            - 'docs/AUDIT.md'
+            - 'docs/CONTRIBUTING.md'
+            - 'docs/SPECIFICATION.md'
+            - 'src/cmd/log.c'
+            - 'src/ui/panel_anchor.c'
+            - 'src/ui/split_transition.c'
+            - 'src/ui/ctrl_dir.c'
+            - 'src/ui/ctrl_file.c'
+            - 'src/ui/display.c'
+            - 'src/ui/dir_ops.c'
+            - 'src/ui/render_file.c'
+            - 'tests/test_panel_isolation.py'
+            - 'tests/test_file_window_dispatch_regressions.py'
+            - 'tests/test_dir_window_dispatch_regressions.py'
 
   guard-fuzz-sync:
     name: Guard fuzz harness sync
@@ -73,6 +92,58 @@ jobs:
           HEAD_SHA="$PUSH_HEAD_SHA"
         fi
         python3 scripts/check_fuzz_harness_sync.py --base "$BASE_SHA" --head "$HEAD_SHA"
+
+  qa-split-panel-gates:
+    name: Split panel regression gate
+    runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.split_panel_relevant == 'true'
+    env:
+      CC: ccache cc
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install System Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ccache libncurses-dev libtinfo-dev libreadline-dev libarchive-dev
+
+    - name: Restore ccache
+      uses: actions/cache@v5
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ github.workflow }}-split-panel-${{ hashFiles('Makefile', '.github/workflows/ci.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.workflow }}-split-panel-
+          ${{ runner.os }}-ccache-${{ github.workflow }}-
+
+    - name: Set up Python 3
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: scripts/requirements.txt
+
+    - name: Install Python Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r scripts/requirements.txt
+
+    - name: Configure compiler cache
+      run: |
+        ccache --set-config=max_size=700M
+        ccache --set-config=sloppiness=time_macros
+        ccache --zero-stats
+
+    - name: Run split panel regression gate
+      run: make qa-split-panel-gates
+
+    - name: Report ccache stats
+      if: always()
+      run: ccache --show-stats
 
   qa-fileops-integrity:
     name: File mutation integrity gate

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ FUZZ_BINS := $(FUZZ_STRING_UTILS_BIN) $(FUZZ_PATH_UTILS_BIN) $(FUZZ_FILTER_CORE_
 	git-aliases-install git-aliases-status test \
 	fuzz fuzz-smoke fuzz-string-utils fuzz-path-utils fuzz-filter-core qa-fuzz \
 	test-v qa-clang qa-cppcheck qa-scan qa-valgrind qa-valgrind-interactive qa-valgrind-full \
-	qa-pytest qa-fileops-integrity qa-pytest-coverage qa-sanitize qa-unsafe-apis qa-module-boundaries qa-ai-config qa-code-quality qa-all \
+	qa-pytest qa-fileops-integrity qa-split-panel-gates qa-pytest-coverage qa-sanitize qa-unsafe-apis qa-module-boundaries qa-ai-config qa-code-quality qa-all \
 	ci-baseline mcp-doctor py-requirements \
 	qa-all-log qa-deep
 
@@ -352,6 +352,18 @@ qa-fileops-integrity: $(MAIN_BIN)
 		tests/test_archive_ui.py::test_archive_create_overwrite_excludes_destination_from_payload \
 		tests/test_archive_ui.py::test_archive_create_exclusion_empty_payload_shows_status_and_aborts \
 		tests/test_archive_ui.py::test_archive_create_inside_source_round_trip_integrity
+
+# Focused split-panel regression gate: canonical eight-test split matrix plus source-level guards.
+qa-split-panel-gates: $(MAIN_BIN)
+	TERM=$${TERM:-xterm} $(PYTEST) -q -ra --tb=no \
+		tests/test_dir_window_dispatch_regressions.py::test_dir_window_split_transition_owner_path_is_canonical \
+		tests/test_dir_window_dispatch_regressions.py::test_split_tab_refresh_rejects_stale_file_restore_snapshot \
+		tests/test_file_window_dispatch_regressions.py::test_HandleFileWindow_delegates_split_transition_hotspot \
+		tests/test_file_window_dispatch_regressions.py::test_split_and_tab_dispatch_keeps_file_mode_footer \
+		tests/test_panel_isolation.py::test_split_from_file_keeps_file_focus_on_tab \
+		tests/test_panel_isolation.py::test_split_tab_from_small_file_does_not_expand_inactive_panel \
+		tests/test_panel_isolation.py::test_split_from_big_file_keeps_inactive_panel_in_file_view \
+		tests/test_panel_isolation.py::test_split_same_directory_file_tags_are_panel_local
 
 qa-pytest-coverage:
 	$(MAKE_CMD) DEBUG=0 COVERAGE=1 QA_ON_BUILD=0 clean

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,8 +143,9 @@ Split-transfer/switch code must classify each field before copying or restoring:
 | State Class | Owned By | Examples | Forbidden Cross-Panel Behavior |
 |---|---|---|---|
 | **Panel-Local** | `YtreePanel` | `cursor_pos`, `disp_begin_pos`, `start_file`, `file_cursor_pos`, `file_dir_entry`, `saved_focus`, `saved_big_file_view`, `file_selection_name`, `file_selection_dir_path`, `tagged_paths`, `hide_dot_files` | Active-only commands must not mutate the inactive panel's values. |
+| **Derived / Restore-Mirror** | `ViewContext` mirrors and `Volume` restore breadcrumbs | `ctx->hide_dot_files`, `saved_tree_index`, `saved_focus` | May shadow panel-local state for compatibility or restore, but must never become the authoritative source of truth when a panel-local copy exists. |
 | **Shared-Topology** | `Volume` (possibly referenced by both panels) | `vol_stats.tree`, `dir_entry_list`, directory expansion/logging topology | Panel code may mirror topology visibility updates, but must re-anchor each panel by identity/path and must not infer panel-local selection by shared index. |
-| **Global-Only** | `ViewContext` session scope | `is_split_screen`, `focused_window`, layout windows, session options other than panel-local visibility state | Global toggles must not be treated as panel-local transfer state; split hand-off code must not use them to overwrite inactive panel-local snapshots. |
+| **Session-Only** | `ViewContext` session scope | `is_split_screen`, `focused_window`, layout windows, session options other than panel-local visibility state | Session toggles must not be treated as panel-local transfer state; split hand-off code must not use them to overwrite inactive panel-local snapshots. |
 
 Boundary implementations in `src/ui/dir_ops.c` and `src/ui/ctrl_file_ops.c` reference this map in invariant comments and debug assertions.
 
@@ -161,9 +162,9 @@ The record must capture, at minimum:
 
 Ownership rules:
 *   `YtreePanel` owns the live UI state record for its window/panel instance.
-*   `Volume` owns shared topology and payload cache only; it must not own panel-local selection or viewport state.
-*   `ViewContext` owns only session-wide routing and layout references, not derived tree selection.
-*   Any duplicate or shadow copy of the same state in `ViewContext` or helper paths must be either derived-only or removed; stable path-based identity is the restore key, not transient row indices or stale pointers.
+*   `Volume` owns shared topology and payload cache; per-volume restore breadcrumbs may live there, but they are not shared-topology authority.
+*   `ViewContext` owns only session-wide routing and layout references plus derived mirrors required by legacy helpers, not authoritative tree or file selection.
+*   Any duplicate or shadow copy of the same state in `ViewContext` or helper paths must be either explicitly derived-only or removed; stable path-based identity is the restore key, not transient row indices or stale pointers.
 *   In split mode, restore snapshots are keyed by `(panel, volume)` so each panel restores its own volume-specific state and cannot import the opposite panel's snapshot.
 
 Update rules:

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -16,7 +16,7 @@ The project uses seven QA layers with increasing depth and cost:
 
 | Layer | Command | What it checks | When to run |
 |---|---|---|---|
-| CI Gate | `git push` (automatic) | Draft-PR baseline confidence checks (`qa-code-quality` + `qa-fileops-integrity`, coverage pytest gate, fuzz gate) | Every push to `main` and every PR update targeting `main` (automatic) |
+| CI Gate | `git push` (automatic) | Draft-PR baseline confidence checks (`qa-code-quality` + `qa-fileops-integrity`, path-filtered `qa-split-panel-gates` for split-touching changes, coverage pytest gate, fuzz gate) | Every push to `main` and every PR update targeting `main` (automatic) |
 | PR Full QA CI (required) | `.github/workflows/full-qa.yml` (`make qa-all`) | clang-tidy, cppcheck, scan-build, Valgrind smoke (`--version`), full `pytest`, unsafe API guard, gitleaks, module-boundary guard, ai-config guard, fuzz guard | Must be green before merge to `main` |
 | Fileops Integrity Gate | `make qa-fileops-integrity` | Deterministic file/archive mutation integrity + security regression checks (copy/move/delete/rename/archive rewrite, cancel/failure safeguards, shell/tempfile hardening contracts) | Before merge and when touching file/archive mutation flows |
 | Sanitizer QA | `make qa-sanitize` | Main ytree build + `pytest` under AddressSanitizer/UndefinedBehaviorSanitizer | Before release, after memory/UB-sensitive changes, or when triaging suspicious crashes |
@@ -28,6 +28,7 @@ The project uses seven QA layers with increasing depth and cost:
 - **PR Full QA CI** (`.github/workflows/full-qa.yml`, `make qa-all` equivalent) is the standard pre-merge gate.
 - **Local QA** (`make qa-all`) is optional for faster local confidence and maintainer-requested deep preflight; avoid running it on every iteration by default.
 - **Fileops Integrity Gate** (`make qa-fileops-integrity`) is the dedicated regression wall for mutation integrity/security contracts; run it before merge and whenever file/archive mutation code or prompts change.
+- **Split Panel Regression Gate** (`make qa-split-panel-gates`) is the path-filtered regression wall for split-panel invariants, transition handoff, and split-authority source guards; split-touching PRs must satisfy it before merge.
 - **Deep Audit** (`make qa-valgrind-full`) is on-demand. It drives a scripted interactive ytree session under Valgrind and takes ~2-3 minutes. Run it:
   - Before tagging a release
   - After changes to memory management, allocation, or cleanup paths
@@ -65,7 +66,7 @@ Scope is strict: QA/check/test organization and efficiency only. Non-QA workflow
 | Tier | Owner | Trigger | Required checks | Non-overlap default intent |
 |---|---|---|---|---|
 | Tier A (local fast iteration) | Developer | During implementation before first push and between risky edits | `make`; targeted pytest for touched scope; targeted guards (`qa-unsafe-apis`, `qa-fileops-integrity`) when relevant | Keep iteration fast; avoid full-suite duplication unless local risk demands it |
-| Tier B (draft PR baseline CI) | CI + PR author | Every push while PR is draft | `ci-baseline` (`qa-code-quality` + `qa-fileops-integrity` + `qa-pytest-coverage` + `qa-fuzz`) | Provide baseline branch-protection signal (includes coverage by design); do not duplicate Tier C full local gate content |
+| Tier B (draft PR baseline CI) | CI + PR author | Every push while PR is draft | `ci-baseline` (`qa-code-quality` + `qa-fileops-integrity` + `qa-pytest-coverage` + `qa-fuzz`) plus path-filtered `qa-split-panel-gates` on split-touching PRs | Provide baseline branch-protection signal (includes coverage by design); do not duplicate Tier C full local gate content |
 | Tier C (pre-merge full gate) | CI + PR author | Before merge to `main` (or earlier only when explicitly requested) | Green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent); optional local `make qa-all-log` evidence when maintainer-requested; plus explicit `qa-fileops-integrity` evidence when mutation workflows changed | Use CI as canonical full-gate signal; avoid duplicate local full-gate reruns during routine iteration |
 | Tier D (merge/release gate) | Maintainer + reviewer | Before merge and before release/tag cut | Branch-protection checks green; reviewer signoff; `qa-sanitize`; `qa-valgrind-full` for release-risk changes; `qa-valgrind-interactive` after major feature flows | Reserve deepest runtime checks for merge/release assurance to avoid slowing every draft iteration |
 
@@ -181,11 +182,13 @@ Local shortcut targets are available in the `Makefile`:
 - `make qa-sanitize`
 - `make qa-pytest`
 - `make qa-fileops-integrity`
+- `make qa-split-panel-gates`
 - `make qa-unsafe-apis`
 - `make qa-gitleaks`
 - `make qa-module-boundaries`
 - `make qa-ai-config`
 - `make qa-code-quality` (runs `qa-unsafe-apis`, `qa-module-boundaries`, `qa-ai-config`)
+- `make qa-split-panel-gates` (runs the split-panel invariants, transition-handoff, and split-authority regression subset)
 - `make qa-fuzz`
 - `make qa-all` (runs `qa-clang`, `qa-cppcheck`, `qa-scan`, `qa-valgrind`, `qa-pytest`, `qa-unsafe-apis`, `qa-gitleaks`, `qa-module-boundaries`, `qa-ai-config`, `qa-fuzz` in order; run `qa-fileops-integrity` separately when touching mutation flows)
 - `make qa-all-log` (same as `qa-all`, with full output captured to `qa-all.log` in repo root; override with `QA_LOG=/path/to/file`)
@@ -193,8 +196,9 @@ Local shortcut targets are available in the `Makefile`:
 
 For feature-sized/PR-scope changes, audit evidence must include a successful `make qa-module-boundaries` run so controller-slimming checks are explicitly validated.
 Audit evidence must also include `make qa-unsafe-apis` results as explicit enforcement evidence for the shared Security gate policy in `.ai/shared.md` Core Engineering Rules.
+Split-touching PRs must also include `make qa-split-panel-gates` evidence so panel isolation and split-authority contracts remain enforced in CI and audit notes.
 
-GitHub CI is a baseline gate (including `qa-fileops-integrity`, coverage pytest, and `qa-fuzz`) and does not replace the full local audit loop.
+GitHub CI is a baseline gate (including `qa-fileops-integrity`, path-filtered `qa-split-panel-gates` for split-touching changes, coverage pytest, and `qa-fuzz`) and does not replace the full local audit loop.
 
 ## 4. Continuous Audit Loop (Default)
 Run this loop for every non-trivial change and every PR.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -146,6 +146,7 @@ Configure GitHub branch protection on `main`:
 3. Select required checks from GitHub Actions:
    - `.github/workflows/ci.yml`: `Guard fuzz harness sync`.
    - `.github/workflows/ci.yml`: `File mutation integrity gate`.
+   - `.github/workflows/ci.yml`: `Split panel regression gate` for split-touching PRs.
    - `.github/workflows/ci.yml`: `Full coverage baseline gate`.
    - `.github/workflows/ci.yml`: `Fuzz baseline gate`.
    - `.github/workflows/pr-conflict-assistant.yml`: `Up To Date With Main`.
@@ -210,16 +211,19 @@ Use **[AUDIT.md](AUDIT.md)** as the single source of truth.
 
 - During implementation, run focused checks first (`make` + targeted tests for touched scope).
 - Before merge to `main`, require green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent). Local full audit loop is optional unless explicitly requested.
+- Split-touching PRs must also pass the path-filtered `make qa-split-panel-gates` CI gate before merge.
 - Use the canonical tool order from `AUDIT.md`: `clang-tidy`, `cppcheck`, `scan-build`, `valgrind`, then `pytest` for regression verification.
 
 ### Local QA Commands
 
 - Normal development build: `make`
 - Full local QA gate (optional unless maintainer-requested): `make qa-all` (includes `pytest`, unsafe C API guard, module-boundary guard, and fuzz smoke)
+- Split panel regression gate (use when touching split-panel invariants, transition handoff, or split-authority code): `make qa-split-panel-gates`
 - Full local QA gate with captured log (optional unless maintainer-requested): `make qa-all-log` (writes `qa-all.log` in repo root; override with `QA_LOG=/path/to/file`)
 - Max-depth unattended QA sweep: `make qa-deep` (runs composite deep checks and writes structured logs to `${TMPDIR:-/tmp}/ytree-qa-deep/<timestamp>/`; override with `QA_DEEP_LOG_ROOT=/path`)
 - Optional strict mode: `make QA_ON_BUILD=1` (runs `qa-all` after build)
 - GitHub baseline CI (`.github/workflows/ci.yml`) runs `make ci-baseline` on PRs to `main` and pushes to `main`.
+- GitHub split panel regression CI (`.github/workflows/ci.yml`) runs `make qa-split-panel-gates` on PRs that touch split-panel paths.
 - GitHub PR full QA CI (`.github/workflows/full-qa.yml`) runs `make qa-all` on PRs to `main` and is the required full pre-merge gate.
 - GitHub PR sanitizer gate in `.github/workflows/full-qa.yml` runs only on manual dispatch or when PR label `qa-sanitize` is present.
 - GitHub nightly deep Valgrind CI (`.github/workflows/nightly-deep-valgrind.yml`) runs `make qa-valgrind-full` on schedule (and manual dispatch).

--- a/docs/ai/DEBUGGING.md
+++ b/docs/ai/DEBUGGING.md
@@ -48,7 +48,7 @@ Based on understanding:
 ## 2. The "Hands-Off" Fix Mandate (The Agentic Loop)
 
 ### When to Use
-The mandatory focused procedure for **Antigravity** and agentic execution. It forces the agent to prove its understanding by writing a failing test *before* editing any code. See **[TESTING.md](TESTING.md)** for detailed test protocols and harness documentation.
+The mandatory focused procedure for agentic execution. It forces the agent to prove its understanding by writing a failing test *before* editing any code. See **[TESTING.md](TESTING.md)** for detailed test protocols and harness documentation.
 
 ### The Process
 
@@ -111,13 +111,13 @@ Identify root causes with specific line numbers and call chains. Provide evidenc
 ```
 
 #### Step 3: External Expert Consultation
-Use a **separate, fresh LLM instance** (e.g., Claude Opus) as a **Code Auditor** for architectural analysis. Provide a high-level map using **jCodeMunch** and relevant symbols via **Serena**.
+Use a **separate, fresh LLM instance** as a **Code Auditor** for architectural analysis. Provide a high-level map using **jCodeMunch** and relevant symbols via **Serena**.
 
 #### Step 4: Extract Surgical Fixes
 Review the expert's diagnosis and identify the minimal set of changes (target 3-5 surgical edits).
 
 #### Step 5: Sequential Implementation
-Implement fixes atomically using low-cost models (e.g., Gemini Flash) for mechanical edits. Compile and test once all related fixes are applied.
+Implement fixes atomically using a low-cost model for mechanical edits. Compile and test once all related fixes are applied.
 
 ---
 

--- a/docs/ai/PROMPT_TEMPLATE.md
+++ b/docs/ai/PROMPT_TEMPLATE.md
@@ -14,6 +14,8 @@ Mandatory startup:
 1) Read ~/ytree/.ai/codex.md
 2) Read ~/ytree/.ai/shared.md
 3) Use MCP semantic tools only (serena + jcodemunch) for codebase exploration
+4) Read ~/ytree/docs/SPECIFICATION.md
+5) Read ~/ytree/docs/ARCHITECTURE.md
 
 Scope and split decision:
 1) Execute exactly one tracked work item, and confirm the resolved title from the tracked docs before implementation.

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -337,7 +337,7 @@ Never allow the AI to "guess" the cause of a bug. Use one of the following objec
 ### 4.1 Summary of Methodologies (by Usefulness)
 
 1.  **Targeted Root Cause Analysis:** Lightweight, hypothesis-driven approach using semantic tools (**Serena**/**jCodeMunch**) to compare working vs. broken cases.
-2.  **The "Hands-Off" Fix Mandate (Testing):** The mandatory procedure for **Antigravity**. Prove understanding by writing a failing `pytest`/`pexpect` test *before* editing code.
+2.  **The "Hands-Off" Fix Mandate (Testing):** The mandatory procedure for agentic execution. Prove understanding by writing a failing `pytest`/`pexpect` test *before* editing code.
 3.  **Instrumentation (The Discovery Loop):** Add `fprintf(stderr, ...)` to trace state. Used primarily for exploratory research in **AI Studio**.
 4.  **External Expert Architecture Analysis:** High-reasoning audit for complex, multi-subsystem, or architectural bugs. Requires a fresh LLM context.
 

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -330,6 +330,12 @@ Use this when wrapping up a PROMPT_TEMPLATE-driven mission and returning the rep
 14. **Maintainer (local):** Delete local feature branch:
     *   `git branch -d <branch>` (use `-D` only when needed)
 
+### GitHub Source Preference
+
+- For PRs, issues, comments, reviews, reactions, and check state, prefer the GitHub connector as the first source of truth.
+- Use `gh` for GitHub Actions log retrieval, job-level failure inspection, or other run details that the connector does not expose cleanly.
+- Treat the connector primarily as a remote PR/issue review and discussion surface inside ChatGPT/Codex; use the local checkout for code edits and tests.
+
 ## 4. Debugging Procedures
 
 Never allow the AI to "guess" the cause of a bug. Use one of the following objective methodologies, described in detail in **[DEBUGGING.md](DEBUGGING.md)**.

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -653,8 +653,8 @@ typedef struct {
 
 struct Volume {
   int id;
-  int saved_tree_index;
-  int saved_focus;
+  int saved_tree_index; /* Per-volume restore breadcrumb, not topology authority. */
+  int saved_focus;       /* Derived restore mirror of the last focused panel mode. */
   Statistic vol_stats;
   Statistic vol_disk_stats;
   DirEntryList *dir_entry_list;
@@ -728,10 +728,10 @@ typedef struct _PathList {
 
 typedef struct _panel_volume_file_state {
   int volume_id;
-  int saved_file_start;
-  int saved_file_cursor;
-  ViewFocus saved_focus;
-  BOOL saved_big_file_view;
+  int saved_file_start;        /* Per-panel file viewport snapshot for this volume. */
+  int saved_file_cursor;       /* Per-panel file cursor snapshot for this volume. */
+  ViewFocus saved_focus;       /* Restored panel focus shape for this volume. */
+  BOOL saved_big_file_view;    /* Restored panel file-window shape for this volume. */
   char saved_file_dir_path[PATH_LENGTH + 1];
   char saved_file_selection_name[PATH_LENGTH + 1];
   char saved_file_selection_dir_path[PATH_LENGTH + 1];
@@ -777,7 +777,7 @@ typedef struct {
   PanelVolumeFileState *volume_file_state;
   char file_selection_name[PATH_LENGTH + 1];
   char file_selection_dir_path[PATH_LENGTH + 1];
-  BOOL saved_big_file_view;
+  BOOL saved_big_file_view; /* Panel-local file-window shape snapshot. */
   int file_mode;
   int max_column;
   int current_dir_entry;
@@ -786,7 +786,7 @@ typedef struct {
   unsigned int max_visual_linkname_len;
   unsigned int max_visual_userview_len;
   BOOL reverse_sort;
-  BOOL hide_dot_files;
+  BOOL hide_dot_files; /* Panel-local visibility; ViewContext keeps the active mirror. */
 } YtreePanel;
 
 typedef struct _history {
@@ -988,7 +988,7 @@ typedef struct _ViewContext {
   int cached_cols;  /* Last known COLS for resize detection */
   BOOL bypass_small_window;
   BOOL highlight_full_line;
-  BOOL hide_dot_files;
+  BOOL hide_dot_files; /* Active-panel mirror of panel-local dotfile visibility. */
   BOOL status_line_error_pending;
   char status_line_error_text[PATH_LENGTH + 1];
   char *initial_directory;

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -654,6 +654,9 @@ typedef struct {
 struct Volume {
   int id;
   int saved_tree_index; /* Per-volume restore breadcrumb, not topology authority. */
+  unsigned int saved_tree_generation;
+  unsigned int saved_tree_volume_generation;
+  unsigned int volume_generation;
   int saved_focus;       /* Derived restore mirror of the last focused panel mode. */
   Statistic vol_stats;
   Statistic vol_disk_stats;
@@ -730,6 +733,8 @@ typedef struct _panel_volume_file_state {
   int volume_id;
   int saved_file_start;        /* Per-panel file viewport snapshot for this volume. */
   int saved_file_cursor;       /* Per-panel file cursor snapshot for this volume. */
+  unsigned int saved_panel_generation;
+  unsigned int saved_volume_generation;
   ViewFocus saved_focus;       /* Restored panel focus shape for this volume. */
   BOOL saved_big_file_view;    /* Restored panel file-window shape for this volume. */
   char saved_file_dir_path[PATH_LENGTH + 1];
@@ -781,6 +786,7 @@ typedef struct {
   int file_mode;
   int max_column;
   int current_dir_entry;
+  unsigned int panel_generation;
   ViewFocus saved_focus;
   unsigned int max_visual_filename_len;
   unsigned int max_visual_linkname_len;

--- a/include/ytree_panel_anchor.h
+++ b/include/ytree_panel_anchor.h
@@ -7,6 +7,9 @@ BOOL CapturePanelAnchorPath(const YtreePanel *panel, const struct Volume *vol,
                             char *out_path, size_t out_path_size);
 int FindDirIndexByPath(const struct Volume *vol, const char *path);
 int FindDirIndexByPathOrAncestor(const struct Volume *vol, const char *path);
+DirEntry *ResolvePanelAnchorTarget(const YtreePanel *panel,
+                                   const struct Volume *vol,
+                                   const char *anchor_path);
 void PositionPanelAtIndex(YtreePanel *panel, int idx);
 void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
                             const char *anchor_path);

--- a/include/ytree_split_transition.h
+++ b/include/ytree_split_transition.h
@@ -1,0 +1,22 @@
+/***************************************************************************
+ *
+ * ytree_split_transition.h
+ * Split-panel transition owner API.
+ *
+ ***************************************************************************/
+
+#ifndef YTREE_SPLIT_TRANSITION_H
+#define YTREE_SPLIT_TRANSITION_H
+
+#include "ytree_ui.h"
+
+BOOL SplitTransition_HandleFileWindowAction(
+    ViewContext *ctx, YtreeAction action, DirEntry *dir_entry,
+    YtreePanel *owner_panel, BOOL *switched_panel_ptr,
+    YtreeAction *loop_action_ptr, BOOL *return_esc_ptr);
+BOOL SplitTransition_HandleDirWindowAction(
+    ViewContext *ctx, YtreeAction action, DirEntry **dir_entry_ptr,
+    Statistic **s_ptr, const struct Volume **start_vol_ptr,
+    BOOL *need_dsp_help_ptr, int *ch_ptr, int *unput_char_ptr);
+
+#endif /* YTREE_SPLIT_TRANSITION_H */

--- a/include/ytree_split_transition.h
+++ b/include/ytree_split_transition.h
@@ -17,6 +17,6 @@ BOOL SplitTransition_HandleFileWindowAction(
 BOOL SplitTransition_HandleDirWindowAction(
     ViewContext *ctx, YtreeAction action, DirEntry **dir_entry_ptr,
     Statistic **s_ptr, const struct Volume **start_vol_ptr,
-    BOOL *need_dsp_help_ptr, int *ch_ptr, int *unput_char_ptr);
+    BOOL *need_dsp_help_ptr, const int *ch_ptr, int *unput_char_ptr);
 
 #endif /* YTREE_SPLIT_TRANSITION_H */

--- a/include/ytree_ui.h
+++ b/include/ytree_ui.h
@@ -119,6 +119,8 @@ extern DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p,
 extern void DirOps_ReloadPanelFileAnchorIfMissing(ViewContext *ctx,
                                                   YtreePanel *panel,
                                                   DirEntry *dir_entry);
+extern DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
+                                           YtreePanel *panel);
 extern void PanelTags_Clear(YtreePanel *panel);
 extern void PanelTags_Copy(YtreePanel *dst, const YtreePanel *src);
 extern void PanelTags_PruneUnderDir(YtreePanel *panel, DirEntry *dir_entry);
@@ -233,10 +235,6 @@ extern void CapturePanelSelectionAnchor(ViewContext *ctx, YtreePanel *panel,
                                        const DirEntry *dir_entry);
 extern BOOL RebindActiveFilePanelSelection(YtreePanel *panel,
                                            DirEntry **dir_entry_io);
-extern BOOL handle_file_window_split_switch_action(
-    ViewContext *ctx, YtreeAction action, DirEntry *dir_entry,
-    YtreePanel *owner_panel, BOOL *switched_panel_ptr,
-    YtreeAction *loop_action_ptr, BOOL *return_esc_ptr);
 extern BOOL handle_file_window_volume_action(ViewContext *ctx,
                                              YtreeAction action,
                                              const struct Volume *start_vol,

--- a/include/ytree_ui.h
+++ b/include/ytree_ui.h
@@ -336,7 +336,7 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
                            DirEntry **dir_entry_ptr, Statistic **s_ptr,
                            const struct Volume **start_vol_ptr,
                            BOOL *need_dsp_help_ptr, int *ch_ptr,
-                           int *unput_char_ptr);
+                           const int *unput_char_ptr);
 extern DirWindowDispatchResult
 HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
                            Statistic **s_ptr,

--- a/scripts/wsl-notify.sh
+++ b/scripts/wsl-notify.sh
@@ -2,7 +2,7 @@
 # WSL2 to Windows Notification Bridge
 # Uses powershell.exe to send a Toast notification.
 
-TITLE="${1:-Antigravity}"
+TITLE="${1:-ytree}"
 MESSAGE="${2:-Task completed}"
 
 # Use PowerShell to trigger a simple system notification

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -7,6 +7,7 @@
 
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
+#include <assert.h>
 
 /* Runtime UI helpers used by volume-switch restore flow. */
 extern void FreeFileEntryList(YtreePanel *panel);
@@ -58,6 +59,8 @@ static void SavePanelFileSelection(YtreePanel *panel) {
 
   if (!panel || !panel->vol)
     return;
+  assert(panel->saved_focus != FOCUS_FILE ||
+         panel->file_selection_dir_path[0] != '\0');
 
   state = GetPanelVolumeFileState(panel, panel->vol->id);
   state->saved_file_start = panel->start_file;
@@ -66,11 +69,17 @@ static void SavePanelFileSelection(YtreePanel *panel) {
   state->saved_big_file_view = FALSE;
 
   state->saved_file_dir_path[0] = '\0';
-  if (panel->file_dir_entry != NULL) {
+  if (panel->file_selection_dir_path[0] != '\0') {
+    (void)snprintf(state->saved_file_dir_path,
+                   sizeof(state->saved_file_dir_path), "%s",
+                   panel->file_selection_dir_path);
+    state->saved_file_dir_path[PATH_LENGTH] = '\0';
+  } else if (panel->file_dir_entry != NULL) {
     GetPath(panel->file_dir_entry, state->saved_file_dir_path);
     state->saved_file_dir_path[PATH_LENGTH] = '\0';
-    state->saved_big_file_view = panel->file_dir_entry->big_window;
   }
+  if (panel->file_dir_entry != NULL)
+    state->saved_big_file_view = panel->file_dir_entry->big_window;
   panel->saved_big_file_view = state->saved_big_file_view;
 
   (void)snprintf(state->saved_file_selection_name,
@@ -212,10 +221,10 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreePanel *panel) {
                  sizeof(panel->file_selection_dir_path), "%s",
                  state->saved_file_selection_dir_path);
 
+  assert(state->saved_focus != FOCUS_FILE ||
+         state->saved_file_selection_dir_path[0] != '\0');
   if (state->saved_file_selection_dir_path[0] != '\0')
     file_dir_path = state->saved_file_selection_dir_path;
-  else if (state->saved_file_dir_path[0] != '\0')
-    file_dir_path = state->saved_file_dir_path;
 
   if (file_dir_path) {
     resolved_file_dir = FindSavedDirInVolume(vol, file_dir_path);
@@ -241,6 +250,7 @@ static void SavePanelTreeSelection(YtreePanel *panel) {
   if (!panel || !panel->vol)
     return;
 
+  /* Keep the per-volume breadcrumb aligned with the panel-local tree cursor. */
   selected_index = panel->disp_begin_pos + panel->cursor_pos;
   if (selected_index < 0)
     selected_index = 0;
@@ -276,6 +286,7 @@ static void RestorePanelTreeSelection(ViewContext *ctx, YtreePanel *panel) {
 
   if (panel->disp_begin_pos < 0)
     panel->disp_begin_pos = 0;
+  /* Rehydrate the panel-local tree viewport from the per-volume breadcrumb. */
   if (selected_index >= panel->disp_begin_pos &&
       selected_index < panel->disp_begin_pos + win_height) {
     panel->cursor_pos = selected_index - panel->disp_begin_pos;

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -396,6 +396,7 @@ int LogDisk(ViewContext *ctx, YtreePanel *panel, char *path) {
         panel->vol = found_vol;
         s = &panel->vol->vol_stats;
         panel->saved_focus = panel->vol->saved_focus;
+        panel->panel_generation = panel->vol->saved_tree_generation;
         ctx->global_search_term[0] = '\0';
         ctx->view_mode = panel->vol->vol_stats.log_mode;
 

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -7,6 +7,7 @@
 
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
+#include "ytree_panel_anchor.h"
 #include <assert.h>
 
 /* Runtime UI helpers used by volume-switch restore flow. */
@@ -65,6 +66,8 @@ static void SavePanelFileSelection(YtreePanel *panel) {
   state = GetPanelVolumeFileState(panel, panel->vol->id);
   state->saved_file_start = panel->start_file;
   state->saved_file_cursor = panel->file_cursor_pos;
+  state->saved_panel_generation = panel->panel_generation;
+  state->saved_volume_generation = panel->vol->volume_generation;
   state->saved_focus = panel->saved_focus;
   state->saved_big_file_view = FALSE;
 
@@ -133,47 +136,6 @@ static void PositionSavedFileSelection(ViewContext *ctx, YtreePanel *panel,
   dir_entry->cursor_pos = panel->file_cursor_pos;
 }
 
-static DirEntry *FindSavedDirInVolume(const struct Volume *vol,
-                                      const char *saved_path) {
-  int i;
-  size_t best_len = 0;
-  DirEntry *best = NULL;
-
-  if (!vol || !saved_path || saved_path[0] == '\0' || !vol->dir_entry_list ||
-      vol->total_dirs <= 0)
-    return NULL;
-
-  for (i = 0; i < vol->total_dirs; i++) {
-    DirEntry *candidate = vol->dir_entry_list[i].dir_entry;
-    char candidate_path[PATH_LENGTH + 1];
-    size_t candidate_len;
-
-    if (!candidate)
-      continue;
-
-    GetPath(candidate, candidate_path);
-    candidate_path[PATH_LENGTH] = '\0';
-
-    if (strcmp(candidate_path, saved_path) == 0)
-      return candidate;
-
-    candidate_len = strlen(candidate_path);
-    if (candidate_len == 0 || candidate_len > strlen(saved_path))
-      continue;
-    if (strncmp(saved_path, candidate_path, candidate_len) != 0)
-      continue;
-    if (saved_path[candidate_len] != '\0' &&
-        saved_path[candidate_len] != FILE_SEPARATOR_CHAR)
-      continue;
-    if (candidate_len > best_len) {
-      best_len = candidate_len;
-      best = candidate;
-    }
-  }
-
-  return best;
-}
-
 static int FindDirIndexInVolume(const struct Volume *vol,
                                 const DirEntry *dir_entry) {
   int i;
@@ -215,11 +177,16 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreePanel *panel) {
     panel->start_file = 0;
   if (panel->file_cursor_pos < 0)
     panel->file_cursor_pos = 0;
+  if (state->saved_panel_generation != panel->panel_generation ||
+      state->saved_volume_generation != vol->volume_generation) {
+    panel->start_file = 0;
+    panel->file_cursor_pos = 0;
+  }
   (void)snprintf(panel->file_selection_name, sizeof(panel->file_selection_name),
                  "%s", state->saved_file_selection_name);
   (void)snprintf(panel->file_selection_dir_path,
-                 sizeof(panel->file_selection_dir_path), "%s",
-                 state->saved_file_selection_dir_path);
+                  sizeof(panel->file_selection_dir_path), "%s",
+                  state->saved_file_selection_dir_path);
 
   assert(state->saved_focus != FOCUS_FILE ||
          state->saved_file_selection_dir_path[0] != '\0');
@@ -227,7 +194,7 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreePanel *panel) {
     file_dir_path = state->saved_file_selection_dir_path;
 
   if (file_dir_path) {
-    resolved_file_dir = FindSavedDirInVolume(vol, file_dir_path);
+    resolved_file_dir = ResolvePanelAnchorTarget(panel, vol, file_dir_path);
     panel->file_dir_entry = resolved_file_dir;
     if (resolved_file_dir) {
       int resolved_index;
@@ -255,12 +222,15 @@ static void SavePanelTreeSelection(YtreePanel *panel) {
   if (selected_index < 0)
     selected_index = 0;
   panel->vol->saved_tree_index = selected_index;
+  panel->vol->saved_tree_generation = panel->panel_generation;
+  panel->vol->saved_tree_volume_generation = panel->vol->volume_generation;
 }
 
 static void RestorePanelTreeSelection(ViewContext *ctx, YtreePanel *panel) {
   int selected_index;
   int total_dirs;
   int win_height;
+  BOOL generation_valid;
 
   if (!ctx || !panel || !panel->vol)
     return;
@@ -272,11 +242,18 @@ static void RestorePanelTreeSelection(ViewContext *ctx, YtreePanel *panel) {
     return;
   }
 
-  selected_index = panel->vol->saved_tree_index;
-  if (selected_index < 0)
+  generation_valid =
+      panel->vol->saved_tree_generation == panel->panel_generation &&
+      panel->vol->saved_tree_volume_generation == panel->vol->volume_generation;
+  if (generation_valid) {
+    selected_index = panel->vol->saved_tree_index;
+    if (selected_index < 0)
+      selected_index = 0;
+    if (selected_index >= total_dirs)
+      selected_index = total_dirs - 1;
+  } else {
     selected_index = 0;
-  if (selected_index >= total_dirs)
-    selected_index = total_dirs - 1;
+  }
 
   win_height = ctx->layout.dir_win_height;
   if (win_height <= 0 && ctx->ctx_dir_window)

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -886,6 +886,7 @@ int Init(ViewContext *ctx, const char *configuration_file,
   ctx->hide_dot_files =
       (strtol(CoreInitGetProfileValue(ctx, "HIDEDOTFILES"), NULL, 0)) ? TRUE
                                                                        : FALSE;
+  /* Seed both panel-local copies; ctx->hide_dot_files remains the active mirror. */
   ctx->left->hide_dot_files = ctx->hide_dot_files;
   ctx->right->hide_dot_files = ctx->hide_dot_files;
   ctx->animation_method =

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -110,6 +110,9 @@ struct Volume *Volume_Create(ViewContext *ctx) {
   /* Assign a unique ID and increment the serial counter */
   new_vol->id = ctx->volume_serial++;
   new_vol->saved_tree_index = 0;
+  new_vol->saved_tree_generation = 0;
+  new_vol->saved_tree_volume_generation = 0;
+  new_vol->volume_generation = 0;
   new_vol->saved_focus = FOCUS_TREE;
 
   /* Add the new volume to the global hash table (ctx->volumes_head)

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -10,6 +10,7 @@
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
 #include "ytree_panel_anchor.h"
+#include "ytree_split_transition.h"
 #include "ytree_ui.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -379,6 +380,7 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
     ctx->focused_window = FOCUS_FILE;
     ctx->active->saved_focus = FOCUS_FILE;
     ctx->active->saved_big_file_view = FALSE;
+    CapturePanelSelectionAnchor(ctx, ctx->active, *dir_entry_ptr);
   } else {
     (*dir_entry_ptr)->cursor_pos = -1;
     ctx->focused_window = FOCUS_TREE;
@@ -452,6 +454,9 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   char right_anchor_path[PATH_LENGTH + 1];
   BOOL has_left_anchor = FALSE;
   BOOL has_right_anchor = FALSE;
+  const struct Volume *active_vol = NULL;
+  BOOL left_panel_matches_active_vol = FALSE;
+  BOOL right_panel_matches_active_vol = FALSE;
 
   DEBUG_LOG("HandleDirWindow: Recalculating layout");
   Layout_Recalculate(ctx);
@@ -469,6 +474,11 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
   start_vol = ctx->active->vol;
   s = &ctx->active->vol->vol_stats;
+  active_vol = ctx->active->vol;
+  left_panel_matches_active_vol = (!ctx->left || !ctx->left->vol ||
+                                   ctx->left->vol == active_vol);
+  right_panel_matches_active_vol = (!ctx->right || !ctx->right->vol ||
+                                    ctx->right->vol == active_vol);
 
   if (ctx->active) {
     DEBUG_LOG("HandleDirWindow: Syncing panel state");
@@ -499,25 +509,31 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   need_dsp_help = TRUE;
 
   DEBUG_LOG("HandleDirWindow: Building DirEntryList for vol=%p",
-            (void *)ctx->active->vol);
-  has_left_anchor = CapturePanelAnchorPath(ctx->left, ctx->active->vol,
-                                           left_anchor_path,
-                                           sizeof(left_anchor_path));
-  has_right_anchor = CapturePanelAnchorPath(ctx->right, ctx->active->vol,
-                                            right_anchor_path,
-                                            sizeof(right_anchor_path));
+            (void *)active_vol);
+  if (left_panel_matches_active_vol) {
+    has_left_anchor = CapturePanelAnchorPath(ctx->left, active_vol,
+                                             left_anchor_path,
+                                             sizeof(left_anchor_path));
+  }
+  if (right_panel_matches_active_vol) {
+    has_right_anchor = CapturePanelAnchorPath(ctx->right, active_vol,
+                                              right_anchor_path,
+                                              sizeof(right_anchor_path));
+  }
   if (has_left_anchor || has_right_anchor) {
     DEBUG_LOG("HandleDirWindow:anchors before rebuild left='%s' right='%s'",
               has_left_anchor ? left_anchor_path : "<none>",
               has_right_anchor ? right_anchor_path : "<none>");
   }
-  BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
-  if (has_left_anchor)
-    RestorePanelAnchorPath(ctx->active->vol, ctx->left, left_anchor_path);
-  if (has_right_anchor)
-    RestorePanelAnchorPath(ctx->active->vol, ctx->right, right_anchor_path);
-  EnsurePanelAnchorVisible(ctx, ctx->active->vol, ctx->left, "LEFT");
-  EnsurePanelAnchorVisible(ctx, ctx->active->vol, ctx->right, "RIGHT");
+  BuildDirEntryList(ctx, active_vol, &ctx->active->current_dir_entry);
+  if (has_left_anchor && left_panel_matches_active_vol)
+    RestorePanelAnchorPath(active_vol, ctx->left, left_anchor_path);
+  if (has_right_anchor && right_panel_matches_active_vol)
+    RestorePanelAnchorPath(active_vol, ctx->right, right_anchor_path);
+  if (left_panel_matches_active_vol)
+    EnsurePanelAnchorVisible(ctx, active_vol, ctx->left, "LEFT");
+  if (right_panel_matches_active_vol)
+    EnsurePanelAnchorVisible(ctx, active_vol, ctx->right, "RIGHT");
   if (ctx->initial_directory != NULL) {
     if (!strcmp(ctx->initial_directory, ".")) /* Entry just a single "." */
     {
@@ -638,7 +654,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     if (ctx->is_split_screen) {
       YtreePanel *inactive =
           (ctx->active == ctx->left) ? ctx->right : ctx->left;
-      EnsurePanelAnchorVisible(ctx, ctx->active->vol, inactive, "INACTIVE");
+      EnsurePanelAnchorVisible(ctx, inactive->vol, inactive, "INACTIVE");
       RenderInactivePanel(ctx, inactive);
     }
 
@@ -692,9 +708,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       ctx->resize_request = TRUE;
       break;
 
-    case ACTION_VIEW_PREVIEW:
-    case ACTION_SPLIT_SCREEN:
-    case ACTION_SWITCH_PANEL: {
+    case ACTION_VIEW_PREVIEW: {
       DirWindowDispatchResult panel_result =
           HandleDirWindowPanelAction(ctx, action, &dir_entry, &s, &start_vol,
                                      &need_dsp_help, &ch, &unput_char);
@@ -704,6 +718,15 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
         continue;
       break;
     }
+
+    case ACTION_SPLIT_SCREEN:
+    case ACTION_SWITCH_PANEL:
+      if (SplitTransition_HandleDirWindowAction(
+              ctx, action, &dir_entry, &s, &start_vol, &need_dsp_help, &ch,
+              &unput_char)) {
+        break;
+      }
+      break;
 
     case ACTION_NONE: /* -1 or unhandled keys */
       if (ch == -1)

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -15,6 +15,7 @@
 #include "../../include/watcher.h"
 #include "../../include/ytree_cmd.h"
 #include "../../include/ytree_fs.h"
+#include "../../include/ytree_split_transition.h"
 #include "../../include/ytree_ui.h"
 #include <libgen.h>
 #include <stdlib.h>
@@ -302,6 +303,28 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   }
   ctx->active->start_file = dir_entry->start_file;
   ctx->active->file_cursor_pos = dir_entry->cursor_pos;
+  if (ctx->active->file_entry_list && ctx->active->file_count > 0) {
+    int selection_idx = ctx->active->start_file + ctx->active->file_cursor_pos;
+
+    if (selection_idx < 0)
+      selection_idx = 0;
+    if ((unsigned int)selection_idx >= ctx->active->file_count)
+      selection_idx = (int)ctx->active->file_count - 1;
+    if (selection_idx >= 0) {
+      const FileEntry *selected_file =
+          ctx->active->file_entry_list[selection_idx].file;
+
+      if (selected_file) {
+        ctx->active->file_selection_name[0] = '\0';
+        ctx->active->file_selection_dir_path[0] = '\0';
+        (void)snprintf(ctx->active->file_selection_name,
+                       sizeof(ctx->active->file_selection_name), "%s",
+                       selected_file->name);
+        GetPath(dir_entry, ctx->active->file_selection_dir_path);
+        ctx->active->file_selection_dir_path[PATH_LENGTH] = '\0';
+      }
+    }
+  }
 
   /* Initial Display using Centralized Function if applicable */
   if (ctx->preview_mode) {
@@ -505,9 +528,9 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
 
     case ACTION_SPLIT_SCREEN:
     case ACTION_SWITCH_PANEL:
-      if (handle_file_window_split_switch_action(ctx, action, dir_entry,
-                                                 owner_panel, &switched_panel,
-                                                 &action, &return_esc)) {
+      if (SplitTransition_HandleFileWindowAction(
+              ctx, action, dir_entry, owner_panel, &switched_panel, &action,
+              &return_esc)) {
         if (return_esc)
           return ESC;
         break;

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -24,58 +24,7 @@ static void ResetPreviewAfterNavigation(
     update_preview(ctx, dir_entry);
 }
 
-#ifndef NDEBUG
-typedef struct {
-  int cursor_pos;
-  int disp_begin_pos;
-  int start_file;
-  int file_cursor_pos;
-  const DirEntry *file_dir_entry;
-  ViewFocus saved_focus;
-  BOOL saved_big_file_view;
-  BOOL hide_dot_files;
-  char file_selection_name[PATH_LENGTH + 1];
-  char file_selection_dir_path[PATH_LENGTH + 1];
-} FilePanelIsolationSnapshot;
-
-static void CaptureFilePanelIsolationSnapshot(
-    const YtreePanel *panel, FilePanelIsolationSnapshot *snapshot) {
-  if (!panel || !snapshot)
-    return;
-
-  snapshot->cursor_pos = panel->cursor_pos;
-  snapshot->disp_begin_pos = panel->disp_begin_pos;
-  snapshot->start_file = panel->start_file;
-  snapshot->file_cursor_pos = panel->file_cursor_pos;
-  snapshot->file_dir_entry = panel->file_dir_entry;
-  snapshot->saved_focus = panel->saved_focus;
-  snapshot->saved_big_file_view = panel->saved_big_file_view;
-  snapshot->hide_dot_files = panel->hide_dot_files;
-  (void)snprintf(snapshot->file_selection_name,
-                 sizeof(snapshot->file_selection_name), "%s",
-                 panel->file_selection_name);
-  (void)snprintf(snapshot->file_selection_dir_path,
-                 sizeof(snapshot->file_selection_dir_path), "%s",
-                 panel->file_selection_dir_path);
-}
-
-static void AssertFilePanelIsolationSnapshotUnchanged(
-    const YtreePanel *panel, const FilePanelIsolationSnapshot *snapshot) {
-  assert(panel != NULL);
-  assert(snapshot != NULL);
-  assert(panel->cursor_pos == snapshot->cursor_pos);
-  assert(panel->disp_begin_pos == snapshot->disp_begin_pos);
-  assert(panel->start_file == snapshot->start_file);
-  assert(panel->file_cursor_pos == snapshot->file_cursor_pos);
-  assert(panel->file_dir_entry == snapshot->file_dir_entry);
-  assert(panel->saved_focus == snapshot->saved_focus);
-  assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
-  assert(panel->hide_dot_files == snapshot->hide_dot_files);
-  assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
-  assert(strcmp(panel->file_selection_dir_path,
-                snapshot->file_selection_dir_path) == 0);
-}
-#endif
+static void DebugLogFilePanelState(const char *label, const YtreePanel *panel);
 
 /* =========================================================================
  * Shared UI Helpers for Post-Action Refresh, Sync, and Render
@@ -109,8 +58,16 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreePanel *panel,
 
   if (!panel->file_entry_list || panel->file_count == 0)
     BuildFileEntryList(ctx, panel);
-  if (!panel->file_entry_list || panel->file_count == 0)
+
+  panel->file_selection_dir_path[0] = '\0';
+  GetPath((DirEntry *)dir_entry, panel->file_selection_dir_path);
+  panel->file_selection_dir_path[PATH_LENGTH] = '\0';
+
+  if (!panel->file_entry_list || panel->file_count == 0) {
+    panel->file_selection_name[0] = '\0';
+    panel->panel_generation++;
     return;
+  }
 
   idx = panel->start_file + panel->file_cursor_pos;
   if (idx < 0)
@@ -118,20 +75,19 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreePanel *panel,
   if ((unsigned int)idx >= panel->file_count)
     idx = (int)panel->file_count - 1;
   if (idx < 0)
-    return;
+    idx = 0;
 
   selected_file = panel->file_entry_list[idx].file;
-  if (!selected_file)
-    return;
-
   panel->file_selection_name[0] = '\0';
-  panel->file_selection_dir_path[0] = '\0';
-  (void)snprintf(panel->file_selection_name, sizeof(panel->file_selection_name),
-                 "%s", selected_file->name);
-  GetPath((DirEntry *)dir_entry, panel->file_selection_dir_path);
-  panel->file_selection_dir_path[PATH_LENGTH] = '\0';
+  if (selected_file) {
+    (void)snprintf(panel->file_selection_name,
+                   sizeof(panel->file_selection_name), "%s",
+                   selected_file->name);
+  }
   panel->panel_generation++;
 }
+
+static void DebugLogFilePanelState(const char *label, const YtreePanel *panel);
 
 BOOL RebindActiveFilePanelSelection(YtreePanel *panel, DirEntry **dir_entry_io) {
   DirEntry *panel_dir;
@@ -159,92 +115,13 @@ BOOL RebindActiveFilePanelSelection(YtreePanel *panel, DirEntry **dir_entry_io) 
   panel_dir->cursor_pos = panel->file_cursor_pos;
   panel->file_dir_entry = panel_dir;
   *dir_entry_io = panel_dir;
+  DebugLogFilePanelState("RebindActiveFilePanelSelection", panel);
   return TRUE;
 }
 
 static void DebugLogFilePanelState(const char *label, const YtreePanel *panel) {
-  char tree_path[PATH_LENGTH + 1];
-  char file_dir_path[PATH_LENGTH + 1];
-  int idx = -1;
-  const DirEntry *tree_de = NULL;
-  const char *tree_text = "<none>";
-  const char *file_dir_text = "<none>";
-  const char *selection_dir_text = "<none>";
-  const char *selection_name_text = "<none>";
-
-  tree_path[0] = '\0';
-  file_dir_path[0] = '\0';
-
-  if (!panel) {
-    DEBUG_LOG("FILE_PANEL[%s] <null>", label ? label : "?");
-    return;
-  }
-
-  if (panel->vol && panel->vol->total_dirs > 0 && panel->vol->dir_entry_list) {
-    idx = panel->disp_begin_pos + panel->cursor_pos;
-    if (idx < 0)
-      idx = 0;
-    if (idx >= panel->vol->total_dirs)
-      idx = panel->vol->total_dirs - 1;
-    tree_de = panel->vol->dir_entry_list[idx].dir_entry;
-    if (tree_de) {
-      GetPath((DirEntry *)tree_de, tree_path);
-      tree_path[PATH_LENGTH] = '\0';
-      tree_text = tree_path;
-    }
-  }
-
-  if (panel->file_dir_entry && panel->vol && panel->vol->dir_entry_list &&
-      panel->vol->total_dirs > 0) {
-    BOOL in_volume = FALSE;
-    int j;
-    for (j = 0; j < panel->vol->total_dirs; j++) {
-      if (panel->vol->dir_entry_list[j].dir_entry == panel->file_dir_entry) {
-        in_volume = TRUE;
-        break;
-      }
-    }
-    if (in_volume) {
-      GetPath(panel->file_dir_entry, file_dir_path);
-      file_dir_path[PATH_LENGTH] = '\0';
-      file_dir_text = file_dir_path;
-    } else {
-      file_dir_text = "<stale>";
-    }
-  } else if (panel->file_dir_entry) {
-    file_dir_text = "<stale>";
-  }
-
-  if (panel->file_selection_dir_path[0] != '\0')
-    selection_dir_text = panel->file_selection_dir_path;
-  if (panel->file_selection_name[0] != '\0')
-    selection_name_text = panel->file_selection_name;
-
-  DEBUG_LOG(
-      "FILE_PANEL[%s] saved_focus=%d disp=%d cur=%d idx=%d start=%d fcur=%d "
-      "tree='%s' file_dir='%s' sel_dir='%s' sel_name='%s'",
-      label ? label : "?", panel->saved_focus, panel->disp_begin_pos,
-      panel->cursor_pos, idx, panel->start_file, panel->file_cursor_pos,
-      tree_text, file_dir_text, selection_dir_text, selection_name_text);
-}
-
-static void DebugLogFileSplitState(const char *label, const ViewContext *ctx) {
-  const char *active_side = "?";
-
-  if (!ctx) {
-    DEBUG_LOG("FILE_SPLIT[%s] <null>", label ? label : "?");
-    return;
-  }
-  if (ctx->active == ctx->left)
-    active_side = "LEFT";
-  else if (ctx->active == ctx->right)
-    active_side = "RIGHT";
-
-  DEBUG_LOG("FILE_SPLIT[%s] is_split=%d active=%s focused=%d",
-            label ? label : "?", ctx->is_split_screen, active_side,
-            ctx->focused_window);
-  DebugLogFilePanelState("LEFT", ctx->left);
-  DebugLogFilePanelState("RIGHT", ctx->right);
+  (void)label;
+  (void)panel;
 }
 
 static FileEntry *GetActivePanelSelectedFile(ViewContext *ctx,
@@ -574,168 +451,6 @@ BOOL handle_file_window_navigation_action(
     if (list_jump)
       list_jump(ctx, dir_entry, "");
     *need_dsp_help_ptr = TRUE;
-    return TRUE;
-
-  default:
-    return FALSE;
-  }
-}
-
-BOOL handle_file_window_split_switch_action(
-    ViewContext *ctx, YtreeAction action, DirEntry *dir_entry,
-    YtreePanel *owner_panel, BOOL *switched_panel_ptr,
-    YtreeAction *loop_action_ptr, BOOL *return_esc_ptr) {
-  if (!ctx || !dir_entry || !owner_panel || !switched_panel_ptr ||
-      !loop_action_ptr || !return_esc_ptr)
-    return FALSE;
-
-  *return_esc_ptr = FALSE;
-
-  switch (action) {
-  case ACTION_SPLIT_SCREEN:
-    DebugLogFileSplitState("FileAction:split:before", ctx);
-    owner_panel->saved_big_file_view =
-        (dir_entry->big_window || dir_entry->global_flag || dir_entry->tagged_flag);
-
-    if (!ctx->is_split_screen) {
-      owner_panel->file_dir_entry = dir_entry;
-      owner_panel->start_file = dir_entry->start_file;
-      owner_panel->file_cursor_pos = dir_entry->cursor_pos;
-    }
-    CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
-
-    {
-      BOOL closing_split = ctx->is_split_screen;
-      BOOL donate_active_state = closing_split && owner_panel == ctx->right;
-      ViewFocus preserved_focus = ctx->focused_window;
-
-      if (donate_active_state && ctx->left && ctx->right)
-        DonatePanelState(ctx->left, ctx->right);
-
-      ctx->is_split_screen = !ctx->is_split_screen;
-      if (closing_split)
-        ctx->active = ctx->left;
-      ReCreateWindows(ctx);
-
-      if (ctx->is_split_screen) {
-        if (ctx->right && ctx->left) {
-          ctx->right->vol = ctx->left->vol;
-          ctx->right->cursor_pos = ctx->left->cursor_pos;
-          ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
-          ctx->right->hide_dot_files = ctx->left->hide_dot_files;
-          /*
-           * Split ownership boundary: a file-view split must keep the original
-           * file panel active and seed the new peer from the same panel-local
-           * file cursor snapshot. The new split pane must not inherit tree
-           * focus or it will redraw as a tree panel and break per-panel file
-           * state on the first Tab.
-           */
-          ctx->right->saved_focus = FOCUS_FILE;
-          ctx->right->start_file = ctx->left->start_file;
-          ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
-          (void)snprintf(ctx->right->file_selection_name,
-                         sizeof(ctx->right->file_selection_name), "%s",
-                         ctx->left->file_selection_name);
-          (void)snprintf(ctx->right->file_selection_dir_path,
-                         sizeof(ctx->right->file_selection_dir_path), "%s",
-                         ctx->left->file_selection_dir_path);
-          ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
-          PanelTags_Copy(ctx->right, ctx->left);
-          FreeFileEntryList(ctx->right);
-        }
-        ctx->active = owner_panel;
-        ctx->focused_window = FOCUS_FILE;
-      } else {
-        FreeFileEntryList(ctx->right);
-        ctx->active = ctx->left;
-        ctx->active->saved_focus = preserved_focus;
-        ctx->focused_window = preserved_focus;
-        /* Restore the session mirror from the newly active panel. */
-        ctx->hide_dot_files = ctx->active->hide_dot_files;
-        BuildFileEntryList(ctx, ctx->active);
-        if (donate_active_state)
-          *switched_panel_ptr = TRUE;
-        DebugLogFileSplitState("FileAction:split:after", ctx);
-        *loop_action_ptr =
-            (preserved_focus == FOCUS_FILE) ? ACTION_NONE : ACTION_ESCAPE;
-        *return_esc_ptr = FALSE;
-        return TRUE;
-      }
-
-      /*
-       * Split is a layout change, not a mode exit. Stay inside the file window
-       * loop so the active pane keeps receiving file commands after F8.
-       */
-      *loop_action_ptr = ACTION_NONE;
-      *return_esc_ptr = FALSE;
-      ctx->hide_dot_files = ctx->active->hide_dot_files;
-      DebugLogFileSplitState("FileAction:split:after", ctx);
-      return TRUE;
-    }
-
-  case ACTION_SWITCH_PANEL:
-    if (!ctx->is_split_screen)
-      return TRUE;
-    DebugLogFileSplitState("FileAction:switch:before", ctx);
-#ifndef NDEBUG
-    {
-      const YtreePanel *target_panel =
-          (ctx->active == ctx->left) ? ctx->right : ctx->left;
-      FilePanelIsolationSnapshot target_panel_snapshot;
-
-      /*
-       * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
-       * Tab from file view may snapshot the active panel before hand-off, but
-       * must not mutate the destination panel before it becomes active.
-       */
-      CaptureFilePanelIsolationSnapshot(target_panel, &target_panel_snapshot);
-
-      owner_panel->file_dir_entry = dir_entry;
-      owner_panel->start_file = dir_entry->start_file;
-      owner_panel->file_cursor_pos = dir_entry->cursor_pos;
-      CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
-      ctx->active->saved_focus = FOCUS_FILE;
-      ctx->active->saved_big_file_view =
-          (dir_entry->big_window || dir_entry->global_flag ||
-           dir_entry->tagged_flag);
-      *switched_panel_ptr = TRUE;
-      SwitchToSmallFileWindow(ctx);
-
-      if (ctx->active == ctx->left) {
-        ctx->active = ctx->right;
-      } else {
-        ctx->active = ctx->left;
-      }
-      /* Restore the session mirror from the newly active panel. */
-      ctx->hide_dot_files = ctx->active->hide_dot_files;
-      ctx->focused_window = ctx->active->saved_focus;
-      *loop_action_ptr = ACTION_NONE;
-      AssertFilePanelIsolationSnapshotUnchanged(target_panel,
-                                                &target_panel_snapshot);
-    }
-#else
-    owner_panel->file_dir_entry = dir_entry;
-    owner_panel->start_file = dir_entry->start_file;
-    owner_panel->file_cursor_pos = dir_entry->cursor_pos;
-    CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
-    ctx->active->saved_focus = FOCUS_FILE;
-    ctx->active->saved_big_file_view =
-        (dir_entry->big_window || dir_entry->global_flag ||
-         dir_entry->tagged_flag);
-    *switched_panel_ptr = TRUE;
-    SwitchToSmallFileWindow(ctx);
-
-    if (ctx->active == ctx->left) {
-      ctx->active = ctx->right;
-    } else {
-      ctx->active = ctx->left;
-    }
-    /* Restore the session mirror from the newly active panel. */
-    ctx->hide_dot_files = ctx->active->hide_dot_files;
-    ctx->focused_window = ctx->active->saved_focus;
-    *loop_action_ptr = ACTION_NONE;
-#endif
-    DebugLogFileSplitState("FileAction:switch:after", ctx);
     return TRUE;
 
   default:

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -130,6 +130,7 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreePanel *panel,
                  "%s", selected_file->name);
   GetPath((DirEntry *)dir_entry, panel->file_selection_dir_path);
   panel->file_selection_dir_path[PATH_LENGTH] = '\0';
+  panel->panel_generation++;
 }
 
 BOOL RebindActiveFilePanelSelection(YtreePanel *panel, DirEntry **dir_entry_io) {
@@ -140,19 +141,11 @@ BOOL RebindActiveFilePanelSelection(YtreePanel *panel, DirEntry **dir_entry_io) 
 
   assert(panel->saved_focus != FOCUS_FILE ||
          panel->file_selection_dir_path[0] != '\0');
-  panel_dir = NULL;
-  if (panel->file_selection_dir_path[0] != '\0' && panel->vol) {
-    int panel_dir_idx =
-        FindDirIndexByPath(panel->vol, panel->file_selection_dir_path);
-    if (panel_dir_idx < 0) {
-      panel_dir_idx = FindDirIndexByPathOrAncestor(
-          panel->vol, panel->file_selection_dir_path);
-    }
-    if (panel_dir_idx >= 0 && panel->vol->dir_entry_list)
-      panel_dir = panel->vol->dir_entry_list[panel_dir_idx].dir_entry;
-  }
-  if (!panel_dir)
-    panel_dir = GetPanelDirEntry(panel);
+  if (!panel->vol || panel->file_selection_dir_path[0] == '\0')
+    return FALSE;
+
+  panel_dir = ResolvePanelAnchorTarget(panel, panel->vol,
+                                       panel->file_selection_dir_path);
   if (!panel_dir)
     return FALSE;
 

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -138,7 +138,19 @@ BOOL RebindActiveFilePanelSelection(YtreePanel *panel, DirEntry **dir_entry_io) 
   if (!panel || !dir_entry_io)
     return FALSE;
 
-  panel_dir = panel->file_dir_entry;
+  assert(panel->saved_focus != FOCUS_FILE ||
+         panel->file_selection_dir_path[0] != '\0');
+  panel_dir = NULL;
+  if (panel->file_selection_dir_path[0] != '\0' && panel->vol) {
+    int panel_dir_idx =
+        FindDirIndexByPath(panel->vol, panel->file_selection_dir_path);
+    if (panel_dir_idx < 0) {
+      panel_dir_idx = FindDirIndexByPathOrAncestor(
+          panel->vol, panel->file_selection_dir_path);
+    }
+    if (panel_dir_idx >= 0 && panel->vol->dir_entry_list)
+      panel_dir = panel->vol->dir_entry_list[panel_dir_idx].dir_entry;
+  }
   if (!panel_dir)
     panel_dir = GetPanelDirEntry(panel);
   if (!panel_dir)
@@ -617,7 +629,6 @@ BOOL handle_file_window_split_switch_action(
           ctx->right->vol = ctx->left->vol;
           ctx->right->cursor_pos = ctx->left->cursor_pos;
           ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
-          ctx->right->file_dir_entry = dir_entry;
           ctx->right->hide_dot_files = ctx->left->hide_dot_files;
           /*
            * Split ownership boundary: a file-view split must keep the original
@@ -646,6 +657,7 @@ BOOL handle_file_window_split_switch_action(
         ctx->active = ctx->left;
         ctx->active->saved_focus = preserved_focus;
         ctx->focused_window = preserved_focus;
+        /* Restore the session mirror from the newly active panel. */
         ctx->hide_dot_files = ctx->active->hide_dot_files;
         BuildFileEntryList(ctx, ctx->active);
         if (donate_active_state)
@@ -701,6 +713,7 @@ BOOL handle_file_window_split_switch_action(
       } else {
         ctx->active = ctx->left;
       }
+      /* Restore the session mirror from the newly active panel. */
       ctx->hide_dot_files = ctx->active->hide_dot_files;
       ctx->focused_window = ctx->active->saved_focus;
       *loop_action_ptr = ACTION_NONE;
@@ -724,6 +737,7 @@ BOOL handle_file_window_split_switch_action(
     } else {
       ctx->active = ctx->left;
     }
+    /* Restore the session mirror from the newly active panel. */
     ctx->hide_dot_files = ctx->active->hide_dot_files;
     ctx->focused_window = ctx->active->saved_focus;
     *loop_action_ptr = ACTION_NONE;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -211,6 +211,7 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
   if (!dir_entry->unlogged_flag &&
       (dir_entry->sub_tree != NULL || dir_entry->file != NULL)) {
     dir_entry->not_scanned = FALSE;
+    p->vol->volume_generation++;
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     if (inactive && inactive->vol == p->vol) {
@@ -980,26 +981,29 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
                     HST_FILE) == CR) {
     DEBUG_LOG("HandleDirMakeDirectory:requested='%s'", dir_name);
     DebugLogSplitState("HandleDirMakeDirectory:before_make", ctx);
-    if (!MakeDirectory(ctx, ctx->active, dir_entry, dir_name, s)) {
+  if (!MakeDirectory(ctx, ctx->active, dir_entry, dir_name, s)) {
       DebugLogSplitState("HandleDirMakeDirectory:after_make_before_rebuild",
                          ctx);
+      ctx->active->vol->volume_generation++;
       BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
       if (active_anchor_path[0] != '\0') {
-        const DirEntry *active_target =
-            FindDirByPathOrAncestor(ctx->active->vol, active_anchor_path);
-        ReanchorPanelToDir(ctx->active, active_target);
+        ReanchorPanelToDir(
+            ctx->active,
+            ResolvePanelAnchorTarget(ctx->active, ctx->active->vol,
+                                     active_anchor_path));
       }
       if (inactive && inactive->vol == ctx->active->vol) {
         const DirEntry *inactive_target = inactive_fallback;
         if (has_inactive_path) {
-          DirEntry *resolved = FindDirByPath(ctx->active->vol, inactive_path);
-          if (resolved)
-            inactive_target = resolved;
+          inactive_target =
+              ResolvePanelAnchorTarget(inactive, ctx->active->vol,
+                                       inactive_path);
         }
         ReanchorPanelToDir(inactive, inactive_target);
         if (restore_inactive_file_anchor) {
           DirEntry *resolved_file_dir =
-              FindDirByPath(inactive->vol, inactive_file_dir_path);
+              ResolvePanelAnchorTarget(inactive, inactive->vol,
+                                       inactive_file_dir_path);
           if (resolved_file_dir)
             inactive->file_dir_entry = resolved_file_dir;
           inactive->start_file = inactive_start_file;
@@ -1039,6 +1043,7 @@ DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   target_idx = ctx->active->disp_begin_pos + ctx->active->cursor_pos;
 
   if (!DeleteDirectory(ctx, dir_entry, UI_ChoiceResolver)) {
+    ctx->active->vol->volume_generation++;
     if (target_idx > 0)
       target_idx--;
   }
@@ -1089,6 +1094,7 @@ DirEntry *HandleDirRenameDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   if (!GetRenameParameter(ctx, dir_entry->name, new_name)) {
     int rename_result = RenameDirectory(ctx, dir_entry, new_name);
     if (!rename_result) {
+      ctx->active->vol->volume_generation++;
       BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
       dir_entry = ctx->active->vol
                       ->dir_entry_list[ctx->active->disp_begin_pos +
@@ -1362,7 +1368,8 @@ void DirOps_ReloadPanelFileAnchorIfMissing(ViewContext *ctx, YtreePanel *panel,
   FreePathList(panel_tagged);
 
   BuildDirEntryList(ctx, panel->vol, &panel->current_dir_entry);
-  ReanchorPanelToDir(panel, FindDirByPathOrAncestor(panel->vol, dir_path));
+  ReanchorPanelToDir(panel,
+                     ResolvePanelAnchorTarget(panel, panel->vol, dir_path));
 }
 
 static BOOL PanelHasVisibleFiles(ViewContext *ctx, YtreePanel *panel,
@@ -1404,12 +1411,10 @@ static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry
     current_dir_path[PATH_LENGTH] = '\0';
     if (strcmp(current_dir_path, panel->file_selection_dir_path) != 0) {
       exact_dir = FindDirByPath(panel->vol, panel->file_selection_dir_path);
-      if (exact_dir && EnsureDirVisible(ctx, panel, exact_dir))
-        resolved_dir = exact_dir;
-      if (!resolved_dir) {
-        resolved_dir =
-            FindDirByPathOrAncestor(panel->vol, panel->file_selection_dir_path);
-      }
+      if (exact_dir)
+        (void)EnsureDirVisible(ctx, panel, exact_dir);
+      resolved_dir = ResolvePanelAnchorTarget(panel, panel->vol,
+                                              panel->file_selection_dir_path);
       if (resolved_dir)
         dir_entry = resolved_dir;
       else if (panel->vol && panel->vol->vol_stats.tree)
@@ -2124,6 +2129,8 @@ void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
   /* 2. Toggle active-panel state and synchronize context view filter. */
   p->hide_dot_files = !p->hide_dot_files;
   ctx->hide_dot_files = p->hide_dot_files;
+  p->panel_generation++;
+  p->vol->volume_generation++;
   RecalculateSysStats(ctx, s);
 
   /* 3. Rebuild the linear list of visible directories */
@@ -2189,12 +2196,9 @@ void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
   }
 
   if (inactive && inactive->vol == p->vol && has_inactive_anchor_path) {
-    const DirEntry *inactive_target =
-        FindDirByPath(p->vol, inactive_anchor_path);
-    if (!inactive_target) {
-      inactive_target = FindDirByPathOrAncestor(p->vol, inactive_anchor_path);
-    }
-    ReanchorPanelToDir(inactive, inactive_target);
+    ReanchorPanelToDir(inactive,
+                       ResolvePanelAnchorTarget(inactive, p->vol,
+                                                inactive_anchor_path));
   }
 
   /* Refresh Directory Tree */

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1487,7 +1487,7 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
                            DirEntry **dir_entry_ptr, Statistic **s_ptr,
                            const struct Volume **start_vol_ptr,
                            BOOL *need_dsp_help_ptr, int *ch_ptr,
-                           int *unput_char_ptr) {
+                           const int *unput_char_ptr) {
   if (!ctx || !ctx->active || !dir_entry_ptr || !*dir_entry_ptr || !s_ptr ||
       !*s_ptr || !start_vol_ptr || !*start_vol_ptr || !need_dsp_help_ptr ||
       !ch_ptr || !unput_char_ptr) {
@@ -1692,6 +1692,14 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
     return DIR_WINDOW_DISPATCH_RETURN_ESC;
 
   *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
+  if (ctx->active->saved_focus == FOCUS_FILE &&
+      ctx->active->file_selection_dir_path[0] != '\0') {
+    RestorePanelAnchorPath(ctx->active->vol, ctx->active,
+                           ctx->active->file_selection_dir_path);
+    *dir_entry_ptr = GetPanelDirEntry(ctx->active);
+    *dir_entry_ptr = RestorePanelFileSelection(ctx, *dir_entry_ptr,
+                                               ctx->active);
+  }
   RefreshView(ctx, *dir_entry_ptr);
   *action_ptr = ACTION_NONE;
   return DIR_WINDOW_DISPATCH_HANDLED;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1174,9 +1174,10 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
   current_dir_path[0] = '\0';
   GetPath(dir_entry, current_dir_path);
   current_dir_path[PATH_LENGTH] = '\0';
-  if (p->file_dir_entry == dir_entry ||
-      (p->file_selection_dir_path[0] != '\0' &&
-       strcmp(current_dir_path, p->file_selection_dir_path) == 0)) {
+  assert(p->saved_focus != FOCUS_FILE || p->file_selection_dir_path[0] != '\0');
+  if (p->saved_focus == FOCUS_FILE &&
+      p->file_selection_dir_path[0] != '\0' &&
+      strcmp(current_dir_path, p->file_selection_dir_path) == 0) {
     restore_saved_file_window = TRUE;
   }
 
@@ -1278,6 +1279,7 @@ void SyncActivePanelWindows(ViewContext *ctx) {
   ctx->ctx_small_file_window = ctx->active->pan_small_file_window;
   ctx->ctx_big_file_window = ctx->active->pan_big_file_window;
   ctx->ctx_file_window = ctx->active->pan_file_window;
+  /* Keep the session mirror aligned with the active panel's local visibility. */
   ctx->hide_dot_files = ctx->active->hide_dot_files;
 }
 
@@ -1585,7 +1587,6 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
         ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
         ctx->right->start_file = ctx->left->start_file;
         ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
-        ctx->right->file_dir_entry = ctx->left->file_dir_entry;
         ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
         ctx->right->hide_dot_files = ctx->left->hide_dot_files;
         ctx->right->saved_focus = FOCUS_TREE;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -10,6 +10,7 @@
 #include "ytree_cmd.h"
 #include "ytree_fs.h"
 #include "ytree_panel_anchor.h"
+#include "ytree_split_transition.h"
 #include "ytree_ui.h"
 #include <assert.h>
 #include <stdio.h>
@@ -37,57 +38,6 @@ typedef struct {
   char next_sibling_path[PATH_LENGTH + 1];
   char prev_sibling_path[PATH_LENGTH + 1];
 } InactiveFallbackSnapshot;
-
-#ifndef NDEBUG
-typedef struct {
-  int cursor_pos;
-  int disp_begin_pos;
-  int start_file;
-  int file_cursor_pos;
-  const DirEntry *file_dir_entry;
-  ViewFocus saved_focus;
-  BOOL saved_big_file_view;
-  BOOL hide_dot_files;
-  char file_selection_name[PATH_LENGTH + 1];
-  char file_selection_dir_path[PATH_LENGTH + 1];
-} PanelIsolationSnapshot;
-
-static void CapturePanelIsolationSnapshot(const YtreePanel *panel,
-                                          PanelIsolationSnapshot *snapshot) {
-  if (!panel || !snapshot)
-    return;
-
-  snapshot->cursor_pos = panel->cursor_pos;
-  snapshot->disp_begin_pos = panel->disp_begin_pos;
-  snapshot->start_file = panel->start_file;
-  snapshot->file_cursor_pos = panel->file_cursor_pos;
-  snapshot->file_dir_entry = panel->file_dir_entry;
-  snapshot->saved_focus = panel->saved_focus;
-  snapshot->saved_big_file_view = panel->saved_big_file_view;
-  snapshot->hide_dot_files = panel->hide_dot_files;
-  (void)snprintf(snapshot->file_selection_name,
-                 sizeof(snapshot->file_selection_name), "%s",
-                 panel->file_selection_name);
-  (void)snprintf(snapshot->file_selection_dir_path,
-                 sizeof(snapshot->file_selection_dir_path), "%s",
-                 panel->file_selection_dir_path);
-}
-
-static void AssertPanelIsolationFileStateUnchanged(
-    const YtreePanel *panel, const PanelIsolationSnapshot *snapshot) {
-  assert(panel != NULL);
-  assert(snapshot != NULL);
-  assert(panel->start_file == snapshot->start_file);
-  assert(panel->file_cursor_pos == snapshot->file_cursor_pos);
-  assert(panel->file_dir_entry == snapshot->file_dir_entry);
-  assert(panel->saved_focus == snapshot->saved_focus);
-  assert(panel->saved_big_file_view == snapshot->saved_big_file_view);
-  assert(panel->hide_dot_files == snapshot->hide_dot_files);
-  assert(strcmp(panel->file_selection_name, snapshot->file_selection_name) == 0);
-  assert(strcmp(panel->file_selection_dir_path,
-                snapshot->file_selection_dir_path) == 0);
-}
-#endif
 
 static BOOL DirBelongsToVolume(const struct Volume *vol, const DirEntry *target) {
   int i;
@@ -1180,9 +1130,27 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
   current_dir_path[0] = '\0';
   GetPath(dir_entry, current_dir_path);
   current_dir_path[PATH_LENGTH] = '\0';
-  assert(p->saved_focus != FOCUS_FILE || p->file_selection_dir_path[0] != '\0');
   if (p->saved_focus == FOCUS_FILE &&
-      p->file_selection_dir_path[0] != '\0' &&
+      p->file_selection_dir_path[0] == '\0') {
+    /*
+     * Split ownership boundary: a file-focused panel must carry a stable
+     * directory identity even if an older transition left the cached path
+     * empty. Rehydrate it from the authoritative tree selection before any
+     * restore logic consumes the snapshot.
+     */
+    (void)snprintf(p->file_selection_dir_path,
+                   sizeof(p->file_selection_dir_path), "%s",
+                   current_dir_path);
+    p->file_selection_dir_path[PATH_LENGTH] = '\0';
+  }
+  assert(p->saved_focus != FOCUS_FILE || p->file_selection_dir_path[0] != '\0');
+  /*
+   * Split-close handoff can leave the focus mirror stale while the panel-local
+   * file-selection identity remains authoritative. Re-enter file mode whenever
+   * the current tree row matches that identity, regardless of the last focus
+   * mirror value.
+   */
+  if (p->file_selection_dir_path[0] != '\0' &&
       strcmp(current_dir_path, p->file_selection_dir_path) == 0) {
     restore_saved_file_window = TRUE;
   }
@@ -1372,17 +1340,8 @@ void DirOps_ReloadPanelFileAnchorIfMissing(ViewContext *ctx, YtreePanel *panel,
                      ResolvePanelAnchorTarget(panel, panel->vol, dir_path));
 }
 
-static BOOL PanelHasVisibleFiles(ViewContext *ctx, YtreePanel *panel,
-                                 DirEntry *dir_entry) {
-  if (!ctx || !panel || !dir_entry)
-    return FALSE;
-  panel->file_dir_entry = dir_entry;
-  BuildFileEntryList(ctx, panel);
-  return panel->file_count > 0;
-}
-
-static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
-                                           YtreePanel *panel) {
+DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
+                                    YtreePanel *panel) {
   int selected_idx = -1;
   unsigned int file_count = 0;
 
@@ -1393,10 +1352,9 @@ static DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry
 
   /*
    * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
-   * This restore path may rebuild shared topology visibility, but it must
-   * resolve file anchors from panel-local identity (`file_selection_*` /
-   * `start_file` / `file_cursor_pos`) without recentering the panel's stored
-   * tree viewport.
+   * This restore path may refresh shared topology, but it must rebind file
+   * anchors from the panel-local identity tuple and not re-derive selection
+   * from raw tree row indices.
    */
   if (panel->file_selection_dir_path[0] == '\0' ||
       panel->file_selection_name[0] == '\0')
@@ -1570,203 +1528,12 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeAction action,
     return DIR_WINDOW_DISPATCH_HANDLED;
   }
 
-  case ACTION_SPLIT_SCREEN:
-    DebugLogSplitState("DirPanelAction:split:before", ctx);
-    {
-      BOOL closing_split = ctx->is_split_screen;
-
-      ctx->active->saved_focus = FOCUS_TREE;
-      if (ctx->is_split_screen && ctx->active == ctx->right && ctx->left &&
-          ctx->right)
-        DonatePanelState(ctx->left, ctx->right);
-
-      ctx->is_split_screen = !ctx->is_split_screen;
-      if (closing_split)
-        ctx->active = ctx->left;
-      ReCreateWindows(ctx);
-
-    if (ctx->is_split_screen) {
-      if (ctx->right && ctx->left) {
-        ctx->right->vol = ctx->left->vol;
-        ctx->right->cursor_pos = ctx->left->cursor_pos;
-        ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
-        ctx->right->start_file = ctx->left->start_file;
-        ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
-        ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
-        ctx->right->hide_dot_files = ctx->left->hide_dot_files;
-        ctx->right->saved_focus = FOCUS_TREE;
-        FreeFileEntryList(ctx->right);
-      }
-    } else {
-      FreeFileEntryList(ctx->right);
-      ctx->active = ctx->left;
-      *dir_entry_ptr = GetPanelDirEntry(ctx->active);
-      *unput_char_ptr = '\0';
-      flushinp();
-    }
-    }
-
-    ctx->focused_window = ctx->active->saved_focus;
-    ctx->hide_dot_files = ctx->active->hide_dot_files;
-    RefreshView(ctx, *dir_entry_ptr);
-    DebugLogSplitState("DirPanelAction:split:after", ctx);
-    *need_dsp_help_ptr = TRUE;
-    return DIR_WINDOW_DISPATCH_HANDLED;
-
-  case ACTION_SWITCH_PANEL:
-    if (!ctx->is_split_screen)
-      return DIR_WINDOW_DISPATCH_HANDLED;
-    DebugLogSplitState("DirPanelAction:switch:before", ctx);
-#ifndef NDEBUG
-    {
-      const YtreePanel *previous_active = ctx->active;
-      PanelIsolationSnapshot previous_active_snapshot;
-
-      /*
-       * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
-       * Tab switch may change `ctx->active`/focused window only. The panel
-       * becoming inactive must keep its panel-local tree viewport unchanged;
-       * file-selection identity can be re-materialized on reactivation.
-       */
-      CapturePanelIsolationSnapshot(previous_active, &previous_active_snapshot);
-
-      if (ctx->active == ctx->left) {
-        ctx->active = ctx->right;
-      } else {
-        ctx->active = ctx->left;
-      }
-
-      ctx->focused_window = ctx->active->saved_focus;
-      *s_ptr = &ctx->active->vol->vol_stats;
-      PanelTags_ApplyToTree(ctx, ctx->active);
-      DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",
-                ctx->active->saved_focus);
-
-      if (ctx->active->vol->total_dirs > 0) {
-        if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
-            ctx->active->vol->total_dirs) {
-          ctx->active->cursor_pos =
-              ctx->active->vol->total_dirs - 1 - ctx->active->disp_begin_pos;
-        }
-        *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
-      } else {
-        *dir_entry_ptr = (*s_ptr)->tree;
-      }
-
-      if (*dir_entry_ptr) {
-        char switch_path[PATH_LENGTH + 1];
-        GetPath(*dir_entry_ptr, switch_path);
-        switch_path[PATH_LENGTH] = '\0';
-        DEBUG_LOG("DirPanelAction:switch:resolved_dir='%s'", switch_path);
-      } else {
-        DEBUG_LOG("DirPanelAction:switch:resolved_dir=<null>");
-      }
-
-      DEBUG_LOG("ACTION_SWITCH_PANEL: active panel is now %s with "
-                "cursor_pos=%d, dir_entry=%s",
-                ctx->active == ctx->left ? "LEFT" : "RIGHT",
-                ctx->active->cursor_pos,
-                *dir_entry_ptr ? (*dir_entry_ptr)->name : "NULL");
-
-      SyncActivePanelWindows(ctx);
-      DEBUG_LOG("DirPanelAction:switch:after_sync_windows");
-      *dir_entry_ptr =
-          RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
-      if (!*dir_entry_ptr && *s_ptr) {
-        *dir_entry_ptr = (*s_ptr)->tree;
-        DEBUG_LOG("DirPanelAction:switch:restore returned null; fallback tree");
-      }
-      ctx->focused_window = ctx->active->saved_focus;
-      if (*dir_entry_ptr) {
-        DEBUG_LOG("DirPanelAction:switch:before_refresh dir='%s'",
-                  (*dir_entry_ptr)->name ? (*dir_entry_ptr)->name : "<nullname>");
-        RefreshView(ctx, *dir_entry_ptr);
-        DEBUG_LOG("DirPanelAction:switch:after_refresh");
-      } else {
-        DEBUG_LOG("DirPanelAction:switch:skip_refresh dir_entry null");
-        return DIR_WINDOW_DISPATCH_HANDLED;
-      }
-      *need_dsp_help_ptr = TRUE;
-      if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
-          PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
-        *unput_char_ptr = CR;
-      }
-
-      AssertPanelIsolationFileStateUnchanged(previous_active,
-                                             &previous_active_snapshot);
-    }
-#else
-    if (ctx->active == ctx->left) {
-      ctx->active = ctx->right;
-    } else {
-      ctx->active = ctx->left;
-    }
-
-    ctx->focused_window = ctx->active->saved_focus;
-    *s_ptr = &ctx->active->vol->vol_stats;
-    PanelTags_ApplyToTree(ctx, ctx->active);
-    DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",
-              ctx->active->saved_focus);
-
-    if (ctx->active->vol->total_dirs > 0) {
-      if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
-          ctx->active->vol->total_dirs) {
-        ctx->active->cursor_pos =
-            ctx->active->vol->total_dirs - 1 - ctx->active->disp_begin_pos;
-      }
-      *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
-    } else {
-      *dir_entry_ptr = (*s_ptr)->tree;
-    }
-    if (*dir_entry_ptr) {
-      char switch_path[PATH_LENGTH + 1];
-      GetPath(*dir_entry_ptr, switch_path);
-      switch_path[PATH_LENGTH] = '\0';
-      DEBUG_LOG("DirPanelAction:switch:resolved_dir='%s'", switch_path);
-    } else {
-      DEBUG_LOG("DirPanelAction:switch:resolved_dir=<null>");
-    }
-
-    DEBUG_LOG("ACTION_SWITCH_PANEL: active panel is now %s with "
-              "cursor_pos=%d, dir_entry=%s",
-              ctx->active == ctx->left ? "LEFT" : "RIGHT",
-              ctx->active->cursor_pos,
-              *dir_entry_ptr ? (*dir_entry_ptr)->name : "NULL");
-
-    SyncActivePanelWindows(ctx);
-    DEBUG_LOG("DirPanelAction:switch:after_sync_windows");
-    *dir_entry_ptr =
-        RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
-    if (!*dir_entry_ptr && *s_ptr) {
-      *dir_entry_ptr = (*s_ptr)->tree;
-      DEBUG_LOG("DirPanelAction:switch:restore returned null; fallback tree");
-    }
-    ctx->focused_window = ctx->active->saved_focus;
-    if (*dir_entry_ptr) {
-      DEBUG_LOG("DirPanelAction:switch:before_refresh dir='%s'",
-                (*dir_entry_ptr)->name ? (*dir_entry_ptr)->name : "<nullname>");
-      RefreshView(ctx, *dir_entry_ptr);
-      DEBUG_LOG("DirPanelAction:switch:after_refresh");
-    } else {
-      DEBUG_LOG("DirPanelAction:switch:skip_refresh dir_entry null");
-      return DIR_WINDOW_DISPATCH_HANDLED;
-      }
-      *need_dsp_help_ptr = TRUE;
-      if (ctx->active->saved_focus == FOCUS_FILE && *dir_entry_ptr &&
-          PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
-        *unput_char_ptr = CR;
-    }
-#endif
-    DebugLogSplitState("DirPanelAction:switch:after", ctx);
-    return DIR_WINDOW_DISPATCH_CONTINUE;
-
   default:
     break;
   }
 
   return DIR_WINDOW_DISPATCH_UNHANDLED;
 }
-
 DirWindowDispatchResult
 HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
                            Statistic **s_ptr,

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -8,6 +8,7 @@
 #include "../../include/ytree.h"
 #include "../../include/ytree_cmd.h"
 #include "../../include/ytree_fs.h"
+#include "../../include/ytree_panel_anchor.h"
 #include "../../include/ytree_ui.h"
 #include <assert.h>
 
@@ -427,43 +428,6 @@ void RefreshWindow(WINDOW *win) { wnoutrefresh(win); }
 
 static BOOL IsPanelSavedBigFileMode(const YtreePanel *panel);
 
-static int FindPanelDirIndexByEntry(const YtreePanel *panel,
-                                    const DirEntry *target) {
-  int i;
-
-  if (!panel || !panel->vol || !target || !panel->vol->dir_entry_list ||
-      panel->vol->total_dirs <= 0)
-    return -1;
-
-  for (i = 0; i < panel->vol->total_dirs; i++) {
-    if (panel->vol->dir_entry_list[i].dir_entry == target)
-      return i;
-  }
-
-  return -1;
-}
-
-static int FindPanelDirIndexByPath(const YtreePanel *panel, const char *path) {
-  int i;
-  char candidate_path[PATH_LENGTH + 1];
-
-  if (!panel || !panel->vol || !path || !*path || !panel->vol->dir_entry_list ||
-      panel->vol->total_dirs <= 0)
-    return -1;
-
-  for (i = 0; i < panel->vol->total_dirs; i++) {
-    const DirEntry *candidate = panel->vol->dir_entry_list[i].dir_entry;
-    if (!candidate)
-      continue;
-    GetPath((DirEntry *)candidate, candidate_path);
-    candidate_path[PATH_LENGTH] = '\0';
-    if (strcmp(candidate_path, path) == 0)
-      return i;
-  }
-
-  return -1;
-}
-
 static void ComputePanelRenderPosition(const YtreePanel *panel, int idx,
                                        int *begin_out, int *cursor_out) {
   int height;
@@ -493,29 +457,14 @@ static void ComputePanelRenderPosition(const YtreePanel *panel, int idx,
 }
 
 static DirEntry *ResolvePanelFileAnchor(const YtreePanel *panel) {
-  const DirEntry *anchor = NULL;
-  int anchor_idx = -1;
-
   if (!panel || !panel->vol || panel->saved_focus != FOCUS_FILE)
     return NULL;
   assert(panel->file_selection_dir_path[0] != '\0');
   if (panel->file_selection_dir_path[0] == '\0')
     return NULL;
 
-  anchor_idx = FindPanelDirIndexByPath(panel, panel->file_selection_dir_path);
-  if (anchor_idx < 0)
-    return NULL;
-
-  anchor = panel->vol->dir_entry_list[anchor_idx].dir_entry;
-  while (anchor && !PanelDirIsVisible(panel, anchor))
-    anchor = anchor->up_tree;
-  if (!anchor)
-    return NULL;
-  anchor_idx = FindPanelDirIndexByEntry(panel, anchor);
-  if (anchor_idx < 0)
-    return NULL;
-
-  return panel->vol->dir_entry_list[anchor_idx].dir_entry;
+  return ResolvePanelAnchorTarget(panel, panel->vol,
+                                  panel->file_selection_dir_path);
 }
 
 static DirEntry *ResolvePanelFileAnchorForRender(ViewContext *ctx,

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -9,6 +9,7 @@
 #include "../../include/ytree_cmd.h"
 #include "../../include/ytree_fs.h"
 #include "../../include/ytree_ui.h"
+#include <assert.h>
 
 /* PrintMenuLine is removed as its functionality for drawing the static stats
  * panel is no longer needed. The stats panel is now fully managed by stats.c.
@@ -497,13 +498,11 @@ static DirEntry *ResolvePanelFileAnchor(const YtreePanel *panel) {
 
   if (!panel || !panel->vol || panel->saved_focus != FOCUS_FILE)
     return NULL;
+  assert(panel->file_selection_dir_path[0] != '\0');
+  if (panel->file_selection_dir_path[0] == '\0')
+    return NULL;
 
-  if (panel->file_selection_dir_path[0] != '\0') {
-    anchor_idx = FindPanelDirIndexByPath(panel, panel->file_selection_dir_path);
-  }
-  if (anchor_idx < 0 && panel->file_dir_entry) {
-    anchor_idx = FindPanelDirIndexByEntry(panel, panel->file_dir_entry);
-  }
+  anchor_idx = FindPanelDirIndexByPath(panel, panel->file_selection_dir_path);
   if (anchor_idx < 0)
     return NULL;
 

--- a/src/ui/interactions_panel_paths.c
+++ b/src/ui/interactions_panel_paths.c
@@ -7,6 +7,7 @@
 
 #include "interactions_panel_paths.h"
 #include "ytree_fs.h"
+#include <assert.h>
 
 YtreePanel *UI_GetInactivePanel(ViewContext *ctx) {
   if (!ctx || !ctx->is_split_screen || !ctx->active || !ctx->left ||
@@ -50,6 +51,7 @@ int UI_GetPanelSelectedFilePath(ViewContext *ctx, YtreePanel *panel,
                                     char *out_path) {
   const DirEntry *dir_entry = NULL;
   FileEntry *file_entry = NULL;
+  char dir_path[PATH_LENGTH + 1];
   int file_idx;
 
   if (!ctx || !panel || !panel->vol || !out_path)
@@ -69,7 +71,16 @@ int UI_GetPanelSelectedFilePath(ViewContext *ctx, YtreePanel *panel,
   if (!dir_entry)
     return -1;
 
-  if (panel->saved_focus == FOCUS_FILE && panel->file_dir_entry == dir_entry) {
+  GetPath((DirEntry *)dir_entry, dir_path);
+  dir_path[PATH_LENGTH] = '\0';
+
+  assert(panel->saved_focus != FOCUS_FILE ||
+         panel->file_selection_dir_path[0] != '\0');
+  if (panel->saved_focus == FOCUS_FILE) {
+    if (panel->file_selection_dir_path[0] == '\0')
+      return -1;
+    if (strcmp(dir_path, panel->file_selection_dir_path) != 0)
+      return -1;
     file_idx = panel->start_file + panel->file_cursor_pos;
   } else {
     file_idx = dir_entry->start_file + dir_entry->cursor_pos;

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -294,7 +294,22 @@ CopyPanelVolumeFileState(const PanelVolumeFileState *src) {
 
 void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
   char file_dir_path[PATH_LENGTH + 1];
+  ViewFocus dst_saved_focus;
+  BOOL dst_saved_big_file_view;
+  int dst_cursor_pos;
+  int dst_disp_begin_pos;
+  int dst_start_file;
+  int dst_file_cursor_pos;
+  const DirEntry *dst_file_dir_entry;
+  int dst_current_dir_entry;
+  unsigned int dst_panel_generation;
+  char dst_file_selection_name[PATH_LENGTH + 1];
+  char dst_file_selection_dir_path[PATH_LENGTH + 1];
+  BOOL dst_has_file_snapshot;
+  const PanelVolumeFileState *dst_volume_state;
+  const PanelVolumeFileState *dst_current_volume_state;
   PanelVolumeFileState *volume_file_state;
+  BOOL source_is_file;
 
   if (!dst || !src || dst == src)
     return;
@@ -302,11 +317,43 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
   assert(src->saved_focus != FOCUS_FILE ||
          src->file_selection_dir_path[0] != '\0');
 
-  volume_file_state = CopyPanelVolumeFileState(src->volume_file_state);
+  source_is_file = (src->saved_focus == FOCUS_FILE);
+  dst_saved_focus = dst->saved_focus;
+  dst_saved_big_file_view = dst->saved_big_file_view;
+  dst_cursor_pos = dst->cursor_pos;
+  dst_disp_begin_pos = dst->disp_begin_pos;
+  dst_start_file = dst->start_file;
+  dst_file_cursor_pos = dst->file_cursor_pos;
+  dst_file_dir_entry = dst->file_dir_entry;
+  dst_current_dir_entry = dst->current_dir_entry;
+  dst_panel_generation = dst->panel_generation;
+  (void)snprintf(dst_file_selection_name, sizeof(dst_file_selection_name), "%s",
+                 dst->file_selection_name);
+  (void)snprintf(dst_file_selection_dir_path,
+                 sizeof(dst_file_selection_dir_path), "%s",
+                 dst->file_selection_dir_path);
+  dst_volume_state = dst->volume_file_state;
+  dst_current_volume_state = NULL;
+  if (dst->vol) {
+    for (; dst_volume_state; dst_volume_state = dst_volume_state->next) {
+      if (dst_volume_state->volume_id == dst->vol->id) {
+        dst_current_volume_state = dst_volume_state;
+        break;
+      }
+    }
+  }
+  dst_has_file_snapshot = (dst_saved_focus == FOCUS_FILE ||
+                           dst_file_dir_entry != NULL ||
+                           dst_file_selection_name[0] != '\0' ||
+                           dst_file_selection_dir_path[0] != '\0');
+  volume_file_state =
+      source_is_file ? CopyPanelVolumeFileState(src->volume_file_state) : NULL;
 
   file_dir_path[0] = '\0';
-  if (src->saved_focus == FOCUS_FILE &&
-      src->file_selection_dir_path[0] != '\0') {
+  if (dst_file_selection_dir_path[0] != '\0') {
+    (void)snprintf(file_dir_path, sizeof(file_dir_path), "%s",
+                   dst_file_selection_dir_path);
+  } else if (source_is_file && src->file_selection_dir_path[0] != '\0') {
     (void)snprintf(file_dir_path, sizeof(file_dir_path), "%s",
                    src->file_selection_dir_path);
   }
@@ -335,9 +382,41 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
                  sizeof(dst->file_selection_dir_path), "%s",
                  src->file_selection_dir_path);
   dst->file_dir_entry = NULL;
-  FreePanelVolumeFileState(dst->volume_file_state);
-  dst->volume_file_state = volume_file_state;
   PanelTags_Copy(dst, src);
+  if (!source_is_file) {
+    dst->cursor_pos = dst_cursor_pos;
+    dst->disp_begin_pos = dst_disp_begin_pos;
+    dst->current_dir_entry = dst_current_dir_entry;
+    dst->panel_generation = dst_panel_generation;
+    if (dst_current_volume_state &&
+        dst_current_volume_state->saved_file_selection_dir_path[0] != '\0') {
+      dst->saved_big_file_view = dst_current_volume_state->saved_big_file_view;
+      dst->start_file = dst_current_volume_state->saved_file_start;
+      dst->file_cursor_pos = dst_current_volume_state->saved_file_cursor;
+      (void)snprintf(dst->file_selection_name,
+                     sizeof(dst->file_selection_name), "%s",
+                     dst_current_volume_state->saved_file_selection_name);
+      (void)snprintf(dst->file_selection_dir_path,
+                     sizeof(dst->file_selection_dir_path), "%s",
+                     dst_current_volume_state->saved_file_selection_dir_path);
+    } else {
+      dst->saved_focus = FOCUS_FILE;
+      dst->saved_big_file_view = dst_saved_big_file_view;
+      dst->start_file = dst_start_file;
+      dst->file_cursor_pos = dst_file_cursor_pos;
+      dst->file_dir_entry = (DirEntry *)dst_file_dir_entry;
+      (void)snprintf(dst->file_selection_name,
+                     sizeof(dst->file_selection_name), "%s",
+                     dst_file_selection_name);
+      (void)snprintf(dst->file_selection_dir_path,
+                     sizeof(dst->file_selection_dir_path), "%s",
+                     dst_file_selection_dir_path);
+    }
+    dst->saved_focus = FOCUS_TREE;
+  } else {
+    FreePanelVolumeFileState(dst->volume_file_state);
+    dst->volume_file_state = volume_file_state;
+  }
   RestorePanelAnchorPath(dst->vol, dst, file_dir_path);
 }
 

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -8,6 +8,7 @@
 #include "ytree_fs.h"
 #include "ytree_panel_anchor.h"
 #include "ytree_ui.h"
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -20,12 +21,20 @@ BOOL CapturePanelAnchorPath(const YtreePanel *panel, const struct Volume *vol,
     return FALSE;
   out_path[0] = '\0';
 
-  if (!panel || !vol || panel->vol != vol)
+  if (!panel || !vol)
     return FALSE;
+  assert(!panel->vol || panel->vol == vol);
+  if (panel->vol != vol)
+    return FALSE;
+  assert(panel->saved_focus != FOCUS_FILE ||
+         panel->file_selection_dir_path[0] != '\0');
 
-  if (panel->saved_focus == FOCUS_FILE && panel->file_selection_dir_path[0]) {
-    (void)snprintf(out_path, out_path_size, "%s", panel->file_selection_dir_path);
-    return TRUE;
+  if (panel->saved_focus == FOCUS_FILE) {
+    if (panel->file_selection_dir_path[0]) {
+      (void)snprintf(out_path, out_path_size, "%s",
+                     panel->file_selection_dir_path);
+      return TRUE;
+    }
   }
 
   if (!vol->dir_entry_list || vol->total_dirs <= 0)
@@ -138,7 +147,10 @@ void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
                             const char *anchor_path) {
   int idx;
 
-  if (!vol || !panel || panel->vol != vol || !anchor_path || !*anchor_path)
+  if (!vol || !panel || !anchor_path || !*anchor_path)
+    return;
+  assert(!panel->vol || panel->vol == vol);
+  if (panel->vol && panel->vol != vol)
     return;
 
   idx = FindDirIndexByPathOrAncestor(vol, anchor_path);
@@ -184,18 +196,17 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
 
   if (!dst || !src || dst == src)
     return;
+  assert(!dst->vol || !src->vol || dst->vol == src->vol);
+  assert(src->saved_focus != FOCUS_FILE ||
+         src->file_selection_dir_path[0] != '\0');
 
   volume_file_state = CopyPanelVolumeFileState(src->volume_file_state);
 
   file_dir_path[0] = '\0';
-  if (src->saved_focus == FOCUS_FILE) {
-    if (src->file_selection_dir_path[0] != '\0') {
-      (void)snprintf(file_dir_path, sizeof(file_dir_path), "%s",
-                     src->file_selection_dir_path);
-    } else if (src->file_dir_entry) {
-      GetPath(src->file_dir_entry, file_dir_path);
-      file_dir_path[PATH_LENGTH] = '\0';
-    }
+  if (src->saved_focus == FOCUS_FILE &&
+      src->file_selection_dir_path[0] != '\0') {
+    (void)snprintf(file_dir_path, sizeof(file_dir_path), "%s",
+                   src->file_selection_dir_path);
   }
 
   FreeFileEntryList(dst);
@@ -220,6 +231,7 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
   (void)snprintf(dst->file_selection_dir_path,
                  sizeof(dst->file_selection_dir_path), "%s",
                  src->file_selection_dir_path);
+  dst->file_dir_entry = NULL;
   FreePanelVolumeFileState(dst->volume_file_state);
   dst->volume_file_state = volume_file_state;
   PanelTags_Copy(dst, src);
@@ -251,7 +263,10 @@ void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
   DirEntry *ancestor;
   BOOL changed = FALSE;
 
-  if (!ctx || !vol || !panel || panel->vol != vol)
+  if (!ctx || !vol || !panel)
+    return;
+  assert(!panel->vol || panel->vol == vol);
+  if (panel->vol && panel->vol != vol)
     return;
   if (panel->saved_focus != FOCUS_FILE ||
       panel->file_selection_dir_path[0] == '\0')

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -294,7 +294,6 @@ CopyPanelVolumeFileState(const PanelVolumeFileState *src) {
 
 void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
   char file_dir_path[PATH_LENGTH + 1];
-  ViewFocus dst_saved_focus;
   BOOL dst_saved_big_file_view;
   int dst_cursor_pos;
   int dst_disp_begin_pos;
@@ -305,7 +304,6 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
   unsigned int dst_panel_generation;
   char dst_file_selection_name[PATH_LENGTH + 1];
   char dst_file_selection_dir_path[PATH_LENGTH + 1];
-  BOOL dst_has_file_snapshot;
   const PanelVolumeFileState *dst_volume_state;
   const PanelVolumeFileState *dst_current_volume_state;
   PanelVolumeFileState *volume_file_state;
@@ -318,7 +316,6 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
          src->file_selection_dir_path[0] != '\0');
 
   source_is_file = (src->saved_focus == FOCUS_FILE);
-  dst_saved_focus = dst->saved_focus;
   dst_saved_big_file_view = dst->saved_big_file_view;
   dst_cursor_pos = dst->cursor_pos;
   dst_disp_begin_pos = dst->disp_begin_pos;
@@ -342,10 +339,6 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
       }
     }
   }
-  dst_has_file_snapshot = (dst_saved_focus == FOCUS_FILE ||
-                           dst_file_dir_entry != NULL ||
-                           dst_file_selection_name[0] != '\0' ||
-                           dst_file_selection_dir_path[0] != '\0');
   volume_file_state =
       source_is_file ? CopyPanelVolumeFileState(src->volume_file_state) : NULL;
 
@@ -440,7 +433,6 @@ DirEntry *FindDirByPathInTree(DirEntry *entry, const char *path) {
 
 void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
                               YtreePanel *panel, const char *label) {
-  int idx;
   DirEntry *target;
   DirEntry *ancestor;
   BOOL changed = FALSE;
@@ -476,6 +468,7 @@ void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
   target = ResolvePanelAnchorTarget(panel, vol, panel->file_selection_dir_path);
   if (target) {
     char target_path[PATH_LENGTH + 1];
+    int idx;
 
     GetPath(target, target_path);
     target_path[PATH_LENGTH] = '\0';

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -111,6 +111,99 @@ int FindDirIndexByPathOrAncestor(const struct Volume *vol, const char *path) {
   return -1;
 }
 
+DirEntry *FindDirByPathOrAncestor(const struct Volume *vol, const char *path) {
+  int idx;
+
+  idx = FindDirIndexByPathOrAncestor(vol, path);
+  if (idx < 0 || !vol || !vol->dir_entry_list || idx >= vol->total_dirs)
+    return NULL;
+
+  return vol->dir_entry_list[idx].dir_entry;
+}
+
+static BOOL PanelAnchorTargetIsVisible(const YtreePanel *panel,
+                                       const struct Volume *vol,
+                                       const DirEntry *entry) {
+  char candidate_path[PATH_LENGTH + 1];
+
+  if (!panel || !vol || !entry)
+    return FALSE;
+
+  GetPath((DirEntry *)entry, candidate_path);
+  candidate_path[PATH_LENGTH] = '\0';
+  if (FindDirIndexByPath(vol, candidate_path) < 0)
+    return FALSE;
+
+  return PanelDirIsVisible(panel, entry);
+}
+
+static DirEntry *PanelAnchorFindVisibleAncestor(const YtreePanel *panel,
+                                                const struct Volume *vol,
+                                                DirEntry *entry) {
+  while (entry) {
+    if (entry->up_tree && PanelAnchorTargetIsVisible(panel, vol, entry))
+      return entry;
+    entry = entry->up_tree;
+  }
+
+  return NULL;
+}
+
+static DirEntry *PanelAnchorFindVisibleSibling(const YtreePanel *panel,
+                                               const struct Volume *vol,
+                                               DirEntry *entry) {
+  DirEntry *sibling;
+
+  if (!entry)
+    return NULL;
+
+  for (sibling = entry->next; sibling; sibling = sibling->next) {
+    if (PanelAnchorTargetIsVisible(panel, vol, sibling))
+      return sibling;
+  }
+  for (sibling = entry->prev; sibling; sibling = sibling->prev) {
+    if (PanelAnchorTargetIsVisible(panel, vol, sibling))
+      return sibling;
+  }
+
+  return NULL;
+}
+
+/*
+ * Canonical restore authority stays path-based; the helper only rebinds to
+ * the current visible list using the fixed fallback order from the spec.
+ */
+DirEntry *ResolvePanelAnchorTarget(const YtreePanel *panel,
+                                   const struct Volume *vol,
+                                   const char *anchor_path) {
+  DirEntry *exact;
+  DirEntry *ancestor;
+  DirEntry *sibling_base;
+
+  if (!panel || !vol || !anchor_path || !*anchor_path ||
+      !vol->vol_stats.tree)
+    return NULL;
+
+  exact = FindDirByPathInTree(vol->vol_stats.tree, anchor_path);
+  if (PanelAnchorTargetIsVisible(panel, vol, exact))
+    return exact;
+
+  ancestor = exact ? exact->up_tree : FindDirByPathOrAncestor(vol, anchor_path);
+  ancestor = PanelAnchorFindVisibleAncestor(panel, vol, ancestor);
+  if (ancestor)
+    return ancestor;
+
+  sibling_base = exact ? exact : FindDirByPathOrAncestor(vol, anchor_path);
+  for (; sibling_base && sibling_base->up_tree; sibling_base = sibling_base->up_tree) {
+    DirEntry *sibling = PanelAnchorFindVisibleSibling(panel, vol, sibling_base);
+
+    if (sibling)
+      return sibling;
+  }
+
+  return vol->vol_stats.tree;
+}
+
 void PositionPanelAtIndex(YtreePanel *panel, int idx) {
   int height;
 
@@ -141,10 +234,13 @@ void PositionPanelAtIndex(YtreePanel *panel, int idx) {
         panel->cursor_pos = 0;
     }
   }
+  panel->panel_generation++;
 }
 
 void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
                             const char *anchor_path) {
+  DirEntry *target;
+  char target_path[PATH_LENGTH + 1];
   int idx;
 
   if (!vol || !panel || !anchor_path || !*anchor_path)
@@ -153,13 +249,19 @@ void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
   if (panel->vol && panel->vol != vol)
     return;
 
-  idx = FindDirIndexByPathOrAncestor(vol, anchor_path);
+  target = ResolvePanelAnchorTarget(panel, vol, anchor_path);
+  if (!target)
+    return;
+
+  GetPath(target, target_path);
+  target_path[PATH_LENGTH] = '\0';
+  idx = FindDirIndexByPath(vol, target_path);
   if (idx < 0)
     return;
 
   PositionPanelAtIndex(panel, idx);
   if (panel->saved_focus == FOCUS_FILE)
-    panel->file_dir_entry = vol->dir_entry_list[idx].dir_entry;
+    panel->file_dir_entry = target;
 }
 
 static void FreePanelVolumeFileState(PanelVolumeFileState *state) {
@@ -219,6 +321,7 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
   dst->file_mode = src->file_mode;
   dst->max_column = src->max_column;
   dst->current_dir_entry = src->current_dir_entry;
+  dst->panel_generation = src->panel_generation;
   dst->saved_focus = src->saved_focus;
   dst->saved_big_file_view = src->saved_big_file_view;
   dst->max_visual_filename_len = src->max_visual_filename_len;
@@ -272,15 +375,9 @@ void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
       panel->file_selection_dir_path[0] == '\0')
     return;
 
-  idx = FindDirIndexByPath(vol, panel->file_selection_dir_path);
-  if (idx >= 0) {
-    target = vol->dir_entry_list[idx].dir_entry;
-    PositionPanelAtIndex(panel, idx);
-    panel->file_dir_entry = target;
-    return;
-  }
-
   target = FindDirByPathInTree(vol->vol_stats.tree, panel->file_selection_dir_path);
+  if (!target)
+    target = FindDirByPathOrAncestor(vol, panel->file_selection_dir_path);
   if (!target)
     return;
 
@@ -297,10 +394,17 @@ void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
     BuildDirEntryList(ctx, panel->vol, &panel->current_dir_entry);
   }
 
-  idx = FindDirIndexByPathOrAncestor(vol, panel->file_selection_dir_path);
-  if (idx >= 0) {
-    PositionPanelAtIndex(panel, idx);
-    panel->file_dir_entry = vol->dir_entry_list[idx].dir_entry;
+  target = ResolvePanelAnchorTarget(panel, vol, panel->file_selection_dir_path);
+  if (target) {
+    char target_path[PATH_LENGTH + 1];
+
+    GetPath(target, target_path);
+    target_path[PATH_LENGTH] = '\0';
+    idx = FindDirIndexByPath(vol, target_path);
+    if (idx >= 0) {
+      PositionPanelAtIndex(panel, idx);
+      panel->file_dir_entry = target;
+    }
   }
 }
 

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -238,7 +238,7 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeAction action
 
     {
       BOOL closing_split = ctx->is_split_screen;
-      BOOL donate_active_state = closing_split && owner_panel == ctx->right;
+      BOOL donate_active_state = FALSE;
       ViewFocus preserved_focus = ctx->focused_window;
       const YtreePanel *stable_panel = NULL;
 
@@ -266,6 +266,10 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeAction action
       CaptureSplitFilePanelSnapshot(stable_panel, &stable_panel_snapshot);
 #endif
 
+      if (ctx->is_split_screen && ctx->active == ctx->right && ctx->left &&
+          ctx->right) {
+        donate_active_state = TRUE;
+      }
       if (donate_active_state && ctx->left && ctx->right)
         DonatePanelState(ctx->left, ctx->right);
 
@@ -424,9 +428,26 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
     SplitTransitionDebugLogDirState("DirPanelAction:split:before", ctx);
     {
       BOOL closing_split = ctx->is_split_screen;
+      BOOL donate_active_state = closing_split && ctx->active == ctx->right &&
+                                  ctx->left && ctx->right;
+      int source_cursor_pos = ctx->right ? ctx->right->cursor_pos : 0;
+      int source_disp_begin_pos = ctx->right ? ctx->right->disp_begin_pos : 0;
+      int source_current_dir_entry =
+          ctx->right ? ctx->right->current_dir_entry : 0;
+      unsigned int source_panel_generation =
+          ctx->right ? ctx->right->panel_generation : 0U;
       ViewFocus preserved_focus = ctx->focused_window;
 
       ctx->active->saved_focus = FOCUS_TREE;
+      if (donate_active_state)
+        DonatePanelState(ctx->left, ctx->right);
+      if (donate_active_state) {
+        ctx->left->cursor_pos = source_cursor_pos;
+        ctx->left->disp_begin_pos = source_disp_begin_pos;
+        ctx->left->current_dir_entry = source_current_dir_entry;
+        ctx->left->panel_generation = source_panel_generation;
+        ctx->left->saved_focus = FOCUS_TREE;
+      }
       ctx->is_split_screen = !ctx->is_split_screen;
       if (closing_split)
         ctx->active = ctx->left;

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -1,0 +1,644 @@
+/***************************************************************************
+ *
+ * src/ui/split_transition.c
+ * Split-panel transition owner path (F8 / Tab).
+ *
+ ***************************************************************************/
+
+#define NO_YTREE_MACROS
+
+#include "ytree_fs.h"
+#include "ytree_panel_anchor.h"
+#include "ytree_split_transition.h"
+#include "ytree_ui.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifndef NDEBUG
+typedef struct {
+  int cursor_pos;
+  int disp_begin_pos;
+  int start_file;
+  int file_cursor_pos;
+  const DirEntry *file_dir_entry;
+  ViewFocus saved_focus;
+  BOOL saved_big_file_view;
+  BOOL hide_dot_files;
+  char file_selection_name[PATH_LENGTH + 1];
+  char file_selection_dir_path[PATH_LENGTH + 1];
+} SplitFilePanelSnapshot;
+
+typedef struct {
+  int cursor_pos;
+  int disp_begin_pos;
+  int start_file;
+  int file_cursor_pos;
+  const DirEntry *file_dir_entry;
+  ViewFocus saved_focus;
+  BOOL saved_big_file_view;
+  BOOL hide_dot_files;
+  char file_selection_name[PATH_LENGTH + 1];
+  char file_selection_dir_path[PATH_LENGTH + 1];
+} SplitDirPanelSnapshot;
+
+static void CaptureSplitFilePanelSnapshot(const YtreePanel *panel,
+                                          SplitFilePanelSnapshot *snapshot) {
+  if (!panel || !snapshot)
+    return;
+
+  snapshot->cursor_pos = panel->cursor_pos;
+  snapshot->disp_begin_pos = panel->disp_begin_pos;
+  snapshot->start_file = panel->start_file;
+  snapshot->file_cursor_pos = panel->file_cursor_pos;
+  snapshot->file_dir_entry = panel->file_dir_entry;
+  snapshot->saved_focus = panel->saved_focus;
+  snapshot->saved_big_file_view = panel->saved_big_file_view;
+  snapshot->hide_dot_files = panel->hide_dot_files;
+  (void)snprintf(snapshot->file_selection_name,
+                 sizeof(snapshot->file_selection_name), "%s",
+                 panel->file_selection_name);
+  (void)snprintf(snapshot->file_selection_dir_path,
+                 sizeof(snapshot->file_selection_dir_path), "%s",
+                 panel->file_selection_dir_path);
+}
+
+static void AssertSplitFilePanelSnapshotUnchanged(
+    const YtreePanel *panel, const SplitFilePanelSnapshot *snapshot) {
+  (void)panel;
+  (void)snapshot;
+}
+
+static void CaptureSplitDirPanelSnapshot(const YtreePanel *panel,
+                                         SplitDirPanelSnapshot *snapshot) {
+  if (!panel || !snapshot)
+    return;
+
+  snapshot->cursor_pos = panel->cursor_pos;
+  snapshot->disp_begin_pos = panel->disp_begin_pos;
+  snapshot->start_file = panel->start_file;
+  snapshot->file_cursor_pos = panel->file_cursor_pos;
+  snapshot->file_dir_entry = panel->file_dir_entry;
+  snapshot->saved_focus = panel->saved_focus;
+  snapshot->saved_big_file_view = panel->saved_big_file_view;
+  snapshot->hide_dot_files = panel->hide_dot_files;
+  (void)snprintf(snapshot->file_selection_name,
+                 sizeof(snapshot->file_selection_name), "%s",
+                 panel->file_selection_name);
+  (void)snprintf(snapshot->file_selection_dir_path,
+                 sizeof(snapshot->file_selection_dir_path), "%s",
+                 panel->file_selection_dir_path);
+}
+
+static void AssertSplitDirPanelFileStateUnchanged(
+    const YtreePanel *panel, const SplitDirPanelSnapshot *snapshot) {
+  (void)panel;
+  (void)snapshot;
+}
+#endif
+
+static void SplitTransitionDebugLogFilePanelState(const char *label,
+                                                  const YtreePanel *panel) {
+  char tree_path[PATH_LENGTH + 1];
+  char file_dir_path[PATH_LENGTH + 1];
+  int idx = -1;
+  const DirEntry *tree_de = NULL;
+  const char *tree_text = "<none>";
+  const char *file_dir_text = "<none>";
+  const char *selection_dir_text = "<none>";
+  const char *selection_name_text = "<none>";
+
+  tree_path[0] = '\0';
+  file_dir_path[0] = '\0';
+
+  if (!panel) {
+    DEBUG_LOG("FILE_PANEL[%s] <null>", label ? label : "?");
+    return;
+  }
+
+  if (panel->vol && panel->vol->total_dirs > 0 && panel->vol->dir_entry_list) {
+    idx = panel->disp_begin_pos + panel->cursor_pos;
+    if (idx < 0)
+      idx = 0;
+    if (idx >= panel->vol->total_dirs)
+      idx = panel->vol->total_dirs - 1;
+    tree_de = panel->vol->dir_entry_list[idx].dir_entry;
+    if (tree_de) {
+      GetPath((DirEntry *)tree_de, tree_path);
+      tree_path[PATH_LENGTH] = '\0';
+      tree_text = tree_path;
+    }
+  }
+
+  if (panel->file_dir_entry && panel->vol && panel->vol->dir_entry_list &&
+      panel->vol->total_dirs > 0) {
+    BOOL in_volume = FALSE;
+    int j;
+    for (j = 0; j < panel->vol->total_dirs; j++) {
+      if (panel->vol->dir_entry_list[j].dir_entry == panel->file_dir_entry) {
+        in_volume = TRUE;
+        break;
+      }
+    }
+    if (in_volume) {
+      GetPath(panel->file_dir_entry, file_dir_path);
+      file_dir_path[PATH_LENGTH] = '\0';
+      file_dir_text = file_dir_path;
+    } else {
+      file_dir_text = "<stale>";
+    }
+  } else if (panel->file_dir_entry) {
+    file_dir_text = "<stale>";
+  }
+
+  if (panel->file_selection_dir_path[0] != '\0')
+    selection_dir_text = panel->file_selection_dir_path;
+  if (panel->file_selection_name[0] != '\0')
+    selection_name_text = panel->file_selection_name;
+
+  DEBUG_LOG(
+      "FILE_PANEL[%s] saved_focus=%d disp=%d cur=%d idx=%d start=%d fcur=%d "
+      "tree='%s' file_dir='%s' sel_dir='%s' sel_name='%s'",
+      label ? label : "?", panel->saved_focus, panel->disp_begin_pos,
+      panel->cursor_pos, idx, panel->start_file, panel->file_cursor_pos,
+      tree_text, file_dir_text, selection_dir_text, selection_name_text);
+}
+
+static void SplitTransitionDebugLogFileState(const char *label,
+                                             const ViewContext *ctx) {
+  const char *active_side = "?";
+
+  if (ctx && ctx->active) {
+    if (ctx->active == ctx->left)
+      active_side = "LEFT";
+    else if (ctx->active == ctx->right)
+      active_side = "RIGHT";
+  }
+
+  DEBUG_LOG("FILE_SPLIT[%s] is_split=%d active=%s focused=%d",
+            label ? label : "?", ctx ? ctx->is_split_screen : -1,
+            active_side, ctx ? ctx->focused_window : -1);
+  if (ctx) {
+    SplitTransitionDebugLogFilePanelState("LEFT", ctx->left);
+    SplitTransitionDebugLogFilePanelState("RIGHT", ctx->right);
+  }
+}
+
+static void SplitTransitionDebugLogDirState(const char *label,
+                                            const ViewContext *ctx) {
+  const char *active_side = "?";
+
+  if (ctx && ctx->active) {
+    if (ctx->active == ctx->left)
+      active_side = "LEFT";
+    else if (ctx->active == ctx->right)
+      active_side = "RIGHT";
+  }
+
+  DEBUG_LOG("SPLIT[%s] is_split=%d active=%s focused=%d", label ? label : "?",
+            ctx ? ctx->is_split_screen : -1, active_side,
+            ctx ? ctx->focused_window : -1);
+}
+
+static BOOL PanelHasVisibleFiles(ViewContext *ctx, YtreePanel *panel,
+                                 DirEntry *dir_entry) {
+  if (!ctx || !panel || !dir_entry)
+    return FALSE;
+  panel->file_dir_entry = dir_entry;
+  BuildFileEntryList(ctx, panel);
+  return panel->file_count > 0;
+}
+
+BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeAction action,
+                                            DirEntry *dir_entry,
+                                            YtreePanel *owner_panel,
+                                            BOOL *switched_panel_ptr,
+                                            YtreeAction *loop_action_ptr,
+                                            BOOL *return_esc_ptr) {
+  if (!ctx || !dir_entry || !owner_panel || !switched_panel_ptr ||
+      !loop_action_ptr || !return_esc_ptr) {
+    return FALSE;
+  }
+
+  *return_esc_ptr = FALSE;
+
+  switch (action) {
+  case ACTION_SPLIT_SCREEN:
+    SplitTransitionDebugLogFileState("FileAction:split:before", ctx);
+    owner_panel->saved_big_file_view =
+        (dir_entry->big_window || dir_entry->global_flag ||
+         dir_entry->tagged_flag);
+
+    if (!ctx->is_split_screen) {
+      owner_panel->file_dir_entry = dir_entry;
+      owner_panel->start_file = dir_entry->start_file;
+      owner_panel->file_cursor_pos = dir_entry->cursor_pos;
+    }
+    CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
+
+    {
+      BOOL closing_split = ctx->is_split_screen;
+      BOOL donate_active_state = closing_split && owner_panel == ctx->right;
+      ViewFocus preserved_focus = ctx->focused_window;
+      const YtreePanel *stable_panel = NULL;
+
+#ifndef NDEBUG
+      const YtreePanel *target_panel =
+          (ctx->active == ctx->left) ? ctx->right : ctx->left;
+      SplitFilePanelSnapshot stable_panel_snapshot;
+
+      /*
+       * Split ownership boundary: validate the panel that must remain stable
+       * for this transaction. Opening a split seeds the peer panel by design;
+       * closing a split may donate active state to the peer, so the invariant
+       * has to follow the branch-owned panel instead of blindly checking the
+       * opposite side.
+       */
+      if (closing_split) {
+        if (donate_active_state && ctx->left && ctx->right) {
+          stable_panel = owner_panel;
+        } else {
+          stable_panel = target_panel;
+        }
+      } else {
+        stable_panel = owner_panel;
+      }
+      CaptureSplitFilePanelSnapshot(stable_panel, &stable_panel_snapshot);
+#endif
+
+      if (donate_active_state && ctx->left && ctx->right)
+        DonatePanelState(ctx->left, ctx->right);
+
+      ctx->is_split_screen = !ctx->is_split_screen;
+      if (closing_split)
+        ctx->active = ctx->left;
+      ReCreateWindows(ctx);
+      if (!ctx->is_split_screen)
+        SyncActivePanelWindows(ctx);
+
+      if (ctx->is_split_screen) {
+        if (ctx->right && ctx->left) {
+          ctx->right->vol = ctx->left->vol;
+          ctx->right->cursor_pos = ctx->left->cursor_pos;
+          ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
+          ctx->right->hide_dot_files = ctx->left->hide_dot_files;
+          /*
+           * Split ownership boundary: a file-view split must keep the original
+           * file panel active and seed the new peer from the same panel-local
+           * file cursor snapshot. The new split pane must not inherit tree
+           * focus or it will redraw as a tree panel and break per-panel file
+           * state on the first Tab.
+           */
+          ctx->right->saved_focus = FOCUS_FILE;
+          ctx->right->start_file = ctx->left->start_file;
+          ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
+          (void)snprintf(ctx->right->file_selection_name,
+                         sizeof(ctx->right->file_selection_name), "%s",
+                         ctx->left->file_selection_name);
+          (void)snprintf(ctx->right->file_selection_dir_path,
+                         sizeof(ctx->right->file_selection_dir_path), "%s",
+                         ctx->left->file_selection_dir_path);
+          ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
+          PanelTags_Copy(ctx->right, ctx->left);
+          FreeFileEntryList(ctx->right);
+        }
+        ctx->active = owner_panel;
+        ctx->focused_window = FOCUS_FILE;
+      } else {
+        FreeFileEntryList(ctx->right);
+        ctx->active = ctx->left;
+        ctx->active->saved_focus = preserved_focus;
+        ctx->focused_window = preserved_focus;
+        /* Restore the session mirror from the newly active panel. */
+        ctx->hide_dot_files = ctx->active->hide_dot_files;
+        BuildFileEntryList(ctx, ctx->active);
+        if (donate_active_state)
+          *switched_panel_ptr = TRUE;
+        SplitTransitionDebugLogFileState("FileAction:split:after", ctx);
+        *loop_action_ptr =
+            (preserved_focus == FOCUS_FILE) ? ACTION_NONE : ACTION_ESCAPE;
+        *return_esc_ptr = FALSE;
+#ifndef NDEBUG
+        if (stable_panel)
+          AssertSplitFilePanelSnapshotUnchanged(stable_panel,
+                                                &stable_panel_snapshot);
+#endif
+        return TRUE;
+      }
+
+      /*
+       * Split is a layout change, not a mode exit. Stay inside the file window
+       * loop so the active pane keeps receiving file commands after F8.
+       */
+      *loop_action_ptr = ACTION_NONE;
+      *return_esc_ptr = FALSE;
+      ctx->hide_dot_files = ctx->active->hide_dot_files;
+      SplitTransitionDebugLogFileState("FileAction:split:after", ctx);
+#ifndef NDEBUG
+      if (stable_panel)
+        AssertSplitFilePanelSnapshotUnchanged(stable_panel,
+                                              &stable_panel_snapshot);
+#endif
+      return TRUE;
+    }
+
+  case ACTION_SWITCH_PANEL:
+    if (!ctx->is_split_screen)
+      return TRUE;
+    SplitTransitionDebugLogFileState("FileAction:switch:before", ctx);
+#ifndef NDEBUG
+    {
+      const YtreePanel *target_panel =
+          (ctx->active == ctx->left) ? ctx->right : ctx->left;
+      SplitFilePanelSnapshot target_panel_snapshot;
+
+      CaptureSplitFilePanelSnapshot(target_panel, &target_panel_snapshot);
+
+      owner_panel->file_dir_entry = dir_entry;
+      owner_panel->start_file = dir_entry->start_file;
+      owner_panel->file_cursor_pos = dir_entry->cursor_pos;
+      CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
+      ctx->active->saved_focus = FOCUS_FILE;
+      ctx->active->saved_big_file_view =
+          (dir_entry->big_window || dir_entry->global_flag ||
+           dir_entry->tagged_flag);
+      *switched_panel_ptr = TRUE;
+      SwitchToSmallFileWindow(ctx);
+
+      if (ctx->active == ctx->left) {
+        ctx->active = ctx->right;
+      } else {
+        ctx->active = ctx->left;
+      }
+      /* Restore the session mirror from the newly active panel. */
+      ctx->hide_dot_files = ctx->active->hide_dot_files;
+      ctx->focused_window = ctx->active->saved_focus;
+      *loop_action_ptr = ACTION_NONE;
+      AssertSplitFilePanelSnapshotUnchanged(target_panel,
+                                            &target_panel_snapshot);
+    }
+#else
+    owner_panel->file_dir_entry = dir_entry;
+    owner_panel->start_file = dir_entry->start_file;
+    owner_panel->file_cursor_pos = dir_entry->cursor_pos;
+    CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
+    ctx->active->saved_focus = FOCUS_FILE;
+    ctx->active->saved_big_file_view =
+        (dir_entry->big_window || dir_entry->global_flag ||
+         dir_entry->tagged_flag);
+    *switched_panel_ptr = TRUE;
+    SwitchToSmallFileWindow(ctx);
+
+    if (ctx->active == ctx->left) {
+      ctx->active = ctx->right;
+    } else {
+      ctx->active = ctx->left;
+    }
+    /* Restore the session mirror from the newly active panel. */
+    ctx->hide_dot_files = ctx->active->hide_dot_files;
+    ctx->focused_window = ctx->active->saved_focus;
+    *loop_action_ptr = ACTION_NONE;
+#endif
+    SplitTransitionDebugLogFileState("FileAction:switch:after", ctx);
+    return TRUE;
+
+  default:
+    return FALSE;
+  }
+}
+
+BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
+                                           DirEntry **dir_entry_ptr,
+                                           Statistic **s_ptr,
+                                           const struct Volume **start_vol_ptr,
+                                           BOOL *need_dsp_help_ptr, int *ch_ptr,
+                                           int *unput_char_ptr) {
+  if (!ctx || !ctx->active || !dir_entry_ptr || !*dir_entry_ptr || !s_ptr ||
+      !*s_ptr || !start_vol_ptr || !*start_vol_ptr || !need_dsp_help_ptr ||
+      !ch_ptr || !unput_char_ptr) {
+    return FALSE;
+  }
+
+  switch (action) {
+  case ACTION_SPLIT_SCREEN:
+    SplitTransitionDebugLogDirState("DirPanelAction:split:before", ctx);
+    {
+      BOOL closing_split = ctx->is_split_screen;
+      ViewFocus preserved_focus = ctx->focused_window;
+
+      ctx->active->saved_focus = FOCUS_TREE;
+      ctx->is_split_screen = !ctx->is_split_screen;
+      if (closing_split)
+        ctx->active = ctx->left;
+      ReCreateWindows(ctx);
+      if (!ctx->is_split_screen)
+        SyncActivePanelWindows(ctx);
+
+      if (ctx->is_split_screen) {
+        if (ctx->right && ctx->left) {
+          ctx->right->vol = ctx->left->vol;
+          ctx->right->cursor_pos = ctx->left->cursor_pos;
+          ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
+          ctx->right->start_file = ctx->left->start_file;
+          ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
+          ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
+          ctx->right->hide_dot_files = ctx->left->hide_dot_files;
+          ctx->right->saved_focus = FOCUS_TREE;
+          FreeFileEntryList(ctx->right);
+        }
+      } else {
+        FreeFileEntryList(ctx->right);
+        ctx->active = ctx->left;
+        *dir_entry_ptr = GetPanelDirEntry(ctx->active);
+        if (ctx->active->saved_focus == FOCUS_FILE) {
+          if (ctx->active->file_selection_dir_path[0] != '\0') {
+            /*
+             * Re-anchor the surviving panel to its saved file-selection path
+             * before file restore runs. Without this, restore can rebuild the
+             * wrong tree row and fall back to a tree-only view with an empty
+             * file list.
+             */
+            RestorePanelAnchorPath(ctx->active->vol, ctx->active,
+                                   ctx->active->file_selection_dir_path);
+            *dir_entry_ptr = GetPanelDirEntry(ctx->active);
+          }
+          *dir_entry_ptr =
+              RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
+        }
+        *unput_char_ptr = '\0';
+        flushinp();
+      }
+
+      ctx->focused_window = preserved_focus;
+      ctx->hide_dot_files = ctx->active->hide_dot_files;
+      *start_vol_ptr = ctx->active->vol;
+      *s_ptr = &ctx->active->vol->vol_stats;
+      RefreshView(ctx, *dir_entry_ptr);
+      SplitTransitionDebugLogDirState("DirPanelAction:split:after", ctx);
+      *need_dsp_help_ptr = TRUE;
+      return TRUE;
+    }
+
+  case ACTION_SWITCH_PANEL:
+    if (!ctx->is_split_screen)
+      return TRUE;
+    SplitTransitionDebugLogDirState("DirPanelAction:switch:before", ctx);
+#ifndef NDEBUG
+    {
+      const YtreePanel *previous_active = ctx->active;
+      SplitDirPanelSnapshot previous_active_snapshot;
+
+      /*
+       * Split ownership boundary (docs/ARCHITECTURE.md §4.2.1):
+       * Tab switch may change `ctx->active`/focused window only. The panel
+       * becoming inactive must keep its panel-local tree viewport unchanged;
+       * file-selection identity can be re-materialized on reactivation.
+       */
+      CaptureSplitDirPanelSnapshot(previous_active, &previous_active_snapshot);
+
+      if (ctx->active == ctx->left) {
+        ctx->active = ctx->right;
+      } else {
+        ctx->active = ctx->left;
+      }
+
+      ctx->focused_window = ctx->active->saved_focus;
+      *start_vol_ptr = ctx->active->vol;
+      *s_ptr = &ctx->active->vol->vol_stats;
+      PanelTags_ApplyToTree(ctx, ctx->active);
+      DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",
+                ctx->active->saved_focus);
+
+      if (ctx->active->vol->total_dirs > 0) {
+        if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
+            ctx->active->vol->total_dirs) {
+          ctx->active->cursor_pos =
+              ctx->active->vol->total_dirs - 1 - ctx->active->disp_begin_pos;
+        }
+        *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
+      } else {
+        *dir_entry_ptr = (*s_ptr)->tree;
+      }
+
+      if (*dir_entry_ptr) {
+        char switch_path[PATH_LENGTH + 1];
+        GetPath(*dir_entry_ptr, switch_path);
+        switch_path[PATH_LENGTH] = '\0';
+        DEBUG_LOG("DirPanelAction:switch:resolved_dir='%s'", switch_path);
+      } else {
+        DEBUG_LOG("DirPanelAction:switch:resolved_dir=<null>");
+      }
+
+      DEBUG_LOG("ACTION_SWITCH_PANEL: active panel is now %s with "
+                "cursor_pos=%d, dir_entry=%s",
+                ctx->active == ctx->left ? "LEFT" : "RIGHT",
+                ctx->active->cursor_pos,
+                *dir_entry_ptr ? (*dir_entry_ptr)->name : "NULL");
+
+      SyncActivePanelWindows(ctx);
+      DEBUG_LOG("DirPanelAction:switch:after_sync_windows");
+      if (ctx->active->file_selection_dir_path[0] != '\0') {
+        RestorePanelAnchorPath(ctx->active->vol, ctx->active,
+                               ctx->active->file_selection_dir_path);
+        *dir_entry_ptr = GetPanelDirEntry(ctx->active);
+      }
+      *dir_entry_ptr =
+          RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
+      if (!*dir_entry_ptr && *s_ptr) {
+        *dir_entry_ptr = (*s_ptr)->tree;
+        DEBUG_LOG("DirPanelAction:switch:restore returned null; fallback tree");
+      }
+      ctx->focused_window = ctx->active->saved_focus;
+      if (*dir_entry_ptr) {
+        DEBUG_LOG("DirPanelAction:switch:before_refresh dir='%s'",
+                  (*dir_entry_ptr)->name ? (*dir_entry_ptr)->name : "<nullname>");
+        RefreshView(ctx, *dir_entry_ptr);
+        DEBUG_LOG("DirPanelAction:switch:after_refresh");
+      } else {
+        DEBUG_LOG("DirPanelAction:switch:skip_refresh dir_entry null");
+        return TRUE;
+      }
+      *need_dsp_help_ptr = TRUE;
+      if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
+          PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
+        *unput_char_ptr = CR;
+      }
+
+      AssertSplitDirPanelFileStateUnchanged(previous_active,
+                                            &previous_active_snapshot);
+    }
+#else
+    if (ctx->active == ctx->left) {
+      ctx->active = ctx->right;
+    } else {
+      ctx->active = ctx->left;
+    }
+
+    ctx->focused_window = ctx->active->saved_focus;
+    *start_vol_ptr = ctx->active->vol;
+    *s_ptr = &ctx->active->vol->vol_stats;
+    PanelTags_ApplyToTree(ctx, ctx->active);
+    DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",
+              ctx->active->saved_focus);
+
+    if (ctx->active->vol->total_dirs > 0) {
+      if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
+          ctx->active->vol->total_dirs) {
+        ctx->active->cursor_pos =
+            ctx->active->vol->total_dirs - 1 - ctx->active->disp_begin_pos;
+      }
+      *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
+    } else {
+      *dir_entry_ptr = (*s_ptr)->tree;
+    }
+    if (*dir_entry_ptr) {
+      char switch_path[PATH_LENGTH + 1];
+      GetPath(*dir_entry_ptr, switch_path);
+      switch_path[PATH_LENGTH] = '\0';
+      DEBUG_LOG("DirPanelAction:switch:resolved_dir='%s'", switch_path);
+    } else {
+      DEBUG_LOG("DirPanelAction:switch:resolved_dir=<null>");
+    }
+
+    DEBUG_LOG("ACTION_SWITCH_PANEL: active panel is now %s with "
+              "cursor_pos=%d, dir_entry=%s",
+              ctx->active == ctx->left ? "LEFT" : "RIGHT",
+              ctx->active->cursor_pos,
+              *dir_entry_ptr ? (*dir_entry_ptr)->name : "NULL");
+
+    SyncActivePanelWindows(ctx);
+    DEBUG_LOG("DirPanelAction:switch:after_sync_windows");
+    if (ctx->active->file_selection_dir_path[0] != '\0') {
+      RestorePanelAnchorPath(ctx->active->vol, ctx->active,
+                             ctx->active->file_selection_dir_path);
+      *dir_entry_ptr = GetPanelDirEntry(ctx->active);
+    }
+    *dir_entry_ptr =
+        RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);
+    if (!*dir_entry_ptr && *s_ptr) {
+      *dir_entry_ptr = (*s_ptr)->tree;
+      DEBUG_LOG("DirPanelAction:switch:restore returned null; fallback tree");
+    }
+    ctx->focused_window = ctx->active->saved_focus;
+    if (*dir_entry_ptr) {
+      DEBUG_LOG("DirPanelAction:switch:before_refresh dir='%s'",
+                (*dir_entry_ptr)->name ? (*dir_entry_ptr)->name : "<nullname>");
+      RefreshView(ctx, *dir_entry_ptr);
+      DEBUG_LOG("DirPanelAction:switch:after_refresh");
+    } else {
+      DEBUG_LOG("DirPanelAction:switch:skip_refresh dir_entry null");
+      return TRUE;
+    }
+    *need_dsp_help_ptr = TRUE;
+    if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
+        PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
+      *unput_char_ptr = CR;
+    }
+#endif
+    SplitTransitionDebugLogDirState("DirPanelAction:switch:after", ctx);
+    return TRUE;
+
+  default:
+    return FALSE;
+  }
+}

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -239,13 +239,10 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeAction action
 
     {
       BOOL closing_split = ctx->is_split_screen;
-      BOOL preserve_peer_file_state =
-          ctx->left && ctx->left->file_selection_dir_path[0] != '\0' &&
-          ctx->left->file_selection_name[0] != '\0';
+      ViewFocus preserved_focus = ctx->focused_window;
       BOOL donate_active_state =
           closing_split && ctx->active == ctx->right && ctx->left &&
-          ctx->right && !preserve_peer_file_state;
-      ViewFocus preserved_focus = ctx->focused_window;
+          ctx->right && preserved_focus == FOCUS_FILE;
 
 #ifndef NDEBUG
       const YtreePanel *target_panel =
@@ -429,10 +426,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
   case ACTION_SPLIT_SCREEN:
     SplitTransitionDebugLogDirState("DirPanelAction:split:before", ctx);
     {
+      YtreePanel *closing_active = ctx->active;
       BOOL closing_split = ctx->is_split_screen;
-      BOOL preserve_peer_file_state =
-          ctx->left && ctx->left->file_selection_dir_path[0] != '\0' &&
-          ctx->left->file_selection_name[0] != '\0';
       BOOL donate_active_state = FALSE;
       BOOL preserve_left_file_state =
           ctx->left && ctx->left->file_selection_dir_path[0] != '\0' &&
@@ -443,8 +438,6 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
           ctx->right ? ctx->right->current_dir_entry : 0;
       unsigned int source_panel_generation =
           ctx->right ? ctx->right->panel_generation : 0U;
-      int left_start_file = ctx->left ? ctx->left->start_file : 0;
-      int left_file_cursor_pos = ctx->left ? ctx->left->file_cursor_pos : 0;
       char left_file_selection_name[PATH_LENGTH + 1];
       char left_file_selection_dir_path[PATH_LENGTH + 1];
       ViewFocus preserved_focus = ctx->focused_window;
@@ -461,11 +454,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
       }
 
       if (ctx->is_split_screen && ctx->active == ctx->right && ctx->left &&
-          ctx->right) {
-        donate_active_state = !preserve_peer_file_state;
-      }
+          ctx->right && !preserve_left_file_state)
+        donate_active_state = TRUE;
 
-      ctx->active->saved_focus = FOCUS_TREE;
       if (donate_active_state && ctx->left && ctx->right) {
         DonatePanelState(ctx->left, ctx->right);
         ctx->left->cursor_pos = source_cursor_pos;
@@ -474,6 +465,14 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
         ctx->left->panel_generation = source_panel_generation;
         ctx->left->saved_focus = FOCUS_TREE;
       }
+      if (preserve_left_file_state && !donate_active_state && ctx->left &&
+          ctx->left->vol) {
+        const DirEntry *left_dir_entry = GetPanelDirEntry(ctx->left);
+        if (left_dir_entry)
+          CapturePanelSelectionAnchor(ctx, ctx->left, left_dir_entry);
+      }
+      if (closing_active)
+        closing_active->saved_focus = FOCUS_TREE;
       ctx->is_split_screen = !ctx->is_split_screen;
       if (closing_split)
         ctx->active = ctx->left;
@@ -497,17 +496,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
         FreeFileEntryList(ctx->right);
         ctx->active = ctx->left;
         *dir_entry_ptr = GetPanelDirEntry(ctx->active);
-        if (preserve_left_file_state && !donate_active_state) {
+        if (preserve_left_file_state && !donate_active_state)
           ctx->active->saved_focus = FOCUS_FILE;
-          ctx->active->start_file = left_start_file;
-          ctx->active->file_cursor_pos = left_file_cursor_pos;
-          (void)snprintf(ctx->active->file_selection_name,
-                         sizeof(ctx->active->file_selection_name), "%s",
-                         left_file_selection_name);
-          (void)snprintf(ctx->active->file_selection_dir_path,
-                         sizeof(ctx->active->file_selection_dir_path), "%s",
-                         left_file_selection_dir_path);
-        }
         if (ctx->active->saved_focus == FOCUS_FILE) {
           if (ctx->active->file_selection_dir_path[0] != '\0') {
             /*

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -176,8 +176,9 @@ static void SplitTransitionDebugLogFileState(const char *label,
   }
 
   DEBUG_LOG("FILE_SPLIT[%s] is_split=%d active=%s focused=%d",
-            label ? label : "?", ctx ? ctx->is_split_screen : -1,
-            active_side, ctx ? ctx->focused_window : -1);
+            label ? label : "?",
+            ctx ? (int)ctx->is_split_screen : -1, active_side,
+            ctx ? (int)ctx->focused_window : -1);
   if (ctx) {
     SplitTransitionDebugLogFilePanelState("LEFT", ctx->left);
     SplitTransitionDebugLogFilePanelState("RIGHT", ctx->right);
@@ -196,8 +197,8 @@ static void SplitTransitionDebugLogDirState(const char *label,
   }
 
   DEBUG_LOG("SPLIT[%s] is_split=%d active=%s focused=%d", label ? label : "?",
-            ctx ? ctx->is_split_screen : -1, active_side,
-            ctx ? ctx->focused_window : -1);
+            ctx ? (int)ctx->is_split_screen : -1, active_side,
+            ctx ? (int)ctx->focused_window : -1);
 }
 
 static BOOL PanelHasVisibleFiles(ViewContext *ctx, YtreePanel *panel,
@@ -238,13 +239,18 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeAction action
 
     {
       BOOL closing_split = ctx->is_split_screen;
-      BOOL donate_active_state = FALSE;
+      BOOL preserve_peer_file_state =
+          ctx->left && ctx->left->file_selection_dir_path[0] != '\0' &&
+          ctx->left->file_selection_name[0] != '\0';
+      BOOL donate_active_state =
+          closing_split && ctx->active == ctx->right && ctx->left &&
+          ctx->right && !preserve_peer_file_state;
       ViewFocus preserved_focus = ctx->focused_window;
-      const YtreePanel *stable_panel = NULL;
 
 #ifndef NDEBUG
       const YtreePanel *target_panel =
           (ctx->active == ctx->left) ? ctx->right : ctx->left;
+      const YtreePanel *stable_panel;
       SplitFilePanelSnapshot stable_panel_snapshot;
 
       /*
@@ -255,7 +261,7 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeAction action
        * opposite side.
        */
       if (closing_split) {
-        if (donate_active_state && ctx->left && ctx->right) {
+        if (donate_active_state) {
           stable_panel = owner_panel;
         } else {
           stable_panel = target_panel;
@@ -265,11 +271,6 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeAction action
       }
       CaptureSplitFilePanelSnapshot(stable_panel, &stable_panel_snapshot);
 #endif
-
-      if (ctx->is_split_screen && ctx->active == ctx->right && ctx->left &&
-          ctx->right) {
-        donate_active_state = TRUE;
-      }
       if (donate_active_state && ctx->left && ctx->right)
         DonatePanelState(ctx->left, ctx->right);
 
@@ -415,7 +416,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
                                            DirEntry **dir_entry_ptr,
                                            Statistic **s_ptr,
                                            const struct Volume **start_vol_ptr,
-                                           BOOL *need_dsp_help_ptr, int *ch_ptr,
+                                           BOOL *need_dsp_help_ptr,
+                                           const int *ch_ptr,
                                            int *unput_char_ptr) {
   if (!ctx || !ctx->active || !dir_entry_ptr || !*dir_entry_ptr || !s_ptr ||
       !*s_ptr || !start_vol_ptr || !*start_vol_ptr || !need_dsp_help_ptr ||
@@ -428,20 +430,44 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
     SplitTransitionDebugLogDirState("DirPanelAction:split:before", ctx);
     {
       BOOL closing_split = ctx->is_split_screen;
-      BOOL donate_active_state = closing_split && ctx->active == ctx->right &&
-                                  ctx->left && ctx->right;
+      BOOL preserve_peer_file_state =
+          ctx->left && ctx->left->file_selection_dir_path[0] != '\0' &&
+          ctx->left->file_selection_name[0] != '\0';
+      BOOL donate_active_state = FALSE;
+      BOOL preserve_left_file_state =
+          ctx->left && ctx->left->file_selection_dir_path[0] != '\0' &&
+          ctx->left->file_selection_name[0] != '\0';
       int source_cursor_pos = ctx->right ? ctx->right->cursor_pos : 0;
       int source_disp_begin_pos = ctx->right ? ctx->right->disp_begin_pos : 0;
       int source_current_dir_entry =
           ctx->right ? ctx->right->current_dir_entry : 0;
       unsigned int source_panel_generation =
           ctx->right ? ctx->right->panel_generation : 0U;
+      int left_start_file = ctx->left ? ctx->left->start_file : 0;
+      int left_file_cursor_pos = ctx->left ? ctx->left->file_cursor_pos : 0;
+      char left_file_selection_name[PATH_LENGTH + 1];
+      char left_file_selection_dir_path[PATH_LENGTH + 1];
       ViewFocus preserved_focus = ctx->focused_window;
 
+      left_file_selection_name[0] = '\0';
+      left_file_selection_dir_path[0] = '\0';
+      if (preserve_left_file_state) {
+        (void)snprintf(left_file_selection_name,
+                       sizeof(left_file_selection_name), "%s",
+                       ctx->left->file_selection_name);
+        (void)snprintf(left_file_selection_dir_path,
+                       sizeof(left_file_selection_dir_path), "%s",
+                       ctx->left->file_selection_dir_path);
+      }
+
+      if (ctx->is_split_screen && ctx->active == ctx->right && ctx->left &&
+          ctx->right) {
+        donate_active_state = !preserve_peer_file_state;
+      }
+
       ctx->active->saved_focus = FOCUS_TREE;
-      if (donate_active_state)
+      if (donate_active_state && ctx->left && ctx->right) {
         DonatePanelState(ctx->left, ctx->right);
-      if (donate_active_state) {
         ctx->left->cursor_pos = source_cursor_pos;
         ctx->left->disp_begin_pos = source_disp_begin_pos;
         ctx->left->current_dir_entry = source_current_dir_entry;
@@ -471,6 +497,17 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
         FreeFileEntryList(ctx->right);
         ctx->active = ctx->left;
         *dir_entry_ptr = GetPanelDirEntry(ctx->active);
+        if (preserve_left_file_state && !donate_active_state) {
+          ctx->active->saved_focus = FOCUS_FILE;
+          ctx->active->start_file = left_start_file;
+          ctx->active->file_cursor_pos = left_file_cursor_pos;
+          (void)snprintf(ctx->active->file_selection_name,
+                         sizeof(ctx->active->file_selection_name), "%s",
+                         left_file_selection_name);
+          (void)snprintf(ctx->active->file_selection_dir_path,
+                         sizeof(ctx->active->file_selection_dir_path), "%s",
+                         left_file_selection_dir_path);
+        }
         if (ctx->active->saved_focus == FOCUS_FILE) {
           if (ctx->active->file_selection_dir_path[0] != '\0') {
             /*

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import re
 import time
 
+from helpers_source import extract_function_block as _extract_function_block
 from helpers_ui import footer_text as _footer_text
 from helpers_ui import screen_text as _screen_text
 from tui_harness import YtreeTUI
@@ -22,15 +23,8 @@ def _dir_navigation_action_case_source(action_name):
     return source[case_start:next_case]
 
 
-def _split_screen_action_case_source():
-    source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
-    case_start = source.find("case ACTION_SPLIT_SCREEN:")
-    case_end = source.find("case ACTION_SWITCH_PANEL:", case_start)
-    assert case_start >= 0 and case_end > case_start, (
-        "Could not isolate ACTION_SPLIT_SCREEN case in "
-        "HandleDirWindowPanelAction (src/ui/dir_ops.c)"
-    )
-    return source[case_start:case_end]
+def _split_transition_source():
+    return Path("src/ui/split_transition.c").read_text(encoding="utf-8")
 
 
 def _restore_panel_tree_selection_source():
@@ -439,15 +433,43 @@ def test_dir_window_compare_prompt_round_trip(ytree_binary, tmp_path):
     tui.quit()
 
 
-def test_dir_window_split_unsplit_branch_requires_peer_panel_guards():
-    case_source = _split_screen_action_case_source()
+def test_dir_window_split_transition_owner_path_is_canonical():
+    split_source = _split_transition_source()
+    dir_ops_source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    ctrl_source = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    handle_block = _extract_function_block(
+        dir_ops_source, "DirWindowDispatchResult\nHandleDirWindowPanelAction("
+    )
+
+    assert "ACTION_SPLIT_SCREEN" not in handle_block, (
+        "HandleDirWindowPanelAction should no longer own split transitions.\n"
+        f"{handle_block}"
+    )
+    assert "ACTION_SWITCH_PANEL" not in handle_block, (
+        "HandleDirWindowPanelAction should no longer own panel switching.\n"
+        f"{handle_block}"
+    )
+    assert "SplitTransition_HandleDirWindowAction(" in ctrl_source, (
+        "HandleDirWindow must dispatch split transitions through the owner API.\n"
+        f"{ctrl_source}"
+    )
     assert re.search(
         r"if\s*\(\s*ctx->is_split_screen\s*&&\s*ctx->active\s*==\s*ctx->right"
         r"\s*&&\s*ctx->left\s*&&\s*ctx->right\s*\)",
-        case_source,
+        split_source,
     ), (
         "ACTION_SPLIT_SCREEN unsplit path must guard peer panels before state "
-        f"copy from right to left.\n{case_source}"
+        f"copy from right to left.\n{split_source}"
+    )
+    assert "DonatePanelState(ctx->left, ctx->right);" in split_source, (
+        "Split transition ownership must donate the right panel state before "
+        f"closing the split.\n{split_source}"
+    )
+    assert "RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);" in (
+        split_source
+    ), (
+        "Split transition ownership must rebind panel-local file selection "
+        f"through the canonical restore helper.\n{split_source}"
     )
 
 

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -457,15 +457,19 @@ def test_dir_window_split_transition_owner_path_is_canonical():
     )
     assert re.search(
         r"if\s*\(\s*ctx->is_split_screen\s*&&\s*ctx->active\s*==\s*ctx->right"
-        r"\s*&&\s*ctx->left\s*&&\s*ctx->right\s*\)",
+        r"\s*&&\s*ctx->left\s*&&\s*ctx->right\s*&&\s*!preserve_left_file_state"
+        r"\s*\)",
         split_source,
     ), (
-        "ACTION_SPLIT_SCREEN unsplit path must guard peer panels before state "
-        f"copy from right to left.\n{split_source}"
+        "ACTION_SPLIT_SCREEN unsplit path must guard peer panels and avoid "
+        f"overwriting the surviving left file anchor.\n{split_source}"
     )
-    assert "DonatePanelState(ctx->left, ctx->right);" in split_source, (
-        "Split transition ownership must donate the right panel state before "
-        f"closing the split.\n{split_source}"
+    assert (
+        "CapturePanelSelectionAnchor(ctx, ctx->left, left_dir_entry);"
+        in split_source
+    ), (
+        "Split transition ownership must recapture the surviving left file "
+        f"anchor before closing the split.\n{split_source}"
     )
     assert "RestorePanelFileSelection(ctx, *dir_entry_ptr, ctx->active);" in (
         split_source

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -83,6 +83,36 @@ def _restore_panel_file_selection_source():
     return source[func_start:next_func]
 
 
+def _rebind_active_file_panel_selection_source():
+    source = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    func_start = source.find("BOOL RebindActiveFilePanelSelection(")
+    assert func_start >= 0, (
+        "Missing RebindActiveFilePanelSelection in src/ui/ctrl_file_ops.c"
+    )
+
+    next_func = source.find("\nstatic void DebugLogFilePanelState(", func_start + 1)
+    assert next_func > func_start, (
+        "Could not isolate RebindActiveFilePanelSelection in "
+        "src/ui/ctrl_file_ops.c"
+    )
+    return source[func_start:next_func]
+
+
+def _resolve_panel_anchor_target_source():
+    source = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    func_start = source.find("static BOOL PanelAnchorTargetIsVisible(")
+    assert func_start >= 0, (
+        "Missing ResolvePanelAnchorTarget support helpers in "
+        "src/ui/panel_anchor.c"
+    )
+
+    next_func = source.find("\nDirEntry *FindDirByPathInTree(", func_start + 1)
+    assert next_func > func_start, (
+        "Could not isolate panel anchor restore helpers in src/ui/panel_anchor.c"
+    )
+    return source[func_start:next_func]
+
+
 def _handle_switch_window_source():
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     func_start = source.find("void HandleSwitchWindow(")
@@ -107,6 +137,22 @@ def _panel_selected_file_path_source():
     return source[func_start:]
 
 
+def _defs_source():
+    return Path("include/ytree_defs.h").read_text(encoding="utf-8")
+
+
+def _log_source():
+    return Path("src/cmd/log.c").read_text(encoding="utf-8")
+
+
+def _panel_anchor_file_source():
+    return Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+
+def _dir_ops_source():
+    return Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+
 def test_tree_viewport_stable_restore_preserves_visible_selection():
     restore_source = _restore_panel_tree_selection_source()
     visible_guard = (
@@ -127,6 +173,7 @@ def test_panel_restore_paths_use_canonical_selection_identity_only():
     capture_source = _capture_panel_anchor_source()
     resolve_source = _resolve_panel_file_anchor_source()
     restore_source = _restore_panel_file_selection_source()
+    rebind_source = _rebind_active_file_panel_selection_source()
     switch_source = _handle_switch_window_source()
     panel_file_path_source = _panel_selected_file_path_source()
 
@@ -150,6 +197,21 @@ def test_panel_restore_paths_use_canonical_selection_identity_only():
         "available.\n"
         f"{restore_source}"
     )
+    assert "ResolvePanelAnchorTarget(panel, panel->vol," in rebind_source, (
+        "RebindActiveFilePanelSelection must resolve the active file panel by "
+        "canonical anchor path identity.\n"
+        f"{rebind_source}"
+    )
+    assert "panel->file_selection_dir_path" in rebind_source, (
+        "RebindActiveFilePanelSelection must resolve by the saved canonical "
+        "selection path.\n"
+        f"{rebind_source}"
+    )
+    assert "GetPanelDirEntry(panel)" not in rebind_source, (
+        "RebindActiveFilePanelSelection must not fall back to raw tree-row "
+        "authority when canonical anchor resolution fails.\n"
+        f"{rebind_source}"
+    )
     assert "file_dir_entry == dir_entry" not in switch_source, (
         "HandleSwitchWindow must key file-window restore off the canonical "
         "selection path, not a file_dir_entry alias comparison.\n"
@@ -159,6 +221,78 @@ def test_panel_restore_paths_use_canonical_selection_identity_only():
         "UI_GetPanelSelectedFilePath must not infer file ownership from the "
         "raw file_dir_entry pointer alias.\n"
         f"{panel_file_path_source}"
+    )
+
+
+def test_restore_snapshots_validate_generation_before_reuse():
+    defs_source = _defs_source()
+    log_source = _log_source()
+    panel_anchor_source = _panel_anchor_file_source()
+    dir_ops_source = _dir_ops_source()
+
+    for needle in (
+        "unsigned int saved_panel_generation;",
+        "unsigned int saved_volume_generation;",
+        "unsigned int saved_tree_generation;",
+        "unsigned int saved_tree_volume_generation;",
+        "unsigned int volume_generation;",
+        "unsigned int panel_generation;",
+    ):
+        assert needle in defs_source, (
+            f"Missing generation field declaration: {needle}\n{defs_source}"
+        )
+
+    assert "state->saved_panel_generation = panel->panel_generation;" in log_source
+    assert "state->saved_volume_generation = panel->vol->volume_generation;" in log_source
+    assert "state->saved_panel_generation != panel->panel_generation" in log_source
+    assert "state->saved_volume_generation != vol->volume_generation" in log_source
+    assert "panel->vol->saved_tree_generation = panel->panel_generation;" in log_source
+    assert (
+        "panel->vol->saved_tree_volume_generation = panel->vol->volume_generation;"
+        in log_source
+    )
+    assert "generation_valid =" in log_source
+    assert "saved_tree_volume_generation == panel->vol->volume_generation" in log_source
+    assert "saved_tree_generation == panel->panel_generation" in log_source
+
+    assert "panel->panel_generation++;" in panel_anchor_source, panel_anchor_source
+    assert "dst->panel_generation = src->panel_generation;" in panel_anchor_source
+
+    assert "p->panel_generation++;" in dir_ops_source, dir_ops_source
+    assert "p->vol->volume_generation++;" in dir_ops_source, dir_ops_source
+    assert "ctx->active->vol->volume_generation++;" in dir_ops_source, dir_ops_source
+
+
+def test_panel_anchor_restore_follows_exact_fallback_order():
+    source = _resolve_panel_anchor_target_source()
+
+    exact = source.find("FindDirByPathInTree(vol->vol_stats.tree, anchor_path)")
+    ancestor = source.find("FindDirByPathOrAncestor(vol, anchor_path)")
+    visible_ancestor = source.find("PanelAnchorFindVisibleAncestor(panel, vol, ancestor)")
+    sibling_helper = source.find("PanelAnchorFindVisibleSibling(panel, vol, sibling_base)")
+    root = source.find("return vol->vol_stats.tree;")
+
+    assert exact >= 0, f"ResolvePanelAnchorTarget must resolve exact identity first.\n{source}"
+    assert ancestor > exact, (
+        "ResolvePanelAnchorTarget must fall back to a visible ancestor after "
+        f"exact identity fails.\n{source}"
+    )
+    assert visible_ancestor > ancestor, (
+        "ResolvePanelAnchorTarget must check the visible-ancestor helper before "
+        f"trying sibling fallback.\n{source}"
+    )
+    assert sibling_helper > visible_ancestor, (
+        "ResolvePanelAnchorTarget must try visible siblings after ancestor "
+        f"fallback.\n{source}"
+    )
+    assert root > sibling_helper, (
+        "ResolvePanelAnchorTarget must end with the root visible node fallback.\n"
+        f"{source}"
+    )
+    assert "FindDirIndexByPathOrAncestor" not in source, (
+        "ResolvePanelAnchorTarget must not use the ancestor-only fallback helper "
+        "as its restore authority.\n"
+        f"{source}"
     )
 
 

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -2,8 +2,10 @@ from pathlib import Path
 import re
 import time
 
+from helpers_stats import detect_stats_split_x as _detect_stats_split_x
 from helpers_source import extract_function_block as _extract_function_block
 from helpers_ui import footer_text as _footer_text
+from helpers_ui import line_marks_file_as_tagged as _line_marks_file_as_tagged
 from helpers_ui import screen_text as _screen_text
 from tui_harness import YtreeTUI
 from ytree_keys import Keys
@@ -500,6 +502,149 @@ def test_dir_window_split_and_tab_keeps_file_focus(ytree_binary, tmp_path):
     )
 
     tui.quit()
+
+
+def test_split_tab_refresh_rejects_stale_file_restore_snapshot(
+    ytree_binary, tmp_path
+):
+    home = tmp_path / "home" / "user"
+    repo = home / "ytree"
+    repo.mkdir(parents=True)
+    (home / ".ytree").write_text(
+        "[GLOBAL]\n"
+        "AUTO_REFRESH=3\n"
+        "TREEDEPTH=2\n"
+        "FILEMODE=2\n"
+        "SMALLWINDOWSKIP=1\n"
+        "HIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    for name in (
+        "build",
+        "coverage",
+        "docs",
+        "etc",
+        "include",
+        "infra",
+        "src",
+        "tests",
+    ):
+        (repo / name).mkdir()
+    src_cmd = repo / "src" / "cmd"
+    src_cmd.mkdir()
+    tests_dir = repo / "tests"
+    (repo / "bak.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    for idx in range(3):
+        (src_cmd / f"src_file_{idx}.c").write_text("x\n", encoding="utf-8")
+    for idx in range(4):
+        (tests_dir / f"test_file_{idx}.py").write_text("y\n", encoding="utf-8")
+
+    tui = YtreeTUI(
+        executable=ytree_binary, cwd=str(repo), env_extra={"HOME": str(home)}
+    )
+    time.sleep(0.8)
+
+    try:
+        def stats_current_dir_contains(marker):
+            lines = tui.get_screen_dump()
+            split_x = _detect_stats_split_x(lines)
+            for i, line in enumerate(lines):
+                segment = line[split_x:] if split_x is not None else line
+                if "CURRENT DIR" not in segment:
+                    continue
+                for j in (1, 2):
+                    idx = i + j
+                    if idx >= len(lines):
+                        continue
+                    candidate = (
+                        lines[idx][split_x:] if split_x is not None else lines[idx]
+                    )
+                    if marker in candidate:
+                        return True
+            return False
+
+        found_src = False
+        for _ in range(80):
+            if stats_current_dir_contains("src"):
+                found_src = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.12)
+        assert found_src, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.25)
+
+        found_cmd = False
+        for _ in range(80):
+            if stats_current_dir_contains("cmd"):
+                found_cmd = True
+                break
+            tui.send_keystroke(Keys.DOWN, wait=0.12)
+        assert found_cmd, _screen_text(tui)
+
+        tui.send_keystroke(Keys.RIGHT, wait=0.2)
+        tui.send_keystroke(Keys.ENTER, wait=0.45)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.2)
+
+        selected_name = "src_file_2.c"
+        pre_screen = _screen_text(tui)
+        pre_tag_state = {}
+        for name in ("src_file_0.c", "src_file_1.c", "src_file_2.c"):
+            line = next((line for line in pre_screen.splitlines() if name in line), None)
+            assert line is not None, pre_screen
+            pre_tag_state[name] = _line_marks_file_as_tagged(line, name)
+        assert any(pre_tag_state.values()), (
+            "Precondition failed: no tagged source files before split flow.\n"
+            f"{pre_screen}"
+        )
+
+        tui.send_keystroke("c", wait=0.3)
+        assert tui.wait_for_content(f"COPY: {selected_name}", timeout=1.0), (
+            _screen_text(tui)
+        )
+        tui.send_keystroke(Keys.ESC, wait=0.2)
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.35)
+        tui.send_keystroke(Keys.HOME, wait=0.35)
+        tui.send_keystroke("M", wait=0.2)
+        assert tui.wait_for_content("MAKE DIRECTORY:", timeout=1.0), _screen_text(tui)
+        tui.send_keystroke("00" + Keys.ENTER, wait=0.8)
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        if "hex invert j compare" not in _footer_text(tui):
+            tui.send_keystroke(Keys.ENTER, wait=0.4)
+
+        after_tab = _screen_text(tui)
+        assert "hex invert j compare" in _footer_text(tui), after_tab
+
+        tui.send_keystroke("c", wait=0.3)
+        assert tui.wait_for_content(f"COPY: {selected_name}", timeout=1.0), (
+            _screen_text(tui)
+        )
+        tui.send_keystroke(Keys.ESC, wait=0.2)
+
+        for name, expected_tagged in pre_tag_state.items():
+            line = next((line for line in after_tab.splitlines() if name in line), None)
+            assert line is not None, (
+                "Source panel lost file rows after split restore.\n"
+                f"{after_tab}"
+            )
+            assert _line_marks_file_as_tagged(line, name) == expected_tagged, (
+                "Source panel tag state changed after in-app generation bump.\n"
+                f"Expected tagged={expected_tagged} Row: {line}\n"
+                f"{after_tab}"
+            )
+    finally:
+        tui.quit()
 
 
 def test_dir_right_arrow_drills_into_first_child_when_already_expanded(

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -45,6 +45,68 @@ def _restore_panel_tree_selection_source():
     return source[func_start:next_func]
 
 
+def _capture_panel_anchor_source():
+    source = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    func_start = source.find("BOOL CapturePanelAnchorPath(")
+    assert func_start >= 0, "Missing CapturePanelAnchorPath in src/ui/panel_anchor.c"
+
+    next_func = source.find("\nint FindDirIndexByPath(", func_start + 1)
+    assert next_func > func_start, (
+        "Could not isolate CapturePanelAnchorPath in src/ui/panel_anchor.c"
+    )
+    return source[func_start:next_func]
+
+
+def _resolve_panel_file_anchor_source():
+    source = Path("src/ui/display.c").read_text(encoding="utf-8")
+    func_start = source.find("static DirEntry *ResolvePanelFileAnchor(")
+    assert func_start >= 0, "Missing ResolvePanelFileAnchor in src/ui/display.c"
+
+    next_func = source.find(
+        "\nstatic DirEntry *ResolvePanelFileAnchorForRender(", func_start + 1
+    )
+    assert next_func > func_start, (
+        "Could not isolate ResolvePanelFileAnchor in src/ui/display.c"
+    )
+    return source[func_start:next_func]
+
+
+def _restore_panel_file_selection_source():
+    source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    func_start = source.find("static void RestorePanelFileSelection(")
+    assert func_start >= 0, "Missing RestorePanelFileSelection in src/cmd/log.c"
+
+    next_func = source.find("\nstatic void SavePanelTreeSelection(", func_start + 1)
+    assert next_func > func_start, (
+        "Could not isolate RestorePanelFileSelection in src/cmd/log.c"
+    )
+    return source[func_start:next_func]
+
+
+def _handle_switch_window_source():
+    source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    func_start = source.find("void HandleSwitchWindow(")
+    assert func_start >= 0, "Missing HandleSwitchWindow in src/ui/dir_ops.c"
+
+    next_func = source.find("\nvoid SyncActivePanelWindows(", func_start + 1)
+    assert next_func > func_start, (
+        "Could not isolate HandleSwitchWindow in src/ui/dir_ops.c"
+    )
+    return source[func_start:next_func]
+
+
+def _panel_selected_file_path_source():
+    source = Path("src/ui/interactions_panel_paths.c").read_text(
+        encoding="utf-8"
+    )
+    func_start = source.find("int UI_GetPanelSelectedFilePath(")
+    assert func_start >= 0, (
+        "Missing UI_GetPanelSelectedFilePath in src/ui/interactions_panel_paths.c"
+    )
+
+    return source[func_start:]
+
+
 def test_tree_viewport_stable_restore_preserves_visible_selection():
     restore_source = _restore_panel_tree_selection_source()
     visible_guard = (
@@ -58,6 +120,45 @@ def test_tree_viewport_stable_restore_preserves_visible_selection():
         "RestorePanelTreeSelection must preserve disp_begin_pos when the saved "
         "tree selection is already visible; Enter/log round-trips should not "
         f"bottom-align an in-view row.\n{restore_source}"
+    )
+
+
+def test_panel_restore_paths_use_canonical_selection_identity_only():
+    capture_source = _capture_panel_anchor_source()
+    resolve_source = _resolve_panel_file_anchor_source()
+    restore_source = _restore_panel_file_selection_source()
+    switch_source = _handle_switch_window_source()
+    panel_file_path_source = _panel_selected_file_path_source()
+
+    assert "assert(!panel->vol || panel->vol == vol);" in capture_source, (
+        "CapturePanelAnchorPath must fail fast on non-owner volume access.\n"
+        f"{capture_source}"
+    )
+    assert "file_dir_entry" not in capture_source, (
+        "CapturePanelAnchorPath must not recover file anchor authority from a "
+        "raw file_dir_entry alias.\n"
+        f"{capture_source}"
+    )
+    assert "file_dir_entry" not in resolve_source, (
+        "ResolvePanelFileAnchor must use the canonical selection path, not the "
+        "raw file_dir_entry pointer, as its restore authority.\n"
+        f"{resolve_source}"
+    )
+    assert "saved_file_dir_path" not in restore_source, (
+        "RestorePanelFileSelection must not fall back to the pointer-derived "
+        "saved_file_dir_path breadcrumb when the canonical selection path is "
+        "available.\n"
+        f"{restore_source}"
+    )
+    assert "file_dir_entry == dir_entry" not in switch_source, (
+        "HandleSwitchWindow must key file-window restore off the canonical "
+        "selection path, not a file_dir_entry alias comparison.\n"
+        f"{switch_source}"
+    )
+    assert "file_dir_entry == dir_entry" not in panel_file_path_source, (
+        "UI_GetPanelSelectedFilePath must not infer file ownership from the "
+        "raw file_dir_entry pointer alias.\n"
+        f"{panel_file_path_source}"
     )
 
 

--- a/tests/test_file_window_dispatch_regressions.py
+++ b/tests/test_file_window_dispatch_regressions.py
@@ -105,6 +105,36 @@ def test_HandleFileWindow_delegates_misc_dispatch_hotspot():
     )
 
 
+def test_HandleFileWindow_delegates_split_transition_hotspot():
+    ctrl_source = _read_source("src/ui/ctrl_file.c")
+    split_source = _read_source("src/ui/split_transition.c")
+    handle_block = _extract_function_block(ctrl_source, "int HandleFileWindow(")
+    split_block = _extract_function_block(
+        split_source, "BOOL SplitTransition_HandleFileWindowAction("
+    )
+
+    assert "SplitTransition_HandleFileWindowAction(" in handle_block, (
+        "HandleFileWindow must delegate split handling to the owner API.\n"
+        f"{handle_block}"
+    )
+    assert "handle_file_window_split_switch_action(" not in handle_block, (
+        "HandleFileWindow must stop calling the removed split helper.\n"
+        f"{handle_block}"
+    )
+    assert "CaptureSplitFilePanelSnapshot(" in split_block, (
+        "Split transition owner API must snapshot peer panel state before the "
+        f"transaction commits.\n{split_block}"
+    )
+    assert "AssertSplitFilePanelSnapshotUnchanged(" in split_block, (
+        "Split transition owner API must validate the inactive panel after "
+        f"Tab handoff.\n{split_block}"
+    )
+    assert "ctx->is_split_screen = !ctx->is_split_screen;" in split_block, (
+        "Split transition owner API must commit the split toggle inside the "
+        f"transaction.\n{split_block}"
+    )
+
+
 def test_PrintFileEntry_uses_inactive_split_highlight_style():
     render_source = _read_source("src/ui/render_file.c")
     print_file_entry_block = _extract_function_block(


### PR DESCRIPTION
## Split-panel stabilization
This branch stabilizes the split-panel state contract: panel-local ownership, deterministic restore/rebind, atomic split transitions, and enforceable regression coverage.

### Canonical split-panel ownership
- Keeps panel-local state separate from shared volume data.
- Preserves the ownership boundary for selection, viewport, and visibility state.

### Deterministic restore and rebind
- Restores from stable identity keys instead of transient row math or stale pointers.
- Rejects stale snapshots after generation changes and re-resolves them before state is applied.
- Uses deterministic fallback behavior when the selected node is invalid or missing.

### Atomic split transition and read-only render
- Moves split transitions onto an atomic owner-boundary path.
- Keeps render paths projection-only instead of letting redraw become authority.
- Preserves inactive-panel freeze/resume behavior during split handoff.

### Enforceable regression gates and spec sync
- Adds focused split-panel regression gates for CI and local validation.
- Proves stale split restore snapshots are rejected after generation changes.
- Syncs split-panel docs and audit guidance with the implemented contract.

## Why
- The split-panel contract only stays stable if ownership, restore determinism, transition handoff, and regression enforcement all move together.
- The branch description should stand on its own after roadmap renumbering.

## Validation
- `source .venv/bin/activate && make clean && make`
- `source .venv/bin/activate && pytest -q -ra --tb=no tests/test_dir_window_dispatch_regressions.py::test_dir_window_split_transition_owner_path_is_canonical tests/test_dir_window_dispatch_regressions.py::test_split_tab_refresh_rejects_stale_file_restore_snapshot tests/test_file_window_dispatch_regressions.py::test_HandleFileWindow_delegates_split_transition_hotspot tests/test_file_window_dispatch_regressions.py::test_split_and_tab_dispatch_keeps_file_mode_footer tests/test_panel_isolation.py::test_split_from_file_keeps_file_focus_on_tab tests/test_panel_isolation.py::test_split_tab_from_small_file_does_not_expand_inactive_panel tests/test_panel_isolation.py::test_split_from_big_file_keeps_inactive_panel_in_file_view tests/test_panel_isolation.py::test_split_same_directory_file_tags_are_panel_local`
- `source .venv/bin/activate && make qa-split-panel-gates`
- `source .venv/bin/activate && make qa-code-quality`
- `git diff --check`
