### PR TITLE
docs(ai): clarify pull request evidence guidance

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -109,11 +109,13 @@ These instructions apply to all AI agents used in this repository.
     - Before first push, run a quick local gate (build plus targeted smoke/tests).
     - Open a draft PR early; red is allowed while iterating.
     - Keep a durable PR title even while checks are red; do not use temporary `WIP:` title prefixes.
+    - PR title, summary, and validation text must describe the durable behavior or architecture aim of the atomic unit, not volatile tracker numbers or broader-roadmap labels.
+    - PR validation text must be concise local evidence only; do not duplicate self-evident CI/check output or paste full check transcripts into PR bodies or comments.
     - While PR is red, keep the PR in draft and do not request reviewers.
     - Before merge to `main`, require green PR full-QA CI gate (`make qa-all` equivalent) and required audit-loop evidence; local `make qa-all` is optional unless the maintainer explicitly requests it.
-    - Convert draft PR to ready only after posting full QA evidence in a PR comment.
+    - Convert draft PR to ready only after green PR evidence is available and maintainer direction allows it; do not trigger another long ready-conversion gate without explicit instruction.
     - Before merge, require green PR checks and reviewer signoff.
-23. Change-description durability is mandatory: commit subjects and PR titles/summaries MUST describe the concrete behavior/problem being changed, and MUST NOT rely on volatile tracker IDs alone (for example `BUG-14`, `TASK-7`) as the primary description.
+23. Change-description durability is mandatory: commit subjects and PR titles/summaries MUST describe the concrete behavior/problem being changed, and MUST NOT rely on volatile tracker IDs alone (for example `BUG-14`, `TASK-7`) as the primary description. For multi-unit roadmap work, describe the current atomic unit's durable aim rather than the broader tracker item; choose the Conventional Commit type for the unit (`chore` for registry/guard/process scaffolding, `test` for test-only changes, `refactor` only for behavior-preserving runtime restructuring).
 24. Agentic-loop autonomy and clarity are mandatory: proactively poll/wait `active` workers to terminal `completed`/`blocked`; worker completion notifications/events are immediate triggers that must progress the loop without maintainer echo/re-send of worker completion text; on completion immediately read the completion report, run required validation checks, close the completed worker agent, proceed to the next planned step, and post a delta-only maintainer update; maintainer-facing status wording must use only `active`, `completed`, or `blocked` and must not use ambiguous runtime labels such as `awaiting instruction`.
 
 ## Source Comment Contract

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -317,9 +317,12 @@ Use this when wrapping up a PROMPT_TEMPLATE-driven mission and returning the rep
 5.  **Architect/AI:** Stage intended changes only (exclude unrelated local edits and workflow artifacts).
 6.  **Architect/AI:** Suggest a Conventional Commit subject and request maintainer commit-message approval.
 7.  **Architect/AI:** Commit, push branch, and open/update a draft PR.
+    *   PR title must use Conventional Commit format and describe the current atomic unit's durable aim, not a volatile task/bug number or the whole roadmap initiative.
+    *   PR body should be concise: summary, scope, and local validation evidence. Do not duplicate obvious CI output or paste check transcripts into the body/comments.
 8.  **Maintainer (GitHub):** Review draft PR scope and evidence.
 9.  **Architect/AI + Maintainer (GitHub):** Monitor PR CI full gate proactively (for example `gh pr checks <pr-number> --watch`). Do not wait passively for a separate reminder when checks change state.
 10. **Architect/AI:** If any checks are red, triage failing jobs immediately, fix CI failures root-cause-first, push updates, and repeat until required PR full-QA CI (`make qa-all` equivalent) is green.
+    *   Do not convert a draft PR to ready, request reviewers, or otherwise trigger another long PR gate unless the maintainer explicitly instructs it.
 11. **Maintainer (GitHub):** Merge PR to `main` after checks are green and review is satisfied.
 12. **Maintainer (GitHub):** Delete remote branch:
     *   `git push origin --delete <branch>`


### PR DESCRIPTION
## Summary
- Clarify durable PR title/summary guidance for atomic roadmap units.
- Keep PR validation evidence concise and avoid duplicating CI output.
- Require explicit maintainer direction before ready conversion can trigger another long gate.

## Scope
- AI/process guidance only.
- No runtime or test behavior changes.

## Validation
- Local checks passed: project AI config guard, code-quality bundle, and clean build.
