### PR TITLE
chore(appstate): cover action transition metadata

### DIFF
--- a/docs/appstate_action_coverage.json
+++ b/docs/appstate_action_coverage.json
@@ -1,0 +1,1474 @@
+{
+  "schema_version": 1,
+  "contract": "YtreeAction AppState transition coverage",
+  "notes": "Non-runtime registry ensuring every YtreeAction enum member has AppState transition metadata coverage. Runtime behavior is unchanged.",
+  "actions": [
+    {
+      "action": "ACTION_NONE",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_MOVE_UP",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_MOVE_DOWN",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_MOVE_SIBLING_NEXT",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_MOVE_SIBLING_PREV",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_MOVE_LEFT",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_MOVE_RIGHT",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_PAGE_UP",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_PAGE_DOWN",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_HOME",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_END",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TREE_EXPAND",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TREE_COLLAPSE",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TREE_EXPAND_ALL",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_ENTER",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_ESCAPE",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_LOG",
+      "transition_id": "transition.refresh-rebuild.manual-refresh",
+      "category": "refresh_rebuild",
+      "owner": "Volume(shared topology)",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.logged_state",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the refresh/rebuild foundation record until log, relog, and refresh actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_QUIT",
+      "transition_id": "transition.command-completion.user-command",
+      "category": "command_completion",
+      "owner": "ViewContext.command_region",
+      "declared_write_set": [
+        "ctx.command_state",
+        "ctx.message_state",
+        "ctx.pending_transition",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_QUIT_DIR",
+      "transition_id": "transition.command-completion.user-command",
+      "category": "command_completion",
+      "owner": "ViewContext.command_region",
+      "declared_write_set": [
+        "ctx.command_state",
+        "ctx.message_state",
+        "ctx.pending_transition",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_TAG",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_UNTAG",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TAG_ALL",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_UNTAG_ALL",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TAG_REST",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_UNTAG_REST",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_FILTER",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TOGGLE_MODE",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_REFRESH",
+      "transition_id": "transition.refresh-rebuild.manual-refresh",
+      "category": "refresh_rebuild",
+      "owner": "Volume(shared topology)",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.logged_state",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the refresh/rebuild foundation record until log, relog, and refresh actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_RESIZE",
+      "transition_id": "transition.terminal-signal-resize",
+      "category": "terminal_signal_or_resize",
+      "owner": "ViewContext.layout_region",
+      "declared_write_set": [
+        "ctx.layout",
+        "ctx.window_handles",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the terminal resize foundation record; signal handlers must only set flags before this transition commits."
+      ]
+    },
+    {
+      "action": "ACTION_VOL_MENU",
+      "transition_id": "transition.menu-action.volume-select",
+      "category": "menu_action",
+      "owner": "ViewContext(session routing) and YtreePanel(active)",
+      "declared_write_set": [
+        "ctx.active",
+        "panel.volume_key",
+        "panel.restore_snapshot",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the volume menu foundation record until menu selection has a runtime transition boundary."
+      ]
+    },
+    {
+      "action": "ACTION_VOL_PREV",
+      "transition_id": "transition.volume-operation.release-cycle",
+      "category": "volume_operation",
+      "owner": "ViewContext.volume_registry and YtreePanel(active)",
+      "declared_write_set": [
+        "ctx.volumes_head",
+        "panel.volume_key",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.volume_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the volume operation foundation record until cycle/release actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_VOL_NEXT",
+      "transition_id": "transition.volume-operation.release-cycle",
+      "category": "volume_operation",
+      "owner": "ViewContext.volume_registry and YtreePanel(active)",
+      "declared_write_set": [
+        "ctx.volumes_head",
+        "panel.volume_key",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.volume_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the volume operation foundation record until cycle/release actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_A",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_B",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_C",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_D",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_E",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_G",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_H",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_I",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_M",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_O",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_P",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_R",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_S",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_V",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_X",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_Y",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_PRINT",
+      "transition_id": "transition.command-completion.user-command",
+      "category": "command_completion",
+      "owner": "ViewContext.command_region",
+      "declared_write_set": [
+        "ctx.command_state",
+        "ctx.message_state",
+        "ctx.pending_transition",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_TOGGLE_HIDDEN",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TOGGLE_COMPACT",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_MKFILE",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_A",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_C",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_D",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_G",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_M",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_O",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_P",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_R",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_S",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_V",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_X",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_Y",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata."
+      ]
+    },
+    {
+      "action": "ACTION_CMD_TAGGED_PRINT",
+      "transition_id": "transition.command-completion.user-command",
+      "category": "command_completion",
+      "owner": "ViewContext.command_region",
+      "declared_write_set": [
+        "ctx.command_state",
+        "ctx.message_state",
+        "ctx.pending_transition",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_LIST_JUMP",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TO_DIR",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TOGGLE_TAGGED_MODE",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_TOGGLE_STATS",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_ASTERISK",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_INVERT",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_SPLIT_SCREEN",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_SWITCH_PANEL",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_VIEW_PREVIEW",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_PREVIEW_SCROLL_UP",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_PREVIEW_SCROLL_DOWN",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_PREVIEW_HOME",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_PREVIEW_END",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_PREVIEW_PAGE_UP",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_PREVIEW_PAGE_DOWN",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_COMPARE_FILE",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_COMPARE_DIR",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_COMPARE_TREE",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "category": "keybinding",
+      "owner": "YtreePanel(active)",
+      "declared_write_set": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+      ]
+    },
+    {
+      "action": "ACTION_EDIT_CONFIG",
+      "transition_id": "transition.command-completion.user-command",
+      "category": "command_completion",
+      "owner": "ViewContext.command_region",
+      "declared_write_set": [
+        "ctx.command_state",
+        "ctx.message_state",
+        "ctx.pending_transition",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records."
+      ]
+    },
+    {
+      "action": "ACTION_USER_CMD",
+      "transition_id": "transition.command-completion.user-command",
+      "category": "command_completion",
+      "owner": "ViewContext.command_region",
+      "declared_write_set": [
+        "ctx.command_state",
+        "ctx.message_state",
+        "ctx.pending_transition",
+        "panel.panel_generation"
+      ],
+      "boundary_status": "documented_foundation_only",
+      "migration_notes": [
+        "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records."
+      ]
+    }
+  ]
+}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_TRANSITIONS = REPO_ROOT / "docs" / "appstate_transition_matrix.json"
 DEFAULT_SHIMS = REPO_ROOT / "docs" / "appstate_compat_shims.json"
+DEFAULT_ACTION_COVERAGE = REPO_ROOT / "docs" / "appstate_action_coverage.json"
+DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytree_defs.h"
 
 REQUIRED_TRANSITION_CATEGORIES = {
     "keybinding",
@@ -56,10 +59,21 @@ REQUIRED_SHIM_FIELDS = {
     "qa_enforcement",
 }
 
+REQUIRED_ACTION_FIELDS = {
+    "action",
+    "transition_id",
+    "category",
+    "owner",
+    "declared_write_set",
+    "boundary_status",
+    "migration_notes",
+}
+
 LIST_FIELDS = {
     "declared_write_set",
     "side_effects",
     "invariant_checks",
+    "migration_notes",
 }
 
 
@@ -82,6 +96,18 @@ def _is_non_empty(value: Any) -> bool:
     return value is not None
 
 
+def _validate_list_field(*, value: Any, label: str, field: str) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(value, list):
+        return [f"{label}: {field} must be a non-empty list"]
+    if not value:
+        failures.append(f"{label}: {field} must be non-empty")
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            failures.append(f"{label}: {field}[{index}] must be a non-empty string")
+    return failures
+
+
 def _validate_required_fields(
     *,
     record: Any,
@@ -97,22 +123,57 @@ def _validate_required_fields(
     if missing:
         failures.append(f"{label}: missing required field(s): {', '.join(missing)}")
 
-    for field in sorted(required_fields & set(record)):
+    for field in sorted((required_fields | list_fields) & set(record)):
         value = record[field]
-        if field in list_fields and not isinstance(value, list):
-            failures.append(f"{label}: {field} must be a non-empty list")
-        if not _is_non_empty(value):
+        if field in list_fields:
+            failures.extend(_validate_list_field(value=value, label=label, field=field))
+        elif not _is_non_empty(value):
             failures.append(f"{label}: {field} must be non-empty")
 
     return failures
 
 
-def validate_contract(transitions_path: Path, shims_path: Path) -> list[str]:
+def _parse_ytree_actions(header_path: Path) -> tuple[list[str], list[str]]:
+    try:
+        source = header_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{header_path}: failed to read: {exc}"]
+
+    match = re.search(r"typedef\s+enum\s*\{(?P<body>.*?)\}\s*YtreeAction\s*;", source, re.S)
+    if match is None:
+        return [], [f"{header_path}: failed to find YtreeAction enum"]
+
+    body = re.sub(r"/\*.*?\*/", "", match.group("body"), flags=re.S)
+    body = re.sub(r"//.*", "", body)
+    actions: list[str] = []
+    for item in body.split(","):
+        action = item.split("=", 1)[0].strip()
+        if not action:
+            continue
+        if not re.fullmatch(r"ACTION_[A-Z0-9_]+", action):
+            return [], [f"{header_path}: invalid YtreeAction enum member: {action}"]
+        actions.append(action)
+
+    if not actions:
+        return [], [f"{header_path}: YtreeAction enum must not be empty"]
+    return actions, []
+
+
+def validate_contract(
+    transitions_path: Path,
+    shims_path: Path,
+    action_coverage_path: Path,
+    actions_header_path: Path,
+) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
     shims_doc, shim_load_failures = _load_json(shims_path)
+    action_coverage_doc, action_coverage_load_failures = _load_json(action_coverage_path)
+    enum_actions, enum_failures = _parse_ytree_actions(actions_header_path)
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
+    failures.extend(action_coverage_load_failures)
+    failures.extend(enum_failures)
     if failures:
         return failures
 
@@ -125,7 +186,7 @@ def validate_contract(transitions_path: Path, shims_path: Path) -> list[str]:
             failures.append(f"{transitions_path}: transitions must be a non-empty list")
             transitions = []
 
-    transition_ids: set[str] = set()
+    transition_ids: dict[str, dict[str, Any]] = {}
     categories: set[str] = set()
     for index, record in enumerate(transitions):
         label = f"transition[{index}]"
@@ -143,7 +204,7 @@ def validate_contract(transitions_path: Path, shims_path: Path) -> list[str]:
         if isinstance(transition_id, str) and transition_id.strip():
             if transition_id in transition_ids:
                 failures.append(f"{label}: duplicate id: {transition_id}")
-            transition_ids.add(transition_id)
+            transition_ids[transition_id] = record
         category = record.get("category")
         if isinstance(category, str) and category.strip():
             categories.add(category)
@@ -189,6 +250,65 @@ def validate_contract(transitions_path: Path, shims_path: Path) -> list[str]:
                     f"{label}: target_transition does not match a transition id: {target_transition}"
                 )
 
+    if not isinstance(action_coverage_doc, dict):
+        failures.append(f"{action_coverage_path}: top-level value must be an object")
+        action_records = []
+    else:
+        action_records = action_coverage_doc.get("actions")
+        if not isinstance(action_records, list) or not action_records:
+            failures.append(f"{action_coverage_path}: actions must be a non-empty list")
+            action_records = []
+
+    expected_actions = set(enum_actions)
+    covered_actions: set[str] = set()
+    for index, record in enumerate(action_records):
+        label = f"action[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_ACTION_FIELDS,
+                list_fields=LIST_FIELDS,
+                label=label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+
+        action = record.get("action")
+        if isinstance(action, str) and action.strip():
+            if action in covered_actions:
+                failures.append(f"{label}: duplicate action: {action}")
+            covered_actions.add(action)
+            if action not in expected_actions:
+                failures.append(f"{label}: unknown YtreeAction enum member: {action}")
+
+        transition_id = record.get("transition_id")
+        transition_record = None
+        if isinstance(transition_id, str) and transition_id.strip():
+            transition_record = transition_ids.get(transition_id)
+            if transition_record is None:
+                failures.append(
+                    f"{label}: transition_id does not match a transition id: {transition_id}"
+                )
+
+        category = record.get("category")
+        if (
+            isinstance(category, str)
+            and category.strip()
+            and transition_record is not None
+            and category != transition_record.get("category")
+        ):
+            failures.append(
+                f"{label}: category does not match transition {transition_id}: {category}"
+            )
+
+    missing_actions = sorted(expected_actions - covered_actions)
+    if missing_actions:
+        failures.append(
+            "action coverage missing YtreeAction enum member(s): "
+            + ", ".join(missing_actions)
+        )
+
     return failures
 
 
@@ -196,9 +316,16 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--transitions", type=Path, default=DEFAULT_TRANSITIONS)
     parser.add_argument("--shims", type=Path, default=DEFAULT_SHIMS)
+    parser.add_argument("--action-coverage", type=Path, default=DEFAULT_ACTION_COVERAGE)
+    parser.add_argument("--actions-header", type=Path, default=DEFAULT_ACTION_HEADER)
     args = parser.parse_args()
 
-    failures = validate_contract(args.transitions, args.shims)
+    failures = validate_contract(
+        args.transitions,
+        args.shims,
+        args.action_coverage,
+        args.actions_header,
+    )
     if failures:
         for failure in failures:
             print(f"FAIL: {failure}")

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4,6 +4,8 @@ import importlib.util
 import subprocess
 from pathlib import Path
 
+import pytest
+
 GUARD_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_appstate_contract.py"
 GUARD_SPEC = importlib.util.spec_from_file_location("check_appstate_contract", GUARD_PATH)
 assert GUARD_SPEC is not None and GUARD_SPEC.loader is not None
@@ -12,6 +14,15 @@ GUARD_SPEC.loader.exec_module(guard)
 
 
 REQUIRED_CATEGORIES = sorted(guard.REQUIRED_TRANSITION_CATEGORIES)
+FIXTURE_ACTIONS = ["ACTION_NONE", "ACTION_MOVE_UP", "ACTION_USER_CMD"]
+REQUIRED_LIST_FIELD_CASES = [
+    ("action", "declared_write_set", "action[0]"),
+    ("action", "migration_notes", "action[0]"),
+    ("transition", "declared_write_set", "transition[0]"),
+    ("transition", "side_effects", "transition[0]"),
+    ("shim", "invariant_checks", "shim[0]"),
+    ("shim", "migration_notes", "shim[0]"),
+]
 
 
 def _write(path: Path, content: str) -> None:
@@ -54,17 +65,42 @@ def _shim(target_transition: str = "transition.keybinding") -> dict[str, object]
     }
 
 
+def _action(
+    action: str,
+    transition_id: str = "transition.keybinding",
+    category: str = "keybinding",
+) -> dict[str, object]:
+    return {
+        "action": action,
+        "transition_id": transition_id,
+        "category": category,
+        "owner": "YtreePanel(active)",
+        "declared_write_set": ["panel.tree_selection_key"],
+        "boundary_status": "test",
+        "migration_notes": ["fixture coverage"],
+    }
+
+
 def _write_fixture(
     tmp_path: Path,
     *,
     transitions: list[dict[str, object]],
     shims: list[dict[str, object]] | None = None,
-) -> tuple[Path, Path]:
+    actions: list[dict[str, object]] | None = None,
+    enum_actions: list[str] | None = None,
+) -> tuple[Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
+    action_coverage_path = tmp_path / "action_coverage.json"
+    actions_header_path = tmp_path / "ytree_defs.h"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
     _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
-    return transitions_path, shims_path
+    _write(
+        action_coverage_path,
+        _jsonish({"schema_version": 1, "actions": actions or _complete_actions()}),
+    )
+    _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
+    return transitions_path, shims_path, action_coverage_path, actions_header_path
 
 
 def _jsonish(value: object) -> str:
@@ -73,11 +109,41 @@ def _jsonish(value: object) -> str:
     return json.dumps(value, indent=2)
 
 
+def _enum_header(actions: list[str]) -> str:
+    members = "\n".join(f"  {action}," for action in actions)
+    return f"typedef enum {{\n{members}\n}} YtreeAction;\n"
+
+
 def _complete_transitions() -> list[dict[str, object]]:
     return [
         _transition(category, "transition.keybinding" if category == "keybinding" else None)
         for category in REQUIRED_CATEGORIES
     ]
+
+
+def _complete_actions() -> list[dict[str, object]]:
+    return [_action(action) for action in FIXTURE_ACTIONS]
+
+
+def _validate(paths: tuple[Path, Path, Path, Path]) -> list[str]:
+    return guard.validate_contract(*paths)
+
+
+def _fixture_with_list_field_value(
+    tmp_path: Path, record_type: str, field: str, value: object
+) -> tuple[Path, Path, Path, Path]:
+    transitions = _complete_transitions()
+    shims = [_shim()]
+    actions = _complete_actions()
+    if record_type == "action":
+        actions[0][field] = value
+    elif record_type == "transition":
+        transitions[0][field] = value
+    elif record_type == "shim":
+        shims[0][field] = value
+    else:
+        raise AssertionError(f"unknown record type: {record_type}")
+    return _write_fixture(tmp_path, transitions=transitions, shims=shims, actions=actions)
 
 
 def test_current_repository_appstate_contract_passes() -> None:
@@ -94,9 +160,9 @@ def test_current_repository_appstate_contract_passes() -> None:
 
 def test_guard_passes_complete_temporary_fixtures(tmp_path: Path) -> None:
     transitions = _complete_transitions()
-    transitions_path, shims_path = _write_fixture(tmp_path, transitions=transitions)
+    paths = _write_fixture(tmp_path, transitions=transitions)
 
-    failures = guard.validate_contract(transitions_path, shims_path)
+    failures = _validate(paths)
 
     assert failures == []
 
@@ -107,9 +173,9 @@ def test_guard_fails_when_required_category_is_missing(tmp_path: Path) -> None:
         for category in REQUIRED_CATEGORIES
         if category != "render_reflow"
     ]
-    transitions_path, shims_path = _write_fixture(tmp_path, transitions=transitions)
+    paths = _write_fixture(tmp_path, transitions=transitions)
 
-    failures = guard.validate_contract(transitions_path, shims_path)
+    failures = _validate(paths)
 
     assert any("missing required category" in failure for failure in failures)
     assert any("render_reflow" in failure for failure in failures)
@@ -118,9 +184,9 @@ def test_guard_fails_when_required_category_is_missing(tmp_path: Path) -> None:
 def test_guard_fails_when_required_transition_field_is_missing(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     transitions[0].pop("owner")
-    transitions_path, shims_path = _write_fixture(tmp_path, transitions=transitions)
+    paths = _write_fixture(tmp_path, transitions=transitions)
 
-    failures = guard.validate_contract(transitions_path, shims_path)
+    failures = _validate(paths)
 
     assert any("missing required field" in failure and "owner" in failure for failure in failures)
 
@@ -129,12 +195,26 @@ def test_guard_fails_when_required_shim_field_is_missing(tmp_path: Path) -> None
     transitions = _complete_transitions()
     shim = _shim()
     shim.pop("removal_trigger")
-    transitions_path, shims_path = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
 
-    failures = guard.validate_contract(transitions_path, shims_path)
+    failures = _validate(paths)
 
     assert any(
         "missing required field" in failure and "removal_trigger" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_required_action_field_is_missing(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0].pop("owner")
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure and "missing required field" in failure and "owner" in failure
         for failure in failures
     )
 
@@ -143,16 +223,27 @@ def test_guard_fails_on_duplicate_transition_and_shim_ids(tmp_path: Path) -> Non
     transitions = _complete_transitions()
     transitions[1]["id"] = transitions[0]["id"]
     duplicate_shim = _shim()
-    transitions_path, shims_path = _write_fixture(
+    paths = _write_fixture(
         tmp_path,
         transitions=transitions,
         shims=[_shim(), duplicate_shim],
     )
 
-    failures = guard.validate_contract(transitions_path, shims_path)
+    failures = _validate(paths)
 
     assert any("transition[1]" in failure and "duplicate id" in failure for failure in failures)
     assert any("shim[1]" in failure and "duplicate id" in failure for failure in failures)
+
+
+def test_guard_fails_on_duplicate_action_records(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[1]["action"] = actions[0]["action"]
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any("action[1]" in failure and "duplicate action" in failure for failure in failures)
 
 
 def test_guard_fails_on_empty_required_list_fields(tmp_path: Path) -> None:
@@ -160,9 +251,11 @@ def test_guard_fails_on_empty_required_list_fields(tmp_path: Path) -> None:
     transitions[0]["declared_write_set"] = []
     shim = _shim()
     shim["invariant_checks"] = []
-    transitions_path, shims_path = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+    actions = _complete_actions()
+    actions[0]["declared_write_set"] = []
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim], actions=actions)
 
-    failures = guard.validate_contract(transitions_path, shims_path)
+    failures = _validate(paths)
 
     assert any(
         "transition[0]" in failure
@@ -173,6 +266,12 @@ def test_guard_fails_on_empty_required_list_fields(tmp_path: Path) -> None:
     assert any(
         "shim[0]" in failure
         and "invariant_checks" in failure
+        and "must be non-empty" in failure
+        for failure in failures
+    )
+    assert any(
+        "action[0]" in failure
+        and "declared_write_set" in failure
         and "must be non-empty" in failure
         for failure in failures
     )
@@ -183,9 +282,11 @@ def test_guard_fails_on_non_list_required_list_fields(tmp_path: Path) -> None:
     transitions[0]["declared_write_set"] = "field"
     shim = _shim()
     shim["invariant_checks"] = "invariant"
-    transitions_path, shims_path = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+    actions = _complete_actions()
+    actions[0]["migration_notes"] = "note"
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim], actions=actions)
 
-    failures = guard.validate_contract(transitions_path, shims_path)
+    failures = _validate(paths)
 
     assert any(
         "transition[0]" in failure
@@ -199,20 +300,133 @@ def test_guard_fails_on_non_list_required_list_fields(tmp_path: Path) -> None:
         and "must be a non-empty list" in failure
         for failure in failures
     )
+    assert any(
+        "action[0]" in failure
+        and "migration_notes" in failure
+        and "must be a non-empty list" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(("record_type", "field", "label"), REQUIRED_LIST_FIELD_CASES)
+@pytest.mark.parametrize("value", ([123], [{"not": "a string"}]))
+def test_guard_fails_on_non_string_required_list_elements(
+    tmp_path: Path, record_type: str, field: str, label: str, value: object
+) -> None:
+    paths = _fixture_with_list_field_value(tmp_path, record_type, field, value)
+
+    failures = _validate(paths)
+
+    assert any(
+        label in failure
+        and f"{field}[0]" in failure
+        and "must be a non-empty string" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(("record_type", "field", "label"), REQUIRED_LIST_FIELD_CASES)
+@pytest.mark.parametrize("value", ([""], ["   "]))
+def test_guard_fails_on_blank_required_list_elements(
+    tmp_path: Path, record_type: str, field: str, label: str, value: object
+) -> None:
+    paths = _fixture_with_list_field_value(tmp_path, record_type, field, value)
+
+    failures = _validate(paths)
+
+    assert any(
+        label in failure
+        and f"{field}[0]" in failure
+        and "must be a non-empty string" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_when_shim_targets_unknown_transition(tmp_path: Path) -> None:
     transitions = _complete_transitions()
-    transitions_path, shims_path = _write_fixture(
+    paths = _write_fixture(
         tmp_path,
         transitions=transitions,
         shims=[_shim(target_transition="transition.missing")],
     )
 
-    failures = guard.validate_contract(transitions_path, shims_path)
+    failures = _validate(paths)
 
     assert any(
         "target_transition does not match a transition id" in failure
         and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_action_coverage_is_missing_enum_action(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    actions = [_action("ACTION_NONE"), _action("ACTION_USER_CMD")]
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action coverage missing YtreeAction enum member" in failure
+        and "ACTION_MOVE_UP" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_action_coverage_has_extra_unknown_action(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions() + [_action("ACTION_NOT_IN_ENUM")]
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "unknown YtreeAction enum member" in failure and "ACTION_NOT_IN_ENUM" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_action_references_unknown_transition(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0]["transition_id"] = "transition.missing"
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_id does not match a transition id" in failure
+        and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_action_category_does_not_match_transition(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0]["category"] = "render_reflow"
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "category does not match transition" in failure and "render_reflow" in failure
+        for failure in failures
+    )
+
+
+def test_guard_catches_enum_drift_from_temporary_header(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        enum_actions=FIXTURE_ACTIONS + ["ACTION_NEW_DRIFT"],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "action coverage missing YtreeAction enum member" in failure
+        and "ACTION_NEW_DRIFT" in failure
         for failure in failures
     )


### PR DESCRIPTION
## Summary
- Add a machine-readable AppState action coverage registry for current `YtreeAction` entries.
- Extend the AppState contract guard to catch enum/registry drift, invalid transition references, category mismatches, and malformed list metadata.
- Add focused guard tests for action coverage and required-list validation.

## Scope
- Registry and QA guard only.
- No runtime, controller, keybinding, prompt, restore, or UI behavior changes.

## Validation
- Local quick gate passed: AppState contract guard, focused AppState guard tests, code-quality bundle, and clean build.
