### PR TITLE
fix(split): preserve panel-local viewport and focus state

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -15,6 +15,7 @@ UV_TOOL_DIR = "/tmp/codex-uv-tools"
 [mcp_servers.jcodemunch]
 command = "uvx"
 args = ["jcodemunch-mcp"]
+startup_timeout_sec = 45
 
 [mcp_servers.jcodemunch.env]
 UV_CACHE_DIR = "/tmp/codex-uv-cache"

--- a/include/ytree_defs.h
+++ b/include/ytree_defs.h
@@ -775,6 +775,7 @@ typedef struct {
   int big_file_x, big_file_y, big_file_w, big_file_h;
   int cursor_pos;
   int disp_begin_pos;
+  char tree_viewport_top_dir_path[2][PATH_LENGTH + 1];
   int start_file;
   int file_cursor_pos;
   DirEntry *file_dir_entry;

--- a/include/ytree_panel_anchor.h
+++ b/include/ytree_panel_anchor.h
@@ -3,14 +3,27 @@
 
 #include "ytree_defs.h"
 
+typedef struct {
+  char selected_dir_path[PATH_LENGTH + 1];
+  char top_dir_path[PATH_LENGTH + 1];
+  BOOL has_selected_dir_path;
+  BOOL has_top_dir_path;
+} PanelViewportSnapshot;
+
 BOOL CapturePanelAnchorPath(const YtreePanel *panel, const struct Volume *vol,
                             char *out_path, size_t out_path_size);
+void CapturePanelViewportSnapshot(YtreePanel *panel, const struct Volume *vol,
+                                  PanelViewportSnapshot *snapshot);
 int FindDirIndexByPath(const struct Volume *vol, const char *path);
 int FindDirIndexByPathOrAncestor(const struct Volume *vol, const char *path);
 DirEntry *ResolvePanelAnchorTarget(const YtreePanel *panel,
                                    const struct Volume *vol,
                                    const char *anchor_path);
 void PositionPanelAtIndex(YtreePanel *panel, int idx);
+BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreePanel *panel,
+                                  const PanelViewportSnapshot *snapshot,
+                                  const char *preferred_top_path);
+void RememberPanelViewportTop(YtreePanel *panel);
 void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
                             const char *anchor_path);
 void DonatePanelState(YtreePanel *dst, const YtreePanel *src);

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -16,12 +16,12 @@ cryptography==48.0.0
     # via google-auth
 google-ai-generativelanguage==0.6.15
     # via google-generativeai
-google-api-core[grpc]==2.30.3
+google-api-core[grpc]==2.31.0
     # via
     #   google-ai-generativelanguage
     #   google-api-python-client
     #   google-generativeai
-google-api-python-client==2.196.0
+google-api-python-client==2.197.0
     # via google-generativeai
 google-auth==2.53.0
     # via
@@ -38,7 +38,7 @@ googleapis-common-protos==1.75.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.80.0
+grpcio==1.81.0
     # via
     #   google-api-core
     #   grpcio-status
@@ -48,7 +48,7 @@ httplib2==0.31.2
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.15
+idna==3.18
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -97,9 +97,9 @@ pytest==9.0.3
     # via -r scripts/requirements.in
 requests==2.34.2
     # via google-api-core
-temporalio==1.27.2
+temporalio==1.28.0
     # via -r scripts/requirements.in
-tqdm==4.67.3
+tqdm==4.68.1
     # via google-generativeai
 types-protobuf==6.32.1.20260221
     # via temporalio
@@ -118,7 +118,7 @@ uritemplate==4.2.0
     # via google-api-python-client
 urllib3==2.7.0
     # via requests
-wcwidth==0.7.0
+wcwidth==0.8.0
     # via
     #   prompt-toolkit
     #   pyte

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -1223,7 +1223,7 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
           found_idx = -1;
           for (i = 0; i < ctx->active->vol->total_dirs; i++) {
             DirEntry *candidate = ctx->active->vol->dir_entry_list[i].dir_entry;
-            if (candidate &&
+            if (candidate && PanelDirIsVisible(ctx->active, candidate) &&
                 strncasecmp(candidate->name, search_buf, buf_len) == 0) {
               found_idx = i;
               break;
@@ -1231,20 +1231,7 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
           }
 
           if (found_idx != -1) {
-            if (found_idx >= ctx->active->disp_begin_pos &&
-                found_idx < ctx->active->disp_begin_pos + height) {
-              ctx->active->cursor_pos = found_idx - ctx->active->disp_begin_pos;
-            } else {
-              ctx->active->disp_begin_pos = found_idx;
-              ctx->active->cursor_pos = 0;
-              if (ctx->active->disp_begin_pos + height >
-                  ctx->active->vol->total_dirs) {
-                ctx->active->disp_begin_pos =
-                    MAXIMUM(0, ctx->active->vol->total_dirs - height);
-                ctx->active->cursor_pos =
-                    found_idx - ctx->active->disp_begin_pos;
-              }
-            }
+            PositionPanelAtIndex(ctx->active, found_idx);
           }
         }
       }
@@ -1256,8 +1243,9 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
         found_idx = -1;
         for (i = 0; i < ctx->active->vol->total_dirs; i++) {
           DirEntry *candidate = ctx->active->vol->dir_entry_list[i].dir_entry;
-          if (candidate && strncasecmp(candidate->name, search_buf,
-                                       (size_t)buf_len + 1) == 0) {
+          if (candidate && PanelDirIsVisible(ctx->active, candidate) &&
+              strncasecmp(candidate->name, search_buf, (size_t)buf_len + 1) ==
+                  0) {
             found_idx = i;
             break;
           }
@@ -1265,19 +1253,7 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
 
         if (found_idx != -1) {
           buf_len++;
-          if (found_idx >= ctx->active->disp_begin_pos &&
-              found_idx < ctx->active->disp_begin_pos + height) {
-            ctx->active->cursor_pos = found_idx - ctx->active->disp_begin_pos;
-          } else {
-            ctx->active->disp_begin_pos = found_idx;
-            ctx->active->cursor_pos = 0;
-            if (ctx->active->disp_begin_pos + height >
-                ctx->active->vol->total_dirs) {
-              ctx->active->disp_begin_pos =
-                  MAXIMUM(0, ctx->active->vol->total_dirs - height);
-              ctx->active->cursor_pos = found_idx - ctx->active->disp_begin_pos;
-            }
-          }
+          PositionPanelAtIndex(ctx->active, found_idx);
         } else {
           /* Sticky cursor: keep current selection when input has no match. */
           buf_len++;

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -107,12 +107,14 @@ BOOL RebindActiveFilePanelSelection(YtreePanel *panel, DirEntry **dir_entry_io) 
 
   /*
    * File-panel ownership is panel-local. When the active file pane changes,
-   * re-seed the shared DirEntry from the newly active panel's saved cursor so
-   * the next keypress continues that panel's own selection instead of
-   * inheriting the last pane's row.
+   * re-seed the shared DirEntry from the newly active panel's saved cursor and
+   * window shape so the next keypress continues that panel's own selection
+   * instead of inheriting the last pane's row or zoom state.
    */
   panel_dir->start_file = panel->start_file;
   panel_dir->cursor_pos = panel->file_cursor_pos;
+  if (!panel_dir->global_flag && !panel_dir->tagged_flag)
+    panel_dir->big_window = panel->saved_big_file_view;
   panel->file_dir_entry = panel_dir;
   *dir_entry_io = panel_dir;
   DebugLogFilePanelState("RebindActiveFilePanelSelection", panel);
@@ -1059,6 +1061,7 @@ BOOL handle_file_window_misc_dispatch_action(
     if (dir_entry->big_window)
       break;
     dir_entry->big_window = TRUE;
+    ctx->active->saved_big_file_view = TRUE;
     RefreshView(ctx, dir_entry);
     FileNav_RereadWindowSize(ctx, dir_entry);
     loop_action = ACTION_NONE;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -528,24 +528,38 @@ static int CountPathSnapshot(const PathList *list) {
 }
 
 static void ReanchorPanelToDir(YtreePanel *panel, const DirEntry *target) {
-  int idx;
+  PanelViewportSnapshot snapshot;
 
   if (!panel)
     return;
   if (!panel->vol || panel->vol->total_dirs <= 0) {
     panel->disp_begin_pos = 0;
     panel->cursor_pos = 0;
+    RememberPanelViewportTop(panel);
     return;
   }
 
   if (!target)
     target = panel->vol->vol_stats.tree;
 
-  idx = FindDirIndex(panel->vol, target);
-  if (idx < 0)
-    idx = 0;
+  CapturePanelViewportSnapshot(panel, panel->vol, &snapshot);
+  if (target) {
+    char target_path[PATH_LENGTH + 1];
 
-  PositionPanelAtIndex(panel, idx);
+    GetPath((DirEntry *)target, target_path);
+    target_path[PATH_LENGTH] = '\0';
+    (void)snprintf(snapshot.selected_dir_path,
+                   sizeof(snapshot.selected_dir_path), "%s", target_path);
+    snapshot.selected_dir_path[PATH_LENGTH] = '\0';
+    snapshot.has_selected_dir_path = TRUE;
+  }
+  if (!RestorePanelViewportSnapshot(panel->vol, panel, &snapshot,
+                                    snapshot.top_dir_path)) {
+    int idx = FindDirIndex(panel->vol, target);
+    if (idx < 0)
+      idx = 0;
+    PositionPanelAtIndex(panel, idx);
+  }
 }
 
 BOOL DirOps_SelectVisibleDirAndRefresh(ViewContext *ctx, YtreePanel *panel,
@@ -987,28 +1001,23 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
 
 DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   InactiveFallbackSnapshot inactive_snapshot;
-  int target_idx;
+  PanelViewportSnapshot active_viewport;
 
   CaptureInactiveFallbackSnapshot(ctx, ctx->active, &inactive_snapshot);
-  target_idx = ctx->active->disp_begin_pos + ctx->active->cursor_pos;
+  CapturePanelViewportSnapshot(ctx->active, ctx->active->vol, &active_viewport);
 
   if (!DeleteDirectory(ctx, dir_entry, UI_ChoiceResolver)) {
     ctx->active->vol->volume_generation++;
-    if (target_idx > 0)
-      target_idx--;
   }
 
   BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
   if (ctx->active->vol && ctx->active->vol->dir_entry_list &&
       ctx->active->vol->total_dirs > 0) {
-    int visible_idx = PanelFindNextVisibleDirIndex(ctx->active, target_idx, -1);
-    if (visible_idx < 0)
-      visible_idx = PanelFindNextVisibleDirIndex(ctx->active, target_idx, 1);
-    if (visible_idx < 0)
-      visible_idx = PanelFindFirstVisibleDirIndex(ctx->active);
-    if (visible_idx >= 0)
-      target_idx = visible_idx;
-    PositionPanelAtIndex(ctx->active, target_idx);
+    if (!RestorePanelViewportSnapshot(ctx->active->vol, ctx->active,
+                                      &active_viewport,
+                                      active_viewport.top_dir_path)) {
+      PositionPanelAtIndex(ctx->active, 0);
+    }
   }
   if (inactive_snapshot.panel && inactive_snapshot.panel->vol == ctx->active->vol) {
     const DirEntry *inactive_target =
@@ -1844,17 +1853,18 @@ HandleDirWindowLogAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
 void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
   DirEntry *target;
   YtreePanel *inactive = NULL;
-  int i, found_idx = -1;
-  int win_height;
   const Statistic *s;
   char inactive_anchor_path[PATH_LENGTH + 1];
   BOOL has_inactive_anchor_path = FALSE;
+  PanelViewportSnapshot active_viewport;
+  const char *preferred_top_path = NULL;
 
   if (!ctx || !p || !p->vol)
     return;
 
   s = &p->vol->vol_stats;
   inactive_anchor_path[0] = '\0';
+  CapturePanelViewportSnapshot(p, p->vol, &active_viewport);
 
   if (ctx->is_split_screen && ctx->left && ctx->right) {
     if (p == ctx->left)
@@ -1892,82 +1902,22 @@ void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
    * rebuild */
   SuspendClock(ctx);
 
-  /* 1. Identify the directory currently under the cursor */
-  if (p->vol->total_dirs > 0 &&
-      (p->disp_begin_pos + p->cursor_pos < p->vol->total_dirs)) {
-    target =
-        p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
-  } else {
-    target = s->tree;
-  }
-
-  /* 2. Toggle active-panel state and synchronize context view filter. */
+  /* Toggle active-panel state and synchronize context view filter. */
   p->hide_dot_files = !p->hide_dot_files;
   ctx->hide_dot_files = p->hide_dot_files;
   p->panel_generation++;
   p->vol->volume_generation++;
   RecalculateSysStats(ctx, s);
 
-  /* 3. Rebuild the linear list of visible directories */
+  /* Rebuild the linear list of visible directories. */
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
 
-  /* 4. Search for the 'target' directory in the new list */
-  DirEntry *search = target;
-  while (search != NULL && found_idx == -1) {
-    for (i = 0; i < p->vol->total_dirs; i++) {
-      if (p->vol->dir_entry_list[i].dir_entry == search &&
-          PanelDirIsVisible(p, search)) {
-        found_idx = i;
-        break;
-      }
-    }
-    /* If the target directory is now hidden, walk up to its parent */
-    if (found_idx == -1)
-      search = search->up_tree;
-  }
-
-  /* 5. Smart Restore of Cursor Position */
-  win_height = getmaxy(p->pan_dir_window);
-
-  if (found_idx != -1) {
-    /* Check if the found directory is within the current visible page */
-    if (found_idx >= p->disp_begin_pos &&
-        found_idx < p->disp_begin_pos + win_height) {
-      /* It's still on screen. Just update the cursor, don't scroll/jump. */
-      p->cursor_pos = found_idx - p->disp_begin_pos;
-    } else {
-      /* It moved off page. Re-center or adjust slightly. */
-      if (found_idx < win_height) {
-        p->disp_begin_pos = 0;
-        p->cursor_pos = found_idx;
-      } else {
-        /* Center the item */
-        p->disp_begin_pos = found_idx - (win_height / 2);
-
-        /* Bounds check for display position */
-        if (p->disp_begin_pos > p->vol->total_dirs - win_height) {
-          p->disp_begin_pos = p->vol->total_dirs - win_height;
-        }
-        if (p->disp_begin_pos < 0)
-          p->disp_begin_pos = 0;
-
-        p->cursor_pos = found_idx - p->disp_begin_pos;
-      }
-    }
-  } else {
-    /* Fallback to root if everything went wrong */
-    p->disp_begin_pos = 0;
-    p->cursor_pos = 0;
-  }
-
-  /* Sanity check cursor limits */
-  if (p->cursor_pos >= win_height)
-    p->cursor_pos = win_height - 1;
-  if (p->disp_begin_pos + p->cursor_pos >= p->vol->total_dirs) {
-    /* Move cursor to last valid item */
-    p->cursor_pos = (p->vol->total_dirs > 0)
-                        ? (p->vol->total_dirs - 1 - p->disp_begin_pos)
-                        : 0;
+  preferred_top_path = p->tree_viewport_top_dir_path[p->hide_dot_files ? 1 : 0];
+  if (preferred_top_path[0] == '\0')
+    preferred_top_path = active_viewport.top_dir_path;
+  if (!RestorePanelViewportSnapshot(p->vol, p, &active_viewport,
+                                    preferred_top_path)) {
+    PositionPanelAtIndex(p, 0);
   }
 
   if (inactive && inactive->vol == p->vol && has_inactive_anchor_path) {
@@ -1984,8 +1934,10 @@ void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
   /* Update current dir pointer using the new accessor function
   because ToggleDotFiles might have changed the list layout */
   if (p->vol->total_dirs > 0) {
-    target =
-        p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
+    int selected_idx = GetPanelVisibleSelectionIndex(p);
+    if (selected_idx < 0)
+      selected_idx = 0;
+    target = p->vol->dir_entry_list[selected_idx].dir_entry;
   } else {
     target = s->tree;
   }
@@ -2013,12 +1965,14 @@ void ToggleDotFiles(ViewContext *ctx, YtreePanel *p) {
 DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p, DirEntry *entry) {
   const Statistic *s;
   int saved_disp_begin;
+  PanelViewportSnapshot viewport;
 
   if (!p || !p->vol)
     return entry;
 
   s = &p->vol->vol_stats;
   saved_disp_begin = p->disp_begin_pos;
+  CapturePanelViewportSnapshot(p, p->vol, &viewport);
 
   /* RescanDir destroys/recreates FileEntry nodes. Any panel cache on this
    * volume would otherwise keep dangling pointers until that panel becomes
@@ -2044,9 +1998,6 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p, DirEntry *entry) {
     char saved_path[PATH_LENGTH + 1];
     int win_height;
     int dummy_width;
-    int found_idx = -1;
-    int i;
-    int max_begin;
 
     GetMaxYX(p->pan_dir_window, &win_height, &dummy_width);
     if (win_height < 1)
@@ -2086,51 +2037,59 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreePanel *p, DirEntry *entry) {
     /* 4. Restore Selection */
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
 
-    /* Try to find the directory we were on */
-    char temp_path[PATH_LENGTH + 1];
-    for (i = 0; i < p->vol->total_dirs; i++) {
-      GetPath(p->vol->dir_entry_list[i].dir_entry, temp_path);
-      if (strcmp(temp_path, saved_path) == 0) {
-        found_idx = i;
-        break;
-      }
-    }
-    max_begin = MAXIMUM(0, p->vol->total_dirs - win_height);
-
-    if (found_idx != -1) {
-      int next_disp_begin = saved_disp_begin;
-
-      if (next_disp_begin < 0)
-        next_disp_begin = 0;
-      if (next_disp_begin > max_begin)
-        next_disp_begin = max_begin;
-
-      if (found_idx < next_disp_begin) {
-        next_disp_begin = found_idx;
-      } else if (found_idx >= next_disp_begin + win_height) {
-        next_disp_begin = found_idx - (win_height - 1);
-      }
-
-      if (next_disp_begin < 0)
-        next_disp_begin = 0;
-      if (next_disp_begin > max_begin)
-        next_disp_begin = max_begin;
-
-      p->disp_begin_pos = next_disp_begin;
-      p->cursor_pos = found_idx - p->disp_begin_pos;
-      if (p->cursor_pos < 0)
-        p->cursor_pos = 0;
-      if (p->cursor_pos >= win_height)
-        p->cursor_pos = win_height - 1;
-      entry =
-          p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
+    if (RestorePanelViewportSnapshot(p->vol, p, &viewport, viewport.top_dir_path)) {
+      entry = GetPanelDirEntry(p);
     } else {
-      /* Fallback to start if dir moved/deleted */
-      if (p->vol->total_dirs > 0 &&
-          (p->disp_begin_pos + p->cursor_pos >= p->vol->total_dirs)) {
-        p->disp_begin_pos = 0;
-        p->cursor_pos = 0;
-        entry = p->vol->dir_entry_list[0].dir_entry;
+      /* Try to find the directory we were on */
+      char temp_path[PATH_LENGTH + 1];
+      int found_idx = -1;
+      int i;
+      int max_begin;
+
+      for (i = 0; i < p->vol->total_dirs; i++) {
+        GetPath(p->vol->dir_entry_list[i].dir_entry, temp_path);
+        if (strcmp(temp_path, saved_path) == 0) {
+          found_idx = i;
+          break;
+        }
+      }
+      max_begin = MAXIMUM(0, p->vol->total_dirs - win_height);
+
+      if (found_idx != -1) {
+        int next_disp_begin = saved_disp_begin;
+
+        if (next_disp_begin < 0)
+          next_disp_begin = 0;
+        if (next_disp_begin > max_begin)
+          next_disp_begin = max_begin;
+
+        if (found_idx < next_disp_begin) {
+          next_disp_begin = found_idx;
+        } else if (found_idx >= next_disp_begin + win_height) {
+          next_disp_begin = found_idx - (win_height - 1);
+        }
+
+        if (next_disp_begin < 0)
+          next_disp_begin = 0;
+        if (next_disp_begin > max_begin)
+          next_disp_begin = max_begin;
+
+        p->disp_begin_pos = next_disp_begin;
+        p->cursor_pos = found_idx - p->disp_begin_pos;
+        if (p->cursor_pos < 0)
+          p->cursor_pos = 0;
+        if (p->cursor_pos >= win_height)
+          p->cursor_pos = win_height - 1;
+        entry =
+            p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
+      } else {
+        /* Fallback to start if dir moved/deleted */
+        if (p->vol->total_dirs > 0 &&
+            (p->disp_begin_pos + p->cursor_pos >= p->vol->total_dirs)) {
+          p->disp_begin_pos = 0;
+          p->cursor_pos = 0;
+          entry = p->vol->dir_entry_list[0].dir_entry;
+        }
       }
     }
   } else {
@@ -2198,6 +2157,7 @@ int RefreshDirWindow(ViewContext *ctx, YtreePanel *p) {
   int result = -1;
   const Statistic *s;
   WINDOW *win;
+  PanelViewportSnapshot viewport;
 
   if (!p || !p->vol)
     return -1;
@@ -2205,8 +2165,27 @@ int RefreshDirWindow(ViewContext *ctx, YtreePanel *p) {
   s = &p->vol->vol_stats;
   win = p->pan_dir_window;
 
-  de_ptr = p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
+  CapturePanelViewportSnapshot(p, p->vol, &viewport);
+  de_ptr = GetPanelDirEntry(p);
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
+
+  if (RestorePanelViewportSnapshot(p->vol, p, &viewport, viewport.top_dir_path)) {
+    de_ptr = GetPanelDirEntry(p);
+    if (!de_ptr)
+      return -1;
+    DisplayTree(ctx, p->vol, win, p->disp_begin_pos,
+                p->disp_begin_pos + p->cursor_pos, TRUE);
+    DisplayAvailBytes(ctx, s);
+    DisplayDiskStatistic(ctx, s);
+    UpdateStatsPanel(ctx, de_ptr, s);
+    DisplayFileWindow(ctx, p, de_ptr);
+    {
+      char path[PATH_LENGTH];
+      GetPath(de_ptr, path);
+      DisplayHeaderPath(ctx, path);
+    }
+    return 0;
+  }
 
   /* Search old entry */
   for (n = -1, i = 0; i < p->vol->total_dirs; i++) {

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -616,7 +616,10 @@ static BOOL IsActivePanelBigFileMode(const ViewContext *ctx,
   if (!dir_entry)
     return FALSE;
 
-  return (dir_entry->big_window || dir_entry->global_flag ||
+  if (!ctx->active || ctx->active->saved_focus != FOCUS_FILE)
+    return FALSE;
+
+  return (ctx->active->saved_big_file_view || dir_entry->global_flag ||
           dir_entry->tagged_flag);
 }
 

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -12,6 +12,49 @@
 #include <stdio.h>
 #include <string.h>
 
+static int PanelViewportSlot(const YtreePanel *panel) {
+  return (panel && panel->hide_dot_files) ? 1 : 0;
+}
+
+static int FindTopVisibleDirIndex(const YtreePanel *panel) {
+  int idx;
+
+  if (!panel || !panel->vol || !panel->vol->dir_entry_list ||
+      panel->vol->total_dirs <= 0)
+    return -1;
+
+  idx = panel->disp_begin_pos;
+  if (idx < 0)
+    idx = 0;
+  if (idx >= panel->vol->total_dirs)
+    idx = panel->vol->total_dirs - 1;
+
+  idx = PanelFindNextVisibleDirIndex(panel, idx, 1);
+  if (idx < 0)
+    idx = PanelFindFirstVisibleDirIndex(panel);
+
+  return idx;
+}
+
+void RememberPanelViewportTop(YtreePanel *panel) {
+  int idx;
+  int slot;
+
+  if (!panel)
+    return;
+
+  slot = PanelViewportSlot(panel);
+  panel->tree_viewport_top_dir_path[slot][0] = '\0';
+
+  idx = FindTopVisibleDirIndex(panel);
+  if (idx < 0)
+    return;
+
+  GetPath(panel->vol->dir_entry_list[idx].dir_entry,
+          panel->tree_viewport_top_dir_path[slot]);
+  panel->tree_viewport_top_dir_path[slot][PATH_LENGTH] = '\0';
+}
+
 BOOL CapturePanelAnchorPath(const YtreePanel *panel, const struct Volume *vol,
                             char *out_path, size_t out_path_size) {
   int idx;
@@ -40,11 +83,9 @@ BOOL CapturePanelAnchorPath(const YtreePanel *panel, const struct Volume *vol,
   if (!vol->dir_entry_list || vol->total_dirs <= 0)
     return FALSE;
 
-  idx = panel->disp_begin_pos + panel->cursor_pos;
+  idx = GetPanelVisibleSelectionIndex(panel);
   if (idx < 0)
-    idx = 0;
-  if (idx >= vol->total_dirs)
-    idx = vol->total_dirs - 1;
+    return FALSE;
   entry = vol->dir_entry_list[idx].dir_entry;
   if (!entry)
     return FALSE;
@@ -52,6 +93,36 @@ BOOL CapturePanelAnchorPath(const YtreePanel *panel, const struct Volume *vol,
   GetPath(entry, out_path);
   out_path[out_path_size - 1] = '\0';
   return TRUE;
+}
+
+void CapturePanelViewportSnapshot(YtreePanel *panel, const struct Volume *vol,
+                                  PanelViewportSnapshot *snapshot) {
+  int idx;
+
+  if (!snapshot)
+    return;
+
+  snapshot->selected_dir_path[0] = '\0';
+  snapshot->top_dir_path[0] = '\0';
+  snapshot->has_selected_dir_path = FALSE;
+  snapshot->has_top_dir_path = FALSE;
+
+  if (!panel || !vol || panel->vol != vol)
+    return;
+
+  RememberPanelViewportTop(panel);
+
+  if (CapturePanelAnchorPath(panel, vol, snapshot->selected_dir_path,
+                             sizeof(snapshot->selected_dir_path))) {
+    snapshot->has_selected_dir_path = TRUE;
+  }
+
+  idx = FindTopVisibleDirIndex(panel);
+  if (idx >= 0) {
+    GetPath(panel->vol->dir_entry_list[idx].dir_entry, snapshot->top_dir_path);
+    snapshot->top_dir_path[PATH_LENGTH] = '\0';
+    snapshot->has_top_dir_path = TRUE;
+  }
 }
 
 int FindDirIndexByPath(const struct Volume *vol, const char *path) {
@@ -206,6 +277,8 @@ DirEntry *ResolvePanelAnchorTarget(const YtreePanel *panel,
 
 void PositionPanelAtIndex(YtreePanel *panel, int idx) {
   int height;
+  int begin;
+  int cursor;
 
   if (!panel || !panel->vol || !panel->vol->dir_entry_list ||
       panel->vol->total_dirs <= 0)
@@ -220,25 +293,123 @@ void PositionPanelAtIndex(YtreePanel *panel, int idx) {
   if (height < 1)
     height = 1;
 
-  if (idx >= panel->disp_begin_pos && idx < panel->disp_begin_pos + height) {
-    panel->cursor_pos = idx - panel->disp_begin_pos;
-  } else {
-    panel->disp_begin_pos = idx;
-    panel->cursor_pos = 0;
-    if (panel->disp_begin_pos + height > panel->vol->total_dirs) {
-      panel->disp_begin_pos = panel->vol->total_dirs - height;
-      if (panel->disp_begin_pos < 0)
-        panel->disp_begin_pos = 0;
-      panel->cursor_pos = idx - panel->disp_begin_pos;
-      if (panel->cursor_pos < 0)
-        panel->cursor_pos = 0;
-    }
+  begin = panel->disp_begin_pos;
+  cursor = panel->cursor_pos;
+  if (!PanelComputeViewportPosition(panel, idx, height, &begin, &cursor)) {
+    begin = 0;
+    cursor = 0;
   }
+
+  panel->disp_begin_pos = begin;
+  panel->cursor_pos = cursor;
+  RememberPanelViewportTop(panel);
   panel->panel_generation++;
+}
+
+static BOOL VisibleIndexWithinTopPath(const struct Volume *vol,
+                                      const YtreePanel *panel,
+                                      const char *top_path, int selected_idx,
+                                      int height, int *top_idx_out) {
+  int top_idx;
+  int idx;
+  int visible_rows;
+
+  if (top_idx_out)
+    *top_idx_out = -1;
+
+  if (!vol || !panel || !top_path || !*top_path || selected_idx < 0 ||
+      height < 1)
+    return FALSE;
+
+  top_idx = FindDirIndexByPath(vol, top_path);
+  if (top_idx < 0)
+    return FALSE;
+  if (!PanelDirIsVisible(panel, vol->dir_entry_list[top_idx].dir_entry))
+    return FALSE;
+
+  visible_rows = 0;
+  for (idx = top_idx; idx < vol->total_dirs; idx++) {
+    const DirEntry *candidate = vol->dir_entry_list[idx].dir_entry;
+
+    if (!PanelDirIsVisible(panel, candidate))
+      continue;
+    if (idx == selected_idx) {
+      if (top_idx_out)
+        *top_idx_out = top_idx;
+      return visible_rows < height;
+    }
+    visible_rows++;
+    if (visible_rows >= height)
+      break;
+  }
+
+  return FALSE;
+}
+
+BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreePanel *panel,
+                                  const PanelViewportSnapshot *snapshot,
+                                  const char *preferred_top_path) {
+  DirEntry *target;
+  char target_path[PATH_LENGTH + 1];
+  const char *top_path = NULL;
+  int target_idx;
+  int top_idx = -1;
+  int height;
+  int begin;
+  int cursor;
+
+  if (!vol || !panel || !snapshot)
+    return FALSE;
+  assert(!panel->vol || panel->vol == vol);
+  if (panel->vol && panel->vol != vol)
+    return FALSE;
+  if (!snapshot->has_selected_dir_path || !snapshot->selected_dir_path[0])
+    return FALSE;
+
+  target = ResolvePanelAnchorTarget(panel, vol, snapshot->selected_dir_path);
+  if (!target)
+    return FALSE;
+
+  GetPath(target, target_path);
+  target_path[PATH_LENGTH] = '\0';
+  target_idx = FindDirIndexByPath(vol, target_path);
+  if (target_idx < 0)
+    return FALSE;
+
+  height = panel->pan_dir_window ? getmaxy(panel->pan_dir_window) : 1;
+  if (height < 1)
+    height = 1;
+
+  if (preferred_top_path && preferred_top_path[0])
+    top_path = preferred_top_path;
+  else if (snapshot->has_top_dir_path && snapshot->top_dir_path[0])
+    top_path = snapshot->top_dir_path;
+
+  if (top_path &&
+      VisibleIndexWithinTopPath(vol, panel, top_path, target_idx, height,
+                                &top_idx)) {
+    panel->disp_begin_pos = top_idx;
+    panel->cursor_pos = target_idx - top_idx;
+  } else {
+    begin = panel->disp_begin_pos;
+    cursor = panel->cursor_pos;
+    if (!PanelComputeViewportPosition(panel, target_idx, height, &begin,
+                                      &cursor)) {
+      begin = target_idx;
+      cursor = 0;
+    }
+    panel->disp_begin_pos = begin;
+    panel->cursor_pos = cursor;
+  }
+
+  RememberPanelViewportTop(panel);
+  panel->panel_generation++;
+  return TRUE;
 }
 
 void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
                             const char *anchor_path) {
+  PanelViewportSnapshot snapshot;
   DirEntry *target;
   char target_path[PATH_LENGTH + 1];
   int idx;
@@ -248,6 +419,20 @@ void RestorePanelAnchorPath(const struct Volume *vol, YtreePanel *panel,
   assert(!panel->vol || panel->vol == vol);
   if (panel->vol && panel->vol != vol)
     return;
+
+  CapturePanelViewportSnapshot(panel, vol, &snapshot);
+  (void)snprintf(snapshot.selected_dir_path, sizeof(snapshot.selected_dir_path),
+                 "%s", anchor_path);
+  snapshot.selected_dir_path[PATH_LENGTH] = '\0';
+  snapshot.has_selected_dir_path = TRUE;
+  if (RestorePanelViewportSnapshot(vol, panel, &snapshot, snapshot.top_dir_path)) {
+    if (panel->saved_focus == FOCUS_FILE) {
+      target = ResolvePanelAnchorTarget(panel, vol, anchor_path);
+      if (target)
+        panel->file_dir_entry = target;
+    }
+    return;
+  }
 
   target = ResolvePanelAnchorTarget(panel, vol, anchor_path);
   if (!target)
@@ -355,6 +540,8 @@ void DonatePanelState(YtreePanel *dst, const YtreePanel *src) {
   dst->vol = src->vol;
   dst->cursor_pos = src->cursor_pos;
   dst->disp_begin_pos = src->disp_begin_pos;
+  memcpy(dst->tree_viewport_top_dir_path, src->tree_viewport_top_dir_path,
+         sizeof(dst->tree_viewport_top_dir_path));
   dst->start_file = src->start_file;
   dst->file_cursor_pos = src->file_cursor_pos;
   dst->file_dir_entry = src->file_dir_entry;

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -283,6 +283,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeAction action
           ctx->right->vol = ctx->left->vol;
           ctx->right->cursor_pos = ctx->left->cursor_pos;
           ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
+          memcpy(ctx->right->tree_viewport_top_dir_path,
+                 ctx->left->tree_viewport_top_dir_path,
+                 sizeof(ctx->right->tree_viewport_top_dir_path));
           ctx->right->hide_dot_files = ctx->left->hide_dot_files;
           /*
            * Split ownership boundary: a file-view split must keep the original
@@ -485,6 +488,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeAction action,
           ctx->right->vol = ctx->left->vol;
           ctx->right->cursor_pos = ctx->left->cursor_pos;
           ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
+          memcpy(ctx->right->tree_viewport_top_dir_path,
+                 ctx->left->tree_viewport_top_dir_path,
+                 sizeof(ctx->right->tree_viewport_top_dir_path));
           ctx->right->start_file = ctx->left->start_file;
           ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
           ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;

--- a/tests/helpers_ui.py
+++ b/tests/helpers_ui.py
@@ -1,5 +1,18 @@
+import re
+
+
+_TREE_CONNECTOR_RE = re.compile(r"(?P<connector>[mt]q)(?!q)(?P<label>.+?)\s*$")
+_PATH_HEADER_RE = re.compile(
+    r"\bPath:\s+(?P<path>.*?)(?:\s*\d{2}-\d{2}-\d{4}\s+\d{2}:\d{2}:\d{2}\s*)?$"
+)
+
+
 def screen_text(tui):
     return "\n".join(tui.get_screen_dump())
+
+
+def _screen_lines_text(lines):
+    return "\n".join(lines)
 
 
 def footer_lines(tui):
@@ -32,3 +45,272 @@ def assert_file_tag_state(tui, filename, expected_tagged):
         f"Unexpected tag state for {filename!r}. Expected tagged={expected_tagged}, got {is_tagged}.\n"
         f"Row: {line}\nScreen:\n{screen_text(tui)}"
     )
+
+
+def _detect_split_column(lines):
+    if len(lines) < 3:
+        return None
+
+    top = lines[1]
+    for ch in ("w", "┬", "+"):
+        idx = top.find(ch, 1)
+        if idx != -1:
+            return idx
+
+    counts = {}
+    for row in lines[2:-4]:
+        for x, ch in enumerate(row):
+            if ch in ("x", "|"):
+                counts[x] = counts.get(x, 0) + 1
+
+    if not counts:
+        return None
+    return max(counts, key=counts.get)
+
+
+def _tree_panel_segment(line, split_col, panel):
+    if split_col is None:
+        return line
+    if panel == "left":
+        return line[:split_col]
+    if panel == "right":
+        return line[split_col + 1 :]
+    raise ValueError(f"Unknown tree panel: {panel!r}")
+
+
+def _tree_panel_rows(lines, split_col=None, panel="left"):
+    return [_tree_panel_segment(line, split_col, panel).rstrip() for line in lines[2:-4]]
+
+
+def _clean_tree_label(label):
+    return label.strip().rstrip("/")
+
+
+def _join_tree_path(parent, label):
+    if parent in (None, ""):
+        return label
+    return parent.rstrip("/") + "/" + label
+
+
+def _tree_row_infos(lines, split_col=None, panel="left"):
+    root_connector_col = None
+    stack = []
+    infos = []
+
+    for segment in _tree_panel_rows(lines, split_col=split_col, panel=panel):
+        match = _TREE_CONNECTOR_RE.search(segment)
+        if not match:
+            continue
+
+        label = _clean_tree_label(match.group("label"))
+        if not label:
+            continue
+
+        connector_col = match.start("connector")
+        if root_connector_col is None:
+            root_connector_col = connector_col
+
+        depth = max(0, (connector_col - root_connector_col) // 2)
+        if depth < len(stack):
+            del stack[depth:]
+        while len(stack) < depth:
+            stack.append("")
+        stack.append(label)
+
+        if depth == 0:
+            full_path = label
+        else:
+            full_path = stack[0]
+            for part in stack[1: depth + 1]:
+                full_path = _join_tree_path(full_path, part)
+
+        infos.append(
+            {
+                "segment": segment,
+                "label": label,
+                "path": full_path,
+                "depth": depth,
+            }
+        )
+
+    return infos
+
+
+def first_tree_row_segment(lines, split_col=None, panel="left"):
+    for segment in _tree_panel_rows(lines, split_col=split_col, panel=panel):
+        if segment.strip():
+            return segment
+    return None
+
+
+def _first_tree_row_info(lines, split_col=None, panel="left"):
+    infos = _tree_row_infos(lines, split_col=split_col, panel=panel)
+    if not infos:
+        return None
+    return infos[0]
+
+
+def _panel_path_header(lines, split_col=None, panel="left"):
+    if not lines:
+        return None
+    header = lines[0]
+    match = _PATH_HEADER_RE.search(header)
+    if not match:
+        return None
+    return match.group("path").strip().rstrip("/")
+
+
+def _strip_panel_border_text(segment):
+    text = segment.strip()
+    if text and text[0] in ("x", "|"):
+        text = text[1:]
+    if text and text[-1] in ("x", "|"):
+        text = text[:-1]
+    return text.strip()
+
+
+def _current_dir_from_stats(lines, split_col=None):
+    for idx, line in enumerate(lines):
+        segment = line[split_col:] if split_col is not None else line
+        if "CURRENT DIR" not in segment:
+            continue
+        for offset in (1, 2):
+            row_idx = idx + offset
+            if row_idx >= len(lines):
+                continue
+            candidate = lines[row_idx][split_col:] if split_col is not None else lines[row_idx]
+            text = _strip_panel_border_text(candidate)
+            if text:
+                return text.rstrip("/")
+    return None
+
+
+def _path_label(path):
+    if path is None:
+        return None
+    stripped = path.strip().rstrip("/")
+    if "/" not in stripped:
+        return stripped
+    return stripped.rsplit("/", 1)[-1]
+
+
+def _tree_panel_selected_identity(lines, split_col=None, panel="left"):
+    path = _panel_path_header(lines, split_col=split_col, panel=panel)
+    if path is not None:
+        return {"path": path, "label": _path_label(path)}
+
+    stats_current = _current_dir_from_stats(lines, split_col=split_col)
+    if stats_current is not None:
+        return {"path": stats_current, "label": _path_label(stats_current)}
+
+    return {"path": None, "label": None}
+
+
+def tree_panel_selected_label(lines, split_col=None, panel="left"):
+    return _tree_panel_selected_identity(
+        lines, split_col=split_col, panel=panel
+    )["label"]
+
+
+def _identity_candidates(value):
+    if value is None:
+        return []
+    clean = _clean_tree_label(value)
+    candidates = [clean]
+    label = _path_label(clean)
+    if label is not None and label not in candidates:
+        candidates.append(label)
+    return candidates
+
+
+def tree_row_visible(lines, label, split_col=None, panel="left"):
+    if split_col is None:
+        split_col = _detect_split_column(lines)
+    candidates = _identity_candidates(label)
+    for info in _tree_row_infos(lines, split_col=split_col, panel=panel):
+        for candidate in candidates:
+            if candidate in (info["label"], info["path"]):
+                return True
+    return False
+
+
+def _tree_identity_visible(lines, identity, split_col=None, panel="left"):
+    if split_col is None:
+        split_col = _detect_split_column(lines)
+    candidates = []
+    for value in (identity.get("path"), identity.get("label")):
+        for candidate in _identity_candidates(value):
+            if candidate not in candidates:
+                candidates.append(candidate)
+
+    for info in _tree_row_infos(lines, split_col=split_col, panel=panel):
+        for candidate in candidates:
+            if candidate in (info["label"], info["path"]):
+                return True
+    return False
+
+
+def _origin_identity_changed(before_origin, after_origin):
+    if before_origin is None or after_origin is None:
+        return before_origin != after_origin
+    return (
+        before_origin["segment"] != after_origin["segment"]
+        or before_origin["label"] != after_origin["label"]
+        or before_origin["path"] != after_origin["path"]
+    )
+
+
+def assert_tree_viewport_origin_stable(
+    before_lines,
+    after_lines,
+    *,
+    selected_label=None,
+    split_col=None,
+    panel="left",
+    label="",
+):
+    if split_col is None:
+        split_col = _detect_split_column(after_lines)
+    before_origin = _first_tree_row_info(before_lines, split_col=split_col, panel=panel)
+    after_origin = _first_tree_row_info(after_lines, split_col=split_col, panel=panel)
+    before_origin_segment = before_origin["segment"] if before_origin is not None else None
+    after_origin_segment = after_origin["segment"] if after_origin is not None else None
+    selected_identity = _tree_panel_selected_identity(
+        before_lines, split_col=split_col, panel=panel
+    )
+    if selected_label is None:
+        selected_label = selected_identity["path"] or selected_identity["label"]
+    else:
+        selected_identity = {
+            "path": selected_label if "/" in selected_label else None,
+            "label": _path_label(selected_label),
+        }
+
+    assert selected_label is not None, (
+        f"Could not identify selected tree row for viewport check ({label}).\n"
+        f"Before:\n{_screen_lines_text(before_lines)}"
+    )
+
+    selected_visible = _tree_identity_visible(
+        after_lines, selected_identity, split_col=split_col, panel=panel
+    )
+    if selected_visible:
+        assert not _origin_identity_changed(before_origin, after_origin), (
+            f"Tree viewport origin changed while selected row {selected_label!r} stayed visible"
+            + (f" ({label})" if label else "")
+            + f".\nBefore: {before_origin_segment!r}\nAfter:  {after_origin_segment!r}\n"
+            f"Before origin path: {before_origin['path'] if before_origin else None!r}\n"
+            f"After origin path:  {after_origin['path'] if after_origin else None!r}\n"
+            f"Selected row: {selected_label!r}\nAfter screen:\n{_screen_lines_text(after_lines)}"
+        )
+
+    return {
+        "before_origin": before_origin_segment,
+        "after_origin": after_origin_segment,
+        "before_origin_path": before_origin["path"] if before_origin else None,
+        "after_origin_path": after_origin["path"] if after_origin else None,
+        "selected_label": selected_label,
+        "selected_visible": selected_visible,
+        "split_col": split_col,
+        "panel": panel,
+    }

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -7,10 +7,13 @@ from pathlib import Path
 from helpers_files import wait_for_file as _wait_for_file
 from helpers_stats import detect_stats_split_x as _detect_stats_split_x
 from helpers_ui import (
+    assert_tree_viewport_origin_stable as _assert_tree_viewport_origin_stable,
     find_line_with_text as _find_line_with_text,
     footer_text as _footer_text,
     line_marks_file_as_tagged as _line_marks_file_as_tagged,
     screen_text as _screen_text,
+    tree_panel_selected_label as _tree_panel_selected_label,
+    tree_row_visible as _tree_row_visible,
 )
 from tui_harness import YtreeTUI
 from ytree_keys import Keys
@@ -119,6 +122,62 @@ def _first_tree_row_segment(lines, split_col=None):
 
 def _tree_segment_rows(lines, split_col):
     return [line[:split_col].rstrip() for line in lines[2:-4]]
+
+
+def _populate_hidden_prefix_viewport_tree(root):
+    root.mkdir(parents=True)
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=4\nHIDEDOTFILES=1\nSMALLWINDOWSKIP=0\n",
+        encoding="utf-8",
+    )
+
+    for i in range(40):
+        (root / f".hidden_{i:02d}").mkdir()
+
+    for name, child in (
+        ("go", "pkg"),
+        ("gone", "home"),
+        ("snap", "glow"),
+        ("wikiteam3_utilities", "for later"),
+        ("ytree", "docs"),
+    ):
+        d = root / name
+        d.mkdir()
+        (d / child).mkdir(parents=True)
+
+
+def _move_to_stats_dir(tui, marker, *, max_steps=160):
+    marker_token = f" {marker} "
+    for _ in range(max_steps):
+        if _stats_current_dir_contains(tui.get_screen_dump(), marker_token):
+            return
+        tui.send_keystroke(Keys.DOWN, wait=0.12)
+    pytest.fail(f"Failed to move selection to stats marker '{marker}'.\n{_screen_text(tui)}")
+
+
+def test_tree_viewport_helper_uses_current_row_and_exact_labels():
+    left_width = 60
+    lines = [
+        "Path: /work/wikiteam3_utilities/for later                                                    05-06-2026 20:46:55",
+        "l" + "q" * (left_width - 1) + "wqqqqq FILTER qqqqqk",
+        "x   mq/work".ljust(left_width) + "x           *       x",
+        "x     tqsnap".ljust(left_width) + "tqqq CURRENT DIR qqqu",
+        "x     tqgone".ljust(left_width) + "x for later         x",
+        "x     tqwikiteam3_utilities".ljust(left_width) + "x                   x",
+        "x     x mqfor later".ljust(left_width) + "x                   x",
+        "t" + "q" * left_width + "j                   x",
+        "x  No files".ljust(left_width) + "x                   x",
+        "m" + "q" * left_width + "vqqqqqqqqqqqqqqqqqqqj",
+        "DIR      Attributes Brief Copy Delete Filter Global Invert J compare Log Makedir Newfile",
+        "COMMANDS Only tagged Pipe Quit Rename Showall Tag Untag moVedir Write eXecute Z archive",
+        "←j Tree  F1 help  F5 refresh  F6 stats  F7 autoview  F8 split  F10 config  Esc cancel",
+    ]
+
+    assert _tree_panel_selected_label(lines) == "for later"
+    assert _tree_row_visible(lines, "for later")
+    assert not _tree_row_visible(lines, "for")
+    assert _tree_row_visible(lines, "gone")
+    assert not _tree_row_visible(lines, "go")
 
 
 def test_panel_switch_updates_small_window(dual_panel_sandbox, ytree_binary):
@@ -1534,10 +1593,10 @@ def test_enter_repo_src_cmd_preserves_tree_viewport_anchor(ytree_binary):
         move_to_stats_dir("src")
         before_src_lines = tui.get_screen_dump()
         before_src_screen = "\n".join(before_src_lines)
-        before_src_first_row = _first_tree_row_segment(
+        before_src_selected_label = _tree_panel_selected_label(
             before_src_lines, _detect_stats_split_x(before_src_lines)
         )
-        assert before_src_first_row is not None, before_src_screen
+        assert before_src_selected_label == "src", before_src_screen
 
         tui.send_keystroke(Keys.ENTER, wait=0.6)
         _assert_dir_mode_footer(tui, "Expected tree mode after entering src subtree.")
@@ -1548,25 +1607,25 @@ def test_enter_repo_src_cmd_preserves_tree_viewport_anchor(ytree_binary):
             "ENTER moved selection away from src unexpectedly.\n"
             f"{after_src_screen}"
         )
-        assert (
-            _first_tree_row_segment(
-                after_src_lines, _detect_stats_split_x(after_src_lines)
-            )
-            == before_src_first_row
-        ), (
-            "ENTER on src recentered tree viewport instead of preserving the "
-            "existing viewport origin.\n"
-            f"before_src_first_row={before_src_first_row!r}\n"
+        viewport = _assert_tree_viewport_origin_stable(
+            before_src_lines,
+            after_src_lines,
+            split_col=_detect_stats_split_x(after_src_lines),
+            label="ENTER on src",
+        )
+        assert viewport["selected_visible"], (
+            "ENTER on src should keep the selected tree row visible.\n"
             f"{after_src_screen}"
         )
+        assert "build" in after_src_screen and "src" in after_src_screen, after_src_screen
 
         move_to_stats_dir("cmd")
         before_cmd_lines = tui.get_screen_dump()
         before_cmd_screen = "\n".join(before_cmd_lines)
-        before_cmd_first_row = _first_tree_row_segment(
+        before_cmd_selected_label = _tree_panel_selected_label(
             before_cmd_lines, _detect_stats_split_x(before_cmd_lines)
         )
-        assert before_cmd_first_row is not None, before_cmd_screen
+        assert before_cmd_selected_label == "cmd", before_cmd_screen
 
         tui.send_keystroke(Keys.ENTER, wait=0.6)
         assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
@@ -1581,15 +1640,14 @@ def test_enter_repo_src_cmd_preserves_tree_viewport_anchor(ytree_binary):
             "Returning from cmd file view moved selection unexpectedly.\n"
             f"{after_cmd_screen}"
         )
-        assert (
-            _first_tree_row_segment(
-                after_cmd_lines, _detect_stats_split_x(after_cmd_lines)
-            )
-            == before_cmd_first_row
-        ), (
-            "Second ENTER on src/cmd recentered tree viewport after returning "
-            "from file view instead of preserving the existing viewport origin.\n"
-            f"before_cmd_first_row={before_cmd_first_row!r}\n"
+        viewport = _assert_tree_viewport_origin_stable(
+            before_cmd_lines,
+            after_cmd_lines,
+            split_col=_detect_stats_split_x(after_cmd_lines),
+            label="ENTER on src/cmd after file view",
+        )
+        assert viewport["selected_visible"], (
+            "Returning from cmd file view should keep the selected tree row visible.\n"
             f"{after_cmd_screen}"
         )
     finally:
@@ -1959,6 +2017,47 @@ def test_down_from_root_does_not_scroll_hidden_prefix(tmp_path, ytree_binary):
         tui.quit()
 
 
+def test_tree_jump_ignores_hidden_dot_prefix_descendants(tmp_path, ytree_binary):
+    root = tmp_path / "jump_hidden_prefix" / "home" / "rob"
+    root.mkdir(parents=True)
+    (root / ".ytree").write_text(
+        "[GLOBAL]\nTREEDEPTH=4\nHIDEDOTFILES=1\n",
+        encoding="utf-8",
+    )
+
+    hidden_src = root / ".local" / "src"
+    visible_src = root / "ytree" / "src"
+    hidden_src.mkdir(parents=True)
+    visible_src.mkdir(parents=True)
+    (hidden_src / "hidden_src_marker.txt").write_text("hidden\n", encoding="utf-8")
+    (visible_src / "visible_src_marker.txt").write_text("visible\n", encoding="utf-8")
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(root),
+        env_extra={"HOME": str(root)},
+    )
+    time.sleep(1.0)
+    try:
+        tui.send_keystroke("/src" + Keys.ENTER, wait=0.8)
+
+        screen = _screen_text(tui)
+        assert "visible_src_marker.txt" in screen, (
+            "Visible tree jump should select the visible src directory.\n"
+            f"{screen}"
+        )
+        assert "hidden_src_marker.txt" not in screen, (
+            "Visible tree jump selected a hidden dot-directory descendant.\n"
+            f"{screen}"
+        )
+        assert "/.local/src" not in screen, (
+            "Visible tree jump resolved through a hidden dot-directory path.\n"
+            f"{screen}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_mkdir_preserves_collapsed_children_after_left_enter(
     tmp_path, ytree_binary
 ):
@@ -2106,6 +2205,99 @@ def test_end_preserves_tree_viewport_with_hidden_prefix(tmp_path, ytree_binary):
         tui.quit()
 
 
+# Viewport-origin regression coverage notes:
+# - Dotfile reveal/conceal and visible-child delete exercise rebuild/mutation
+#   paths where selection remains visible and the top visible row must stay
+#   anchored.
+# - Mixed split-panel file/tree reactivation is covered by adjacent split
+#   viewport tests; these hidden-prefix fixtures stay filesystem-independent.
+def test_dotfiles_toggle_restores_tree_viewport_origin_with_hidden_prefix(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "dotfiles_toggle_hidden_prefix_viewport" / "home" / "rob"
+    _populate_hidden_prefix_viewport_tree(root)
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(root),
+        env_extra={"HOME": str(root)},
+    )
+    time.sleep(1.0)
+    try:
+        _move_to_stats_dir(tui, "for later")
+        before_lines = tui.get_screen_dump()
+        before_screen = "\n".join(before_lines)
+        assert _tree_panel_selected_label(before_lines) == "for later", before_screen
+
+        tui.send_keystroke("`", wait=0.8)
+        assert _tree_panel_selected_label(tui.get_screen_dump()) == "for later", (
+            "Revealing dotfiles should preserve the selected directory.\n"
+            f"{_screen_text(tui)}"
+        )
+        tui.send_keystroke("`", wait=0.8)
+
+        after_lines = tui.get_screen_dump()
+        after_screen = "\n".join(after_lines)
+        assert _tree_panel_selected_label(after_lines) == "for later", after_screen
+        viewport = _assert_tree_viewport_origin_stable(
+            before_lines,
+            after_lines,
+            split_col=_detect_stats_split_x(after_lines),
+            label="dotfile reveal/conceal",
+        )
+        assert viewport["selected_visible"], (
+            "Dotfile reveal/conceal should keep the selected tree row visible.\n"
+            f"{after_screen}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_delete_visible_child_restores_tree_viewport_origin_with_hidden_prefix(
+    tmp_path, ytree_binary
+):
+    root = tmp_path / "delete_hidden_prefix_viewport" / "home" / "rob"
+    _populate_hidden_prefix_viewport_tree(root)
+
+    tui = YtreeTUI(
+        executable=ytree_binary,
+        cwd=str(root),
+        env_extra={"HOME": str(root)},
+    )
+    time.sleep(1.0)
+    try:
+        _move_to_stats_dir(tui, "for later")
+        before_lines = tui.get_screen_dump()
+        before_screen = "\n".join(before_lines)
+        assert _tree_panel_selected_label(before_lines) == "for later", before_screen
+
+        tui.send_keystroke("d", wait=0.4)
+        assert tui.wait_for_content("Delete this directory", timeout=1.0), _screen_text(
+            tui
+        )
+        tui.send_keystroke("y", wait=1.2)
+
+        after_lines = tui.get_screen_dump()
+        after_screen = "\n".join(after_lines)
+        assert not (root / "wikiteam3_utilities" / "for later").exists()
+        assert _tree_panel_selected_label(after_lines) == "wikiteam3_utilities", (
+            after_screen
+        )
+        viewport = _assert_tree_viewport_origin_stable(
+            before_lines,
+            after_lines,
+            selected_label="wikiteam3_utilities",
+            split_col=_detect_stats_split_x(after_lines),
+            label="delete visible child",
+        )
+        assert viewport["selected_visible"], (
+            "Deleting a visible child should keep the parent tree row visible.\n"
+            f"{after_screen}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_split_tab_round_trip_preserves_tree_viewport_with_hidden_prefix(
     tmp_path, ytree_binary
 ):
@@ -2133,23 +2325,31 @@ def test_split_tab_round_trip_preserves_tree_viewport_with_hidden_prefix(
     tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
     time.sleep(1.0)
     try:
-        before = _first_tree_row_segment(tui.get_screen_dump())
-        assert before is not None, _screen_text(tui)
+        before_lines = tui.get_screen_dump()
+        before_selected_label = _tree_panel_selected_label(before_lines)
+        assert before_selected_label is not None, _screen_text(tui)
 
         tui.send_keystroke(Keys.F8, wait=0.6)
         tui.send_keystroke(Keys.TAB, wait=0.6)
         tui.send_keystroke(Keys.TAB, wait=0.6)
 
-        lines = tui.get_screen_dump()
-        split_col = _detect_split_column(lines)
-        assert split_col is not None, _screen_text(tui)
-        after = _first_tree_row_segment(lines, split_col=split_col)
-        stable_width = min(split_col, 40)
-        assert before[:stable_width].rstrip() == after[:stable_width].rstrip(), (
-            "Split Tab round-trip should not reanchor the first panel's tree "
-            "viewport when the visible rows still fit.\n"
-            f"Before: {before!r}\nAfter:  {after!r}\n{_screen_text(tui)}"
+        after_lines = tui.get_screen_dump()
+        viewport = _assert_tree_viewport_origin_stable(
+            before_lines,
+            after_lines,
+            split_col=_detect_split_column(after_lines),
+            label="Split Tab round-trip",
         )
+        if not viewport["selected_visible"]:
+            assert not _tree_row_visible(
+                after_lines,
+                viewport["selected_label"],
+                split_col=viewport["split_col"],
+                panel=viewport["panel"],
+            ), (
+                "Split Tab round-trip allowed the viewport to reanchor because the selected row is no longer visible.\n"
+                f"{_screen_text(tui)}"
+            )
     finally:
         tui.quit()
 

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -307,6 +307,107 @@ def test_split_tab_from_small_file_does_not_expand_inactive_panel(tmp_path, ytre
         tui.quit()
 
 
+def test_split_tab_enter_tab_keeps_tree_panel_focus_local(tmp_path, ytree_binary):
+    root = tmp_path / "split_tab_enter_tab_tree_focus_local"
+    root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nSMALLWINDOWSKIP=1\n", encoding="utf-8")
+    for filename in (
+        "AGENTS.md",
+        "compile_commands.json",
+        "LICENSE.md",
+        "Makefile",
+        "README.md",
+        "SECURITY.md",
+        "todo.txt",
+        "update.txt",
+        "valgrind.log",
+    ):
+        (root / filename).write_text(f"{filename}\n", encoding="utf-8")
+    for name in ("build", "docs", "etc", "include", "obj", "scripts", "src"):
+        subdir = root / name
+        subdir.mkdir()
+        (subdir / f"{name}.txt").write_text(f"{name}\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        _assert_dir_mode_footer(tui, "Expected tree focus before split.")
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        _assert_dir_mode_footer(
+            tui,
+            "Tree-focused panel imported file/small-window focus after "
+            "F8 -> Tab -> Enter -> Tab.",
+        )
+        lines = tui.get_screen_dump()
+        split_col = _detect_split_column(lines)
+        assert split_col is not None, _screen_text(tui)
+        left_top = [line[:split_col] for line in lines[2:12]]
+        assert any("build" in segment for segment in left_top) and not any(
+            "AGENTS.md" in segment for segment in left_top
+        ), (
+            "Tree-focused panel kept the tree footer but rendered the active "
+            "peer's big-file window shape after F8 -> Tab -> Enter -> Tab.\n"
+            f"{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
+def test_split_tab_enter_tab_restores_small_file_shape_local(tmp_path, ytree_binary):
+    root = tmp_path / "split_tab_enter_tab_small_shape_local"
+    root.mkdir()
+    (root / ".ytree").write_text("[GLOBAL]\nSMALLWINDOWSKIP=0\n", encoding="utf-8")
+    (root / "root_file.txt").write_text("root\n", encoding="utf-8")
+    for name in ("alpha", "beta"):
+        subdir = root / name
+        subdir.mkdir()
+        (subdir / f"{name}.txt").write_text(f"{name}\n", encoding="utf-8")
+
+    tui = YtreeTUI(executable=ytree_binary, cwd=str(root))
+    time.sleep(0.8)
+
+    try:
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke(Keys.F8, wait=0.4)
+        tui.send_keystroke(Keys.TAB, wait=0.4)
+        tui.send_keystroke(Keys.ENTER, wait=0.4)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        tui.send_keystroke(Keys.TAB, wait=0.5)
+        assert "hex invert j compare" in _footer_text(tui), _screen_text(tui)
+
+        lines = tui.get_screen_dump()
+        split_col = _detect_split_column(lines)
+        assert split_col is not None, _screen_text(tui)
+        left_top = [line[:split_col] for line in lines[2:12]]
+        left_file_idx = next(
+            (
+                idx
+                for idx, line in enumerate(lines)
+                if "root_file.txt" in line[:split_col]
+            ),
+            -1,
+        )
+        assert left_file_idx > 10 and not any(
+            "root_file.txt" in segment for segment in left_top
+        ), (
+            "Tab back imported the other panel's big-file shape instead of "
+            "restoring the left panel's saved small-file shape.\n"
+            f"{_screen_text(tui)}"
+        )
+    finally:
+        tui.quit()
+
+
 def test_split_from_big_file_keeps_inactive_panel_in_file_view(tmp_path, ytree_binary):
     root = tmp_path / "split_from_big_file_inactive_file_view"
     root.mkdir()


### PR DESCRIPTION
## Summary
- Adds a panel-owned tree viewport top identity and canonical viewport snapshot/restore helpers.
- Routes dotfile toggle, delete, refresh, restore, and split seeding paths through the panel-anchor owner instead of raw flat-list reanchors.
- Keeps render as a consumer of resolved viewport state while preserving inactive-panel isolation.
- Excludes hidden dot-directory descendants from ordinary visible-tree jump selection while dot directories are hidden.

## Validation
- Targeted hidden-prefix jump and viewport-origin regressions — passed.
- Focused viewport/split regression subset — passed.
- `make qa-cppcheck` — passed.
- `make` — passed.
- `git diff --check` — passed.

## Notes
This PR now includes the production viewport-owner fix. Tree viewport origin is
restored as panel-owned identity state rather than as a raw flattened-list row
position, so rebuild, refresh, toggle, and mutation paths restore through the
canonical viewport owner instead of letting render/rebuild paths reanchor the
tree.

The PR also makes ordinary visible-tree jump selection honor the active panel's
hidden-entry visibility: hidden dot-directory descendants are not candidates
while dot directories are hidden.

The included regressions cover hidden-prefix jump selection, dotfile
reveal/conceal and delete-visible-child viewport shifts, plus adjacent
split/viewport flows.