### PR TITLE
chore(appstate): define transition diff harness

### DIFF
--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -1,0 +1,200 @@
+{
+  "schema_version": 1,
+  "contract": "AppState transition-diff harness registry",
+  "notes": "Non-runtime registry for future before/after AppState snapshot and diff checks. Runtime behavior is unchanged.",
+  "diff_harness_checks": [
+    {
+      "harness_id": "harness.transition-before-after-snapshot",
+      "check_category": "transition_before_after_snapshot",
+      "snapshot_phases": ["before_guard", "after_allowed_or_blocked_result"],
+      "snapshot_regions": ["ctx/session state", "panel-local state", "volume/shared topology and payload state", "render/projection/invalidation state"],
+      "transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
+      "owner_field_refs": [
+        "ctx.active",
+        "ctx.volumes_head",
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.restore_snapshot",
+        "panel.panel_generation",
+        "volume.dir_tree",
+        "volume.volume_generation"
+      ],
+      "invariant_ids": [
+        "invariant.inactive-panel-frozen",
+        "invariant.shared-state-panel-local-isolation",
+        "invariant.viewport-identity-rebind"
+      ],
+      "generation_domain_ids": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key"
+      ],
+      "expected_behavior": "A later dynamic harness snapshots every referenced AppState region before guard evaluation and after the transition result, then compares only authoritative state owned by the registered transition boundary.",
+      "failure_mode": "Any unclassified region change, stale snapshot reuse, or missing before/after phase is reported as a transition contract violation.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "This registry entry defines the machine-readable coverage target; no runtime C runner exists in this unit."
+      ]
+    },
+    {
+      "harness_id": "harness.declared-write-set-diff",
+      "check_category": "declared_write_set_diff",
+      "snapshot_phases": ["before_transition", "after_transition_commit"],
+      "snapshot_regions": ["ctx/session state", "panel-local state", "volume/shared topology and payload state"],
+      "transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.menu-action.volume-select",
+        "transition.modal-action.dismiss",
+        "transition.command-completion.user-command"
+      ],
+      "owner_field_refs": [
+        "ctx.command_state",
+        "ctx.message_state",
+        "ctx.modal_state",
+        "ctx.pending_transition",
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ],
+      "invariant_ids": [
+        "invariant.panel-local-focus-restore",
+        "invariant.shared-state-panel-local-isolation"
+      ],
+      "generation_domain_ids": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "target.modal-command.session"
+      ],
+      "expected_behavior": "The after snapshot may differ from the before snapshot only in owner fields named by the transition's declared_write_set or by an explicitly registered follow-up transition.",
+      "failure_mode": "A changed owner field outside the registered write set is rejected as an undeclared AppState mutation.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Runtime migration should derive concrete field comparisons from docs/appstate_transition_matrix.json declared_write_set records."
+      ]
+    },
+    {
+      "harness_id": "harness.render-projection-read-only-diff",
+      "check_category": "render_projection_read_only_diff",
+      "snapshot_phases": ["before_render_projection", "after_render_projection"],
+      "snapshot_regions": ["panel-local state", "volume/shared topology and payload state", "render/projection/invalidation state"],
+      "transition_ids": [
+        "transition.render-reflow.project-state"
+      ],
+      "owner_field_refs": [
+        "ctx.render_dirty_flags",
+        "ctx.window_handles",
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.focus_shape",
+        "panel.panel_generation",
+        "volume.volume_generation"
+      ],
+      "invariant_ids": [
+        "invariant.render-projection-read-only",
+        "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_ids": [
+        "reflow.layout.projection",
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority"
+      ],
+      "expected_behavior": "Render/reflow projection may consume settled AppState and stage terminal output, but it must not mutate authoritative selection, identity, focus, or generation fields.",
+      "failure_mode": "Any authoritative owner or generation delta produced by render projection is rejected as render-state leakage into AppState authority.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Dirty-flag clearing and window-handle staging remain named so the future harness can distinguish projection bookkeeping from selection authority."
+      ]
+    },
+    {
+      "harness_id": "harness.generation-mismatch-check",
+      "check_category": "generation_mismatch_check",
+      "snapshot_phases": ["saved_snapshot", "current_authority", "restore_attempt_result"],
+      "snapshot_regions": ["panel-local state", "volume/shared topology and payload state"],
+      "transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor",
+        "transition.terminal-signal-resize"
+      ],
+      "owner_field_refs": [
+        "panel.restore_snapshot",
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.panel_generation",
+        "volume.dir_tree",
+        "volume.payload_cache",
+        "volume.volume_generation"
+      ],
+      "invariant_ids": [
+        "invariant.stale-snapshot-fail-closed",
+        "invariant.viewport-identity-rebind",
+        "invariant.hidden-entry-visible-navigation"
+      ],
+      "generation_domain_ids": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
+      ],
+      "expected_behavior": "Saved panel or volume snapshots whose generation markers mismatch current authority must be rejected or rebound through stable identity fallback before any restore commit.",
+      "failure_mode": "Reusing stale row, pointer, or payload identity after a generation mismatch is rejected as a fail-closed violation.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "The future runner should seed mismatched saved/current generations to verify deterministic restore fallback."
+      ]
+    },
+    {
+      "harness_id": "harness.blocked-transition-no-unrelated-mutation",
+      "check_category": "blocked_transition_no_unrelated_mutation",
+      "snapshot_phases": ["before_guard", "after_blocked_result"],
+      "snapshot_regions": ["ctx/session state", "panel-local state", "volume/shared topology and payload state"],
+      "transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.modal-action.dismiss",
+        "transition.volume-operation.release-cycle",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.command-completion.user-command"
+      ],
+      "owner_field_refs": [
+        "ctx.message_state",
+        "ctx.modal_state",
+        "panel.volume_key",
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.panel_generation",
+        "volume.dir_tree",
+        "volume.volume_generation"
+      ],
+      "invariant_ids": [
+        "invariant.blocked-transition-determinism",
+        "invariant.inactive-panel-frozen",
+        "invariant.shared-state-panel-local-isolation"
+      ],
+      "generation_domain_ids": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "lifecycle.volume.registry",
+        "target.modal-command.session"
+      ],
+      "expected_behavior": "A blocked transition may report only the registered user-visible failure state and must leave unrelated owner fields and all unaffected generations byte-for-byte unchanged.",
+      "failure_mode": "Any unrelated owner-field or generation delta after a blocked result is rejected as nondeterministic blocked-transition mutation.",
+      "enforcement_status": "documented_foundation_only",
+      "migration_notes": [
+        "Concrete blocked-result allowances should be derived from the target transition's blocked_result and declared_write_set records."
+      ]
+    }
+  ]
+}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -18,6 +18,7 @@ DEFAULT_OWNER_FIELDS = REPO_ROOT / "docs" / "appstate_owner_fields.json"
 DEFAULT_DISPATCH_SURFACES = REPO_ROOT / "docs" / "appstate_dispatch_surfaces.json"
 DEFAULT_INVARIANTS = REPO_ROOT / "docs" / "appstate_invariants.json"
 DEFAULT_GENERATION_DOMAINS = REPO_ROOT / "docs" / "appstate_generation_domains.json"
+DEFAULT_DIFF_HARNESS = REPO_ROOT / "docs" / "appstate_diff_harness.json"
 DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytree_defs.h"
 
 REQUIRED_TRANSITION_CATEGORIES = {
@@ -124,6 +125,14 @@ REQUIRED_GENERATION_DOMAIN_CATEGORIES = {
     "layout_reflow",
 }
 
+REQUIRED_DIFF_HARNESS_CATEGORIES = {
+    "transition_before_after_snapshot",
+    "declared_write_set_diff",
+    "render_projection_read_only_diff",
+    "generation_mismatch_check",
+    "blocked_transition_no_unrelated_mutation",
+}
+
 REQUIRED_DISPATCH_SURFACE_FIELDS = {
     "surface_id",
     "category",
@@ -185,6 +194,21 @@ REQUIRED_GENERATION_DOMAIN_FIELDS = {
     "migration_notes",
 }
 
+REQUIRED_DIFF_HARNESS_FIELDS = {
+    "harness_id",
+    "check_category",
+    "snapshot_phases",
+    "snapshot_regions",
+    "transition_ids",
+    "owner_field_refs",
+    "invariant_ids",
+    "generation_domain_ids",
+    "expected_behavior",
+    "failure_mode",
+    "enforcement_status",
+    "migration_notes",
+}
+
 LIST_FIELDS = {
     "declared_write_set",
     "side_effects",
@@ -200,6 +224,15 @@ INVARIANT_LIST_FIELDS = {
     "migration_notes",
 }
 GENERATION_DOMAIN_LIST_FIELDS = {"identity_fields", "migration_notes"}
+DIFF_HARNESS_LIST_FIELDS = {
+    "snapshot_phases",
+    "snapshot_regions",
+    "transition_ids",
+    "owner_field_refs",
+    "invariant_ids",
+    "generation_domain_ids",
+    "migration_notes",
+}
 GENERATION_FIELD_RE = re.compile(r"\b(?:[A-Za-z0-9_]+\.)?[A-Za-z0-9_]+_generation\b")
 
 
@@ -416,6 +449,112 @@ def _validate_allowed_direct_writes(
             failures.append(
                 f"{label}: allowed_direct_writes references unregistered owner field: {field}"
             )
+    return failures
+
+
+def _validate_appstate_diff_harness(
+    *,
+    diff_harness_doc: Any,
+    diff_harness_path: Path,
+    transition_ids: dict[str, dict[str, Any]],
+    registered_owner_fields: set[str],
+    invariant_ids: set[str],
+    generation_domain_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(diff_harness_doc, dict):
+        failures.append(f"{diff_harness_path}: top-level value must be an object")
+        return failures
+
+    records = diff_harness_doc.get("diff_harness_checks")
+    if not isinstance(records, list) or not records:
+        failures.append(
+            f"{diff_harness_path}: diff_harness_checks must be a non-empty list"
+        )
+        records = []
+
+    harness_ids: set[str] = set()
+    covered_categories: set[str] = set()
+    for index, record in enumerate(records):
+        label = f"diff_harness_check[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_DIFF_HARNESS_FIELDS,
+                list_fields=DIFF_HARNESS_LIST_FIELDS,
+                label=label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+
+        harness_id = record.get("harness_id")
+        if isinstance(harness_id, str) and harness_id.strip():
+            if harness_id in harness_ids:
+                failures.append(f"{label}: duplicate harness_id: {harness_id}")
+            harness_ids.add(harness_id)
+
+        check_category = record.get("check_category")
+        if isinstance(check_category, str) and check_category.strip():
+            covered_categories.add(check_category)
+            if check_category not in REQUIRED_DIFF_HARNESS_CATEGORIES:
+                failures.append(f"{label}: unknown check_category: {check_category}")
+
+        transition_refs = record.get("transition_ids")
+        if isinstance(transition_refs, list):
+            for transition_id in transition_refs:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in transition_ids
+                ):
+                    failures.append(
+                        f"{label}: transition_ids references unknown transition id: {transition_id}"
+                    )
+
+        owner_field_refs = record.get("owner_field_refs")
+        if isinstance(owner_field_refs, list):
+            for field in owner_field_refs:
+                if (
+                    isinstance(field, str)
+                    and field.strip()
+                    and field not in registered_owner_fields
+                ):
+                    failures.append(
+                        f"{label}: owner_field_refs references unregistered owner field: {field}"
+                    )
+
+        invariant_refs = record.get("invariant_ids")
+        if isinstance(invariant_refs, list):
+            for invariant_id in invariant_refs:
+                if (
+                    isinstance(invariant_id, str)
+                    and invariant_id.strip()
+                    and invariant_id not in invariant_ids
+                ):
+                    failures.append(
+                        f"{label}: invariant_ids references unknown invariant id: {invariant_id}"
+                    )
+
+        generation_domain_refs = record.get("generation_domain_ids")
+        if isinstance(generation_domain_refs, list):
+            for domain_id in generation_domain_refs:
+                if (
+                    isinstance(domain_id, str)
+                    and domain_id.strip()
+                    and domain_id not in generation_domain_ids
+                ):
+                    failures.append(
+                        f"{label}: generation_domain_ids references unknown generation domain id: {domain_id}"
+                    )
+
+    missing_categories = sorted(REQUIRED_DIFF_HARNESS_CATEGORIES - covered_categories)
+    if missing_categories:
+        failures.append(
+            "diff harness missing required check_category/categories: "
+            + ", ".join(missing_categories)
+        )
+
     return failures
 
 
@@ -917,6 +1056,7 @@ def validate_contract(
     dispatch_surfaces_path: Path = DEFAULT_DISPATCH_SURFACES,
     invariants_path: Path = DEFAULT_INVARIANTS,
     generation_domains_path: Path = DEFAULT_GENERATION_DOMAINS,
+    diff_harness_path: Path = DEFAULT_DIFF_HARNESS,
 ) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
@@ -931,6 +1071,7 @@ def validate_contract(
     generation_domains_doc, generation_domains_load_failures = _load_json(
         generation_domains_path
     )
+    diff_harness_doc, diff_harness_load_failures = _load_json(diff_harness_path)
     enum_actions, enum_failures = _parse_ytree_actions(actions_header_path)
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
@@ -940,6 +1081,7 @@ def validate_contract(
     failures.extend(dispatch_surfaces_load_failures)
     failures.extend(invariants_load_failures)
     failures.extend(generation_domains_load_failures)
+    failures.extend(diff_harness_load_failures)
     failures.extend(enum_failures)
     if failures:
         return failures
@@ -1140,6 +1282,26 @@ def validate_contract(
             dispatch_surface_ids=dispatch_surface_ids,
         )
     )
+    invariant_ids = _collect_string_ids(
+        invariants_doc,
+        collection_key="invariants",
+        id_field="invariant_id",
+    )
+    generation_domain_ids = _collect_string_ids(
+        generation_domains_doc,
+        collection_key="generation_domains",
+        id_field="domain_id",
+    )
+    failures.extend(
+        _validate_appstate_diff_harness(
+            diff_harness_doc=diff_harness_doc,
+            diff_harness_path=diff_harness_path,
+            transition_ids=transition_ids,
+            registered_owner_fields=registered_owner_fields,
+            invariant_ids=invariant_ids,
+            generation_domain_ids=generation_domain_ids,
+        )
+    )
 
     return failures
 
@@ -1158,6 +1320,7 @@ def main() -> int:
     parser.add_argument(
         "--generation-domains", type=Path, default=DEFAULT_GENERATION_DOMAINS
     )
+    parser.add_argument("--diff-harness", type=Path, default=DEFAULT_DIFF_HARNESS)
     parser.add_argument("--actions-header", type=Path, default=DEFAULT_ACTION_HEADER)
     args = parser.parse_args()
 
@@ -1171,6 +1334,7 @@ def main() -> int:
         args.dispatch_surfaces,
         args.invariants,
         args.generation_domains,
+        args.diff_harness,
     )
     if failures:
         for failure in failures:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -20,6 +20,7 @@ REQUIRED_INVARIANT_CATEGORIES = sorted(guard.REQUIRED_INVARIANT_CATEGORIES)
 REQUIRED_GENERATION_DOMAIN_CATEGORIES = sorted(
     guard.REQUIRED_GENERATION_DOMAIN_CATEGORIES
 )
+REQUIRED_DIFF_HARNESS_CATEGORIES = sorted(guard.REQUIRED_DIFF_HARNESS_CATEGORIES)
 FIXTURE_ACTIONS = ["ACTION_NONE", "ACTION_MOVE_UP", "ACTION_USER_CMD"]
 REQUIRED_LIST_FIELD_CASES = [
     ("action", "declared_write_set", "action[0]"),
@@ -35,6 +36,13 @@ REQUIRED_LIST_FIELD_CASES = [
     ("invariant", "protected_fields", "invariant[0]"),
     ("invariant", "transition_ids", "invariant[0]"),
     ("invariant", "migration_notes", "invariant[0]"),
+    ("diff_harness", "snapshot_phases", "diff_harness_check[0]"),
+    ("diff_harness", "snapshot_regions", "diff_harness_check[0]"),
+    ("diff_harness", "transition_ids", "diff_harness_check[0]"),
+    ("diff_harness", "owner_field_refs", "diff_harness_check[0]"),
+    ("diff_harness", "invariant_ids", "diff_harness_check[0]"),
+    ("diff_harness", "generation_domain_ids", "diff_harness_check[0]"),
+    ("diff_harness", "migration_notes", "diff_harness_check[0]"),
     ("shim", "invariant_checks", "shim[0]"),
     ("shim", "migration_notes", "shim[0]"),
 ]
@@ -200,6 +208,30 @@ def _generation_domain(
     }
 
 
+def _diff_harness(
+    category: str,
+    harness_id: str | None = None,
+    transition_ids: list[str] | None = None,
+    owner_field_refs: list[str] | None = None,
+    invariant_ids: list[str] | None = None,
+    generation_domain_ids: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "harness_id": harness_id or f"harness.{category}",
+        "check_category": category,
+        "snapshot_phases": ["before", "after"],
+        "snapshot_regions": ["panel-local state"],
+        "transition_ids": transition_ids or ["transition.keybinding"],
+        "owner_field_refs": owner_field_refs or ["field"],
+        "invariant_ids": invariant_ids or ["invariant.inactive_panel_frozen"],
+        "generation_domain_ids": generation_domain_ids or ["domain.panel_generation"],
+        "expected_behavior": "fixture expected behavior",
+        "failure_mode": "fixture failure mode",
+        "enforcement_status": "documented_foundation_only",
+        "migration_notes": ["fixture coverage"],
+    }
+
+
 def _owner_field(field: str = "field") -> dict[str, object]:
     return {
         "field": field,
@@ -223,9 +255,10 @@ def _write_fixture(
     dispatch_surfaces: list[dict[str, object]] | None = None,
     invariants: list[dict[str, object]] | None = None,
     generation_domains: list[dict[str, object]] | None = None,
+    diff_harness_checks: list[dict[str, object]] | None = None,
     required_event_classes: list[str] | None = None,
     enum_actions: list[str] | None = None,
-) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
     action_coverage_path = tmp_path / "action_coverage.json"
@@ -234,6 +267,7 @@ def _write_fixture(
     dispatch_surfaces_path = tmp_path / "dispatch_surfaces.json"
     invariants_path = tmp_path / "invariants.json"
     generation_domains_path = tmp_path / "generation_domains.json"
+    diff_harness_path = tmp_path / "diff_harness.json"
     actions_header_path = tmp_path / "ytree_defs.h"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
     _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
@@ -279,6 +313,17 @@ def _write_fixture(
             }
         ),
     )
+    _write(
+        diff_harness_path,
+        _jsonish(
+            {
+                "schema_version": 1,
+                "diff_harness_checks": (
+                    diff_harness_checks or _complete_diff_harness_checks()
+                ),
+            }
+        ),
+    )
     _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
     return (
         transitions_path,
@@ -290,6 +335,7 @@ def _write_fixture(
         dispatch_surfaces_path,
         invariants_path,
         generation_domains_path,
+        diff_harness_path,
     )
 
 
@@ -340,19 +386,31 @@ def _complete_generation_domains() -> list[dict[str, object]]:
     ]
 
 
+def _complete_diff_harness_checks() -> list[dict[str, object]]:
+    return [
+        _diff_harness(
+            category,
+            "harness.transition_before_after_snapshot"
+            if category == "transition_before_after_snapshot"
+            else None,
+        )
+        for category in REQUIRED_DIFF_HARNESS_CATEGORIES
+    ]
+
+
 def _complete_owner_fields() -> list[dict[str, object]]:
     return [_owner_field("field"), _owner_field("panel.tree_selection_key")]
 
 
 def _validate(
-    paths: tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path],
+    paths: tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path],
 ) -> list[str]:
     return guard.validate_contract(*paths)
 
 
 def _fixture_with_list_field_value(
     tmp_path: Path, record_type: str, field: str, value: object
-) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions = _complete_transitions()
     shims = [_shim()]
     actions = _complete_actions()
@@ -361,6 +419,7 @@ def _fixture_with_list_field_value(
     dispatch_surfaces = _complete_dispatch_surfaces()
     invariants = _complete_invariants()
     generation_domains = _complete_generation_domains()
+    diff_harness_checks = _complete_diff_harness_checks()
     if record_type == "action":
         actions[0][field] = value
     elif record_type == "event":
@@ -377,6 +436,8 @@ def _fixture_with_list_field_value(
         dispatch_surfaces[0][field] = value
     elif record_type == "invariant":
         invariants[0][field] = value
+    elif record_type == "diff_harness":
+        diff_harness_checks[0][field] = value
     else:
         raise AssertionError(f"unknown record type: {record_type}")
     return _write_fixture(
@@ -389,6 +450,7 @@ def _fixture_with_list_field_value(
         dispatch_surfaces=dispatch_surfaces,
         invariants=invariants,
         generation_domains=generation_domains,
+        diff_harness_checks=diff_harness_checks,
     )
 
 
@@ -461,6 +523,164 @@ def test_guard_accepts_generation_domain_registry_cli_override(tmp_path: Path) -
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_guard_accepts_diff_harness_registry_cli_override(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    override_path = tmp_path / "appstate_diff_harness.json"
+    override_path.write_text(
+        (repo_root / "docs" / "appstate_diff_harness.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    run = subprocess.run(
+        [
+            "python3",
+            "scripts/check_appstate_contract.py",
+            "--diff-harness",
+            str(override_path),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_guard_fails_when_required_diff_harness_field_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    diff_harness_checks[0].pop("failure_mode")
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "diff_harness_check[0]" in failure
+        and "missing required field(s): failure_mode" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_duplicate_diff_harness_ids(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    diff_harness_checks[1]["harness_id"] = diff_harness_checks[0]["harness_id"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any("duplicate harness_id" in failure for failure in failures)
+
+
+def test_guard_fails_when_diff_harness_has_unknown_check_category(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    diff_harness_checks[0]["check_category"] = "unknown_diff_harness_check"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "diff_harness_check[0]" in failure
+        and "unknown check_category" in failure
+        and "unknown_diff_harness_check" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_diff_harness_references_unknown_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    diff_harness_checks[0]["transition_ids"] = ["transition.missing"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "diff_harness_check[0]" in failure
+        and "transition_ids references unknown transition id" in failure
+        and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_diff_harness_references_unknown_owner_field(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    diff_harness_checks[0]["owner_field_refs"] = ["field.unknown"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "diff_harness_check[0]" in failure
+        and "owner_field_refs references unregistered owner field" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_diff_harness_references_unknown_invariant(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    diff_harness_checks[0]["invariant_ids"] = ["invariant.missing"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "diff_harness_check[0]" in failure
+        and "invariant_ids references unknown invariant id" in failure
+        and "invariant.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_diff_harness_references_unknown_generation_domain(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    diff_harness_checks[0]["generation_domain_ids"] = ["domain.missing"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "diff_harness_check[0]" in failure
+        and "generation_domain_ids references unknown generation domain id" in failure
+        and "domain.missing" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_when_required_generation_domain_category_is_missing(


### PR DESCRIPTION
## Summary
- Adds a machine-readable AppState diff-harness registry for transition snapshot/diff checks.
- Extends the AppState contract guard to validate the diff harness and cross-check transition, owner-field, invariant, and generation-domain references.
- Adds guard tests for valid overrides and malformed/unknown registry references.

## Validation
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `git diff --check`
- `make qa-code-quality`
- `make clean && make` (passes with pre-existing warnings in unchanged runtime files)
