### PR TITLE
feat(ui): add key trace recording

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1349,9 +1349,9 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Offers complex templating logic that goes beyond simple pipe/xargs, and critically allows the user to review/edit the generated script before execution for safety.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-37: Implement Keyboard Macros (F12 Record/Playback)**
-*   **Goal:** Implement keystroke recording and replay. `F12` starts/stops recording command/input sequences for deterministic playback.
-*   **Rationale:** Allows automation of repetitive interaction sequences (for example "Tag, Move, Rename, Repeat") without creating shell command templates.
+### **Idea FE-37: Implement Keyboard Macros (F12 Macros Submenu)**
+*   **Goal:** Add an `F12` macros submenu with explicit `Record` and `Playback` actions for keystroke recording and deterministic replay.
+*   **Rationale:** Allows automation of repetitive interaction sequences (for example "Tag, Move, Rename, Repeat") without creating shell command templates, while keeping the footer truthful and the common path simple.
 *   - [ ] **Status:** Not Started.
 
 ### **Idea FE-38: Enhance Built-In Viewer**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1349,10 +1349,9 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Offers complex templating logic that goes beyond simple pipe/xargs, and critically allows the user to review/edit the generated script before execution for safety.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-37: Implement Keyboard Macros (F12 Macros Submenu)**
-*   **Goal:** Add an `F12` macros submenu with explicit `Record` and `Playback` actions for keystroke recording and deterministic replay.
-*   **Rationale:** Allows automation of repetitive interaction sequences (for example "Tag, Move, Rename, Repeat") without creating shell command templates, while keeping the footer truthful and the common path simple.
-*   - [ ] **Status:** Not Started.
+### **Idea FE-37: Keyboard Macros**
+*   **Status:** Deferred.
+*   **Note:** Revisit only after a safe design exists that cannot turn traces into a secret-capturing scripting surface.
 
 ### **Idea FE-38: Enhance Built-In Viewer**
 *   **Goal:** Evolve ytree's internal viewer from a basic fallback inspector into a more capable built-in viewing tool for normal terminal workflows.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -174,7 +174,7 @@ The `ytree` input system follows a layered model designed for high-speed interac
 *   **`F8`**: split-screen toggle.
 *   **`F9`**: user menu (Macros).
 *   **`F10`**: configuration.
-*   **`F12`**: incremental jump (Legacy alias for `/`).
+*   **`F12`**: start key trace recording and prompt for an output file.
 
 ### 4.5 Prompt Interaction Standards
 When a text prompt is active, specialized conventions ensure a refined editing experience:

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -174,7 +174,7 @@ The `ytree` input system follows a layered model designed for high-speed interac
 *   **`F8`**: split-screen toggle.
 *   **`F9`**: user menu (Macros).
 *   **`F10`**: configuration.
-*   **`F12`**: start key trace recording and prompt for an output file.
+*   **`F12`**: start/stop key trace recording; when inactive, prompt for an output file with a default `ytree-keys-001.txt`-style name.
 
 ### 4.5 Prompt Interaction Standards
 When a text prompt is active, specialized conventions ensure a refined editing experience:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -133,9 +133,9 @@ symbol `^` denotes the **CTRL** key. For most commands, pressing
 **^key** (indicated in footer menus only where different) applies the
 action to all **tagged** files in the current scope.
 
-### Global Commands
+### Function Keys
 
-These commands work in most modes:
+These keys work in most modes:
 
 - **F1**: Help (context-sensitive in prompts/dialogs).
 - **F5**: Refresh (same as **^L**).
@@ -145,11 +145,18 @@ These commands work in most modes:
 - **F10**: Edit `~/.ytree` in `$EDITOR`. If the file does not exist yet,
   the editor opens a new buffer at that path; save to create it (or run
   `ytree --init` to generate defaults first).
-- **/** (or **F12**): **Incremental Jump** (List Jump). Start typing to
-  jump to the first matching entry in the current list (directory names
-  in the Directory Window, filenames in the File Window). The selection
-  updates immediately as you type. Press **Enter** to accept the current
-  match, or **Esc** to cancel and restore the original selection.
+- **F12**: Start key trace recording. You will be prompted for an output
+  file, and subsequent key input is recorded until ytree exits.
+
+### Global Commands
+
+These commands work in most modes:
+
+- **/**: **Incremental Jump** (List Jump). Start typing to jump to the
+  first matching entry in the current list (directory names in the
+  Directory Window, filenames in the File Window). The selection updates
+  immediately as you type. Press **Enter** to accept the current match,
+  or **Esc** to cancel and restore the original selection.
 - **\\**: In **Showall**/**Global** file lists, exit that mode and jump
   to the selected file in its owner directory. In Archive-Dir mode, `\\`
   jumps to archive root when used below root, and exits to the parent

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -145,8 +145,10 @@ These keys work in most modes:
 - **F10**: Edit `~/.ytree` in `$EDITOR`. If the file does not exist yet,
   the editor opens a new buffer at that path; save to create it (or run
   `ytree --init` to generate defaults first).
-- **F12**: Start key trace recording. You will be prompted for an output
-  file, and subsequent key input is recorded until ytree exits.
+- **F12**: Start/stop key trace recording. When inactive, ytree prompts
+  for an output file and pre-fills `ytree-keys-001.txt` or the next
+  available incremented name. When active, pressing **F12** stops
+  recording; recording also closes cleanly when ytree exits.
 
 ### Global Commands
 

--- a/etc/ytree.1.md
+++ b/etc/ytree.1.md
@@ -84,8 +84,8 @@ Activated by **F7**. The screen layout changes to show the file list on the left
 
 **Note:** All keys are case insensitive unless otherwise noted. The symbol `^` denotes the **CTRL** key. For most commands, pressing **^key** (indicated in footer menus only where different) applies the action to all **tagged** files in the current scope.
 
-### Global Commands
-These commands work in most modes:
+### Function Keys
+These keys work in most modes:
 
 *   **F1**: Help (context-sensitive in prompts/dialogs).
 *   **F5**: Refresh (same as **^L**).
@@ -93,7 +93,12 @@ These commands work in most modes:
 *   **F7**: Toggle File Preview Pane.
 *   **F8**: Toggle Split Screen Mode.
 *   **F10**: Edit `~/.ytree` in `$EDITOR`. If the file does not exist yet, the editor opens a new buffer at that path; save to create it (or run `ytree --init` to generate defaults first).
-*   **/** (or **F12**): **Incremental Jump** (List Jump). Start typing to jump to the first matching entry in the current list (directory names in the Directory Window, filenames in the File Window). The selection updates immediately as you type. Press **Enter** to accept the current match, or **Esc** to cancel and restore the original selection.
+*   **F12**: Start key trace recording. You will be prompted for an output file, and subsequent key input is recorded until ytree exits.
+
+### Global Commands
+These commands work in most modes:
+
+*   **/**: **Incremental Jump** (List Jump). Start typing to jump to the first matching entry in the current list (directory names in the Directory Window, filenames in the File Window). The selection updates immediately as you type. Press **Enter** to accept the current match, or **Esc** to cancel and restore the original selection.
 *   **\\**: In **Showall**/**Global** file lists, exit that mode and jump to the selected file in its owner directory. In Archive-Dir mode, `\\` jumps to archive root when used below root, and exits to the parent physical directory when used at archive root. In normal filesystem dir/file windows and Archive-File mode, `\\` is a no-op.
 *   **B**: Toggle Brief (Compact) filename view in the File Window.
 *   **^L**: **Reload**. Re-read the contents of the current directory from disk and refresh the view.

--- a/etc/ytree.1.md
+++ b/etc/ytree.1.md
@@ -93,7 +93,7 @@ These keys work in most modes:
 *   **F7**: Toggle File Preview Pane.
 *   **F8**: Toggle Split Screen Mode.
 *   **F10**: Edit `~/.ytree` in `$EDITOR`. If the file does not exist yet, the editor opens a new buffer at that path; save to create it (or run `ytree --init` to generate defaults first).
-*   **F12**: Start key trace recording. You will be prompted for an output file, and subsequent key input is recorded until ytree exits.
+*   **F12**: Start/stop key trace recording. When inactive, ytree prompts for an output file and pre-fills `ytree-keys-001.txt` or the next available incremented name. When active, pressing **F12** stops recording; recording also closes cleanly when ytree exits.
 
 ### Global Commands
 These commands work in most modes:

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -369,6 +369,7 @@ typedef enum {
   ACTION_CMD_TAGGED_Y,
   ACTION_CMD_TAGGED_PRINT,
   ACTION_LIST_JUMP,
+  ACTION_RECORD_KEYS,
   ACTION_TO_DIR,
   ACTION_TOGGLE_TAGGED_MODE,
   ACTION_TOGGLE_STATS,
@@ -1000,6 +1001,10 @@ typedef struct _ViewContext {
   char *initial_directory;
   char *confirm_quit;
   void *file_color_rules_head;
+
+  /* Optional raw key stream capture for bug-report repro files. */
+  FILE *key_record_file;
+  BOOL key_record_pause;
 
   /* ctrl_file state */
   int ctrl_file_max_disp_files;

--- a/include/ytree_key_record.h
+++ b/include/ytree_key_record.h
@@ -13,6 +13,8 @@ int KeyRecord_Start(ViewContext *ctx, const char *path);
 void KeyRecord_Stop(ViewContext *ctx);
 void KeyRecord_Log(ViewContext *ctx, int ch);
 void KeyRecord_Pause(ViewContext *ctx, BOOL pause);
+BOOL KeyRecord_IsActive(const ViewContext *ctx);
+int KeyRecord_Toggle(ViewContext *ctx);
 int KeyRecord_BeginPrompt(ViewContext *ctx);
 
 #endif

--- a/include/ytree_key_record.h
+++ b/include/ytree_key_record.h
@@ -14,6 +14,7 @@ void KeyRecord_Stop(ViewContext *ctx);
 void KeyRecord_Log(ViewContext *ctx, int ch);
 void KeyRecord_Pause(ViewContext *ctx, BOOL pause);
 BOOL KeyRecord_IsActive(const ViewContext *ctx);
+
 int KeyRecord_Toggle(ViewContext *ctx);
 int KeyRecord_BeginPrompt(ViewContext *ctx);
 

--- a/include/ytree_key_record.h
+++ b/include/ytree_key_record.h
@@ -1,0 +1,18 @@
+/***************************************************************************
+ *
+ * ytree_key_record.h
+ * Optional key-stream recording helpers
+ *
+ ***************************************************************************/
+#ifndef YTREE_KEY_RECORD_H
+#define YTREE_KEY_RECORD_H
+
+#include "ytree_defs.h"
+
+int KeyRecord_Start(ViewContext *ctx, const char *path);
+void KeyRecord_Stop(ViewContext *ctx);
+void KeyRecord_Log(ViewContext *ctx, int ch);
+void KeyRecord_Pause(ViewContext *ctx, BOOL pause);
+int KeyRecord_BeginPrompt(ViewContext *ctx);
+
+#endif

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -7,6 +7,7 @@
 
 #include "ytree_defs.h"
 #include "default_profile_template.h"
+#include "ytree_key_record.h"
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -387,6 +388,8 @@ int main(int argc, char **argv) {
   ctx.core_main_ops.suspend_clock(
       &ctx); /* Stop SIGALRM (now no-op but kept for API consistency) before
                 touching curses/memory */
+
+  KeyRecord_Stop(&ctx);
 
   attrset(0);  /* Reset attributes */
   clear();     /* Clear internal buffer */

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -8,6 +8,7 @@
 #define NO_YTREE_MACROS
 #include "watcher.h"
 #include "ytree_cmd.h"
+#include "ytree_key_record.h"
 #include "ytree_fs.h"
 #include "ytree_panel_anchor.h"
 #include "ytree_split_transition.h"
@@ -903,6 +904,10 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       break;
     case ACTION_LIST_JUMP:
       DirListJump(ctx, &dir_entry, s);
+      need_dsp_help = TRUE;
+      break;
+    case ACTION_RECORD_KEYS:
+      (void)KeyRecord_BeginPrompt(ctx);
       need_dsp_help = TRUE;
       break;
     case ACTION_TAG:

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -907,7 +907,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       need_dsp_help = TRUE;
       break;
     case ACTION_RECORD_KEYS:
-      (void)KeyRecord_BeginPrompt(ctx);
+      (void)KeyRecord_Toggle(ctx);
       need_dsp_help = TRUE;
       break;
     case ACTION_TAG:

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -1207,7 +1207,9 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
 
     DrawDirListJumpPrompt(ctx, jump_win, search_buf);
 
+    KeyRecord_Pause(ctx, TRUE);
     ch = Getch(ctx);
+    KeyRecord_Pause(ctx, FALSE);
     if (ch == -1)
       break;
 
@@ -1215,6 +1217,8 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
       ctx->active->disp_begin_pos = original_disp_begin_pos;
       ctx->active->cursor_pos = original_cursor_pos;
     } else if (ch == CR || ch == LF) {
+      if (ctx != NULL)
+        KeyRecord_Log(ctx, CR);
       break;
     } else if (ch == KEY_BACKSPACE || ch == 127 || ch == '\b' || ch == KEY_DC) {
       if (buf_len > 0) {

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -1017,7 +1017,9 @@ static void ListJump(ViewContext *ctx, DirEntry *dir_entry, char *str) {
 
     DrawFileListJumpPrompt(ctx, jump_win, search_buf);
 
+    KeyRecord_Pause(ctx, TRUE);
     ch = Getch(ctx);
+    KeyRecord_Pause(ctx, FALSE);
 
     /* Handle Resize or Error */
     if (ch == -1)
@@ -1034,6 +1036,8 @@ static void ListJump(ViewContext *ctx, DirEntry *dir_entry, char *str) {
     }
 
     if (ch == CR || ch == LF) {
+      if (ctx != NULL)
+        KeyRecord_Log(ctx, CR);
       /* Confirm: Keep new position */
       break;
     }

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -652,7 +652,7 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
       break;
 
     case ACTION_RECORD_KEYS:
-      (void)KeyRecord_BeginPrompt(ctx);
+      (void)KeyRecord_Toggle(ctx);
       need_dsp_help = TRUE;
       break;
 

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -14,6 +14,7 @@
 #include "../../include/sort.h"
 #include "../../include/watcher.h"
 #include "../../include/ytree_cmd.h"
+#include "../../include/ytree_key_record.h"
 #include "../../include/ytree_fs.h"
 #include "../../include/ytree_split_transition.h"
 #include "../../include/ytree_ui.h"
@@ -648,6 +649,11 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
       (void)handle_file_window_navigation_action(
           ctx, action, dir_entry, &start_x, &need_dsp_help,
           &preview_line_offset, UpdatePreview, ListJump);
+      break;
+
+    case ACTION_RECORD_KEYS:
+      (void)KeyRecord_BeginPrompt(ctx);
+      need_dsp_help = TRUE;
       break;
 
     case ACTION_TO_DIR:

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -8,6 +8,7 @@
 #include "../../include/ytree.h"
 #include "../../include/ytree_cmd.h"
 #include "../../include/ytree_fs.h"
+#include "../../include/ytree_key_record.h"
 #include "../../include/ytree_panel_anchor.h"
 #include "../../include/ytree_ui.h"
 #include <assert.h>
@@ -46,15 +47,6 @@ static char dir_help_disk_mode_1[] =
     "COMMANDS (O)nly tagged (P)ipe (Q)uit (R)ename (S)howall (T)ag (U)ntag mo(V)edir "
     "(W)rite e(X)ecute "
     "(Z) archive (/) jump (`) dotfiles";
-static char dir_help_nav[] =
-    "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (F12) record  (Esc) cancel";
-static char dir_help_nav_archive_to_root[] =
-    "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (F12) record  (\\) root  (Esc) cancel";
-static char dir_help_nav_archive_exit[] =
-    "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (F12) record  (\\) exit  (Esc) cancel";
 static char *dir_help[MAX_MODES][2] = {
     {/* DISK_MODE */
      dir_help_disk_mode_0, dir_help_disk_mode_1},
@@ -79,15 +71,6 @@ static char file_help_disk_mode_1[] =
     "(P)ipe (Q)uit (R)ename (S)ort (W)rite e(X)ecute pathcop(Y) "
     "(Z) archive "
     "(/) jump (`) dotfiles";
-static char file_help_nav[] =
-    "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (F12) record  (Esc) cancel";
-static char file_help_nav_showall[] =
-    "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (F12) record  (\\) to dir  (Esc) cancel";
-static char file_help_nav_global[] =
-    "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (F12) record  (\\) to dir  (Esc) cancel";
 static char *file_help[MAX_MODES][2] = {
     {/* DISK_MODE */
      file_help_disk_mode_0, file_help_disk_mode_1},
@@ -104,10 +87,65 @@ static char *file_help[MAX_MODES][2] = {
      file_help_disk_mode_0, /* Default unless changed by user prefs */
      file_help_disk_mode_1}};
 
+static const char *KeyRecordFooterLabel(const ViewContext *ctx) {
+  return KeyRecord_IsActive(ctx) ? "stop" : "record";
+}
+
+static void BuildDirNavLine(const ViewContext *ctx, const DirEntry *dir_entry,
+                            char *nav_line, size_t nav_line_size) {
+  const char *record_label = KeyRecordFooterLabel(ctx);
+
+  if (!nav_line || nav_line_size == 0)
+    return;
+
+  if (ctx->view_mode == ARCHIVE_MODE && dir_entry != NULL) {
+    if (dir_entry->up_tree != NULL) {
+      (void)snprintf(
+          nav_line, nav_line_size,
+          "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
+          "(F8) split  (F10) config  (F12) %s  (\\) root  (Esc) cancel",
+          record_label);
+    } else {
+      (void)snprintf(
+          nav_line, nav_line_size,
+          "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
+          "(F8) split  (F10) config  (F12) %s  (\\) exit  (Esc) cancel",
+          record_label);
+    }
+    return;
+  }
+
+  (void)snprintf(nav_line, nav_line_size,
+                 "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
+                 "(F8) split  (F10) config  (F12) %s  (Esc) cancel",
+                 record_label);
+}
+
+static void BuildFileNavLine(const ViewContext *ctx, const DirEntry *dir_entry,
+                             char *nav_line, size_t nav_line_size) {
+  const char *record_label = KeyRecordFooterLabel(ctx);
+
+  if (!nav_line || nav_line_size == 0)
+    return;
+
+  if (dir_entry && dir_entry->global_flag) {
+    (void)snprintf(nav_line, nav_line_size,
+                   "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
+                   "(F8) split  (F10) config  (F12) %s  (\\) to dir  (Esc) "
+                   "cancel",
+                   record_label);
+  } else {
+    (void)snprintf(nav_line, nav_line_size,
+                   "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
+                   "(F8) split  (F10) config  (F12) %s  (Esc) cancel",
+                   record_label);
+  }
+}
+
 void DisplayDirHelp(ViewContext *ctx, const DirEntry *dir_entry) {
   int i;
   char *cptr;
-  const char *nav_line = dir_help_nav;
+  char nav_line[256];
 
   if (!ctx->ctx_menu_window)
     return;
@@ -124,10 +162,7 @@ void DisplayDirHelp(ViewContext *ctx, const DirEntry *dir_entry) {
   for (i = 0; i < 2; i++) {
     PrintOptions(ctx->ctx_menu_window, i, 0, dir_help[ctx->view_mode][i]);
   }
-  if (ctx->view_mode == ARCHIVE_MODE && dir_entry != NULL) {
-    nav_line = (dir_entry->up_tree != NULL) ? dir_help_nav_archive_to_root
-                                            : dir_help_nav_archive_exit;
-  }
+  BuildDirNavLine(ctx, dir_entry, nav_line, sizeof(nav_line));
   PrintNavLine(ctx->ctx_menu_window, 2, nav_line);
   UI_RenderStatusLineError(ctx);
   wnoutrefresh(ctx->ctx_menu_window);
@@ -136,7 +171,7 @@ void DisplayDirHelp(ViewContext *ctx, const DirEntry *dir_entry) {
 void DisplayFileHelp(ViewContext *ctx, const DirEntry *dir_entry) {
   int i;
   char *cptr;
-  const char *nav_line;
+  char nav_line[256];
 
   if (!ctx->ctx_menu_window)
     return;
@@ -153,12 +188,7 @@ void DisplayFileHelp(ViewContext *ctx, const DirEntry *dir_entry) {
   for (i = 0; i < 2; i++) {
     PrintOptions(ctx->ctx_menu_window, i, 0, file_help[ctx->view_mode][i]);
   }
-  if (dir_entry && dir_entry->global_flag) {
-    nav_line = dir_entry->global_all_volumes ? file_help_nav_global
-                                             : file_help_nav_showall;
-  } else {
-    nav_line = file_help_nav;
-  }
+  BuildFileNavLine(ctx, dir_entry, nav_line, sizeof(nav_line));
   PrintNavLine(ctx->ctx_menu_window, 2, nav_line);
   UI_RenderStatusLineError(ctx);
   wnoutrefresh(ctx->ctx_menu_window);

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -48,13 +48,13 @@ static char dir_help_disk_mode_1[] =
     "(Z) archive (/) jump (`) dotfiles";
 static char dir_help_nav[] =
     "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (Esc) cancel";
+    "(F8) split  (F10) config  (F12) record  (Esc) cancel";
 static char dir_help_nav_archive_to_root[] =
     "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (\\) root  (Esc) cancel";
+    "(F8) split  (F10) config  (F12) record  (\\) root  (Esc) cancel";
 static char dir_help_nav_archive_exit[] =
     "Tree  (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (\\) exit  (Esc) cancel";
+    "(F8) split  (F10) config  (F12) record  (\\) exit  (Esc) cancel";
 static char *dir_help[MAX_MODES][2] = {
     {/* DISK_MODE */
      dir_help_disk_mode_0, dir_help_disk_mode_1},
@@ -81,13 +81,13 @@ static char file_help_disk_mode_1[] =
     "(/) jump (`) dotfiles";
 static char file_help_nav[] =
     "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (Esc) cancel";
+    "(F8) split  (F10) config  (F12) record  (Esc) cancel";
 static char file_help_nav_showall[] =
     "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (\\) to dir  (Esc) cancel";
+    "(F8) split  (F10) config  (F12) record  (\\) to dir  (Esc) cancel";
 static char file_help_nav_global[] =
     "Dir   (F1) help  (F5) refresh  (F6) stats  (F7) autoview  "
-    "(F8) split  (F10) config  (\\) to dir  (Esc) cancel";
+    "(F8) split  (F10) config  (F12) record  (\\) to dir  (Esc) cancel";
 static char *file_help[MAX_MODES][2] = {
     {/* DISK_MODE */
      file_help_disk_mode_0, file_help_disk_mode_1},

--- a/src/ui/input_line.c
+++ b/src/ui/input_line.c
@@ -9,6 +9,7 @@
  ***************************************************************************/
 
 #include "ytree_cmd.h"
+#include "ytree_key_record.h"
 #include "ytree_ui.h"
 #include <ctype.h>  /* For isalnum */
 #include <stdlib.h> /* For getenv */
@@ -85,16 +86,16 @@ static void format_mode_from_octal(const char *octal_digits, char mode_type,
   (void)snprintf(out, out_size, "%s", attrs);
 }
 
-static int normalize_prompt_escape_key(WINDOW *win, int ch) {
+static int normalize_prompt_escape_key(ViewContext *ctx, WINDOW *win, int ch) {
   int c1;
 
   if (!win || ch != ESC)
     return ch;
 
   nodelay(win, TRUE);
-  c1 = wgetch(win);
+  c1 = WGetch(ctx, win);
   if (c1 == '[' || c1 == 'O') {
-    int c2 = wgetch(win);
+    int c2 = WGetch(ctx, win);
     switch (c2) {
     case 'A':
       ch = KEY_UP;
@@ -272,17 +273,22 @@ static int UI_ReadStringInternal(ViewContext *ctx, YtreePanel *panel,
     wrefresh(win);
 
     curs_set(1); /* Ensure cursor is visible */
+    if (ctx != NULL)
+      KeyRecord_Pause(ctx, TRUE);
     ch = WGetch(ctx, win);
-    ch = normalize_prompt_escape_key(win, ch);
+    ch = normalize_prompt_escape_key(ctx, win, ch);
+    if (ctx != NULL)
+      KeyRecord_Pause(ctx, FALSE);
 
-
-    if (ch == ESC) {
-      break;
-    }
     if (ch == ERR) {
       /* Wait a tiny amount to prevent CPU hang on EOF/NonBlocking */
       napms(10);
       continue;
+    }
+    if (ctx != NULL && ch >= 0)
+      KeyRecord_Log(ctx, ch);
+    if (ch == ESC) {
+      break;
     }
     if (ch == '\n' || ch == '\r') {
       ch = CR; /* Standardize return */

--- a/src/ui/input_line.c
+++ b/src/ui/input_line.c
@@ -56,6 +56,39 @@ static BOOL is_date_literal_char(int ch) {
   return (isdigit((unsigned char)ch) || ch == '-' || ch == ':' || ch == ' ');
 }
 
+static BOOL is_sensitive_prompt(const char *prompt) {
+  static const char *const sensitive_markers[] = {
+      "password",          "passphrase",      "passcode",
+      "secret",            "token",           "credential",
+      "verification code", "one-time code",   "otp",
+      "2fa",               "auth code",       "api key",
+  };
+  size_t i;
+
+  if (!prompt || *prompt == '\0')
+    return FALSE;
+
+  for (i = 0; i < sizeof(sensitive_markers) / sizeof(sensitive_markers[0]);
+       i++) {
+    const char *needle = sensitive_markers[i];
+    size_t needle_len = strlen(needle);
+    const char *hit = prompt;
+
+    while ((hit = strcasestr(hit, needle)) != NULL) {
+      int before = (hit == prompt) ? '\0' : (unsigned char)hit[-1];
+      int after = (unsigned char)hit[needle_len];
+
+      if ((before == '\0' || !isalnum((unsigned char)before)) &&
+          (after == '\0' || !isalnum((unsigned char)after))) {
+        return TRUE;
+      }
+      hit += needle_len;
+    }
+  }
+
+  return FALSE;
+}
+
 static void format_mode_from_octal(const char *octal_digits, char mode_type,
                                    char *out, size_t out_size) {
   mode_t mode_bits;
@@ -285,13 +318,15 @@ static int UI_ReadStringInternal(ViewContext *ctx, YtreePanel *panel,
       napms(10);
       continue;
     }
-    if (ctx != NULL && ch >= 0)
-      KeyRecord_Log(ctx, ch);
     if (ch == ESC) {
       break;
     }
     if (ch == '\n' || ch == '\r') {
       ch = CR; /* Standardize return */
+
+      if (ctx != NULL) {
+        KeyRecord_Log(ctx, ch);
+      }
 
       /* Handle Tilde Expansion on Enter */
       if (buffer[0] == '~') {
@@ -669,7 +704,7 @@ static int UI_ReadStringInternal(ViewContext *ctx, YtreePanel *panel,
   UI_Dialog_Close(ctx, win);
 
   /* Update History on success */
-  if (ch == CR && buffer[0] != '\0') {
+  if (ch == CR && buffer[0] != '\0' && !is_sensitive_prompt(prompt)) {
     InsHistory(ctx, buffer, history_type);
   }
 

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -819,8 +819,6 @@ int GetEventOrKey(ViewContext *ctx) {
 
   if (ch != ERR) {
     ch = NormalizeEscSequence(ctx, ch);
-    if (ctx != NULL && ch >= 0)
-      KeyRecord_Log(ctx, ch);
     return ch;
   }
 
@@ -868,8 +866,6 @@ int GetEventOrKey(ViewContext *ctx) {
         nodelay(stdscr, FALSE);
         if (ch != ERR) {
           ch = NormalizeEscSequence(ctx, ch);
-          if (ctx != NULL && ch >= 0)
-            KeyRecord_Log(ctx, ch);
           return ch;
         }
         if (ctx && ctx->resize_request)
@@ -895,8 +891,6 @@ int GetEventOrKey(ViewContext *ctx) {
       if (ctx != NULL)
         KeyRecord_Pause(ctx, FALSE);
       ch = NormalizeEscSequence(ctx, ch);
-      if (ctx != NULL && ch >= 0)
-        KeyRecord_Log(ctx, ch);
       return ch;
     }
   }

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -819,6 +819,8 @@ int GetEventOrKey(ViewContext *ctx) {
 
   if (ch != ERR) {
     ch = NormalizeEscSequence(ctx, ch);
+    if (ctx != NULL && ch >= 0)
+      KeyRecord_Log(ctx, ch);
     return ch;
   }
 
@@ -866,6 +868,8 @@ int GetEventOrKey(ViewContext *ctx) {
         nodelay(stdscr, FALSE);
         if (ch != ERR) {
           ch = NormalizeEscSequence(ctx, ch);
+          if (ctx != NULL && ch >= 0)
+            KeyRecord_Log(ctx, ch);
           return ch;
         }
         if (ctx && ctx->resize_request)
@@ -891,6 +895,8 @@ int GetEventOrKey(ViewContext *ctx) {
       if (ctx != NULL)
         KeyRecord_Pause(ctx, FALSE);
       ch = NormalizeEscSequence(ctx, ch);
+      if (ctx != NULL && ch >= 0)
+        KeyRecord_Log(ctx, ch);
       return ch;
     }
   }

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -7,6 +7,7 @@
  ***************************************************************************/
 
 #include "watcher.h"
+#include "ytree_key_record.h"
 #include "ytree_cmd.h"
 #include "ytree_ui.h"
 #include <ctype.h>
@@ -321,9 +322,11 @@ void HitReturnToContinue(void) {
 
 BOOL KeyPressed() {
   BOOL pressed = FALSE;
+  int c;
 
   nodelay(stdscr, TRUE);
-  int c = wgetch(stdscr);
+  c = wgetch(stdscr);
+
   if (c != ERR) {
     pressed = TRUE;
     ungetch(c);
@@ -340,7 +343,9 @@ BOOL EscapeKeyPressed(void) {
   BOOL pressed = FALSE;
 
   nodelay(stdscr, TRUE);
-  if ((c = wgetch(stdscr)) != ERR) {
+  c = wgetch(stdscr);
+
+  if (c != ERR) {
     DEBUG_KEYSTROKE_LOG("EscapeKeyPressed() saw: %3d ('%c')", c,
                         (c >= 32 && c <= 126) ? c : '.');
 
@@ -607,7 +612,7 @@ YtreeAction GetKeyAction(const ViewContext *ctx, int ch) {
 
 #ifdef KEY_F
   case KEY_F(12):
-    return ACTION_LIST_JUMP;
+    return ACTION_RECORD_KEYS;
   case KEY_F(8):
     return ACTION_SPLIT_SCREEN;
   case KEY_F(7):
@@ -693,35 +698,52 @@ int WGetch(ViewContext *ctx, WINDOW *win) {
   }
 #endif
 
+  if (ctx != NULL && c >= 0)
+    KeyRecord_Log(ctx, c);
+
   return (c);
 }
 
 int Getch(ViewContext *ctx) { return WGetch(ctx, stdscr); }
 
-static int NormalizeEscSequence(int ch) {
+static int NormalizeEscSequence(ViewContext *ctx, int ch) {
   int seq1;
   int seq2;
+  BOOL restore_pause = FALSE;
+  BOOL was_paused = FALSE;
 
   if (ch != ESC)
     return ch;
 
+  if (ctx != NULL) {
+    was_paused = ctx->key_record_pause;
+    KeyRecord_Pause(ctx, TRUE);
+    restore_pause = TRUE;
+  }
+
   nodelay(stdscr, TRUE);
-  seq1 = wgetch(stdscr);
+  seq1 = WGetch(ctx, stdscr);
   if (seq1 == ERR) {
     nodelay(stdscr, FALSE);
+    if (restore_pause)
+      KeyRecord_Pause(ctx, was_paused);
     return ESC;
   }
 
   if (seq1 != '[' && seq1 != 'O') {
     ungetch(seq1);
     nodelay(stdscr, FALSE);
+    if (restore_pause)
+      KeyRecord_Pause(ctx, was_paused);
     return ESC;
   }
 
-  seq2 = wgetch(stdscr);
+  seq2 = WGetch(ctx, stdscr);
   if (seq2 == ERR) {
     ungetch(seq1);
     nodelay(stdscr, FALSE);
+    if (restore_pause)
+      KeyRecord_Pause(ctx, was_paused);
     return ESC;
   }
 
@@ -748,7 +770,7 @@ static int NormalizeEscSequence(int ch) {
   case '4':
   case '7':
   case '8': {
-    int seq3 = wgetch(stdscr);
+    int seq3 = WGetch(ctx, stdscr);
     if (seq3 == '~') {
       ch = (seq2 == '1' || seq2 == '7') ? KEY_HOME : KEY_END;
     } else {
@@ -768,6 +790,8 @@ static int NormalizeEscSequence(int ch) {
   }
 
   nodelay(stdscr, FALSE);
+  if (restore_pause)
+    KeyRecord_Pause(ctx, was_paused);
   return ch;
 }
 
@@ -786,11 +810,18 @@ int GetEventOrKey(ViewContext *ctx) {
 
   /* Check if input is already available to avoid select delay */
   nodelay(stdscr, TRUE);
+  if (ctx != NULL)
+    KeyRecord_Pause(ctx, TRUE);
   ch = WGetch(ctx, stdscr);
+  if (ctx != NULL)
+    KeyRecord_Pause(ctx, FALSE);
   nodelay(stdscr, FALSE);
 
   if (ch != ERR) {
-    return NormalizeEscSequence(ch);
+    ch = NormalizeEscSequence(ctx, ch);
+    if (ctx != NULL && ch >= 0)
+      KeyRecord_Log(ctx, ch);
+    return ch;
   }
 
   if (ctx && ctx->resize_request)
@@ -829,10 +860,18 @@ int GetEventOrKey(ViewContext *ctx) {
           return 'q';
 
         nodelay(stdscr, TRUE);
+        if (ctx != NULL)
+          KeyRecord_Pause(ctx, TRUE);
         ch = WGetch(ctx, stdscr);
+        if (ctx != NULL)
+          KeyRecord_Pause(ctx, FALSE);
         nodelay(stdscr, FALSE);
-        if (ch != ERR)
-          return NormalizeEscSequence(ch);
+        if (ch != ERR) {
+          ch = NormalizeEscSequence(ctx, ch);
+          if (ctx != NULL && ch >= 0)
+            KeyRecord_Log(ctx, ch);
+          return ch;
+        }
         if (ctx && ctx->resize_request)
           return KEY_RESIZE;
 
@@ -850,7 +889,15 @@ int GetEventOrKey(ViewContext *ctx) {
 
     if (FD_ISSET(STDIN_FILENO, &fds)) {
       /* Input available, perform WGetch */
-      return NormalizeEscSequence(WGetch(ctx, stdscr));
+      if (ctx != NULL)
+        KeyRecord_Pause(ctx, TRUE);
+      ch = WGetch(ctx, stdscr);
+      if (ctx != NULL)
+        KeyRecord_Pause(ctx, FALSE);
+      ch = NormalizeEscSequence(ctx, ch);
+      if (ctx != NULL && ch >= 0)
+        KeyRecord_Log(ctx, ch);
+      return ch;
     }
   }
 }

--- a/src/ui/key_record.c
+++ b/src/ui/key_record.c
@@ -9,6 +9,25 @@
 #include "ytree_key_record.h"
 #include "ytree_ui.h"
 
+static int BuildDefaultRecordPath(char *path, size_t path_size) {
+  int index;
+
+  if (!path || path_size == 0)
+    return -1;
+
+  for (index = 1; index <= 999; index++) {
+    int written;
+
+    written = snprintf(path, path_size, "ytree-keys-%03d.txt", index);
+    if (written < 0 || (size_t)written >= path_size)
+      return -1;
+    if (access(path, F_OK) != 0)
+      return 0;
+  }
+
+  return -1;
+}
+
 static void CloseRecordingFile(ViewContext *ctx) {
   FILE *fp;
 
@@ -62,6 +81,10 @@ int KeyRecord_Start(ViewContext *ctx, const char *path) {
 
 void KeyRecord_Stop(ViewContext *ctx) { CloseRecordingFile(ctx); }
 
+BOOL KeyRecord_IsActive(const ViewContext *ctx) {
+  return (ctx != NULL && ctx->key_record_file != NULL) ? TRUE : FALSE;
+}
+
 void KeyRecord_Log(ViewContext *ctx, int ch) {
   FILE *fp;
   const char *name;
@@ -92,30 +115,44 @@ void KeyRecord_Pause(ViewContext *ctx, BOOL pause) {
   ctx->key_record_pause = pause;
 }
 
+int KeyRecord_Toggle(ViewContext *ctx) {
+  if (!ctx)
+    return -1;
+
+  if (KeyRecord_IsActive(ctx)) {
+    KeyRecord_Stop(ctx);
+    return 0;
+  }
+
+  return KeyRecord_BeginPrompt(ctx);
+}
+
 int KeyRecord_BeginPrompt(ViewContext *ctx) {
   char path[PATH_LENGTH + 1];
 
   if (!ctx)
     return -1;
 
-  if (ctx->key_record_file != NULL) {
+  if (KeyRecord_IsActive(ctx)) {
     (void)UI_Notice(ctx, "Key trace recording is already active.");
     return 0;
   }
 
-  path[0] = '\0';
-  if (UI_ReadString(ctx, ctx->active, "Record key trace to:", path,
-                    (int)sizeof(path), HST_PATH) != CR)
+  if (BuildDefaultRecordPath(path, sizeof(path)) != 0)
+    path[0] = '\0';
+  if (UI_ReadStringWithHelp(ctx, ctx->active, "Record key trace to:", path,
+                            (int)sizeof(path), HST_PATH,
+                            "(Enter) OK  (Esc) cancel", NULL, NULL) != CR)
     return -1;
 
   if (path[0] == '\0')
     return -1;
 
   if (KeyRecord_Start(ctx, path) != 0) {
-    (void)UI_Notice(ctx, "Failed to open key trace file: %s", path);
+    (void)UI_ShowStatusLineError(ctx, "Failed to open key trace file: %s",
+                                 path);
     return -1;
   }
 
-  (void)UI_Notice(ctx, "Recording key trace to %s", path);
   return 0;
 }

--- a/src/ui/key_record.c
+++ b/src/ui/key_record.c
@@ -1,0 +1,121 @@
+/***************************************************************************
+ *
+ * src/ui/key_record.c
+ * Optional raw key stream recorder
+ *
+ ***************************************************************************/
+
+#include "ytree_cmd.h"
+#include "ytree_key_record.h"
+#include "ytree_ui.h"
+
+static void CloseRecordingFile(ViewContext *ctx) {
+  FILE *fp;
+
+  if (!ctx)
+    return;
+
+  fp = ctx->key_record_file;
+  ctx->key_record_file = NULL;
+  if (!fp)
+    return;
+
+  if (fclose(fp) != 0) {
+    fprintf(stderr, "WARNING: failed to close key recording: %s\n",
+            strerror(errno));
+  }
+}
+
+int KeyRecord_Start(ViewContext *ctx, const char *path) {
+  int fd;
+  FILE *fp;
+
+  if (!ctx || !path || !*path)
+    return -1;
+
+  CloseRecordingFile(ctx);
+
+  fd = open(path, O_WRONLY | O_CREAT | O_TRUNC
+#ifdef O_CLOEXEC
+            | O_CLOEXEC
+#endif
+#ifdef O_NOFOLLOW
+            | O_NOFOLLOW
+#endif
+            ,
+            S_IRUSR | S_IWUSR);
+  if (fd == -1)
+    return -1;
+
+  fp = fdopen(fd, "w");
+  if (!fp) {
+    close(fd);
+    return -1;
+  }
+
+  setvbuf(fp, NULL, _IOLBF, 0);
+  fprintf(fp, "# ytree key trace v1\n");
+  ctx->key_record_file = fp;
+  ctx->key_record_pause = FALSE;
+  return 0;
+}
+
+void KeyRecord_Stop(ViewContext *ctx) { CloseRecordingFile(ctx); }
+
+void KeyRecord_Log(ViewContext *ctx, int ch) {
+  FILE *fp;
+  const char *name;
+
+  if (!ctx || ch < 0)
+    return;
+
+  fp = ctx->key_record_file;
+  if (!fp)
+    return;
+
+  name = keyname(ch);
+  if (name == NULL)
+    name = "<unknown>";
+
+  if (fprintf(fp, "%d %s\n", ch, name) < 0 || fflush(fp) != 0) {
+    int saved_errno = errno;
+
+    CloseRecordingFile(ctx);
+    fprintf(stderr, "WARNING: failed to write key recording: %s\n",
+            strerror(saved_errno));
+  }
+}
+
+void KeyRecord_Pause(ViewContext *ctx, BOOL pause) {
+  if (!ctx)
+    return;
+  ctx->key_record_pause = pause;
+}
+
+int KeyRecord_BeginPrompt(ViewContext *ctx) {
+  char path[PATH_LENGTH + 1];
+
+  if (!ctx)
+    return -1;
+
+  if (ctx->key_record_file != NULL) {
+    (void)UI_Notice(ctx, "Key trace recording is already active.");
+    return 0;
+  }
+
+  path[0] = '\0';
+  if (UI_ReadString(ctx, ctx->active, "Record key trace to:", path,
+                    (int)sizeof(path), HST_PATH) != CR)
+    return -1;
+
+  if (path[0] == '\0')
+    return -1;
+
+  if (KeyRecord_Start(ctx, path) != 0) {
+    (void)UI_Notice(ctx, "Failed to open key trace file: %s", path);
+    return -1;
+  }
+
+  (void)UI_Notice(ctx, "Recording key trace to %s", path);
+  return 0;
+}

--- a/src/ui/key_record.c
+++ b/src/ui/key_record.c
@@ -1,13 +1,123 @@
 /***************************************************************************
  *
  * src/ui/key_record.c
- * Optional raw key stream recorder
+ * Optional human-readable key trace recorder
+ * Redact secrets before emitting trace text; traces are for bug reports.
  *
  ***************************************************************************/
+
+#include <ctype.h>
 
 #include "ytree_cmd.h"
 #include "ytree_key_record.h"
 #include "ytree_ui.h"
+
+static const char *FormatTraceKey(int ch, char *buf, size_t buf_size) {
+  static const struct {
+    const char *from;
+    const char *to;
+  } aliases[] = {
+      {"KEY_BACKSPACE", "backspace"}, {"KEY_DOWN", "down"},
+      {"KEY_UP", "up"},               {"KEY_LEFT", "left"},
+      {"KEY_RIGHT", "right"},         {"KEY_HOME", "home"},
+      {"KEY_END", "end"},             {"KEY_PPAGE", "page-up"},
+      {"KEY_NPAGE", "page-down"},     {"KEY_IC", "insert"},
+      {"KEY_DC", "delete"},           {"KEY_BTAB", "shift-tab"},
+      {"KEY_ENTER", "enter"},
+  };
+  const char *name;
+  size_t i;
+
+  if (buf == NULL || buf_size == 0)
+    return NULL;
+
+  if (ch == '\n' || ch == '\r'
+#ifdef KEY_ENTER
+      || ch == KEY_ENTER
+#endif
+  ) {
+    snprintf(buf, buf_size, "enter");
+    return buf;
+  }
+
+  if (ch == '\t') {
+    snprintf(buf, buf_size, "tab");
+    return buf;
+  }
+
+  if (ch == ' ') {
+    snprintf(buf, buf_size, "space");
+    return buf;
+  }
+
+  if (ch == 8 || ch == 127) {
+    snprintf(buf, buf_size, "backspace");
+    return buf;
+  }
+
+  if (ch == 27) {
+    snprintf(buf, buf_size, "esc");
+    return buf;
+  }
+
+  if (ch >= 32 && ch <= 126 && isprint((unsigned char)ch)) {
+    buf[0] = (char)ch;
+    buf[1] = '\0';
+    return buf;
+  }
+
+  name = keyname(ch);
+  if (name == NULL) {
+    snprintf(buf, buf_size, "unknown");
+    return buf;
+  }
+
+  for (i = 0; i < sizeof(aliases) / sizeof(aliases[0]); i++) {
+    if (strcmp(name, aliases[i].from) == 0) {
+      snprintf(buf, buf_size, "%s", aliases[i].to);
+      return buf;
+    }
+  }
+
+#ifdef KEY_F
+  if (strncmp(name, "KEY_F(", 6) == 0) {
+    int fn = -1;
+
+    if (sscanf(name, "KEY_F(%d)", &fn) == 1 && fn >= 0) {
+      snprintf(buf, buf_size, "f%d", fn);
+      return buf;
+    }
+  }
+#endif
+
+  if (strncmp(name, "KEY_", 4) == 0)
+    name += 4;
+
+  for (i = 0; name[i] != '\0' && i + 1 < buf_size; i++) {
+    unsigned char ch_u = (unsigned char)name[i];
+
+    if (name[i] == '_')
+      buf[i] = '-';
+    else
+      buf[i] = (char)tolower(ch_u);
+  }
+  buf[i] = '\0';
+  return buf;
+}
+
+static int WriteKeyTraceLine(FILE *fp, int ch) {
+  char token[64];
+  const char *name;
+
+  name = FormatTraceKey(ch, token, sizeof(token));
+  if (name == NULL)
+    return -1;
+
+  if (fprintf(fp, "key %s\n", name) < 0)
+    return -1;
+
+  return 0;
+}
 
 static int BuildDefaultRecordPath(char *path, size_t path_size) {
   int index;
@@ -73,7 +183,7 @@ int KeyRecord_Start(ViewContext *ctx, const char *path) {
   }
 
   setvbuf(fp, NULL, _IOLBF, 0);
-  fprintf(fp, "# ytree key trace v1\n");
+  fprintf(fp, "# ytree key trace v2\n");
   ctx->key_record_file = fp;
   ctx->key_record_pause = FALSE;
   return 0;
@@ -87,20 +197,18 @@ BOOL KeyRecord_IsActive(const ViewContext *ctx) {
 
 void KeyRecord_Log(ViewContext *ctx, int ch) {
   FILE *fp;
-  const char *name;
 
   if (!ctx || ch < 0)
+    return;
+
+  if (ctx->key_record_pause)
     return;
 
   fp = ctx->key_record_file;
   if (!fp)
     return;
 
-  name = keyname(ch);
-  if (name == NULL)
-    name = "<unknown>";
-
-  if (fprintf(fp, "%d %s\n", ch, name) < 0 || fflush(fp) != 0) {
+  if (WriteKeyTraceLine(fp, ch) != 0 || fflush(fp) != 0) {
     int saved_errno = errno;
 
     CloseRecordingFile(ctx);

--- a/tests/test_key_recording.py
+++ b/tests/test_key_recording.py
@@ -4,39 +4,67 @@ from tui_harness import YtreeTUI
 from ytree_keys import Keys
 
 
-def test_f12_starts_key_trace_recording(tmp_path, ytree_binary):
+def test_f12_toggles_key_trace_recording_and_default_name(
+    tmp_path, ytree_binary
+):
     root = tmp_path / "root"
     root.mkdir()
     (root / "src").mkdir()
 
-    record_path = tmp_path / "keys.txt"
     tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+
+    assert tui.wait_for_content("F12 record"), "Record footer did not appear."
 
     tui.send_keystroke(Keys.F12)
     assert tui.wait_for_content("Record key trace to:"), "Trace prompt did not appear."
-    tui.send_keystroke(str(record_path))
+    assert tui.wait_for_content("ytree-keys-001.txt"), (
+        "The default recording filename should be incremented and prefilled."
+    )
+    screen = tui.get_screen_dump()
+    assert not any("F2 browse" in line for line in screen), (
+        "The recording prompt should not advertise unrelated input helpers."
+    )
     tui.send_keystroke(Keys.ENTER)
+    assert tui.wait_for_content("F12 stop"), "Stop footer did not appear."
 
     tui.send_keystroke(Keys.DOWN)
     tui.send_keystroke(Keys.UP)
+
+    tui.send_keystroke(Keys.F12)
+    assert tui.wait_for_content("F12 record"), "Record footer did not return."
+
+    tui.send_keystroke(Keys.DOWN)
+    tui.send_keystroke(Keys.UP)
+
+    tui.send_keystroke(Keys.F12)
+    assert tui.wait_for_content("Record key trace to:"), "Second trace prompt did not appear."
+    assert tui.wait_for_content("ytree-keys-002.txt"), (
+        "The next recording should default to the next incremented filename."
+    )
+    tui.send_keystroke(Keys.ESC)
+
     tui.send_keystroke(Keys.QUIT)
     tui.child.expect(pexpect.EOF)
 
     recorded_lines = [
         line.strip()
-        for line in record_path.read_text(encoding="utf-8").splitlines()
+        for line in (root / "ytree-keys-001.txt").read_text(encoding="utf-8").splitlines()
         if line.strip() and not line.startswith("#")
     ]
 
-    assert any(line.endswith("KEY_DOWN") for line in recorded_lines), (
-        "The recorded trace should capture the normalized down-arrow key.\n"
+    assert sum(line.endswith("KEY_DOWN") for line in recorded_lines) == 1, (
+        "Recording should stop after the first F12 toggle.\n"
         f"Recorded lines: {recorded_lines}"
     )
-    assert any(line.endswith("KEY_UP") for line in recorded_lines), (
-        "The recorded trace should capture the normalized up-arrow key.\n"
+    assert sum(line.endswith("KEY_UP") for line in recorded_lines) == 1, (
+        "Recording should stop after the first F12 toggle.\n"
         f"Recorded lines: {recorded_lines}"
     )
-    assert any(line.endswith("q") for line in recorded_lines), (
-        "The recorded trace should capture the quit key.\n"
+    assert sum(line.endswith("KEY_F(12)") for line in recorded_lines) == 1, (
+        "Only the stop F12 press should be present in the trace.\n"
+        f"Recorded lines: {recorded_lines}"
+    )
+    assert sum(line.endswith("q") for line in recorded_lines) == 0, (
+        "Keys pressed after stopping should not be recorded.\n"
         f"Recorded lines: {recorded_lines}"
     )

--- a/tests/test_key_recording.py
+++ b/tests/test_key_recording.py
@@ -1,0 +1,42 @@
+import pexpect
+
+from tui_harness import YtreeTUI
+from ytree_keys import Keys
+
+
+def test_f12_starts_key_trace_recording(tmp_path, ytree_binary):
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "src").mkdir()
+
+    record_path = tmp_path / "keys.txt"
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+
+    tui.send_keystroke(Keys.F12)
+    assert tui.wait_for_content("Record key trace to:"), "Trace prompt did not appear."
+    tui.send_keystroke(str(record_path))
+    tui.send_keystroke(Keys.ENTER)
+
+    tui.send_keystroke(Keys.DOWN)
+    tui.send_keystroke(Keys.UP)
+    tui.send_keystroke(Keys.QUIT)
+    tui.child.expect(pexpect.EOF)
+
+    recorded_lines = [
+        line.strip()
+        for line in record_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+
+    assert any(line.endswith("KEY_DOWN") for line in recorded_lines), (
+        "The recorded trace should capture the normalized down-arrow key.\n"
+        f"Recorded lines: {recorded_lines}"
+    )
+    assert any(line.endswith("KEY_UP") for line in recorded_lines), (
+        "The recorded trace should capture the normalized up-arrow key.\n"
+        f"Recorded lines: {recorded_lines}"
+    )
+    assert any(line.endswith("q") for line in recorded_lines), (
+        "The recorded trace should capture the quit key.\n"
+        f"Recorded lines: {recorded_lines}"
+    )

--- a/tests/test_key_recording.py
+++ b/tests/test_key_recording.py
@@ -29,6 +29,10 @@ def test_f12_toggles_key_trace_recording_and_default_name(
 
     tui.send_keystroke(Keys.DOWN)
     tui.send_keystroke(Keys.UP)
+    tui.send_keystroke("/")
+    assert tui.wait_for_content("Jump to:"), "Jump prompt did not appear."
+    tui.send_keystroke("src")
+    tui.send_keystroke(Keys.ENTER)
 
     tui.send_keystroke(Keys.F12)
     assert tui.wait_for_content("F12 record"), "Record footer did not return."
@@ -52,19 +56,10 @@ def test_f12_toggles_key_trace_recording_and_default_name(
         if line.strip() and not line.startswith("#")
     ]
 
-    assert sum(line.endswith("KEY_DOWN") for line in recorded_lines) == 1, (
-        "Recording should stop after the first F12 toggle.\n"
-        f"Recorded lines: {recorded_lines}"
-    )
-    assert sum(line.endswith("KEY_UP") for line in recorded_lines) == 1, (
-        "Recording should stop after the first F12 toggle.\n"
-        f"Recorded lines: {recorded_lines}"
-    )
-    assert sum(line.endswith("KEY_F(12)") for line in recorded_lines) == 1, (
-        "Only the stop F12 press should be present in the trace.\n"
-        f"Recorded lines: {recorded_lines}"
-    )
-    assert sum(line.endswith("q") for line in recorded_lines) == 0, (
-        "Keys pressed after stopping should not be recorded.\n"
-        f"Recorded lines: {recorded_lines}"
-    )
+    assert recorded_lines == [
+        "key down",
+        "key up",
+        "key /",
+        "key enter",
+        "key f12",
+    ], f"Recorded lines did not use the human-readable trace format: {recorded_lines}"

--- a/tests/ytree_keys.py
+++ b/tests/ytree_keys.py
@@ -25,6 +25,7 @@ class Keys:
     F5 = "\033[15~"
     F7 = "\033[18~"
     F8 = "\033[19~"
+    F12 = "\033[24~"
 
     # Core Commands
     ATTRIBUTE = "a"


### PR DESCRIPTION
## What changed
- Add an F12 key trace recorder that writes human-readable key events.
- Keep the trace as a bug-report aid rather than a macro system.
- Remove text recording from the trace path so prompts are key-only.
- Defer macro playback design in the roadmap.
- Update the footer/help text and regression coverage.

## Why
- The original text-recording path created too much security and maintenance risk for a bug-report feature.
- Keeping the recorder key-only avoids secret capture and keeps the feature simple.

## Validation
- `make clean && make`
- `pytest -q tests/test_key_recording.py`
