### PR TITLE
chore(appstate): register generation domains

### DIFF
--- a/docs/appstate_generation_domains.json
+++ b/docs/appstate_generation_domains.json
@@ -1,0 +1,277 @@
+{
+  "schema_version": 1,
+  "contract": "AppState generation-domain registry",
+  "notes": "Non-runtime registry for identity and generation domains used by stale snapshot, restore, and rebind invariants.",
+  "generation_domains": [
+    {
+      "domain_id": "generation.panel.local-authority",
+      "category": "panel_generation",
+      "owner_region": "panel-local state",
+      "generation_owner_field": "panel.panel_generation",
+      "identity_fields": [
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.focus_shape",
+        "panel.restore_snapshot"
+      ],
+      "advances_on_transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.menu-action.volume-select",
+        "transition.modal-action.dismiss",
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.terminal-signal-resize",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "stale_snapshot_policy": "Reject snapshots whose saved panel_generation does not match the panel-local generation marker before restore authority is applied.",
+      "fail_closed_fallback": "Re-resolve by stable identity, then nearest visible ancestor, next visible sibling, previous visible sibling, and finally root visible node.",
+      "restore_boundary": "Canonical panel-anchor restore helpers commit panel-local selection, viewport, focus shape, and snapshot generation together.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Runtime panel_generation is still documented foundation; later runtime migration must wire this field to the canonical panel UI state record."
+      ]
+    },
+    {
+      "domain_id": "generation.volume.shared-authority",
+      "category": "volume_generation",
+      "owner_region": "volume/shared topology and payload state",
+      "generation_owner_field": "volume.volume_generation",
+      "identity_fields": [
+        "ctx.volumes_head",
+        "volume.dir_tree",
+        "volume.logged_state",
+        "volume.payload_cache",
+        "panel.volume_key"
+      ],
+      "advances_on_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.filesystem-mutation-result.mkdir-copy-delete"
+      ],
+      "stale_snapshot_policy": "Treat any saved volume_generation mismatch as stale and require topology/payload identity re-resolution before panel snapshots are reused.",
+      "fail_closed_fallback": "Keep the previous settled topology on blocked transitions; after invalidation, rebind panels through stable identities or fall back to root visible node.",
+      "restore_boundary": "Refresh/rebuild and mutation-result commits advance volume generation before panel restore consumers can observe the changed volume.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Runtime volume_generation is still documented foundation; later runtime migration must attach it to Volume topology and payload commits."
+      ]
+    },
+    {
+      "domain_id": "identity.directory.stable-key",
+      "category": "directory_identity",
+      "owner_region": "panel-local state plus volume/shared topology and payload state",
+      "generation_owner_field": "volume.volume_generation",
+      "identity_fields": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "volume.dir_tree",
+        "volume.logged_state"
+      ],
+      "advances_on_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.volume-operation.release-cycle",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "stale_snapshot_policy": "Directory snapshots must compare stable path identity against the current volume generation before row or cursor state is trusted.",
+      "fail_closed_fallback": "Exact directory identity, nearest visible ancestor, next visible sibling, previous visible sibling, then root visible node.",
+      "restore_boundary": "Directory rebind runs through panel-anchor helpers after the shared topology generation has settled.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Directory identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative invalidation owner for topology changes."
+      ]
+    },
+    {
+      "domain_id": "identity.file.stable-key",
+      "category": "file_identity",
+      "owner_region": "panel-local state plus volume/shared topology and payload state",
+      "generation_owner_field": "volume.volume_generation",
+      "identity_fields": [
+        "panel.file_selection_key",
+        "panel.file_viewport_origin",
+        "volume.payload_cache",
+        "volume.dir_tree"
+      ],
+      "advances_on_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "stale_snapshot_policy": "File snapshots must revalidate path/name identity and payload membership when volume generation changes.",
+      "fail_closed_fallback": "Preserve the directory anchor when possible and choose a valid visible file only after exact file identity is unavailable.",
+      "restore_boundary": "File identity restore is committed with the panel snapshot after topology or payload mutation has settled.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "File identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative owner for payload and namespace invalidation."
+      ]
+    },
+    {
+      "domain_id": "shape.panel.focus",
+      "category": "focus_shape",
+      "owner_region": "panel-local state",
+      "generation_owner_field": "panel.panel_generation",
+      "identity_fields": [
+        "panel.focus_shape",
+        "panel.restore_snapshot"
+      ],
+      "advances_on_transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.modal-action.dismiss",
+        "transition.menu-action.volume-select",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "stale_snapshot_policy": "Saved focus shape is stale when panel_generation differs and must not be restored by transient render shape.",
+      "fail_closed_fallback": "Restore the recorded panel shape directly or keep the current settled shape without rendering an intermediate guess.",
+      "restore_boundary": "Modal dismissal, panel reactivation, and rebind callbacks commit focus shape only through panel-local state.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Focus-shape invalidation is represented by panel.panel_generation until a narrower runtime focus-shape generation exists."
+      ]
+    },
+    {
+      "domain_id": "target.modal-command.session",
+      "category": "modal_command_target",
+      "owner_region": "ctx/session state",
+      "generation_owner_field": "panel.panel_generation",
+      "identity_fields": [
+        "ctx.modal_state",
+        "ctx.command_state",
+        "ctx.pending_transition",
+        "ctx.message_state"
+      ],
+      "advances_on_transition_ids": [
+        "transition.modal-action.dismiss",
+        "transition.command-completion.user-command"
+      ],
+      "stale_snapshot_policy": "Modal and command targets may write panel or volume state only through a declared follow-up transition boundary.",
+      "fail_closed_fallback": "On blocked or failed command completion, preserve authoritative panel and volume state and write only declared message/modal fields.",
+      "restore_boundary": "Modal dismissal and command completion settle session state before any panel restore or refresh follow-up observes the result.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "No dedicated ctx command/modal generation exists yet; panel.panel_generation is the closest guard for command paths that restore focus or queue panel-local follow-up work."
+      ]
+    },
+    {
+      "domain_id": "state.visibility-filter.panel-volume",
+      "category": "visibility_filter_state",
+      "owner_region": "panel-local state plus volume/shared topology and payload state",
+      "generation_owner_field": "panel.panel_generation",
+      "identity_fields": [
+        "panel.tree_selection_key",
+        "panel.tree_viewport_origin",
+        "panel.file_selection_key",
+        "panel.file_viewport_origin",
+        "volume.logged_state"
+      ],
+      "advances_on_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.keybinding.navigate-tree",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "stale_snapshot_policy": "Visibility/filter changes that alter rendered rows invalidate saved panel anchors before any snapshot can be reused.",
+      "fail_closed_fallback": "Rebind visible identity through the deterministic fallback order rather than deriving from hidden or filtered row indexes.",
+      "restore_boundary": "Visibility-filter commits update panel generation before rebind and render projection.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Dedicated filter and dotfile visibility owner fields are not registered yet; panel.panel_generation is the closest panel-local invalidation owner."
+      ]
+    },
+    {
+      "domain_id": "state.topology.volume",
+      "category": "topology_state",
+      "owner_region": "volume/shared topology and payload state",
+      "generation_owner_field": "volume.volume_generation",
+      "identity_fields": [
+        "volume.dir_tree",
+        "volume.logged_state",
+        "ctx.volumes_head"
+      ],
+      "advances_on_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.filesystem-mutation-result.mkdir-copy-delete"
+      ],
+      "stale_snapshot_policy": "Topology snapshots are invalid after any volume_generation advance and must be rebuilt or rebound by identity.",
+      "fail_closed_fallback": "Blocked topology changes retain the previous settled tree; completed invalidation falls back panel anchors only after exact identity fails.",
+      "restore_boundary": "Topology rebuild commits settle volume.dir_tree and volume.logged_state before panel rebind callbacks run.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Topology generation is represented by volume.volume_generation until runtime Volume commit hooks are migrated."
+      ]
+    },
+    {
+      "domain_id": "state.file-payload.volume",
+      "category": "file_payload_state",
+      "owner_region": "volume/shared topology and payload state",
+      "generation_owner_field": "volume.volume_generation",
+      "identity_fields": [
+        "volume.payload_cache",
+        "panel.file_selection_key",
+        "panel.file_viewport_origin"
+      ],
+      "advances_on_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "stale_snapshot_policy": "Payload cache identity must be revalidated on generation mismatch before saved file selection is restored.",
+      "fail_closed_fallback": "If payload cannot be loaded safely, preserve directory selection and leave file authority unchanged or empty according to current AppState.",
+      "restore_boundary": "Payload changes settle in Volume before panel file anchors are rebound.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "File payload invalidation uses volume.volume_generation until a narrower payload generation field is registered."
+      ]
+    },
+    {
+      "domain_id": "lifecycle.volume.registry",
+      "category": "volume_lifecycle",
+      "owner_region": "ctx/session state plus volume/shared topology and payload state",
+      "generation_owner_field": "volume.volume_generation",
+      "identity_fields": [
+        "ctx.volumes_head",
+        "panel.volume_key",
+        "panel.restore_snapshot",
+        "volume.logged_state"
+      ],
+      "advances_on_transition_ids": [
+        "transition.volume-operation.release-cycle",
+        "transition.menu-action.volume-select",
+        "transition.refresh-rebuild.manual-refresh"
+      ],
+      "stale_snapshot_policy": "Panel volume bindings must resolve to an existing volume identity before per-volume snapshots can be restored.",
+      "fail_closed_fallback": "Do not orphan panel bindings; use deterministic volume fallback and then panel identity fallback after release or cycle invalidation.",
+      "restore_boundary": "Volume lifecycle transitions update registry/binding state before panel-local restore snapshots are applied.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Volume lifecycle has no separate registry generation yet; volume.volume_generation is the closest shared invalidation owner while ctx.volumes_head remains the registry identity field."
+      ]
+    },
+    {
+      "domain_id": "reflow.layout.projection",
+      "category": "layout_reflow",
+      "owner_region": "render/projection/invalidation state",
+      "generation_owner_field": "panel.panel_generation",
+      "identity_fields": [
+        "ctx.layout",
+        "ctx.window_handles",
+        "ctx.render_dirty_flags",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin"
+      ],
+      "advances_on_transition_ids": [
+        "transition.terminal-signal-resize"
+      ],
+      "stale_snapshot_policy": "Layout reflow must project from settled AppState and may advance panel generation only for viewport bounds correction.",
+      "fail_closed_fallback": "If safe projection cannot be computed, degrade or skip render without choosing new authoritative identities.",
+      "restore_boundary": "Resize handling runs in the main loop and commits any viewport correction before render projection.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Render projection itself is read-only/projection-only and does not advance generations; terminal resize uses panel.panel_generation only when saved viewport origins are corrected."
+      ]
+    }
+  ]
+}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -17,6 +17,7 @@ DEFAULT_EVENT_COVERAGE = REPO_ROOT / "docs" / "appstate_event_coverage.json"
 DEFAULT_OWNER_FIELDS = REPO_ROOT / "docs" / "appstate_owner_fields.json"
 DEFAULT_DISPATCH_SURFACES = REPO_ROOT / "docs" / "appstate_dispatch_surfaces.json"
 DEFAULT_INVARIANTS = REPO_ROOT / "docs" / "appstate_invariants.json"
+DEFAULT_GENERATION_DOMAINS = REPO_ROOT / "docs" / "appstate_generation_domains.json"
 DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytree_defs.h"
 
 REQUIRED_TRANSITION_CATEGORIES = {
@@ -109,6 +110,20 @@ REQUIRED_INVARIANT_CATEGORIES = {
     "blocked_transition_determinism",
 }
 
+REQUIRED_GENERATION_DOMAIN_CATEGORIES = {
+    "panel_generation",
+    "volume_generation",
+    "directory_identity",
+    "file_identity",
+    "focus_shape",
+    "modal_command_target",
+    "visibility_filter_state",
+    "topology_state",
+    "file_payload_state",
+    "volume_lifecycle",
+    "layout_reflow",
+}
+
 REQUIRED_DISPATCH_SURFACE_FIELDS = {
     "surface_id",
     "category",
@@ -156,6 +171,20 @@ REQUIRED_INVARIANT_FIELDS = {
     "migration_notes",
 }
 
+REQUIRED_GENERATION_DOMAIN_FIELDS = {
+    "domain_id",
+    "category",
+    "owner_region",
+    "generation_owner_field",
+    "identity_fields",
+    "advances_on_transition_ids",
+    "stale_snapshot_policy",
+    "fail_closed_fallback",
+    "restore_boundary",
+    "enforcement_status",
+    "migration_notes",
+}
+
 LIST_FIELDS = {
     "declared_write_set",
     "side_effects",
@@ -170,6 +199,8 @@ INVARIANT_LIST_FIELDS = {
     "transition_ids",
     "migration_notes",
 }
+GENERATION_DOMAIN_LIST_FIELDS = {"identity_fields", "migration_notes"}
+GENERATION_FIELD_RE = re.compile(r"\b(?:[A-Za-z0-9_]+\.)?[A-Za-z0-9_]+_generation\b")
 
 
 def _load_json(path: Path) -> tuple[Any | None, list[str]]:
@@ -624,6 +655,165 @@ def _validate_invariants(
     return failures
 
 
+def _validate_generation_transition_refs(
+    *,
+    value: Any,
+    label: str,
+    transition_ids: dict[str, dict[str, Any]],
+    migration_notes: Any,
+) -> list[str]:
+    failures: list[str] = []
+    field = "advances_on_transition_ids"
+    if not isinstance(value, list):
+        return [f"{label}: {field} must be a list"]
+
+    for index, transition_id in enumerate(value):
+        if not isinstance(transition_id, str) or not transition_id.strip():
+            failures.append(f"{label}: {field}[{index}] must be a non-empty string")
+            continue
+        if transition_id not in transition_ids:
+            failures.append(
+                f"{label}: {field} references unknown transition id: {transition_id}"
+            )
+
+    if not value:
+        has_projection_note = (
+            isinstance(migration_notes, list)
+            and any(
+                isinstance(note, str)
+                and (
+                    "read-only" in note.lower()
+                    or "projection-only" in note.lower()
+                )
+                for note in migration_notes
+            )
+        )
+        if not has_projection_note:
+            failures.append(
+                f"{label}: empty {field} requires a read-only/projection-only migration_notes explanation"
+            )
+
+    return failures
+
+
+def _validate_generation_domains(
+    *,
+    generation_domains_doc: Any,
+    generation_domains_path: Path,
+    transition_ids: dict[str, dict[str, Any]],
+    registered_owner_fields: set[str],
+) -> tuple[set[str], list[str]]:
+    failures: list[str] = []
+    generation_owner_fields: set[str] = set()
+    if not isinstance(generation_domains_doc, dict):
+        failures.append(f"{generation_domains_path}: top-level value must be an object")
+        return generation_owner_fields, failures
+
+    domain_records = generation_domains_doc.get("generation_domains")
+    if not isinstance(domain_records, list) or not domain_records:
+        failures.append(
+            f"{generation_domains_path}: generation_domains must be a non-empty list"
+        )
+        domain_records = []
+
+    domain_ids: set[str] = set()
+    covered_categories: set[str] = set()
+    for index, record in enumerate(domain_records):
+        label = f"generation_domain[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_GENERATION_DOMAIN_FIELDS
+                - {"advances_on_transition_ids"},
+                list_fields=GENERATION_DOMAIN_LIST_FIELDS,
+                label=label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+
+        if "advances_on_transition_ids" not in record:
+            failures.append(
+                f"{label}: missing required field(s): advances_on_transition_ids"
+            )
+        else:
+            failures.extend(
+                _validate_generation_transition_refs(
+                    value=record.get("advances_on_transition_ids"),
+                    label=label,
+                    transition_ids=transition_ids,
+                    migration_notes=record.get("migration_notes"),
+                )
+            )
+
+        domain_id = record.get("domain_id")
+        if isinstance(domain_id, str) and domain_id.strip():
+            if domain_id in domain_ids:
+                failures.append(f"{label}: duplicate domain_id: {domain_id}")
+            domain_ids.add(domain_id)
+
+        category = record.get("category")
+        if isinstance(category, str) and category.strip():
+            covered_categories.add(category)
+            if category not in REQUIRED_GENERATION_DOMAIN_CATEGORIES:
+                failures.append(f"{label}: unknown category: {category}")
+
+        generation_owner_field = record.get("generation_owner_field")
+        if isinstance(generation_owner_field, str) and generation_owner_field.strip():
+            generation_owner_fields.add(generation_owner_field)
+            if generation_owner_field not in registered_owner_fields:
+                failures.append(
+                    f"{label}: generation_owner_field references unregistered owner field: {generation_owner_field}"
+                )
+
+        identity_fields = record.get("identity_fields")
+        if isinstance(identity_fields, list):
+            for field in identity_fields:
+                if (
+                    isinstance(field, str)
+                    and field.strip()
+                    and field not in registered_owner_fields
+                ):
+                    failures.append(
+                        f"{label}: identity_fields references unregistered owner field: {field}"
+                    )
+
+    missing_categories = sorted(
+        REQUIRED_GENERATION_DOMAIN_CATEGORIES - covered_categories
+    )
+    if missing_categories:
+        failures.append(
+            "generation domains missing required category/categories: "
+            + ", ".join(missing_categories)
+        )
+
+    return generation_owner_fields, failures
+
+
+def _validate_transition_generation_effects(
+    *,
+    transitions: list[Any],
+    generation_owner_fields: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    registered_names = set(generation_owner_fields)
+    registered_names.update(field.rsplit(".", 1)[-1] for field in generation_owner_fields)
+
+    for index, record in enumerate(transitions):
+        if not isinstance(record, dict):
+            continue
+        effect = record.get("generation_effect")
+        if not isinstance(effect, str):
+            continue
+        for field in sorted(set(GENERATION_FIELD_RE.findall(effect))):
+            if field not in registered_names:
+                failures.append(
+                    f"transition[{index}]: generation_effect names unregistered generation field: {field}"
+                )
+
+    return failures
+
+
 def _validate_event_coverage(
     *,
     event_coverage_doc: Any,
@@ -726,6 +916,7 @@ def validate_contract(
     owner_fields_path: Path = DEFAULT_OWNER_FIELDS,
     dispatch_surfaces_path: Path = DEFAULT_DISPATCH_SURFACES,
     invariants_path: Path = DEFAULT_INVARIANTS,
+    generation_domains_path: Path = DEFAULT_GENERATION_DOMAINS,
 ) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
@@ -737,6 +928,9 @@ def validate_contract(
         dispatch_surfaces_path
     )
     invariants_doc, invariants_load_failures = _load_json(invariants_path)
+    generation_domains_doc, generation_domains_load_failures = _load_json(
+        generation_domains_path
+    )
     enum_actions, enum_failures = _parse_ytree_actions(actions_header_path)
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
@@ -745,6 +939,7 @@ def validate_contract(
     failures.extend(owner_fields_load_failures)
     failures.extend(dispatch_surfaces_load_failures)
     failures.extend(invariants_load_failures)
+    failures.extend(generation_domains_load_failures)
     failures.extend(enum_failures)
     if failures:
         return failures
@@ -800,6 +995,20 @@ def validate_contract(
             "transition matrix missing required category/categories: "
             + ", ".join(missing_categories)
         )
+
+    generation_owner_fields, generation_domain_failures = _validate_generation_domains(
+        generation_domains_doc=generation_domains_doc,
+        generation_domains_path=generation_domains_path,
+        transition_ids=transition_ids,
+        registered_owner_fields=registered_owner_fields,
+    )
+    failures.extend(generation_domain_failures)
+    failures.extend(
+        _validate_transition_generation_effects(
+            transitions=transitions,
+            generation_owner_fields=generation_owner_fields,
+        )
+    )
 
     if not isinstance(shims_doc, dict):
         failures.append(f"{shims_path}: top-level value must be an object")
@@ -946,6 +1155,9 @@ def main() -> int:
         "--dispatch-surfaces", type=Path, default=DEFAULT_DISPATCH_SURFACES
     )
     parser.add_argument("--invariants", type=Path, default=DEFAULT_INVARIANTS)
+    parser.add_argument(
+        "--generation-domains", type=Path, default=DEFAULT_GENERATION_DOMAINS
+    )
     parser.add_argument("--actions-header", type=Path, default=DEFAULT_ACTION_HEADER)
     args = parser.parse_args()
 
@@ -958,6 +1170,7 @@ def main() -> int:
         args.owner_fields,
         args.dispatch_surfaces,
         args.invariants,
+        args.generation_domains,
     )
     if failures:
         for failure in failures:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -17,6 +17,9 @@ REQUIRED_CATEGORIES = sorted(guard.REQUIRED_TRANSITION_CATEGORIES)
 REQUIRED_EVENT_CLASSES = sorted(guard.REQUIRED_EVENT_CLASSES)
 REQUIRED_DISPATCH_SURFACE_CATEGORIES = sorted(guard.REQUIRED_DISPATCH_SURFACE_CATEGORIES)
 REQUIRED_INVARIANT_CATEGORIES = sorted(guard.REQUIRED_INVARIANT_CATEGORIES)
+REQUIRED_GENERATION_DOMAIN_CATEGORIES = sorted(
+    guard.REQUIRED_GENERATION_DOMAIN_CATEGORIES
+)
 FIXTURE_ACTIONS = ["ACTION_NONE", "ACTION_MOVE_UP", "ACTION_USER_CMD"]
 REQUIRED_LIST_FIELD_CASES = [
     ("action", "declared_write_set", "action[0]"),
@@ -27,6 +30,8 @@ REQUIRED_LIST_FIELD_CASES = [
     ("transition", "declared_write_set", "transition[0]"),
     ("transition", "side_effects", "transition[0]"),
     ("owner_field", "invariant_checks", "owner_field[0]"),
+    ("generation_domain", "identity_fields", "generation_domain[0]"),
+    ("generation_domain", "migration_notes", "generation_domain[0]"),
     ("invariant", "protected_fields", "invariant[0]"),
     ("invariant", "transition_ids", "invariant[0]"),
     ("invariant", "migration_notes", "invariant[0]"),
@@ -173,6 +178,28 @@ def _invariant(
     }
 
 
+def _generation_domain(
+    category: str,
+    domain_id: str | None = None,
+    advances_on_transition_ids: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "domain_id": domain_id or f"domain.{category}",
+        "category": category,
+        "owner_region": "panel-local state",
+        "generation_owner_field": "field",
+        "identity_fields": ["field"],
+        "advances_on_transition_ids": (
+            advances_on_transition_ids or ["transition.keybinding"]
+        ),
+        "stale_snapshot_policy": "fixture stale snapshot policy",
+        "fail_closed_fallback": "fixture fail-closed fallback",
+        "restore_boundary": "fixture restore boundary",
+        "enforcement_status": "documented_foundation_only",
+        "migration_notes": ["fixture coverage"],
+    }
+
+
 def _owner_field(field: str = "field") -> dict[str, object]:
     return {
         "field": field,
@@ -195,9 +222,10 @@ def _write_fixture(
     owner_fields: list[dict[str, object]] | None = None,
     dispatch_surfaces: list[dict[str, object]] | None = None,
     invariants: list[dict[str, object]] | None = None,
+    generation_domains: list[dict[str, object]] | None = None,
     required_event_classes: list[str] | None = None,
     enum_actions: list[str] | None = None,
-) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
     action_coverage_path = tmp_path / "action_coverage.json"
@@ -205,6 +233,7 @@ def _write_fixture(
     owner_fields_path = tmp_path / "owner_fields.json"
     dispatch_surfaces_path = tmp_path / "dispatch_surfaces.json"
     invariants_path = tmp_path / "invariants.json"
+    generation_domains_path = tmp_path / "generation_domains.json"
     actions_header_path = tmp_path / "ytree_defs.h"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
     _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
@@ -239,6 +268,17 @@ def _write_fixture(
         invariants_path,
         _jsonish({"schema_version": 1, "invariants": invariants or _complete_invariants()}),
     )
+    _write(
+        generation_domains_path,
+        _jsonish(
+            {
+                "schema_version": 1,
+                "generation_domains": (
+                    generation_domains or _complete_generation_domains()
+                ),
+            }
+        ),
+    )
     _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
     return (
         transitions_path,
@@ -249,6 +289,7 @@ def _write_fixture(
         owner_fields_path,
         dispatch_surfaces_path,
         invariants_path,
+        generation_domains_path,
     )
 
 
@@ -289,17 +330,29 @@ def _complete_invariants() -> list[dict[str, object]]:
     return [_invariant(category) for category in REQUIRED_INVARIANT_CATEGORIES]
 
 
+def _complete_generation_domains() -> list[dict[str, object]]:
+    return [
+        _generation_domain(
+            category,
+            "domain.panel_generation" if category == "panel_generation" else None,
+        )
+        for category in REQUIRED_GENERATION_DOMAIN_CATEGORIES
+    ]
+
+
 def _complete_owner_fields() -> list[dict[str, object]]:
     return [_owner_field("field"), _owner_field("panel.tree_selection_key")]
 
 
-def _validate(paths: tuple[Path, Path, Path, Path, Path, Path, Path, Path]) -> list[str]:
+def _validate(
+    paths: tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path],
+) -> list[str]:
     return guard.validate_contract(*paths)
 
 
 def _fixture_with_list_field_value(
     tmp_path: Path, record_type: str, field: str, value: object
-) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions = _complete_transitions()
     shims = [_shim()]
     actions = _complete_actions()
@@ -307,12 +360,15 @@ def _fixture_with_list_field_value(
     owner_fields = _complete_owner_fields()
     dispatch_surfaces = _complete_dispatch_surfaces()
     invariants = _complete_invariants()
+    generation_domains = _complete_generation_domains()
     if record_type == "action":
         actions[0][field] = value
     elif record_type == "event":
         events[0][field] = value
     elif record_type == "owner_field":
         owner_fields[0][field] = value
+    elif record_type == "generation_domain":
+        generation_domains[0][field] = value
     elif record_type == "transition":
         transitions[0][field] = value
     elif record_type == "shim":
@@ -332,6 +388,7 @@ def _fixture_with_list_field_value(
         owner_fields=owner_fields,
         dispatch_surfaces=dispatch_surfaces,
         invariants=invariants,
+        generation_domains=generation_domains,
     )
 
 
@@ -378,6 +435,263 @@ def test_guard_accepts_invariant_registry_cli_override(tmp_path: Path) -> None:
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_guard_accepts_generation_domain_registry_cli_override(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    override_path = tmp_path / "appstate_generation_domains.json"
+    override_path.write_text(
+        (repo_root / "docs" / "appstate_generation_domains.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    run = subprocess.run(
+        [
+            "python3",
+            "scripts/check_appstate_contract.py",
+            "--generation-domains",
+            str(override_path),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_guard_fails_when_required_generation_domain_category_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = [
+        domain
+        for domain in _complete_generation_domains()
+        if domain["category"] != "layout_reflow"
+    ]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation domains missing required category" in failure
+        for failure in failures
+    )
+    assert any("layout_reflow" in failure for failure in failures)
+
+
+def test_guard_fails_when_required_generation_domain_field_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0].pop("restore_boundary")
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and "missing required field" in failure
+        and "restore_boundary" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_duplicate_generation_domain_ids(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[1]["domain_id"] = generation_domains[0]["domain_id"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[1]" in failure and "duplicate domain_id" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_generation_domain_has_unknown_category(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["category"] = "unknown_generation_domain"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and "unknown category" in failure
+        and "unknown_generation_domain" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_generation_domain_owner_field_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["generation_owner_field"] = "field.unknown"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and "generation_owner_field references unregistered owner field" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_generation_domain_identity_field_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["identity_fields"] = ["field.unknown"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and "identity_fields references unregistered owner field" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_generation_domain_transition_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["advances_on_transition_ids"] = ["transition.missing"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and "advances_on_transition_ids references unknown transition id" in failure
+        and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_generation_domain_advances_is_not_a_list(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["advances_on_transition_ids"] = "transition.keybinding"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and "advances_on_transition_ids must be a list" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_generation_domain_advances_element_is_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["advances_on_transition_ids"] = [123]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and "advances_on_transition_ids[0]" in failure
+        and "must be a non-empty string" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_empty_generation_domain_advances_lack_projection_note(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["advances_on_transition_ids"] = []
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and "empty advances_on_transition_ids requires" in failure
+        for failure in failures
+    )
+
+
+def test_guard_accepts_empty_generation_domain_advances_with_projection_note(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["advances_on_transition_ids"] = []
+    generation_domains[0]["migration_notes"] = [
+        "read-only/projection-only fixture domain"
+    ]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert failures == []
+
+
+def test_guard_fails_when_generation_effect_names_unregistered_generation_field(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transitions[0]["generation_effect"] = "Increment missing_generation."
+    paths = _write_fixture(tmp_path, transitions=transitions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition[0]" in failure
+        and "generation_effect names unregistered generation field" in failure
+        and "missing_generation" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_when_required_invariant_category_is_missing(


### PR DESCRIPTION
## Summary
- Add a machine-readable registry for AppState identity and generation domains used by stale snapshot, restore, and rebind checks.
- Extend the AppState contract guard to validate domain categories, owner-field references, transition links, and generation-effect references.
- Add focused guard tests for generation-domain registry drift and malformed generation metadata.

## Scope
- Registry and QA guard only.
- No runtime, controller, keybinding, prompt, restore, render, workflow, or UI behavior changes.

## Validation
- Local quick gate passed: AppState contract guard, focused AppState guard tests, code-quality bundle, and clean build.
