### PR TITLE
chore(appstate): register transition invariants

### DIFF
--- a/.github/workflows/full-qa.yml
+++ b/.github/workflows/full-qa.yml
@@ -3,7 +3,7 @@ name: C/C++ Full QA
 on:
   pull_request:
     branches: [ "main" ]
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:

--- a/docs/appstate_invariants.json
+++ b/docs/appstate_invariants.json
@@ -1,0 +1,292 @@
+{
+  "schema_version": 1,
+  "contract": "AppState transition invariant registry",
+  "notes": "Non-runtime registry for invariants that future state-sequence tests must enforce at AppState transition boundaries. Runtime behavior is unchanged.",
+  "invariants": [
+    {
+      "invariant_id": "invariant.inactive-panel-frozen",
+      "category": "inactive_panel_frozen",
+      "owner_region": "panel-local state",
+      "protected_fields": [
+        "ctx.active",
+        "panel.volume_key",
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.file_selection_key",
+        "panel.file_viewport_origin",
+        "panel.focus_shape",
+        "panel.restore_snapshot",
+        "panel.panel_generation"
+      ],
+      "transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.menu-action.volume-select",
+        "transition.modal-action.dismiss",
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.terminal-signal-resize"
+      ],
+      "dispatch_surface_ids": [
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch",
+        "surface.menu-modal-completion",
+        "surface.refresh-rebuild-rebind",
+        "surface.volume-operation",
+        "surface.resize-signal-handling"
+      ],
+      "failure_mode": "Fail if an active-only transition mutates inactive panel-local identity, viewport, focus, restore, or generation fields outside an explicitly targeted transition.",
+      "enforcement_status": "documented_foundation_only",
+      "test_strategy": "State-sequence harness snapshots both panels before each active-panel transition and compares inactive panel fields after allowed and blocked outcomes.",
+      "migration_notes": [
+        "Future dynamic tests should distinguish shared topology mirroring from inactive panel-local mutation."
+      ]
+    },
+    {
+      "invariant_id": "invariant.render-projection-read-only",
+      "category": "render_projection_read_only",
+      "owner_region": "render/projection/invalidation state",
+      "protected_fields": [
+        "ctx.layout",
+        "ctx.render_dirty_flags",
+        "ctx.window_handles",
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation",
+        "volume.volume_generation"
+      ],
+      "transition_ids": [
+        "transition.render-reflow.project-state",
+        "transition.terminal-signal-resize"
+      ],
+      "dispatch_surface_ids": [
+        "surface.render-reflow-projection",
+        "surface.resize-signal-handling"
+      ],
+      "failure_mode": "Fail if render or reflow chooses new authoritative selection, focus, viewport, panel generation, or volume generation from projected rows or window geometry.",
+      "enforcement_status": "documented_foundation_only",
+      "test_strategy": "Transition-diff harness runs render/reflow passes after settled transitions and verifies only declared render projection fields change.",
+      "migration_notes": [
+        "Runtime migration must keep ncurses drawing and temporary row calculations from becoming restore authority."
+      ]
+    },
+    {
+      "invariant_id": "invariant.hidden-entry-visible-navigation",
+      "category": "hidden_entry_visible_navigation",
+      "owner_region": "panel-local state",
+      "protected_fields": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.dir_tree",
+        "volume.logged_state",
+        "volume.volume_generation"
+      ],
+      "transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "dispatch_surface_ids": [
+        "surface.directory-window-action-dispatch",
+        "surface.refresh-rebuild-rebind",
+        "surface.watcher-live-refresh"
+      ],
+      "failure_mode": "Fail if visible navigation lands on a hidden entry or resurrects a concealed identity after visibility/topology changes.",
+      "enforcement_status": "documented_foundation_only",
+      "test_strategy": "Generated navigation sequences toggle visibility, rebuild, and move through visible rows while asserting the selected identity remains visible or falls back deterministically.",
+      "migration_notes": [
+        "Hidden-entry checks must use stable identity and visibility metadata rather than stale row positions."
+      ]
+    },
+    {
+      "invariant_id": "invariant.panel-local-focus-restore",
+      "category": "panel_local_focus_restore",
+      "owner_region": "panel-local state",
+      "protected_fields": [
+        "ctx.modal_state",
+        "panel.focus_shape",
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.restore_snapshot",
+        "panel.panel_generation"
+      ],
+      "transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.menu-action.volume-select",
+        "transition.modal-action.dismiss",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "dispatch_surface_ids": [
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch",
+        "surface.menu-modal-completion",
+        "surface.volume-operation"
+      ],
+      "failure_mode": "Fail if focus restoration imports another panel's shape, briefly renders a different shape, or restores focus from session mirrors instead of panel-local records.",
+      "enforcement_status": "documented_foundation_only",
+      "test_strategy": "Sequence tests alternate modal dismissal, Tab/F8-style routing, and file/tree transitions while asserting each panel restores its own recorded focus shape.",
+      "migration_notes": [
+        "Compatibility session mirrors may shadow focus only after the panel-local owner has committed the transition."
+      ]
+    },
+    {
+      "invariant_id": "invariant.viewport-identity-rebind",
+      "category": "viewport_identity_rebind",
+      "owner_region": "panel-local state",
+      "protected_fields": [
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.dir_tree",
+        "volume.volume_generation"
+      ],
+      "transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.terminal-signal-resize",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "dispatch_surface_ids": [
+        "surface.refresh-rebuild-rebind",
+        "surface.resize-signal-handling",
+        "surface.filesystem-mutation-result",
+        "surface.watcher-live-refresh"
+      ],
+      "failure_mode": "Fail if rebuild, mutation, or resize restores viewport from raw rows when the stable identity is still visible or before deterministic fallback order is exhausted.",
+      "enforcement_status": "documented_foundation_only",
+      "test_strategy": "Snapshot/diff tests rebuild or resize around stable directory and file identities, then assert exact rebind when visible and deterministic fallback otherwise.",
+      "migration_notes": [
+        "Canonical restore helpers must remain the only authority for rebind after topology or layout invalidation."
+      ]
+    },
+    {
+      "invariant_id": "invariant.shared-state-panel-local-isolation",
+      "category": "shared_state_panel_local_isolation",
+      "owner_region": "volume/shared topology and payload state",
+      "protected_fields": [
+        "ctx.active",
+        "ctx.volumes_head",
+        "panel.volume_key",
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.focus_shape",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.dir_tree",
+        "volume.logged_state",
+        "volume.payload_cache",
+        "volume.volume_generation"
+      ],
+      "transition_ids": [
+        "transition.menu-action.volume-select",
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.filesystem-mutation-result.mkdir-copy-delete"
+      ],
+      "dispatch_surface_ids": [
+        "surface.volume-operation",
+        "surface.refresh-rebuild-rebind",
+        "surface.filesystem-mutation-result",
+        "surface.watcher-live-refresh"
+      ],
+      "failure_mode": "Fail if shared volume topology or registry changes overwrite panel-local selection, focus, tags, viewport, or restore snapshots by shared index or pointer aliasing.",
+      "enforcement_status": "documented_foundation_only",
+      "test_strategy": "Split-panel sequences share a volume, mutate shared topology, and verify each panel rebinds through its own identity without cross-panel field drift.",
+      "migration_notes": [
+        "Shared topology mirroring must be followed by panel-local rebind rather than copying active panel state into inactive panels."
+      ]
+    },
+    {
+      "invariant_id": "invariant.stale-snapshot-fail-closed",
+      "category": "stale_snapshot_fail_closed",
+      "owner_region": "panel-local state",
+      "protected_fields": [
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.dir_tree",
+        "volume.volume_generation"
+      ],
+      "transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "dispatch_surface_ids": [
+        "surface.refresh-rebuild-rebind",
+        "surface.volume-operation",
+        "surface.filesystem-mutation-result",
+        "surface.watcher-live-refresh"
+      ],
+      "failure_mode": "Fail if a generation mismatch reuses stale DirEntry/FileEntry pointers, stale flat-list rows, or stale snapshot payloads instead of exact rebind or deterministic fallback.",
+      "enforcement_status": "documented_foundation_only",
+      "test_strategy": "Harness corrupts or invalidates saved generations around rebuild/mutation transitions and asserts stale snapshots fail closed without unrelated mutation.",
+      "migration_notes": [
+        "Generation validation must happen before any restore snapshot is applied to a panel record."
+      ]
+    },
+    {
+      "invariant_id": "invariant.blocked-transition-determinism",
+      "category": "blocked_transition_determinism",
+      "owner_region": "ctx/session state",
+      "protected_fields": [
+        "ctx.command_state",
+        "ctx.message_state",
+        "ctx.modal_state",
+        "ctx.pending_transition",
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation"
+      ],
+      "transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.menu-action.volume-select",
+        "transition.modal-action.dismiss",
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.terminal-signal-resize",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.command-completion.user-command",
+        "transition.rebuild-rebind-callback.panel-anchor",
+        "transition.render-reflow.project-state"
+      ],
+      "dispatch_surface_ids": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch",
+        "surface.menu-modal-completion",
+        "surface.resize-signal-handling",
+        "surface.refresh-rebuild-rebind",
+        "surface.filesystem-mutation-result",
+        "surface.volume-operation",
+        "surface.watcher-live-refresh",
+        "surface.render-reflow-projection"
+      ],
+      "failure_mode": "Fail if a blocked or invalid transition partially mutates authoritative panel/volume state, advances generations, performs hidden side effects, or chooses a non-deterministic fallback.",
+      "enforcement_status": "documented_foundation_only",
+      "test_strategy": "Negative state-sequence tests force guard failures and unavailable targets, then assert no unrelated owner fields differ and any message/modal output is declared.",
+      "migration_notes": [
+        "Blocked outcomes are cross-cutting across all registered transition and dispatch surfaces but are listed explicitly here for guard traceability."
+      ]
+    }
+  ]
+}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -16,6 +16,7 @@ DEFAULT_ACTION_COVERAGE = REPO_ROOT / "docs" / "appstate_action_coverage.json"
 DEFAULT_EVENT_COVERAGE = REPO_ROOT / "docs" / "appstate_event_coverage.json"
 DEFAULT_OWNER_FIELDS = REPO_ROOT / "docs" / "appstate_owner_fields.json"
 DEFAULT_DISPATCH_SURFACES = REPO_ROOT / "docs" / "appstate_dispatch_surfaces.json"
+DEFAULT_INVARIANTS = REPO_ROOT / "docs" / "appstate_invariants.json"
 DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytree_defs.h"
 
 REQUIRED_TRANSITION_CATEGORIES = {
@@ -97,6 +98,17 @@ REQUIRED_DISPATCH_SURFACE_CATEGORIES = {
     "render_reflow_projection",
 }
 
+REQUIRED_INVARIANT_CATEGORIES = {
+    "inactive_panel_frozen",
+    "render_projection_read_only",
+    "hidden_entry_visible_navigation",
+    "panel_local_focus_restore",
+    "viewport_identity_rebind",
+    "shared_state_panel_local_isolation",
+    "stale_snapshot_fail_closed",
+    "blocked_transition_determinism",
+}
+
 REQUIRED_DISPATCH_SURFACE_FIELDS = {
     "surface_id",
     "category",
@@ -131,6 +143,19 @@ REQUIRED_OWNER_FIELDS = {
     "invariant_checks",
 }
 
+REQUIRED_INVARIANT_FIELDS = {
+    "invariant_id",
+    "category",
+    "owner_region",
+    "protected_fields",
+    "transition_ids",
+    "dispatch_surface_ids",
+    "failure_mode",
+    "enforcement_status",
+    "test_strategy",
+    "migration_notes",
+}
+
 LIST_FIELDS = {
     "declared_write_set",
     "side_effects",
@@ -140,6 +165,11 @@ LIST_FIELDS = {
 
 EVENT_LIST_FIELDS = LIST_FIELDS | {"trigger_paths"}
 DISPATCH_LIST_FIELDS = {"migration_notes"}
+INVARIANT_LIST_FIELDS = {
+    "protected_fields",
+    "transition_ids",
+    "migration_notes",
+}
 
 
 def _load_json(path: Path) -> tuple[Any | None, list[str]]:
@@ -313,6 +343,21 @@ def _validate_registered_write_set(
     return failures
 
 
+def _collect_string_ids(doc: Any, *, collection_key: str, id_field: str) -> set[str]:
+    if not isinstance(doc, dict):
+        return set()
+    records = doc.get(collection_key)
+    if not isinstance(records, list):
+        return set()
+    return {
+        value
+        for record in records
+        if isinstance(record, dict)
+        for value in [record.get(id_field)]
+        if isinstance(value, str) and value.strip()
+    }
+
+
 def _validate_allowed_direct_writes(
     *,
     record: dict[str, Any],
@@ -460,6 +505,125 @@ def _validate_dispatch_surfaces(
     return failures
 
 
+def _validate_invariants(
+    *,
+    invariants_doc: Any,
+    invariants_path: Path,
+    transition_ids: dict[str, dict[str, Any]],
+    registered_owner_fields: set[str],
+    dispatch_surface_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(invariants_doc, dict):
+        failures.append(f"{invariants_path}: top-level value must be an object")
+        return failures
+
+    invariant_records = invariants_doc.get("invariants")
+    if not isinstance(invariant_records, list) or not invariant_records:
+        failures.append(f"{invariants_path}: invariants must be a non-empty list")
+        invariant_records = []
+
+    invariant_ids: set[str] = set()
+    covered_categories: set[str] = set()
+    for index, record in enumerate(invariant_records):
+        label = f"invariant[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_INVARIANT_FIELDS - {"dispatch_surface_ids"},
+                list_fields=INVARIANT_LIST_FIELDS,
+                label=label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+        if "dispatch_surface_ids" not in record:
+            failures.append(f"{label}: missing required field(s): dispatch_surface_ids")
+        else:
+            surface_refs_value = record.get("dispatch_surface_ids")
+            if not isinstance(surface_refs_value, list):
+                failures.append(
+                    f"{label}: dispatch_surface_ids must be a list"
+                )
+            else:
+                for surface_index, surface_id in enumerate(surface_refs_value):
+                    if not isinstance(surface_id, str) or not surface_id.strip():
+                        failures.append(
+                            f"{label}: dispatch_surface_ids[{surface_index}] must be a non-empty string"
+                        )
+
+        invariant_id = record.get("invariant_id")
+        if isinstance(invariant_id, str) and invariant_id.strip():
+            if invariant_id in invariant_ids:
+                failures.append(f"{label}: duplicate invariant_id: {invariant_id}")
+            invariant_ids.add(invariant_id)
+
+        category = record.get("category")
+        if isinstance(category, str) and category.strip():
+            covered_categories.add(category)
+            if category not in REQUIRED_INVARIANT_CATEGORIES:
+                failures.append(f"{label}: unknown category: {category}")
+
+        protected_fields = record.get("protected_fields")
+        if isinstance(protected_fields, list):
+            for field in protected_fields:
+                if (
+                    isinstance(field, str)
+                    and field.strip()
+                    and field not in registered_owner_fields
+                ):
+                    failures.append(
+                        f"{label}: protected_fields references unregistered owner field: {field}"
+                    )
+
+        transition_refs = record.get("transition_ids")
+        if isinstance(transition_refs, list):
+            for transition_id in transition_refs:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in transition_ids
+                ):
+                    failures.append(
+                        f"{label}: transition_ids references unknown transition id: {transition_id}"
+                    )
+
+        surface_refs = record.get("dispatch_surface_ids")
+        if isinstance(surface_refs, list):
+            if not surface_refs:
+                migration_notes = record.get("migration_notes")
+                has_cross_cutting_note = (
+                    isinstance(migration_notes, list)
+                    and any(
+                        isinstance(note, str)
+                        and "cross-cutting" in note.lower()
+                        for note in migration_notes
+                    )
+                )
+                if not has_cross_cutting_note:
+                    failures.append(
+                        f"{label}: empty dispatch_surface_ids requires a cross-cutting migration_notes explanation"
+                    )
+            for surface_id in surface_refs:
+                if (
+                    isinstance(surface_id, str)
+                    and surface_id.strip()
+                    and surface_id not in dispatch_surface_ids
+                ):
+                    failures.append(
+                        f"{label}: dispatch_surface_ids references unknown dispatch surface id: {surface_id}"
+                    )
+
+    missing_categories = sorted(REQUIRED_INVARIANT_CATEGORIES - covered_categories)
+    if missing_categories:
+        failures.append(
+            "invariants missing required category/categories: "
+            + ", ".join(missing_categories)
+        )
+
+    return failures
+
+
 def _validate_event_coverage(
     *,
     event_coverage_doc: Any,
@@ -561,6 +725,7 @@ def validate_contract(
     event_coverage_path: Path = DEFAULT_EVENT_COVERAGE,
     owner_fields_path: Path = DEFAULT_OWNER_FIELDS,
     dispatch_surfaces_path: Path = DEFAULT_DISPATCH_SURFACES,
+    invariants_path: Path = DEFAULT_INVARIANTS,
 ) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
@@ -571,6 +736,7 @@ def validate_contract(
     dispatch_surfaces_doc, dispatch_surfaces_load_failures = _load_json(
         dispatch_surfaces_path
     )
+    invariants_doc, invariants_load_failures = _load_json(invariants_path)
     enum_actions, enum_failures = _parse_ytree_actions(actions_header_path)
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
@@ -578,6 +744,7 @@ def validate_contract(
     failures.extend(event_coverage_load_failures)
     failures.extend(owner_fields_load_failures)
     failures.extend(dispatch_surfaces_load_failures)
+    failures.extend(invariants_load_failures)
     failures.extend(enum_failures)
     if failures:
         return failures
@@ -750,6 +917,20 @@ def validate_contract(
             registered_owner_fields=registered_owner_fields,
         )
     )
+    dispatch_surface_ids = _collect_string_ids(
+        dispatch_surfaces_doc,
+        collection_key="dispatch_surfaces",
+        id_field="surface_id",
+    )
+    failures.extend(
+        _validate_invariants(
+            invariants_doc=invariants_doc,
+            invariants_path=invariants_path,
+            transition_ids=transition_ids,
+            registered_owner_fields=registered_owner_fields,
+            dispatch_surface_ids=dispatch_surface_ids,
+        )
+    )
 
     return failures
 
@@ -764,6 +945,7 @@ def main() -> int:
     parser.add_argument(
         "--dispatch-surfaces", type=Path, default=DEFAULT_DISPATCH_SURFACES
     )
+    parser.add_argument("--invariants", type=Path, default=DEFAULT_INVARIANTS)
     parser.add_argument("--actions-header", type=Path, default=DEFAULT_ACTION_HEADER)
     args = parser.parse_args()
 
@@ -775,6 +957,7 @@ def main() -> int:
         args.event_coverage,
         args.owner_fields,
         args.dispatch_surfaces,
+        args.invariants,
     )
     if failures:
         for failure in failures:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -16,6 +16,7 @@ GUARD_SPEC.loader.exec_module(guard)
 REQUIRED_CATEGORIES = sorted(guard.REQUIRED_TRANSITION_CATEGORIES)
 REQUIRED_EVENT_CLASSES = sorted(guard.REQUIRED_EVENT_CLASSES)
 REQUIRED_DISPATCH_SURFACE_CATEGORIES = sorted(guard.REQUIRED_DISPATCH_SURFACE_CATEGORIES)
+REQUIRED_INVARIANT_CATEGORIES = sorted(guard.REQUIRED_INVARIANT_CATEGORIES)
 FIXTURE_ACTIONS = ["ACTION_NONE", "ACTION_MOVE_UP", "ACTION_USER_CMD"]
 REQUIRED_LIST_FIELD_CASES = [
     ("action", "declared_write_set", "action[0]"),
@@ -26,6 +27,9 @@ REQUIRED_LIST_FIELD_CASES = [
     ("transition", "declared_write_set", "transition[0]"),
     ("transition", "side_effects", "transition[0]"),
     ("owner_field", "invariant_checks", "owner_field[0]"),
+    ("invariant", "protected_fields", "invariant[0]"),
+    ("invariant", "transition_ids", "invariant[0]"),
+    ("invariant", "migration_notes", "invariant[0]"),
     ("shim", "invariant_checks", "shim[0]"),
     ("shim", "migration_notes", "shim[0]"),
 ]
@@ -147,6 +151,28 @@ def _dispatch_surface(
     }
 
 
+def _invariant(
+    category: str,
+    invariant_id: str | None = None,
+    transition_ids: list[str] | None = None,
+    dispatch_surface_ids: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "invariant_id": invariant_id or f"invariant.{category}",
+        "category": category,
+        "owner_region": "panel-local state",
+        "protected_fields": ["field", "panel.tree_selection_key"],
+        "transition_ids": transition_ids or ["transition.keybinding"],
+        "dispatch_surface_ids": (
+            dispatch_surface_ids or ["surface.key_decode_input_dispatch"]
+        ),
+        "failure_mode": "fixture failure mode",
+        "enforcement_status": "documented_foundation_only",
+        "test_strategy": "fixture state-sequence coverage",
+        "migration_notes": ["fixture coverage"],
+    }
+
+
 def _owner_field(field: str = "field") -> dict[str, object]:
     return {
         "field": field,
@@ -168,15 +194,17 @@ def _write_fixture(
     events: list[dict[str, object]] | None = None,
     owner_fields: list[dict[str, object]] | None = None,
     dispatch_surfaces: list[dict[str, object]] | None = None,
+    invariants: list[dict[str, object]] | None = None,
     required_event_classes: list[str] | None = None,
     enum_actions: list[str] | None = None,
-) -> tuple[Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
     action_coverage_path = tmp_path / "action_coverage.json"
     event_coverage_path = tmp_path / "event_coverage.json"
     owner_fields_path = tmp_path / "owner_fields.json"
     dispatch_surfaces_path = tmp_path / "dispatch_surfaces.json"
+    invariants_path = tmp_path / "invariants.json"
     actions_header_path = tmp_path / "ytree_defs.h"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
     _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
@@ -207,6 +235,10 @@ def _write_fixture(
             }
         ),
     )
+    _write(
+        invariants_path,
+        _jsonish({"schema_version": 1, "invariants": invariants or _complete_invariants()}),
+    )
     _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
     return (
         transitions_path,
@@ -216,6 +248,7 @@ def _write_fixture(
         event_coverage_path,
         owner_fields_path,
         dispatch_surfaces_path,
+        invariants_path,
     )
 
 
@@ -252,23 +285,28 @@ def _complete_dispatch_surfaces() -> list[dict[str, object]]:
     ]
 
 
+def _complete_invariants() -> list[dict[str, object]]:
+    return [_invariant(category) for category in REQUIRED_INVARIANT_CATEGORIES]
+
+
 def _complete_owner_fields() -> list[dict[str, object]]:
     return [_owner_field("field"), _owner_field("panel.tree_selection_key")]
 
 
-def _validate(paths: tuple[Path, Path, Path, Path, Path, Path, Path]) -> list[str]:
+def _validate(paths: tuple[Path, Path, Path, Path, Path, Path, Path, Path]) -> list[str]:
     return guard.validate_contract(*paths)
 
 
 def _fixture_with_list_field_value(
     tmp_path: Path, record_type: str, field: str, value: object
-) -> tuple[Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions = _complete_transitions()
     shims = [_shim()]
     actions = _complete_actions()
     events = _complete_events()
     owner_fields = _complete_owner_fields()
     dispatch_surfaces = _complete_dispatch_surfaces()
+    invariants = _complete_invariants()
     if record_type == "action":
         actions[0][field] = value
     elif record_type == "event":
@@ -281,6 +319,8 @@ def _fixture_with_list_field_value(
         shims[0][field] = value
     elif record_type == "dispatch_surface":
         dispatch_surfaces[0][field] = value
+    elif record_type == "invariant":
+        invariants[0][field] = value
     else:
         raise AssertionError(f"unknown record type: {record_type}")
     return _write_fixture(
@@ -291,6 +331,7 @@ def _fixture_with_list_field_value(
         events=events,
         owner_fields=owner_fields,
         dispatch_surfaces=dispatch_surfaces,
+        invariants=invariants,
     )
 
 
@@ -309,6 +350,217 @@ def test_current_repository_appstate_contract_passes() -> None:
 def test_guard_passes_complete_temporary_fixtures(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     paths = _write_fixture(tmp_path, transitions=transitions)
+
+    failures = _validate(paths)
+
+    assert failures == []
+
+
+def test_guard_accepts_invariant_registry_cli_override(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    override_path = tmp_path / "appstate_invariants.json"
+    override_path.write_text(
+        (repo_root / "docs" / "appstate_invariants.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    run = subprocess.run(
+        [
+            "python3",
+            "scripts/check_appstate_contract.py",
+            "--invariants",
+            str(override_path),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_guard_fails_when_required_invariant_category_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = [
+        invariant
+        for invariant in _complete_invariants()
+        if invariant["category"] != "stale_snapshot_fail_closed"
+    ]
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any("invariants missing required category" in failure for failure in failures)
+    assert any("stale_snapshot_fail_closed" in failure for failure in failures)
+
+
+def test_guard_fails_when_required_invariant_field_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0].pop("failure_mode")
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[0]" in failure
+        and "missing required field" in failure
+        and "failure_mode" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_duplicate_invariant_ids(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[1]["invariant_id"] = invariants[0]["invariant_id"]
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[1]" in failure and "duplicate invariant_id" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_invariant_has_unknown_category(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0]["category"] = "unknown_invariant"
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[0]" in failure
+        and "unknown category" in failure
+        and "unknown_invariant" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_invariant_references_unknown_owner_field(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0]["protected_fields"] = ["field.unknown"]
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[0]" in failure
+        and "protected_fields references unregistered owner field" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_invariant_references_unknown_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0]["transition_ids"] = ["transition.missing"]
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[0]" in failure
+        and "transition_ids references unknown transition id" in failure
+        and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_invariant_references_unknown_dispatch_surface(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0]["dispatch_surface_ids"] = ["surface.missing"]
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[0]" in failure
+        and "dispatch_surface_ids references unknown dispatch surface id" in failure
+        and "surface.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_invariant_dispatch_surfaces_are_not_a_list(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0]["dispatch_surface_ids"] = "surface.key_decode_input_dispatch"
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[0]" in failure
+        and "dispatch_surface_ids must be a list" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_invariant_dispatch_surface_element_is_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0]["dispatch_surface_ids"] = [123]
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[0]" in failure
+        and "dispatch_surface_ids[0]" in failure
+        and "must be a non-empty string" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_empty_invariant_dispatch_surfaces_lack_cross_cutting_note(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0]["dispatch_surface_ids"] = []
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[0]" in failure
+        and "empty dispatch_surface_ids requires a cross-cutting" in failure
+        for failure in failures
+    )
+
+
+def test_guard_accepts_empty_invariant_dispatch_surfaces_with_cross_cutting_note(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    invariants[0]["dispatch_surface_ids"] = []
+    invariants[0]["migration_notes"] = ["cross-cutting fixture invariant"]
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
 
     failures = _validate(paths)
 


### PR DESCRIPTION
## Summary
- Add a machine-readable registry for AppState transition invariants that future state-sequence checks will enforce.
- Extend the AppState contract guard to validate invariant categories, owner-field references, transition links, and dispatch-surface links.
- Remove the redundant full-QA ready-for-review trigger while keeping code-change, label, and manual QA triggers intact.

## Scope
- Registry, QA guard, focused tests, and full-QA trigger hardening only.
- No runtime, controller, keybinding, prompt, restore, render, or UI behavior changes.

## Validation
- Local quick gate passed: AppState contract guard, focused AppState guard tests, code-quality bundle, and clean build.
