### PR TITLE
fix(split): preserve tree viewport on visible jumps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ VERSIONDATE = April 2026
 # -------------------------------------------------------------------------
 SRC_DIR     = src
 INC_DIR     = include
-OBJ_DIR     = obj
 DOC_DIR     = docs
 BUILD_DIR   = build
 BIN_DIR     = .
@@ -91,10 +90,16 @@ endif
 # Run 'make DEBUG=1' for development (AddressSanitizer enabled)
 # Run 'make' for release (Optimized, no runtime dependency on ASan)
 # -------------------------------------------------------------------------
+BUILD_VARIANT ?= release
 ifeq ($(DEBUG),1)
+    BUILD_VARIANT = debug
     # Debug Build: Enable ASan, Debug Symbols, disable optimization
     CFLAGS  += -fsanitize=address -g -O1 -fno-omit-frame-pointer
     LDFLAGS += -fsanitize=address
+else ifeq ($(SANITIZE),1)
+    BUILD_VARIANT = sanitize
+else ifeq ($(COVERAGE),1)
+    BUILD_VARIANT = coverage
 else
     # Release Build: Standard Optimization.
     # Keep sanitizer builds at -O1 for better diagnostics and deterministic PTY timing.
@@ -102,6 +107,7 @@ else
         CFLAGS  += -O2
     endif
 endif
+OBJ_DIR     = obj/$(BUILD_VARIANT)
 
 # -------------------------------------------------------------------------
 # Files
@@ -247,7 +253,7 @@ git-aliases-status:
 
 # Clean build artifacts
 clean:
-	rm -rf $(OBJ_DIR) $(BUILD_DIR)
+	rm -rf obj $(BUILD_DIR)
 	rm -f core *~ *.orig *.bak
 	find $(SRC_DIR) -name "*.o" -o -name "*.d" -delete
 

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -123,6 +123,17 @@ Ordering policy (for all editors, including AI editors):
     *   Enforce active-only mutation and inactive freeze semantics for filter state.
 *   **Status**: Confirmed.
 
+### **BUG-2.6: Hidden UI Entries Still Influence Visible-Tree State**
+*   **Description**: Entries that are hidden from the UI are not being fully excluded from navigation/state resolution. Hidden-dotfile and hidden-prefix paths can still influence visible-tree behavior, so the app can resolve or restore against a hidden ancestor or sibling path instead of treating the visible tree as authoritative.
+*   **Repro (manual, 2026-06-04)**:
+    *   Open a tree that contains both a visible target such as `src` and hidden-prefix content such as `./tmp/session.cast` or `~/.local/src`.
+    *   Perform a normal jump/search flow that should land on the visible target.
+*   **Expected**: Items hidden from the UI should not participate in ordinary visible-tree jumps, selection, or restore decisions.
+*   **Actual**: The jump resolves to a hidden-prefix path such as `/home/rob/.local/src` instead of the visible `~/ytree/src`.
+*   **Impact**: Demonstrates a broader architectural defect in hidden-item accounting and visible-tree authority, not just a one-off wrong row. It can misdirect routine navigation and make hidden entries behave as if they were still visible.
+*   **Remediation**: Make hidden-from-UI entries non-participants in the normal visible-tree resolver paths unless explicitly requested, and keep the visible-tree contract authoritative for jump, selection, and restore logic. Add regression coverage that distinguishes visible-tree targets from hidden-prefix matches.
+*   **Status**: Confirmed.
+
 ### **BUG-3: F8 Dotfiles Toggle Leaks Across Panels**
 *   **Description**: In `F8` split mode, toggling dotfiles visibility (`` ` `` do/undo) in the active panel can apply the same visibility change to the inactive panel.
 *   **Repro (manual)**:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1349,10 +1349,11 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** Offers complex templating logic that goes beyond simple pipe/xargs, and critically allows the user to review/edit the generated script before execution for safety.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-37: Implement Keyboard Macros (F12 Record/Playback)**
-*   **Goal:** Implement keystroke recording and replay. `F12` starts/stops recording command/input sequences for deterministic playback.
-*   **Rationale:** Allows automation of repetitive interaction sequences (for example "Tag, Move, Rename, Repeat") without creating shell command templates.
-*   - [ ] **Status:** Not Started.
+### **Idea FE-37: Keyboard Macros (F12 Record/Playback)**
+*   **Goal:** Record and replay simple keystroke sequences.
+*   **Rationale:** Useful for repeating safe, local interaction sequences.
+*   **Status:** Deferred.
+*   **Note:** Revisit only after a safe design exists that cannot turn traces into a secret-capturing scripting surface.
 
 ### **Idea FE-38: Enhance Built-In Viewer**
 *   **Goal:** Evolve ytree's internal viewer from a basic fallback inspector into a more capable built-in viewing tool for normal terminal workflows.

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -1187,7 +1187,7 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
 
   height = getmaxy(ctx->ctx_dir_window);
   if (height <= 0)
-    return;
+    height = 1;
 
   original_disp_begin_pos = ctx->active->disp_begin_pos;
   original_cursor_pos = ctx->active->cursor_pos;
@@ -1230,22 +1230,8 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
             }
           }
 
-          if (found_idx != -1) {
-            if (found_idx >= ctx->active->disp_begin_pos &&
-                found_idx < ctx->active->disp_begin_pos + height) {
-              ctx->active->cursor_pos = found_idx - ctx->active->disp_begin_pos;
-            } else {
-              ctx->active->disp_begin_pos = found_idx;
-              ctx->active->cursor_pos = 0;
-              if (ctx->active->disp_begin_pos + height >
-                  ctx->active->vol->total_dirs) {
-                ctx->active->disp_begin_pos =
-                    MAXIMUM(0, ctx->active->vol->total_dirs - height);
-                ctx->active->cursor_pos =
-                    found_idx - ctx->active->disp_begin_pos;
-              }
-            }
-          }
+          if (found_idx != -1)
+            PositionPanelAtIndex(ctx->active, found_idx);
         }
       }
     } else if (isprint(ch)) {
@@ -1265,19 +1251,7 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
 
         if (found_idx != -1) {
           buf_len++;
-          if (found_idx >= ctx->active->disp_begin_pos &&
-              found_idx < ctx->active->disp_begin_pos + height) {
-            ctx->active->cursor_pos = found_idx - ctx->active->disp_begin_pos;
-          } else {
-            ctx->active->disp_begin_pos = found_idx;
-            ctx->active->cursor_pos = 0;
-            if (ctx->active->disp_begin_pos + height >
-                ctx->active->vol->total_dirs) {
-              ctx->active->disp_begin_pos =
-                  MAXIMUM(0, ctx->active->vol->total_dirs - height);
-              ctx->active->cursor_pos = found_idx - ctx->active->disp_begin_pos;
-            }
-          }
+          PositionPanelAtIndex(ctx->active, found_idx);
         } else {
           /* Sticky cursor: keep current selection when input has no match. */
           buf_len++;

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -206,6 +206,8 @@ DirEntry *ResolvePanelAnchorTarget(const YtreePanel *panel,
 
 void PositionPanelAtIndex(YtreePanel *panel, int idx) {
   int height;
+  int begin;
+  int cursor;
 
   if (!panel || !panel->vol || !panel->vol->dir_entry_list ||
       panel->vol->total_dirs <= 0)
@@ -220,19 +222,14 @@ void PositionPanelAtIndex(YtreePanel *panel, int idx) {
   if (height < 1)
     height = 1;
 
-  if (idx >= panel->disp_begin_pos && idx < panel->disp_begin_pos + height) {
-    panel->cursor_pos = idx - panel->disp_begin_pos;
+  begin = panel->disp_begin_pos;
+  cursor = panel->cursor_pos;
+  if (PanelComputeViewportPosition(panel, idx, height, &begin, &cursor)) {
+    panel->disp_begin_pos = begin;
+    panel->cursor_pos = cursor;
   } else {
-    panel->disp_begin_pos = idx;
     panel->cursor_pos = 0;
-    if (panel->disp_begin_pos + height > panel->vol->total_dirs) {
-      panel->disp_begin_pos = panel->vol->total_dirs - height;
-      if (panel->disp_begin_pos < 0)
-        panel->disp_begin_pos = 0;
-      panel->cursor_pos = idx - panel->disp_begin_pos;
-      if (panel->cursor_pos < 0)
-        panel->cursor_pos = 0;
-    }
+    panel->disp_begin_pos = 0;
   }
   panel->panel_generation++;
 }

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -1596,6 +1596,54 @@ def test_enter_repo_src_cmd_preserves_tree_viewport_anchor(ytree_binary):
         tui.quit()
 
 
+def test_list_jump_preserves_visible_tree_viewport_with_hidden_prefix(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "list_jump_visible_viewport_hidden_prefix"
+    root.mkdir()
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=2\nHIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    for i in range(60):
+        (root / f".hidden_{i:02d}").mkdir()
+
+    for name in ("alpha", "src", "tests", "zeta"):
+        (root / name).mkdir()
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(1.0)
+
+    try:
+        before_lines = tui.get_screen_dump()
+        before_screen = "\n".join(before_lines)
+        before_first_row = _first_tree_row_segment(before_lines)
+        assert before_first_row is not None, before_screen
+        assert "src" in before_screen, before_screen
+
+        tui.send_keystroke("/", wait=0.2)
+        tui.send_keystroke("src", wait=0.3)
+        tui.send_keystroke(Keys.ENTER, wait=0.6)
+
+        after_lines = tui.get_screen_dump()
+        after_screen = "\n".join(after_lines)
+        after_first_row = _first_tree_row_segment(after_lines)
+
+        assert _stats_current_dir_contains(after_lines, "src"), (
+            "List-jump stopped on the wrong tree row.\n" f"{after_screen}"
+        )
+        assert after_first_row == before_first_row, (
+            "List-jump reanchored the tree viewport even though the target "
+            "directory was already visible.\n"
+            f"before_first_row={before_first_row!r}\n"
+            f"after_first_row={after_first_row!r}\n"
+            f"{after_screen}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_split_tab_end_home_preserves_left_tree_viewport(tmp_path, ytree_binary):
     repo_root = Path(__file__).resolve().parents[1]
     home = tmp_path / "split_tab_end_home_home"


### PR DESCRIPTION
## Summary
- Keep the tree viewport anchored when a search jump lands on a directory that is already visible.
- Route list-jump selection updates through the shared panel viewport helper.
- Add a regression for the hidden-prefix case that previously reanchored the tree unnecessarily.

## Validation
- `source .venv/bin/activate && pytest -q -vv tests/test_panel_isolation.py::test_list_jump_preserves_visible_tree_viewport_with_hidden_prefix`
- `source .venv/bin/activate && make clean && make`
- `source .venv/bin/activate && pytest -q -ra --tb=no tests/test_panel_isolation.py`