### PR TITLE
chore(appstate): register owner write sets

### DIFF
--- a/docs/appstate_owner_fields.json
+++ b/docs/appstate_owner_fields.json
@@ -1,0 +1,271 @@
+{
+  "schema_version": 1,
+  "contract": "AppState owner/write-set field registry",
+  "notes": "Non-runtime registry for every declared_write_set field in the AppState transition, action, and event coverage registries.",
+  "owner_fields": [
+    {
+      "field": "ctx.active",
+      "owner_region": "ctx/session state",
+      "canonical_owner": "ViewContext.session routing",
+      "runtime_carrier": "ViewContext.active",
+      "mutation_rule": "May change only during an allowed panel-routing or volume/menu transition commit.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Active panel changes must preserve inactive panel-local records.",
+        "Panel routing must resolve to an existing YtreePanel carrier before render projection."
+      ]
+    },
+    {
+      "field": "ctx.command_state",
+      "owner_region": "ctx/session state",
+      "canonical_owner": "ViewContext.command_region",
+      "runtime_carrier": "ViewContext command state fields",
+      "mutation_rule": "May change only through command start/completion/cancel transitions.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Command completion must not mutate panel or volume fields outside the declared follow-up transition.",
+        "Command failure or cancellation must preserve authoritative panel and volume state."
+      ]
+    },
+    {
+      "field": "ctx.message_state",
+      "owner_region": "ctx/session state",
+      "canonical_owner": "ViewContext.message_region",
+      "runtime_carrier": "ViewContext message/footer state fields",
+      "mutation_rule": "May change only through transitions that declare user-visible outcome or constraint messaging.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Blocked transitions may write message state only when needed for outcome clarity.",
+        "Message writes must not imply filesystem or panel state success."
+      ]
+    },
+    {
+      "field": "ctx.modal_state",
+      "owner_region": "ctx/session state",
+      "canonical_owner": "ViewContext.modal_region",
+      "runtime_carrier": "ViewContext modal/dialog state fields",
+      "mutation_rule": "May change only when entering, completing, or dismissing a registered modal transition.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Modal dismissal must leave underlying panel and volume authority unchanged unless declared.",
+        "Destructive confirmations must remain explicit and default-safe."
+      ]
+    },
+    {
+      "field": "ctx.pending_transition",
+      "owner_region": "ctx/session state",
+      "canonical_owner": "ViewContext.transition_queue",
+      "runtime_carrier": "ViewContext pending transition marker",
+      "mutation_rule": "May be queued only by transitions that declare a deterministic follow-up boundary.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Pending transitions must name a registered transition before later mutation.",
+        "Queueing a transition must not advance panel or volume generations by itself."
+      ]
+    },
+    {
+      "field": "ctx.volumes_head",
+      "owner_region": "volume/shared topology and payload state",
+      "canonical_owner": "ViewContext.volume_registry",
+      "runtime_carrier": "ViewContext.volumes_head",
+      "mutation_rule": "May change only through volume lifecycle transitions that validate panel bindings.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Releasing a volume must not leave active or inactive panels with stale volume pointers.",
+        "Volume registry changes must rebind affected panels through stable identity or deterministic fallback."
+      ]
+    },
+    {
+      "field": "ctx.layout",
+      "owner_region": "render/projection/invalidation state",
+      "canonical_owner": "ViewContext.layout_region",
+      "runtime_carrier": "ViewContext layout geometry fields",
+      "mutation_rule": "May change only during resize/reflow transitions executed in the main loop.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Resize handling must not choose a new authoritative selection from rendered rows.",
+        "Layout changes alone must not advance volume_generation."
+      ]
+    },
+    {
+      "field": "ctx.render_dirty_flags",
+      "owner_region": "render/projection/invalidation state",
+      "canonical_owner": "ViewContext.render_region",
+      "runtime_carrier": "ViewContext render invalidation fields",
+      "mutation_rule": "May change only when a transition marks or clears declared projection surfaces.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Render invalidation writes must not mutate selection, focus, or identity state.",
+        "Render projection may clear only surfaces produced from settled AppState records."
+      ]
+    },
+    {
+      "field": "ctx.window_handles",
+      "owner_region": "render/projection/invalidation state",
+      "canonical_owner": "ViewContext ncurses window/layout handles",
+      "runtime_carrier": "ViewContext window handle fields",
+      "mutation_rule": "May change only during main-loop layout/reflow or render projection setup.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Ncurses window recreation must happen outside signal handlers.",
+        "Window handles must not become restore authority for panel selection or viewport state."
+      ]
+    },
+    {
+      "field": "panel.file_selection_key",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.file identity owner",
+      "runtime_carrier": "YtreePanel file selection identity fields",
+      "mutation_rule": "May change only for the targeted panel through navigation, restore, or rebind transitions.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "File selection identity must be path/name based, not a stale FileEntry pointer.",
+        "Inactive panel file selection must remain frozen across active-only actions."
+      ]
+    },
+    {
+      "field": "panel.file_viewport_origin",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.file viewport owner",
+      "runtime_carrier": "YtreePanel file viewport fields",
+      "mutation_rule": "May change only for the targeted panel when navigation, bounds correction, or reflow declares it.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "File viewport correction must preserve the stored selection when it remains visible.",
+        "Render paths may compute temporary file projection without overwriting this origin."
+      ]
+    },
+    {
+      "field": "panel.focus_shape",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.focus owner",
+      "runtime_carrier": "YtreePanel focus/window-shape fields",
+      "mutation_rule": "May change only during allowed focus, modal restore, split, or file/tree transition commits.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Reactivation must restore the recorded tree/small-file/big-file shape directly.",
+        "Focus shape changes must not import the inactive panel's state."
+      ]
+    },
+    {
+      "field": "panel.panel_generation",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.generation owner",
+      "runtime_carrier": "YtreePanel panel generation field",
+      "mutation_rule": "May increment only when panel-local restore authority changes.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Render projection alone must not advance panel_generation.",
+        "Snapshot restore must compare panel_generation before applying saved state."
+      ]
+    },
+    {
+      "field": "panel.restore_snapshot",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.restore snapshot owner",
+      "runtime_carrier": "YtreePanel restore snapshot fields",
+      "mutation_rule": "May change only through snapshot capture, rebind, fallback, or volume-binding transitions.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Restore snapshots must use stable identities plus generation validation.",
+        "Stale snapshots must fail closed through the deterministic fallback order."
+      ]
+    },
+    {
+      "field": "panel.tree_cursor_pos",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.tree cursor owner",
+      "runtime_carrier": "YtreePanel tree cursor field",
+      "mutation_rule": "May change only for the targeted panel during tree navigation or rebind/fallback transitions.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Tree cursor position is interpreted against visible rows, not raw topology indices.",
+        "Inactive panel cursor must remain unchanged unless the transition explicitly targets that panel."
+      ]
+    },
+    {
+      "field": "panel.tree_selection_key",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.tree selection owner",
+      "runtime_carrier": "YtreePanel tree selection identity fields",
+      "mutation_rule": "May change only through tree navigation, restore, or topology rebind transitions for the targeted panel.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Tree selection identity must be stable and path based within the current volume namespace.",
+        "Selection restore must not derive authority from disp_begin_pos plus cursor_pos."
+      ]
+    },
+    {
+      "field": "panel.tree_viewport_origin",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.tree viewport owner",
+      "runtime_carrier": "YtreePanel tree viewport fields",
+      "mutation_rule": "May change only when navigation, bounds correction, resize, or rebind declares viewport mutation.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Hidden dotfile visibility must not cause extra viewport shifts when selection remains visible.",
+        "Render-side temporary placement must not overwrite the saved viewport origin."
+      ]
+    },
+    {
+      "field": "panel.volume_key",
+      "owner_region": "panel-local state",
+      "canonical_owner": "YtreePanel.volume binding owner",
+      "runtime_carrier": "YtreePanel volume binding fields",
+      "mutation_rule": "May change only through volume selection, cycle, release, or restore transitions.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Panel volume binding must point to an existing volume/archive namespace or deterministic fallback.",
+        "A panel must not import the opposite panel's volume-specific snapshot."
+      ]
+    },
+    {
+      "field": "volume.dir_tree",
+      "owner_region": "volume/shared topology and payload state",
+      "canonical_owner": "Volume.topology owner",
+      "runtime_carrier": "Volume directory tree fields",
+      "mutation_rule": "May change only through logging, rebuild, refresh, release, or completed filesystem mutation transitions.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Shared topology changes must re-anchor each panel by its own stable identity.",
+        "Topology mutation must advance volume_generation before restore consumers observe it."
+      ]
+    },
+    {
+      "field": "volume.logged_state",
+      "owner_region": "volume/shared topology and payload state",
+      "canonical_owner": "Volume.logged topology owner",
+      "runtime_carrier": "Volume logged/unlogged directory state",
+      "mutation_rule": "May change only through explicit log, relog, release, collapse, refresh, or rebuild transitions.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Logged state is shared topology and must not store panel-local cursor or tag authority.",
+        "Unlogged placeholders must not degrade a frozen file-view anchor without rebind or payload reload."
+      ]
+    },
+    {
+      "field": "volume.payload_cache",
+      "owner_region": "volume/shared topology and payload state",
+      "canonical_owner": "Volume.payload cache owner",
+      "runtime_carrier": "Volume file payload/statistics cache fields",
+      "mutation_rule": "May change only through payload load, refresh, archive, or completed filesystem mutation transitions.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Payload cache changes must not overwrite panel-local file selection identity.",
+        "Mutation-result commits must distinguish filesystem side effects from AppState metadata updates."
+      ]
+    },
+    {
+      "field": "volume.volume_generation",
+      "owner_region": "volume/shared topology and payload state",
+      "canonical_owner": "Volume.generation owner",
+      "runtime_carrier": "Volume topology/payload generation field",
+      "mutation_rule": "May increment only when shared topology, payload identity, logged state, or namespace mapping changes.",
+      "migration_status": "documented_foundation_only",
+      "invariant_checks": [
+        "Render projection alone must not advance volume_generation.",
+        "Generation mismatch must force stable-identity re-resolution before snapshot restore."
+      ]
+    }
+  ]
+}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -14,6 +14,7 @@ DEFAULT_TRANSITIONS = REPO_ROOT / "docs" / "appstate_transition_matrix.json"
 DEFAULT_SHIMS = REPO_ROOT / "docs" / "appstate_compat_shims.json"
 DEFAULT_ACTION_COVERAGE = REPO_ROOT / "docs" / "appstate_action_coverage.json"
 DEFAULT_EVENT_COVERAGE = REPO_ROOT / "docs" / "appstate_event_coverage.json"
+DEFAULT_OWNER_FIELDS = REPO_ROOT / "docs" / "appstate_owner_fields.json"
 DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytree_defs.h"
 
 REQUIRED_TRANSITION_CATEGORIES = {
@@ -93,6 +94,16 @@ REQUIRED_EVENT_FIELDS = {
     "boundary_status",
     "trigger_paths",
     "migration_notes",
+}
+
+REQUIRED_OWNER_FIELDS = {
+    "field",
+    "owner_region",
+    "canonical_owner",
+    "runtime_carrier",
+    "mutation_rule",
+    "migration_status",
+    "invariant_checks",
 }
 
 LIST_FIELDS = {
@@ -219,11 +230,69 @@ def _validate_required_string_list(
     return failures
 
 
+def _validate_owner_fields(
+    *,
+    owner_fields_doc: Any,
+    owner_fields_path: Path,
+) -> tuple[set[str], list[str]]:
+    failures: list[str] = []
+    registered_fields: set[str] = set()
+    if not isinstance(owner_fields_doc, dict):
+        failures.append(f"{owner_fields_path}: top-level value must be an object")
+        return registered_fields, failures
+
+    owner_records = owner_fields_doc.get("owner_fields")
+    if not isinstance(owner_records, list) or not owner_records:
+        failures.append(f"{owner_fields_path}: owner_fields must be a non-empty list")
+        owner_records = []
+
+    for index, record in enumerate(owner_records):
+        label = f"owner_field[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_OWNER_FIELDS,
+                list_fields={"invariant_checks"},
+                label=label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+
+        field = record.get("field")
+        if isinstance(field, str) and field.strip():
+            if field in registered_fields:
+                failures.append(f"{label}: duplicate field: {field}")
+            registered_fields.add(field)
+
+    return registered_fields, failures
+
+
+def _validate_registered_write_set(
+    *,
+    record: dict[str, Any],
+    registered_fields: set[str],
+    label: str,
+) -> list[str]:
+    write_set = record.get("declared_write_set")
+    if not isinstance(write_set, list):
+        return []
+
+    failures: list[str] = []
+    for field in write_set:
+        if isinstance(field, str) and field.strip() and field not in registered_fields:
+            failures.append(
+                f"{label}: declared_write_set references unregistered owner field: {field}"
+            )
+    return failures
+
+
 def _validate_event_coverage(
     *,
     event_coverage_doc: Any,
     event_coverage_path: Path,
     transition_ids: dict[str, dict[str, Any]],
+    registered_owner_fields: set[str],
 ) -> list[str]:
     failures: list[str] = []
     if not isinstance(event_coverage_doc, dict):
@@ -259,6 +328,13 @@ def _validate_event_coverage(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_registered_write_set(
+                record=record,
+                registered_fields=registered_owner_fields,
+                label=label,
+            )
+        )
 
         event_id = record.get("event_id")
         if isinstance(event_id, str) and event_id.strip():
@@ -310,20 +386,29 @@ def validate_contract(
     action_coverage_path: Path,
     actions_header_path: Path,
     event_coverage_path: Path = DEFAULT_EVENT_COVERAGE,
+    owner_fields_path: Path = DEFAULT_OWNER_FIELDS,
 ) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
     shims_doc, shim_load_failures = _load_json(shims_path)
     action_coverage_doc, action_coverage_load_failures = _load_json(action_coverage_path)
     event_coverage_doc, event_coverage_load_failures = _load_json(event_coverage_path)
+    owner_fields_doc, owner_fields_load_failures = _load_json(owner_fields_path)
     enum_actions, enum_failures = _parse_ytree_actions(actions_header_path)
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
     failures.extend(event_coverage_load_failures)
+    failures.extend(owner_fields_load_failures)
     failures.extend(enum_failures)
     if failures:
         return failures
+
+    registered_owner_fields, owner_field_failures = _validate_owner_fields(
+        owner_fields_doc=owner_fields_doc,
+        owner_fields_path=owner_fields_path,
+    )
+    failures.extend(owner_field_failures)
 
     if not isinstance(transitions_doc, dict):
         failures.append(f"{transitions_path}: top-level value must be an object")
@@ -348,6 +433,13 @@ def validate_contract(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_registered_write_set(
+                record=record,
+                registered_fields=registered_owner_fields,
+                label=label,
+            )
+        )
         transition_id = record.get("id")
         if isinstance(transition_id, str) and transition_id.strip():
             if transition_id in transition_ids:
@@ -421,6 +513,13 @@ def validate_contract(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_registered_write_set(
+                record=record,
+                registered_fields=registered_owner_fields,
+                label=label,
+            )
+        )
 
         action = record.get("action")
         if isinstance(action, str) and action.strip():
@@ -462,6 +561,7 @@ def validate_contract(
             event_coverage_doc=event_coverage_doc,
             event_coverage_path=event_coverage_path,
             transition_ids=transition_ids,
+            registered_owner_fields=registered_owner_fields,
         )
     )
 
@@ -474,6 +574,7 @@ def main() -> int:
     parser.add_argument("--shims", type=Path, default=DEFAULT_SHIMS)
     parser.add_argument("--action-coverage", type=Path, default=DEFAULT_ACTION_COVERAGE)
     parser.add_argument("--event-coverage", type=Path, default=DEFAULT_EVENT_COVERAGE)
+    parser.add_argument("--owner-fields", type=Path, default=DEFAULT_OWNER_FIELDS)
     parser.add_argument("--actions-header", type=Path, default=DEFAULT_ACTION_HEADER)
     args = parser.parse_args()
 
@@ -483,6 +584,7 @@ def main() -> int:
         args.action_coverage,
         args.actions_header,
         args.event_coverage,
+        args.owner_fields,
     )
     if failures:
         for failure in failures:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -24,6 +24,7 @@ REQUIRED_LIST_FIELD_CASES = [
     ("event", "trigger_paths", "event[0]"),
     ("transition", "declared_write_set", "transition[0]"),
     ("transition", "side_effects", "transition[0]"),
+    ("owner_field", "invariant_checks", "owner_field[0]"),
     ("shim", "invariant_checks", "shim[0]"),
     ("shim", "migration_notes", "shim[0]"),
 ]
@@ -116,6 +117,18 @@ def _event(
     }
 
 
+def _owner_field(field: str = "field") -> dict[str, object]:
+    return {
+        "field": field,
+        "owner_region": "panel-local state",
+        "canonical_owner": "YtreePanel(fixture)",
+        "runtime_carrier": "YtreePanel fixture carrier",
+        "mutation_rule": "Fixture transitions may mutate only declared fields.",
+        "migration_status": "test",
+        "invariant_checks": ["fixture invariant"],
+    }
+
+
 def _write_fixture(
     tmp_path: Path,
     *,
@@ -123,13 +136,15 @@ def _write_fixture(
     shims: list[dict[str, object]] | None = None,
     actions: list[dict[str, object]] | None = None,
     events: list[dict[str, object]] | None = None,
+    owner_fields: list[dict[str, object]] | None = None,
     required_event_classes: list[str] | None = None,
     enum_actions: list[str] | None = None,
-) -> tuple[Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
     action_coverage_path = tmp_path / "action_coverage.json"
     event_coverage_path = tmp_path / "event_coverage.json"
+    owner_fields_path = tmp_path / "owner_fields.json"
     actions_header_path = tmp_path / "ytree_defs.h"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
     _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
@@ -147,8 +162,19 @@ def _write_fixture(
             }
         ),
     )
+    _write(
+        owner_fields_path,
+        _jsonish({"schema_version": 1, "owner_fields": owner_fields or _complete_owner_fields()}),
+    )
     _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
-    return transitions_path, shims_path, action_coverage_path, actions_header_path, event_coverage_path
+    return (
+        transitions_path,
+        shims_path,
+        action_coverage_path,
+        actions_header_path,
+        event_coverage_path,
+        owner_fields_path,
+    )
 
 
 def _jsonish(value: object) -> str:
@@ -177,21 +203,28 @@ def _complete_events() -> list[dict[str, object]]:
     return [_event(event_class) for event_class in REQUIRED_EVENT_CLASSES]
 
 
-def _validate(paths: tuple[Path, Path, Path, Path, Path]) -> list[str]:
+def _complete_owner_fields() -> list[dict[str, object]]:
+    return [_owner_field("field"), _owner_field("panel.tree_selection_key")]
+
+
+def _validate(paths: tuple[Path, Path, Path, Path, Path, Path]) -> list[str]:
     return guard.validate_contract(*paths)
 
 
 def _fixture_with_list_field_value(
     tmp_path: Path, record_type: str, field: str, value: object
-) -> tuple[Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path]:
     transitions = _complete_transitions()
     shims = [_shim()]
     actions = _complete_actions()
     events = _complete_events()
+    owner_fields = _complete_owner_fields()
     if record_type == "action":
         actions[0][field] = value
     elif record_type == "event":
         events[0][field] = value
+    elif record_type == "owner_field":
+        owner_fields[0][field] = value
     elif record_type == "transition":
         transitions[0][field] = value
     elif record_type == "shim":
@@ -199,7 +232,12 @@ def _fixture_with_list_field_value(
     else:
         raise AssertionError(f"unknown record type: {record_type}")
     return _write_fixture(
-        tmp_path, transitions=transitions, shims=shims, actions=actions, events=events
+        tmp_path,
+        transitions=transitions,
+        shims=shims,
+        actions=actions,
+        events=events,
+        owner_fields=owner_fields,
     )
 
 
@@ -222,6 +260,98 @@ def test_guard_passes_complete_temporary_fixtures(tmp_path: Path) -> None:
     failures = _validate(paths)
 
     assert failures == []
+
+
+def test_guard_fails_on_duplicate_owner_field_records(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    owner_fields = _complete_owner_fields()
+    owner_fields[1]["field"] = owner_fields[0]["field"]
+    paths = _write_fixture(tmp_path, transitions=transitions, owner_fields=owner_fields)
+
+    failures = _validate(paths)
+
+    assert any(
+        "owner_field[1]" in failure and "duplicate field" in failure for failure in failures
+    )
+
+
+def test_guard_fails_when_required_owner_metadata_is_missing(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    owner_fields = _complete_owner_fields()
+    owner_fields[0].pop("canonical_owner")
+    paths = _write_fixture(tmp_path, transitions=transitions, owner_fields=owner_fields)
+
+    failures = _validate(paths)
+
+    assert any(
+        "owner_field[0]" in failure
+        and "missing required field" in failure
+        and "canonical_owner" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_malformed_owner_invariant_checks(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    owner_fields = _complete_owner_fields()
+    owner_fields[0]["invariant_checks"] = []
+    paths = _write_fixture(tmp_path, transitions=transitions, owner_fields=owner_fields)
+
+    failures = _validate(paths)
+
+    assert any(
+        "owner_field[0]" in failure
+        and "invariant_checks" in failure
+        and "must be non-empty" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_unknown_transition_declared_write_set(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    transitions[0]["declared_write_set"] = ["field.unknown"]
+    paths = _write_fixture(tmp_path, transitions=transitions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition[0]" in failure
+        and "unregistered owner field" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_unknown_action_declared_write_set(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0]["declared_write_set"] = ["field.unknown"]
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure
+        and "unregistered owner field" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_unknown_event_declared_write_set(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[0]["declared_write_set"] = ["field.unknown"]
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure
+        and "unregistered owner field" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_when_required_category_is_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a machine-readable AppState owner/write-set registry for declared transition fields.
- Extend the AppState contract guard to reject unregistered declared write-set values across transition, action, and event coverage registries.
- Add focused guard tests for owner registry drift and malformed owner metadata.

## Scope
- Registry and QA guard only.
- No runtime, controller, keybinding, prompt, restore, or UI behavior changes.

## Validation
- Local quick gate passed: AppState contract guard, focused AppState guard tests, code-quality bundle, and clean build.
