### PR TITLE
chore(appstate): cover non-key transition events

### DIFF
--- a/docs/appstate_event_coverage.json
+++ b/docs/appstate_event_coverage.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 1,
+  "contract": "AppState non-key UI-affecting event coverage",
+  "notes": "Non-runtime registry for non-key UI-affecting AppState events. Event records link required event classes to the current transition matrix during migration.",
+  "required_event_classes": [
+    "terminal_resize_signal",
+    "refresh_rebuild",
+    "rebuild_rebind_callback",
+    "filesystem_mutation_result",
+    "watcher_live_refresh",
+    "command_completion",
+    "modal_completion",
+    "volume_lifecycle",
+    "render_reflow"
+  ],
+  "events": [
+    {
+      "event_id": "event.terminal-resize-signal",
+      "event_class": "terminal_resize_signal",
+      "transition_id": "transition.terminal-signal-resize",
+      "category": "terminal_signal_or_resize",
+      "source": "SIGWINCH flag handling and resize polling in the main loop",
+      "owner": "ViewContext.layout_region",
+      "declared_write_set": ["ctx.layout", "ctx.window_handles", "panel.tree_viewport_origin", "panel.file_viewport_origin", "panel.panel_generation"],
+      "boundary_status": "covered_by_transition_record",
+      "trigger_paths": ["Signal flag set outside curses work", "Main-loop resize/reflow handling"],
+      "migration_notes": ["Signal handlers may only set flags; resize commits through the main-loop transition boundary."]
+    },
+    {
+      "event_id": "event.refresh-rebuild",
+      "event_class": "refresh_rebuild",
+      "transition_id": "transition.refresh-rebuild.manual-refresh",
+      "category": "refresh_rebuild",
+      "source": "Manual refresh, explicit relog, or declared refresh boundary",
+      "owner": "Volume(shared topology)",
+      "declared_write_set": ["volume.dir_tree", "volume.logged_state", "volume.volume_generation", "panel.restore_snapshot", "panel.panel_generation"],
+      "boundary_status": "covered_by_transition_record",
+      "trigger_paths": ["Manual refresh command", "Explicit relog of the current path"],
+      "migration_notes": ["Rebuild must settle topology, advance generation, then rebind panels by stable identity."]
+    },
+    {
+      "event_id": "event.rebuild-rebind-callback",
+      "event_class": "rebuild_rebind_callback",
+      "transition_id": "transition.rebuild-rebind-callback.panel-anchor",
+      "category": "rebuild_rebind_callback",
+      "source": "Post-rebuild panel anchor re-resolution callback",
+      "owner": "YtreePanel(affected) and Volume(current)",
+      "declared_write_set": ["panel.tree_selection_key", "panel.file_selection_key", "panel.tree_cursor_pos", "panel.tree_viewport_origin", "panel.file_viewport_origin", "panel.panel_generation"],
+      "boundary_status": "covered_by_transition_record",
+      "trigger_paths": ["Post-refresh restore", "Post-mutation restore", "Visibility or topology generation mismatch rebind"],
+      "migration_notes": ["Callback coverage points to the existing rebuild/rebind transition rather than inventing a separate runtime event."]
+    },
+    {
+      "event_id": "event.filesystem-mutation-result",
+      "event_class": "filesystem_mutation_result",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "category": "filesystem_mutation_result",
+      "source": "Completed filesystem mutation command result",
+      "owner": "Volume(shared topology) plus YtreePanel(active) for active selection",
+      "declared_write_set": ["volume.dir_tree", "volume.payload_cache", "volume.volume_generation", "panel.restore_snapshot", "panel.panel_generation", "ctx.message_state"],
+      "boundary_status": "covered_by_transition_record",
+      "trigger_paths": ["Create directory result", "Copy or move result", "Delete or chmod-like result"],
+      "migration_notes": ["Command side effects remain outside AppState commit; only completed results may update AppState metadata."]
+    },
+    {
+      "event_id": "event.watcher-live-refresh",
+      "event_class": "watcher_live_refresh",
+      "transition_id": "transition.refresh-rebuild.manual-refresh",
+      "category": "refresh_rebuild",
+      "source": "Filesystem watcher or live-refresh notification after debounce/settle",
+      "owner": "Volume(shared topology)",
+      "declared_write_set": ["volume.dir_tree", "volume.logged_state", "volume.volume_generation", "panel.restore_snapshot", "panel.panel_generation"],
+      "boundary_status": "mapped_to_existing_broad_transition",
+      "trigger_paths": ["Watcher notification", "Live refresh scheduling", "Settled topology refresh"],
+      "migration_notes": ["Watcher/live-refresh intentionally maps to the broad refresh_rebuild transition until a dedicated watcher runtime boundary exists."]
+    },
+    {
+      "event_id": "event.command-completion",
+      "event_class": "command_completion",
+      "transition_id": "transition.command-completion.user-command",
+      "category": "command_completion",
+      "source": "External or user command exit-status completion",
+      "owner": "ViewContext.command_region",
+      "declared_write_set": ["ctx.command_state", "ctx.message_state", "ctx.pending_transition", "panel.panel_generation"],
+      "boundary_status": "covered_by_transition_record",
+      "trigger_paths": ["External command completion", "User command menu completion", "Command failure or cancellation outcome"],
+      "migration_notes": ["Command completion may schedule refresh only when the command contract declares filesystem impact."]
+    },
+    {
+      "event_id": "event.modal-completion",
+      "event_class": "modal_completion",
+      "transition_id": "transition.modal-action.dismiss",
+      "category": "modal_action",
+      "source": "Modal prompt, menu, or dialog completion",
+      "owner": "ViewContext.modal_region",
+      "declared_write_set": ["ctx.modal_state", "ctx.message_state", "panel.focus_shape", "panel.panel_generation"],
+      "boundary_status": "mapped_to_existing_broad_transition",
+      "trigger_paths": ["Modal Enter completion", "Modal Esc cancellation", "Neutral dialog dismissal"],
+      "migration_notes": ["Modal completion maps to the modal_action dismiss record while destructive confirmations remain governed by their own command transitions."]
+    },
+    {
+      "event_id": "event.volume-lifecycle",
+      "event_class": "volume_lifecycle",
+      "transition_id": "transition.volume-operation.release-cycle",
+      "category": "volume_operation",
+      "source": "Volume cycle, release, or loaded-volume selection lifecycle event",
+      "owner": "ViewContext.volume_registry and YtreePanel(active)",
+      "declared_write_set": ["ctx.volumes_head", "panel.volume_key", "panel.restore_snapshot", "panel.panel_generation", "volume.volume_generation"],
+      "boundary_status": "covered_by_transition_record",
+      "trigger_paths": ["Cycle loaded volume", "Release volume", "Bind active panel to selected volume"],
+      "migration_notes": ["Lifecycle coverage keeps inactive panels from inheriting stale volume pointers during migration."]
+    },
+    {
+      "event_id": "event.render-reflow",
+      "event_class": "render_reflow",
+      "transition_id": "transition.render-reflow.project-state",
+      "category": "render_reflow",
+      "source": "Render invalidation projection and doupdate-ready reflow",
+      "owner": "ViewContext.render_region",
+      "declared_write_set": ["ctx.render_dirty_flags", "ctx.window_handles"],
+      "boundary_status": "covered_by_transition_record",
+      "trigger_paths": ["Render dirty flag projection", "Layout reflow projection", "doupdate-ready render tick"],
+      "migration_notes": ["Render/reflow is projection-only and must not become restore authority."]
+    }
+  ]
+}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_TRANSITIONS = REPO_ROOT / "docs" / "appstate_transition_matrix.json"
 DEFAULT_SHIMS = REPO_ROOT / "docs" / "appstate_compat_shims.json"
 DEFAULT_ACTION_COVERAGE = REPO_ROOT / "docs" / "appstate_action_coverage.json"
+DEFAULT_EVENT_COVERAGE = REPO_ROOT / "docs" / "appstate_event_coverage.json"
 DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytree_defs.h"
 
 REQUIRED_TRANSITION_CATEGORIES = {
@@ -69,12 +70,39 @@ REQUIRED_ACTION_FIELDS = {
     "migration_notes",
 }
 
+REQUIRED_EVENT_CLASSES = {
+    "terminal_resize_signal",
+    "refresh_rebuild",
+    "rebuild_rebind_callback",
+    "filesystem_mutation_result",
+    "watcher_live_refresh",
+    "command_completion",
+    "modal_completion",
+    "volume_lifecycle",
+    "render_reflow",
+}
+
+REQUIRED_EVENT_FIELDS = {
+    "event_id",
+    "event_class",
+    "transition_id",
+    "category",
+    "source",
+    "owner",
+    "declared_write_set",
+    "boundary_status",
+    "trigger_paths",
+    "migration_notes",
+}
+
 LIST_FIELDS = {
     "declared_write_set",
     "side_effects",
     "invariant_checks",
     "migration_notes",
 }
+
+EVENT_LIST_FIELDS = LIST_FIELDS | {"trigger_paths"}
 
 
 def _load_json(path: Path) -> tuple[Any | None, list[str]]:
@@ -159,20 +187,140 @@ def _parse_ytree_actions(header_path: Path) -> tuple[list[str], list[str]]:
     return actions, []
 
 
+def _validate_required_string_list(
+    *,
+    value: Any,
+    required_values: set[str],
+    label: str,
+    item_label: str,
+) -> list[str]:
+    failures = _validate_list_field(value=value, label=label, field=item_label)
+    if failures:
+        return failures
+
+    seen: set[str] = set()
+    declared = set()
+    assert isinstance(value, list)
+    for index, item in enumerate(value):
+        assert isinstance(item, str)
+        if item in seen:
+            failures.append(f"{label}: duplicate {item_label}[{index}]: {item}")
+        seen.add(item)
+        declared.add(item)
+
+    missing_values = sorted(required_values - declared)
+    if missing_values:
+        failures.append(f"{label}: missing required value(s): {', '.join(missing_values)}")
+
+    unknown_values = sorted(declared - required_values)
+    if unknown_values:
+        failures.append(f"{label}: unknown value(s): {', '.join(unknown_values)}")
+
+    return failures
+
+
+def _validate_event_coverage(
+    *,
+    event_coverage_doc: Any,
+    event_coverage_path: Path,
+    transition_ids: dict[str, dict[str, Any]],
+) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(event_coverage_doc, dict):
+        failures.append(f"{event_coverage_path}: top-level value must be an object")
+        return failures
+
+    required_event_classes = event_coverage_doc.get("required_event_classes")
+    failures.extend(
+        _validate_required_string_list(
+            value=required_event_classes,
+            required_values=REQUIRED_EVENT_CLASSES,
+            label="event coverage required_event_classes",
+            item_label="required_event_classes",
+        )
+    )
+
+    event_records = event_coverage_doc.get("events")
+    if not isinstance(event_records, list) or not event_records:
+        failures.append(f"{event_coverage_path}: events must be a non-empty list")
+        event_records = []
+
+    event_ids: set[str] = set()
+    covered_event_classes: set[str] = set()
+    for index, record in enumerate(event_records):
+        label = f"event[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_EVENT_FIELDS,
+                list_fields=EVENT_LIST_FIELDS,
+                label=label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+
+        event_id = record.get("event_id")
+        if isinstance(event_id, str) and event_id.strip():
+            if event_id in event_ids:
+                failures.append(f"{label}: duplicate event_id: {event_id}")
+            event_ids.add(event_id)
+
+        event_class = record.get("event_class")
+        if isinstance(event_class, str) and event_class.strip():
+            if event_class in covered_event_classes:
+                failures.append(f"{label}: duplicate event_class: {event_class}")
+            covered_event_classes.add(event_class)
+            if event_class not in REQUIRED_EVENT_CLASSES:
+                failures.append(f"{label}: unknown event_class: {event_class}")
+
+        transition_id = record.get("transition_id")
+        transition_record = None
+        if isinstance(transition_id, str) and transition_id.strip():
+            transition_record = transition_ids.get(transition_id)
+            if transition_record is None:
+                failures.append(
+                    f"{label}: transition_id does not match a transition id: {transition_id}"
+                )
+
+        category = record.get("category")
+        if (
+            isinstance(category, str)
+            and category.strip()
+            and transition_record is not None
+            and category != transition_record.get("category")
+        ):
+            failures.append(
+                f"{label}: category does not match transition {transition_id}: {category}"
+            )
+
+    missing_event_classes = sorted(REQUIRED_EVENT_CLASSES - covered_event_classes)
+    if missing_event_classes:
+        failures.append(
+            "event coverage missing required event_class(es): "
+            + ", ".join(missing_event_classes)
+        )
+
+    return failures
+
+
 def validate_contract(
     transitions_path: Path,
     shims_path: Path,
     action_coverage_path: Path,
     actions_header_path: Path,
+    event_coverage_path: Path = DEFAULT_EVENT_COVERAGE,
 ) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
     shims_doc, shim_load_failures = _load_json(shims_path)
     action_coverage_doc, action_coverage_load_failures = _load_json(action_coverage_path)
+    event_coverage_doc, event_coverage_load_failures = _load_json(event_coverage_path)
     enum_actions, enum_failures = _parse_ytree_actions(actions_header_path)
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
+    failures.extend(event_coverage_load_failures)
     failures.extend(enum_failures)
     if failures:
         return failures
@@ -309,6 +457,14 @@ def validate_contract(
             + ", ".join(missing_actions)
         )
 
+    failures.extend(
+        _validate_event_coverage(
+            event_coverage_doc=event_coverage_doc,
+            event_coverage_path=event_coverage_path,
+            transition_ids=transition_ids,
+        )
+    )
+
     return failures
 
 
@@ -317,6 +473,7 @@ def main() -> int:
     parser.add_argument("--transitions", type=Path, default=DEFAULT_TRANSITIONS)
     parser.add_argument("--shims", type=Path, default=DEFAULT_SHIMS)
     parser.add_argument("--action-coverage", type=Path, default=DEFAULT_ACTION_COVERAGE)
+    parser.add_argument("--event-coverage", type=Path, default=DEFAULT_EVENT_COVERAGE)
     parser.add_argument("--actions-header", type=Path, default=DEFAULT_ACTION_HEADER)
     args = parser.parse_args()
 
@@ -325,6 +482,7 @@ def main() -> int:
         args.shims,
         args.action_coverage,
         args.actions_header,
+        args.event_coverage,
     )
     if failures:
         for failure in failures:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -14,10 +14,14 @@ GUARD_SPEC.loader.exec_module(guard)
 
 
 REQUIRED_CATEGORIES = sorted(guard.REQUIRED_TRANSITION_CATEGORIES)
+REQUIRED_EVENT_CLASSES = sorted(guard.REQUIRED_EVENT_CLASSES)
 FIXTURE_ACTIONS = ["ACTION_NONE", "ACTION_MOVE_UP", "ACTION_USER_CMD"]
 REQUIRED_LIST_FIELD_CASES = [
     ("action", "declared_write_set", "action[0]"),
     ("action", "migration_notes", "action[0]"),
+    ("event", "declared_write_set", "event[0]"),
+    ("event", "migration_notes", "event[0]"),
+    ("event", "trigger_paths", "event[0]"),
     ("transition", "declared_write_set", "transition[0]"),
     ("transition", "side_effects", "transition[0]"),
     ("shim", "invariant_checks", "shim[0]"),
@@ -81,17 +85,51 @@ def _action(
     }
 
 
+def _event(
+    event_class: str,
+    transition_id: str | None = None,
+    category: str | None = None,
+) -> dict[str, object]:
+    event_categories = {
+        "terminal_resize_signal": "terminal_signal_or_resize",
+        "refresh_rebuild": "refresh_rebuild",
+        "rebuild_rebind_callback": "rebuild_rebind_callback",
+        "filesystem_mutation_result": "filesystem_mutation_result",
+        "watcher_live_refresh": "refresh_rebuild",
+        "command_completion": "command_completion",
+        "modal_completion": "modal_action",
+        "volume_lifecycle": "volume_operation",
+        "render_reflow": "render_reflow",
+    }
+    resolved_category = category or event_categories.get(event_class, "refresh_rebuild")
+    return {
+        "event_id": f"event.{event_class}",
+        "event_class": event_class,
+        "transition_id": transition_id or f"transition.{resolved_category}",
+        "category": resolved_category,
+        "source": "fixture source",
+        "owner": "fixture owner",
+        "declared_write_set": ["field"],
+        "boundary_status": "test",
+        "trigger_paths": ["fixture trigger"],
+        "migration_notes": ["fixture coverage"],
+    }
+
+
 def _write_fixture(
     tmp_path: Path,
     *,
     transitions: list[dict[str, object]],
     shims: list[dict[str, object]] | None = None,
     actions: list[dict[str, object]] | None = None,
+    events: list[dict[str, object]] | None = None,
+    required_event_classes: list[str] | None = None,
     enum_actions: list[str] | None = None,
-) -> tuple[Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
     action_coverage_path = tmp_path / "action_coverage.json"
+    event_coverage_path = tmp_path / "event_coverage.json"
     actions_header_path = tmp_path / "ytree_defs.h"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
     _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
@@ -99,8 +137,18 @@ def _write_fixture(
         action_coverage_path,
         _jsonish({"schema_version": 1, "actions": actions or _complete_actions()}),
     )
+    _write(
+        event_coverage_path,
+        _jsonish(
+            {
+                "schema_version": 1,
+                "required_event_classes": required_event_classes or REQUIRED_EVENT_CLASSES,
+                "events": events or _complete_events(),
+            }
+        ),
+    )
     _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
-    return transitions_path, shims_path, action_coverage_path, actions_header_path
+    return transitions_path, shims_path, action_coverage_path, actions_header_path, event_coverage_path
 
 
 def _jsonish(value: object) -> str:
@@ -125,25 +173,34 @@ def _complete_actions() -> list[dict[str, object]]:
     return [_action(action) for action in FIXTURE_ACTIONS]
 
 
-def _validate(paths: tuple[Path, Path, Path, Path]) -> list[str]:
+def _complete_events() -> list[dict[str, object]]:
+    return [_event(event_class) for event_class in REQUIRED_EVENT_CLASSES]
+
+
+def _validate(paths: tuple[Path, Path, Path, Path, Path]) -> list[str]:
     return guard.validate_contract(*paths)
 
 
 def _fixture_with_list_field_value(
     tmp_path: Path, record_type: str, field: str, value: object
-) -> tuple[Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path]:
     transitions = _complete_transitions()
     shims = [_shim()]
     actions = _complete_actions()
+    events = _complete_events()
     if record_type == "action":
         actions[0][field] = value
+    elif record_type == "event":
+        events[0][field] = value
     elif record_type == "transition":
         transitions[0][field] = value
     elif record_type == "shim":
         shims[0][field] = value
     else:
         raise AssertionError(f"unknown record type: {record_type}")
-    return _write_fixture(tmp_path, transitions=transitions, shims=shims, actions=actions)
+    return _write_fixture(
+        tmp_path, transitions=transitions, shims=shims, actions=actions, events=events
+    )
 
 
 def test_current_repository_appstate_contract_passes() -> None:
@@ -219,6 +276,54 @@ def test_guard_fails_when_required_action_field_is_missing(tmp_path: Path) -> No
     )
 
 
+def test_guard_fails_when_required_event_class_is_missing(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    events = [
+        event for event in _complete_events() if event["event_class"] != "render_reflow"
+    ]
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any("event coverage missing required event_class" in failure for failure in failures)
+    assert any("render_reflow" in failure for failure in failures)
+
+
+def test_guard_fails_when_event_has_unknown_class(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events() + [_event("unknown_event_class")]
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any("unknown event_class" in failure and "unknown_event_class" in failure for failure in failures)
+
+
+def test_guard_fails_when_event_class_is_duplicated(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[1]["event_class"] = events[0]["event_class"]
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any("event[1]" in failure and "duplicate event_class" in failure for failure in failures)
+
+
+def test_guard_fails_when_required_event_field_is_missing(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[0].pop("source")
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure and "missing required field" in failure and "source" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_on_duplicate_transition_and_shim_ids(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     transitions[1]["id"] = transitions[0]["id"]
@@ -246,6 +351,17 @@ def test_guard_fails_on_duplicate_action_records(tmp_path: Path) -> None:
     assert any("action[1]" in failure and "duplicate action" in failure for failure in failures)
 
 
+def test_guard_fails_on_duplicate_event_ids(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[1]["event_id"] = events[0]["event_id"]
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any("event[1]" in failure and "duplicate event_id" in failure for failure in failures)
+
+
 def test_guard_fails_on_empty_required_list_fields(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     transitions[0]["declared_write_set"] = []
@@ -253,7 +369,11 @@ def test_guard_fails_on_empty_required_list_fields(tmp_path: Path) -> None:
     shim["invariant_checks"] = []
     actions = _complete_actions()
     actions[0]["declared_write_set"] = []
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim], actions=actions)
+    events = _complete_events()
+    events[0]["trigger_paths"] = []
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, shims=[shim], actions=actions, events=events
+    )
 
     failures = _validate(paths)
 
@@ -275,6 +395,12 @@ def test_guard_fails_on_empty_required_list_fields(tmp_path: Path) -> None:
         and "must be non-empty" in failure
         for failure in failures
     )
+    assert any(
+        "event[0]" in failure
+        and "trigger_paths" in failure
+        and "must be non-empty" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_on_non_list_required_list_fields(tmp_path: Path) -> None:
@@ -284,7 +410,11 @@ def test_guard_fails_on_non_list_required_list_fields(tmp_path: Path) -> None:
     shim["invariant_checks"] = "invariant"
     actions = _complete_actions()
     actions[0]["migration_notes"] = "note"
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim], actions=actions)
+    events = _complete_events()
+    events[0]["declared_write_set"] = "field"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, shims=[shim], actions=actions, events=events
+    )
 
     failures = _validate(paths)
 
@@ -303,6 +433,12 @@ def test_guard_fails_on_non_list_required_list_fields(tmp_path: Path) -> None:
     assert any(
         "action[0]" in failure
         and "migration_notes" in failure
+        and "must be a non-empty list" in failure
+        for failure in failures
+    )
+    assert any(
+        "event[0]" in failure
+        and "declared_write_set" in failure
         and "must be a non-empty list" in failure
         for failure in failures
     )
@@ -401,6 +537,22 @@ def test_guard_fails_when_action_references_unknown_transition(tmp_path: Path) -
     )
 
 
+def test_guard_fails_when_event_references_unknown_transition(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[0]["transition_id"] = "transition.missing"
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure
+        and "transition_id does not match a transition id" in failure
+        and "transition.missing" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_action_category_does_not_match_transition(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     actions = _complete_actions()
@@ -411,6 +563,22 @@ def test_guard_fails_when_action_category_does_not_match_transition(tmp_path: Pa
 
     assert any(
         "category does not match transition" in failure and "render_reflow" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_event_category_does_not_match_transition(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[0]["category"] = "render_reflow"
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure
+        and "category does not match transition" in failure
+        and "render_reflow" in failure
         for failure in failures
     )
 


### PR DESCRIPTION
## Summary
- Add a machine-readable AppState event coverage registry for non-key UI-affecting event classes.
- Extend the AppState contract guard to validate event registry shape, transition references, category matches, and malformed list metadata.
- Add focused guard tests for event coverage drift and required-list validation.

## Scope
- Registry and QA guard only.
- No runtime, controller, keybinding, prompt, restore, or UI behavior changes.

## Validation
- Local quick gate passed: AppState contract guard, focused AppState guard tests, code-quality bundle, and clean build.
