### PR TITLE
chore(appstate): guard transition dispatch surfaces

### DIFF
--- a/docs/appstate_dispatch_surfaces.json
+++ b/docs/appstate_dispatch_surfaces.json
@@ -1,0 +1,163 @@
+{
+  "schema_version": 1,
+  "contract": "AppState UI-affecting dispatch-surface registry",
+  "notes": "Non-runtime registry for current UI-affecting dispatch surfaces before AppState runtime migration. Runtime behavior is unchanged.",
+  "dispatch_surfaces": [
+    {
+      "surface_id": "surface.key-decode-input-dispatch",
+      "category": "key_decode_input_dispatch",
+      "source_path": "src/ui/key_engine.c",
+      "entry_symbol_or_path": "GetEventOrKey",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [],
+      "migration_notes": [
+        "Current input polling and key normalization feed controller dispatch; AppState mutation remains in downstream handlers until runtime transition objects are introduced."
+      ]
+    },
+    {
+      "surface_id": "surface.directory-window-action-dispatch",
+      "category": "directory_window_action_dispatch",
+      "source_path": "src/ui/ctrl_dir.c",
+      "entry_symbol_or_path": "HandleDirWindow",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "migration_notes": [
+        "Current directory-window switch dispatch owns tree navigation and focus updates; later migration should route each action through canonical transition boundaries."
+      ]
+    },
+    {
+      "surface_id": "surface.file-window-action-dispatch",
+      "category": "file_window_action_dispatch",
+      "source_path": "src/ui/ctrl_file.c",
+      "entry_symbol_or_path": "HandleFileWindow",
+      "transition_id": "transition.keybinding.navigate-tree",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [
+        "panel.file_selection_key",
+        "panel.file_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "migration_notes": [
+        "Current file-window switch dispatch updates file selection and viewport state under the broad keybinding foundation record until file-specific transitions are split out."
+      ]
+    },
+    {
+      "surface_id": "surface.menu-modal-completion",
+      "category": "menu_modal_completion",
+      "source_path": "src/ui/key_engine.c",
+      "entry_symbol_or_path": "InputChoice",
+      "transition_id": "transition.modal-action.dismiss",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [],
+      "migration_notes": [
+        "Current menu and modal choice completion returns a selected key to callers; AppState modal writes remain with the caller until modal transition boundaries are introduced."
+      ]
+    },
+    {
+      "surface_id": "surface.resize-signal-handling",
+      "category": "resize_signal_handling",
+      "source_path": "src/ui/key_engine.c",
+      "entry_symbol_or_path": "GetEventOrKey",
+      "transition_id": "transition.terminal-signal-resize",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [
+        "ctx.layout",
+        "ctx.window_handles",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.panel_generation"
+      ],
+      "migration_notes": [
+        "Current resize dispatch converts KEY_RESIZE and resize_request state into controller refresh handling; signal-safe work must remain outside asynchronous handlers."
+      ]
+    },
+    {
+      "surface_id": "surface.refresh-rebuild-rebind",
+      "category": "refresh_rebuild_rebind",
+      "source_path": "src/ui/dir_ops.c",
+      "entry_symbol_or_path": "RefreshTreeSafe",
+      "transition_id": "transition.refresh-rebuild.manual-refresh",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [
+        "volume.dir_tree",
+        "volume.logged_state",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation"
+      ],
+      "migration_notes": [
+        "Current safe refresh saves state, rescans, restores, and rebinds panel anchors; migration must preserve that ordering at the transition boundary."
+      ]
+    },
+    {
+      "surface_id": "surface.filesystem-mutation-result",
+      "category": "filesystem_mutation_result",
+      "source_path": "src/ui/dir_ops.c",
+      "entry_symbol_or_path": "HandleDirMakeDirectory",
+      "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "ctx.message_state"
+      ],
+      "migration_notes": [
+        "Current filesystem command handlers refresh and rebind after successful mutations; only completed mutation results should commit AppState metadata."
+      ]
+    },
+    {
+      "surface_id": "surface.volume-operation",
+      "category": "volume_operation",
+      "source_path": "src/ui/volume_menu.c",
+      "entry_symbol_or_path": "SelectLoadedVolume",
+      "transition_id": "transition.volume-operation.release-cycle",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [
+        "ctx.volumes_head",
+        "panel.volume_key",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.volume_generation"
+      ],
+      "migration_notes": [
+        "Current loaded-volume selection and cycling update panel bindings directly; migration must preserve inactive panel restore records."
+      ]
+    },
+    {
+      "surface_id": "surface.watcher-live-refresh",
+      "category": "watcher_live_refresh",
+      "source_path": "src/fs/watcher.c",
+      "entry_symbol_or_path": "Watcher_ProcessEvents",
+      "transition_id": "transition.refresh-rebuild.manual-refresh",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [],
+      "migration_notes": [
+        "Current watcher processing reports settled filesystem activity to input dispatch; topology mutation remains mapped to the broad refresh/rebuild transition."
+      ]
+    },
+    {
+      "surface_id": "surface.render-reflow-projection",
+      "category": "render_reflow_projection",
+      "source_path": "src/ui/display.c",
+      "entry_symbol_or_path": "RefreshView",
+      "transition_id": "transition.render-reflow.project-state",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [],
+      "migration_notes": [
+        "Current render refresh projects settled state to ncurses windows; projection must not become selection, viewport, or topology authority."
+      ]
+    }
+  ]
+}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -15,6 +15,7 @@ DEFAULT_SHIMS = REPO_ROOT / "docs" / "appstate_compat_shims.json"
 DEFAULT_ACTION_COVERAGE = REPO_ROOT / "docs" / "appstate_action_coverage.json"
 DEFAULT_EVENT_COVERAGE = REPO_ROOT / "docs" / "appstate_event_coverage.json"
 DEFAULT_OWNER_FIELDS = REPO_ROOT / "docs" / "appstate_owner_fields.json"
+DEFAULT_DISPATCH_SURFACES = REPO_ROOT / "docs" / "appstate_dispatch_surfaces.json"
 DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytree_defs.h"
 
 REQUIRED_TRANSITION_CATEGORIES = {
@@ -83,6 +84,30 @@ REQUIRED_EVENT_CLASSES = {
     "render_reflow",
 }
 
+REQUIRED_DISPATCH_SURFACE_CATEGORIES = {
+    "key_decode_input_dispatch",
+    "directory_window_action_dispatch",
+    "file_window_action_dispatch",
+    "menu_modal_completion",
+    "resize_signal_handling",
+    "refresh_rebuild_rebind",
+    "filesystem_mutation_result",
+    "volume_operation",
+    "watcher_live_refresh",
+    "render_reflow_projection",
+}
+
+REQUIRED_DISPATCH_SURFACE_FIELDS = {
+    "surface_id",
+    "category",
+    "source_path",
+    "entry_symbol_or_path",
+    "transition_id",
+    "boundary_status",
+    "allowed_direct_writes",
+    "migration_notes",
+}
+
 REQUIRED_EVENT_FIELDS = {
     "event_id",
     "event_class",
@@ -114,6 +139,7 @@ LIST_FIELDS = {
 }
 
 EVENT_LIST_FIELDS = LIST_FIELDS | {"trigger_paths"}
+DISPATCH_LIST_FIELDS = {"migration_notes"}
 
 
 def _load_json(path: Path) -> tuple[Any | None, list[str]]:
@@ -287,6 +313,153 @@ def _validate_registered_write_set(
     return failures
 
 
+def _validate_allowed_direct_writes(
+    *,
+    record: dict[str, Any],
+    registered_fields: set[str],
+    label: str,
+) -> list[str]:
+    writes = record.get("allowed_direct_writes")
+    if not isinstance(writes, list):
+        return [f"{label}: allowed_direct_writes must be a list"]
+
+    failures: list[str] = []
+    seen: set[str] = set()
+    for index, field in enumerate(writes):
+        if not isinstance(field, str) or not field.strip():
+            failures.append(
+                f"{label}: allowed_direct_writes[{index}] must be a non-empty string"
+            )
+            continue
+        if field in seen:
+            failures.append(
+                f"{label}: duplicate allowed_direct_writes[{index}]: {field}"
+            )
+        seen.add(field)
+        if field not in registered_fields:
+            failures.append(
+                f"{label}: allowed_direct_writes references unregistered owner field: {field}"
+            )
+    return failures
+
+
+def _validate_source_path(value: Any, *, label: str) -> list[str]:
+    if not isinstance(value, str) or not value.strip():
+        return [f"{label}: source_path must be a non-empty string"]
+
+    source_path = value.strip()
+    path = Path(source_path)
+    if (
+        path.is_absolute()
+        or "\\" in source_path
+        or any(part == ".." for part in path.parts)
+    ):
+        return [f"{label}: source_path must be a relative repository path"]
+
+    if not (REPO_ROOT / source_path).is_file():
+        return [f"{label}: source_path does not exist: {source_path}"]
+    return []
+
+
+def _validate_entry_symbol_or_path(value: Any, *, label: str) -> list[str]:
+    if not isinstance(value, str) or not value.strip():
+        return [f"{label}: entry_symbol_or_path must be a non-empty string"]
+
+    entry = value.strip()
+    path = Path(entry)
+    if (
+        path.is_absolute()
+        or "\\" in entry
+        or any(part == ".." for part in path.parts)
+        or re.search(r"\s", entry)
+    ):
+        return [f"{label}: entry_symbol_or_path is malformed: {entry}"]
+    return []
+
+
+def _validate_dispatch_surfaces(
+    *,
+    dispatch_surfaces_doc: Any,
+    dispatch_surfaces_path: Path,
+    transition_ids: dict[str, dict[str, Any]],
+    registered_owner_fields: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(dispatch_surfaces_doc, dict):
+        failures.append(f"{dispatch_surfaces_path}: top-level value must be an object")
+        return failures
+
+    surface_records = dispatch_surfaces_doc.get("dispatch_surfaces")
+    if not isinstance(surface_records, list) or not surface_records:
+        failures.append(
+            f"{dispatch_surfaces_path}: dispatch_surfaces must be a non-empty list"
+        )
+        surface_records = []
+
+    surface_ids: set[str] = set()
+    covered_categories: set[str] = set()
+    for index, record in enumerate(surface_records):
+        label = f"dispatch_surface[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_DISPATCH_SURFACE_FIELDS
+                - {"allowed_direct_writes"},
+                list_fields=DISPATCH_LIST_FIELDS,
+                label=label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+        if "allowed_direct_writes" not in record:
+            failures.append(f"{label}: missing required field(s): allowed_direct_writes")
+        else:
+            failures.extend(
+                _validate_allowed_direct_writes(
+                    record=record,
+                    registered_fields=registered_owner_fields,
+                    label=label,
+                )
+            )
+
+        surface_id = record.get("surface_id")
+        if isinstance(surface_id, str) and surface_id.strip():
+            if surface_id in surface_ids:
+                failures.append(f"{label}: duplicate surface_id: {surface_id}")
+            surface_ids.add(surface_id)
+
+        category = record.get("category")
+        if isinstance(category, str) and category.strip():
+            covered_categories.add(category)
+            if category not in REQUIRED_DISPATCH_SURFACE_CATEGORIES:
+                failures.append(f"{label}: unknown category: {category}")
+
+        transition_id = record.get("transition_id")
+        if isinstance(transition_id, str) and transition_id.strip():
+            if transition_id not in transition_ids:
+                failures.append(
+                    f"{label}: transition_id does not match a transition id: {transition_id}"
+                )
+
+        failures.extend(_validate_source_path(record.get("source_path"), label=label))
+        failures.extend(
+            _validate_entry_symbol_or_path(
+                record.get("entry_symbol_or_path"), label=label
+            )
+        )
+
+    missing_categories = sorted(
+        REQUIRED_DISPATCH_SURFACE_CATEGORIES - covered_categories
+    )
+    if missing_categories:
+        failures.append(
+            "dispatch surfaces missing required category/categories: "
+            + ", ".join(missing_categories)
+        )
+
+    return failures
+
+
 def _validate_event_coverage(
     *,
     event_coverage_doc: Any,
@@ -387,6 +560,7 @@ def validate_contract(
     actions_header_path: Path,
     event_coverage_path: Path = DEFAULT_EVENT_COVERAGE,
     owner_fields_path: Path = DEFAULT_OWNER_FIELDS,
+    dispatch_surfaces_path: Path = DEFAULT_DISPATCH_SURFACES,
 ) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
@@ -394,12 +568,16 @@ def validate_contract(
     action_coverage_doc, action_coverage_load_failures = _load_json(action_coverage_path)
     event_coverage_doc, event_coverage_load_failures = _load_json(event_coverage_path)
     owner_fields_doc, owner_fields_load_failures = _load_json(owner_fields_path)
+    dispatch_surfaces_doc, dispatch_surfaces_load_failures = _load_json(
+        dispatch_surfaces_path
+    )
     enum_actions, enum_failures = _parse_ytree_actions(actions_header_path)
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
     failures.extend(event_coverage_load_failures)
     failures.extend(owner_fields_load_failures)
+    failures.extend(dispatch_surfaces_load_failures)
     failures.extend(enum_failures)
     if failures:
         return failures
@@ -564,6 +742,14 @@ def validate_contract(
             registered_owner_fields=registered_owner_fields,
         )
     )
+    failures.extend(
+        _validate_dispatch_surfaces(
+            dispatch_surfaces_doc=dispatch_surfaces_doc,
+            dispatch_surfaces_path=dispatch_surfaces_path,
+            transition_ids=transition_ids,
+            registered_owner_fields=registered_owner_fields,
+        )
+    )
 
     return failures
 
@@ -575,6 +761,9 @@ def main() -> int:
     parser.add_argument("--action-coverage", type=Path, default=DEFAULT_ACTION_COVERAGE)
     parser.add_argument("--event-coverage", type=Path, default=DEFAULT_EVENT_COVERAGE)
     parser.add_argument("--owner-fields", type=Path, default=DEFAULT_OWNER_FIELDS)
+    parser.add_argument(
+        "--dispatch-surfaces", type=Path, default=DEFAULT_DISPATCH_SURFACES
+    )
     parser.add_argument("--actions-header", type=Path, default=DEFAULT_ACTION_HEADER)
     args = parser.parse_args()
 
@@ -585,6 +774,7 @@ def main() -> int:
         args.actions_header,
         args.event_coverage,
         args.owner_fields,
+        args.dispatch_surfaces,
     )
     if failures:
         for failure in failures:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -15,6 +15,7 @@ GUARD_SPEC.loader.exec_module(guard)
 
 REQUIRED_CATEGORIES = sorted(guard.REQUIRED_TRANSITION_CATEGORIES)
 REQUIRED_EVENT_CLASSES = sorted(guard.REQUIRED_EVENT_CLASSES)
+REQUIRED_DISPATCH_SURFACE_CATEGORIES = sorted(guard.REQUIRED_DISPATCH_SURFACE_CATEGORIES)
 FIXTURE_ACTIONS = ["ACTION_NONE", "ACTION_MOVE_UP", "ACTION_USER_CMD"]
 REQUIRED_LIST_FIELD_CASES = [
     ("action", "declared_write_set", "action[0]"),
@@ -117,6 +118,35 @@ def _event(
     }
 
 
+def _dispatch_surface(
+    category: str,
+    transition_id: str | None = None,
+    surface_id: str | None = None,
+) -> dict[str, object]:
+    transition_by_surface_category = {
+        "key_decode_input_dispatch": "transition.keybinding",
+        "directory_window_action_dispatch": "transition.keybinding",
+        "file_window_action_dispatch": "transition.keybinding",
+        "menu_modal_completion": "transition.modal_action",
+        "resize_signal_handling": "transition.terminal_signal_or_resize",
+        "refresh_rebuild_rebind": "transition.refresh_rebuild",
+        "filesystem_mutation_result": "transition.filesystem_mutation_result",
+        "volume_operation": "transition.volume_operation",
+        "watcher_live_refresh": "transition.refresh_rebuild",
+        "render_reflow_projection": "transition.render_reflow",
+    }
+    return {
+        "surface_id": surface_id or f"surface.{category}",
+        "category": category,
+        "source_path": "src/ui/key_engine.c",
+        "entry_symbol_or_path": "GetEventOrKey",
+        "transition_id": transition_id or transition_by_surface_category[category],
+        "boundary_status": "test",
+        "allowed_direct_writes": ["field"],
+        "migration_notes": ["fixture coverage"],
+    }
+
+
 def _owner_field(field: str = "field") -> dict[str, object]:
     return {
         "field": field,
@@ -137,14 +167,16 @@ def _write_fixture(
     actions: list[dict[str, object]] | None = None,
     events: list[dict[str, object]] | None = None,
     owner_fields: list[dict[str, object]] | None = None,
+    dispatch_surfaces: list[dict[str, object]] | None = None,
     required_event_classes: list[str] | None = None,
     enum_actions: list[str] | None = None,
-) -> tuple[Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
     action_coverage_path = tmp_path / "action_coverage.json"
     event_coverage_path = tmp_path / "event_coverage.json"
     owner_fields_path = tmp_path / "owner_fields.json"
+    dispatch_surfaces_path = tmp_path / "dispatch_surfaces.json"
     actions_header_path = tmp_path / "ytree_defs.h"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
     _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
@@ -166,6 +198,15 @@ def _write_fixture(
         owner_fields_path,
         _jsonish({"schema_version": 1, "owner_fields": owner_fields or _complete_owner_fields()}),
     )
+    _write(
+        dispatch_surfaces_path,
+        _jsonish(
+            {
+                "schema_version": 1,
+                "dispatch_surfaces": dispatch_surfaces or _complete_dispatch_surfaces(),
+            }
+        ),
+    )
     _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
     return (
         transitions_path,
@@ -174,6 +215,7 @@ def _write_fixture(
         actions_header_path,
         event_coverage_path,
         owner_fields_path,
+        dispatch_surfaces_path,
     )
 
 
@@ -203,22 +245,30 @@ def _complete_events() -> list[dict[str, object]]:
     return [_event(event_class) for event_class in REQUIRED_EVENT_CLASSES]
 
 
+def _complete_dispatch_surfaces() -> list[dict[str, object]]:
+    return [
+        _dispatch_surface(category)
+        for category in REQUIRED_DISPATCH_SURFACE_CATEGORIES
+    ]
+
+
 def _complete_owner_fields() -> list[dict[str, object]]:
     return [_owner_field("field"), _owner_field("panel.tree_selection_key")]
 
 
-def _validate(paths: tuple[Path, Path, Path, Path, Path, Path]) -> list[str]:
+def _validate(paths: tuple[Path, Path, Path, Path, Path, Path, Path]) -> list[str]:
     return guard.validate_contract(*paths)
 
 
 def _fixture_with_list_field_value(
     tmp_path: Path, record_type: str, field: str, value: object
-) -> tuple[Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path]:
     transitions = _complete_transitions()
     shims = [_shim()]
     actions = _complete_actions()
     events = _complete_events()
     owner_fields = _complete_owner_fields()
+    dispatch_surfaces = _complete_dispatch_surfaces()
     if record_type == "action":
         actions[0][field] = value
     elif record_type == "event":
@@ -229,6 +279,8 @@ def _fixture_with_list_field_value(
         transitions[0][field] = value
     elif record_type == "shim":
         shims[0][field] = value
+    elif record_type == "dispatch_surface":
+        dispatch_surfaces[0][field] = value
     else:
         raise AssertionError(f"unknown record type: {record_type}")
     return _write_fixture(
@@ -238,6 +290,7 @@ def _fixture_with_list_field_value(
         actions=actions,
         events=events,
         owner_fields=owner_fields,
+        dispatch_surfaces=dispatch_surfaces,
     )
 
 
@@ -256,6 +309,193 @@ def test_current_repository_appstate_contract_passes() -> None:
 def test_guard_passes_complete_temporary_fixtures(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     paths = _write_fixture(tmp_path, transitions=transitions)
+
+    failures = _validate(paths)
+
+    assert failures == []
+
+
+def test_guard_fails_when_required_dispatch_surface_category_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = [
+        surface
+        for surface in _complete_dispatch_surfaces()
+        if surface["category"] != "watcher_live_refresh"
+    ]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any("dispatch surfaces missing required category" in failure for failure in failures)
+    assert any("watcher_live_refresh" in failure for failure in failures)
+
+
+def test_guard_fails_when_required_dispatch_surface_field_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0].pop("source_path")
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "missing required field" in failure
+        and "source_path" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_duplicate_dispatch_surface_ids(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[1]["surface_id"] = dispatch_surfaces[0]["surface_id"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[1]" in failure and "duplicate surface_id" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_has_unknown_category(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["category"] = "unknown_dispatch_surface"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "unknown category" in failure
+        and "unknown_dispatch_surface" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_references_unknown_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["transition_id"] = "transition.missing"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "transition_id does not match a transition id" in failure
+        and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_malformed_dispatch_surface_source_path(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["source_path"] = "../src/ui/key_engine.c"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "source_path must be a relative repository path" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_malformed_dispatch_surface_entry_symbol_or_path(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["entry_symbol_or_path"] = "../GetEventOrKey"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "entry_symbol_or_path is malformed" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_allowed_writes_are_not_a_list(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["allowed_direct_writes"] = "field"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "allowed_direct_writes must be a list" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_allowed_write_is_unregistered(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["allowed_direct_writes"] = ["field.unknown"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "unregistered owner field" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_accepts_empty_dispatch_surface_allowed_writes(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["allowed_direct_writes"] = []
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
 
     failures = _validate(paths)
 


### PR DESCRIPTION
## Summary
- Add a machine-readable registry for current UI-affecting dispatch surfaces before AppState runtime migration.
- Extend the AppState contract guard to validate dispatch surface categories, source references, transition links, and allowed owner write sets.
- Add focused guard tests for dispatch registry drift and malformed dispatch metadata.

## Scope
- Registry and QA guard only.
- No runtime, controller, keybinding, prompt, restore, render, or UI behavior changes.

## Validation
- Local quick gate passed: AppState contract guard, focused AppState guard tests, code-quality bundle, and clean build.
