### PR TITLE
chore(appstate): define transition sequence scenarios

### DIFF
--- a/docs/appstate_action_coverage.json
+++ b/docs/appstate_action_coverage.json
@@ -260,19 +260,18 @@
     },
     {
       "action": "ACTION_ESCAPE",
-      "transition_id": "transition.keybinding.navigate-tree",
-      "category": "keybinding",
-      "owner": "YtreePanel(active)",
+      "transition_id": "transition.modal-action.dismiss",
+      "category": "modal_action",
+      "owner": "ViewContext.modal_region",
       "declared_write_set": [
-        "panel.tree_selection_key",
-        "panel.tree_cursor_pos",
-        "panel.tree_viewport_origin",
+        "ctx.modal_state",
+        "ctx.message_state",
         "panel.focus_shape",
         "panel.panel_generation"
       ],
       "boundary_status": "documented_foundation_only",
       "migration_notes": [
-        "Covered by the current keybinding foundation record until runtime transition objects are split per action."
+        "Esc dismissal for an active modal maps to the modal_action dismiss record; non-modal Esc no-op behavior remains a blocked keybinding outcome for later context-specific runtime coverage."
       ]
     },
     {

--- a/docs/appstate_transition_sequences.json
+++ b/docs/appstate_transition_sequences.json
@@ -1,0 +1,816 @@
+{
+  "schema_version": 1,
+  "scenarios": [
+    {
+      "scenario_id": "sequence.split-toggle-f8",
+      "category": "layout_split",
+      "flow": "split_toggle_f8",
+      "description": "Toggle split layout with F8 and prove inactive-panel and layout ownership after each transition.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "split-open",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_SPLIT_SCREEN"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.inactive-panel-frozen",
+            "invariant.blocked-transition-determinism"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "shape.panel.focus",
+              "expectation": "Preserve or rebind focus shape only through the transition result."
+            },
+            {
+              "domain_id": "reflow.layout.projection",
+              "expectation": "Layout reflow generation is projection-only unless resize transition declares it."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "split-toggle-blocked-by-modal",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_SPLIT_SCREEN"
+          },
+          "expected_result": "blocked",
+          "invariant_ids": [
+            "invariant.blocked-transition-determinism",
+            "invariant.inactive-panel-frozen"
+          ],
+          "diff_harness_ids": [
+            "harness.blocked-transition-no-unrelated-mutation"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "reflow.layout.projection",
+              "expectation": "Layout reflow generation is projection-only unless resize transition declares it."
+            }
+          ],
+          "no_unrelated_mutation": {
+            "diff_harness_id": "harness.blocked-transition-no-unrelated-mutation",
+            "expectation": "The blocked/invalid result may update only the declared diagnostic or dirty state and must not mutate unrelated owner fields."
+          }
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.tab-panel-switch",
+      "category": "panel_navigation",
+      "flow": "tab_panel_switch",
+      "description": "Switch active panel with Tab while preserving inactive-panel cursor, viewport, and focus snapshots.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "tab-to-inactive-panel",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_SWITCH_PANEL"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.inactive-panel-frozen",
+            "invariant.panel-local-focus-restore",
+            "invariant.shared-state-panel-local-isolation"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "shape.panel.focus",
+              "expectation": "Preserve or rebind focus shape only through the transition result."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "tab-back-to-original-panel",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_SWITCH_PANEL"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.inactive-panel-frozen",
+            "invariant.panel-local-focus-restore"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "shape.panel.focus",
+              "expectation": "Preserve or rebind focus shape only through the transition result."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.enter-directory-file-transition",
+      "category": "directory_file_transition",
+      "flow": "enter_directory_file_transition",
+      "description": "Enter from tree/file targets and validate durable directory/file identity after each step.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "enter-directory",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_ENTER"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.hidden-entry-visible-navigation",
+            "invariant.viewport-identity-rebind"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable across rebuild/rebind."
+            },
+            {
+              "domain_id": "identity.file.stable-key",
+              "expectation": "File identity remains durable across payload or view-shape changes."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "enter-file-target",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_TO_DIR"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.panel-local-focus-restore",
+            "invariant.viewport-identity-rebind"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable across rebuild/rebind."
+            },
+            {
+              "domain_id": "identity.file.stable-key",
+              "expectation": "File identity remains durable across payload or view-shape changes."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.esc-modal-dismissal",
+      "category": "modal_command",
+      "flow": "esc_modal_dismissal",
+      "description": "Dismiss command/modal ownership through the registered modal transition and preserve panel-local state.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "active-modal-escape-dismiss",
+          "transition_id": "transition.modal-action.dismiss",
+          "stimulus": {
+            "action_id": "ACTION_ESCAPE",
+            "event_id": "event.modal-completion"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.panel-local-focus-restore",
+            "invariant.blocked-transition-determinism"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "target.modal-command.session",
+              "expectation": "Modal target generation validates before applying completion or dismissal."
+            },
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.dotfile-reveal-conceal",
+      "category": "visibility_filter",
+      "flow": "dotfile_reveal_conceal",
+      "description": "Reveal and conceal dotfiles without letting hidden entries become visible-navigation selections.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "reveal-dotfiles",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_TOGGLE_HIDDEN"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.hidden-entry-visible-navigation",
+            "invariant.panel-local-focus-restore"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "state.visibility-filter.panel-volume",
+              "expectation": "Visibility/filter generation matches the selected panel after the transition."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable across rebuild/rebind."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "conceal-dotfiles",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_TOGGLE_HIDDEN"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.hidden-entry-visible-navigation",
+            "invariant.viewport-identity-rebind"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "state.visibility-filter.panel-volume",
+              "expectation": "Visibility/filter generation matches the selected panel after the transition."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable across rebuild/rebind."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.refresh-rebuild",
+      "category": "refresh_rebuild",
+      "flow": "refresh_rebuild",
+      "description": "Refresh and rebuild with generation validation and deterministic stale-snapshot fail-closed behavior.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "manual-refresh",
+          "transition_id": "transition.refresh-rebuild.manual-refresh",
+          "stimulus": {
+            "action_id": "ACTION_REFRESH"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.viewport-identity-rebind",
+            "invariant.shared-state-panel-local-isolation"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.generation-mismatch-check"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable across rebuild/rebind."
+            },
+            {
+              "domain_id": "identity.file.stable-key",
+              "expectation": "File identity remains durable across payload or view-shape changes."
+            },
+            {
+              "domain_id": "generation.volume.shared-authority",
+              "expectation": "Volume generation advances only for declared shared-volume mutations."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "stale-snapshot-rebind",
+          "transition_id": "transition.rebuild-rebind-callback.panel-anchor",
+          "stimulus": {
+            "event_id": "event.rebuild-rebind-callback"
+          },
+          "expected_result": "fallback",
+          "invariant_ids": [
+            "invariant.stale-snapshot-fail-closed",
+            "invariant.viewport-identity-rebind"
+          ],
+          "diff_harness_ids": [
+            "harness.generation-mismatch-check",
+            "harness.blocked-transition-no-unrelated-mutation"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable across rebuild/rebind."
+            },
+            {
+              "domain_id": "identity.file.stable-key",
+              "expectation": "File identity remains durable across payload or view-shape changes."
+            }
+          ],
+          "precondition": "stale_snapshot",
+          "deterministic_fallback": {
+            "outcome": "Fail closed to the nearest valid durable identity or preserve the prior valid selection without using stale rows.",
+            "allowed_mutation_scope": "Only the registered fallback/no-op result may run; unrelated owner fields remain unchanged."
+          }
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.filesystem-mutation-result",
+      "category": "filesystem_mutation",
+      "flow": "filesystem_mutation_result",
+      "description": "Apply filesystem mutation results through the registered result transition and validate generation mismatch fallback.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "delete-or-mkdir-result",
+          "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+          "stimulus": {
+            "event_id": "event.filesystem-mutation-result"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.viewport-identity-rebind",
+            "invariant.shared-state-panel-local-isolation"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.generation-mismatch-check"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.volume.shared-authority",
+              "expectation": "Volume generation advances only for declared shared-volume mutations."
+            },
+            {
+              "domain_id": "state.topology.volume",
+              "expectation": "Topology generation advances only for declared topology changes."
+            },
+            {
+              "domain_id": "state.file-payload.volume",
+              "expectation": "File payload generation advances only for declared payload rebuilds."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable across rebuild/rebind."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "mutation-generation-mismatch",
+          "transition_id": "transition.filesystem-mutation-result.mkdir-copy-delete",
+          "stimulus": {
+            "action_id": "ACTION_CMD_D",
+            "event_id": "event.filesystem-mutation-result"
+          },
+          "expected_result": "fallback",
+          "invariant_ids": [
+            "invariant.stale-snapshot-fail-closed",
+            "invariant.blocked-transition-determinism"
+          ],
+          "diff_harness_ids": [
+            "harness.generation-mismatch-check",
+            "harness.blocked-transition-no-unrelated-mutation"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.volume.shared-authority",
+              "expectation": "Volume generation advances only for declared shared-volume mutations."
+            },
+            {
+              "domain_id": "state.topology.volume",
+              "expectation": "Topology generation advances only for declared topology changes."
+            },
+            {
+              "domain_id": "state.file-payload.volume",
+              "expectation": "File payload generation advances only for declared payload rebuilds."
+            }
+          ],
+          "precondition": "generation_mismatch",
+          "deterministic_fallback": {
+            "outcome": "Reject stale mutation result, request a registered refresh/rebind, and keep unrelated panel state unchanged.",
+            "allowed_mutation_scope": "Only the registered fallback/no-op result may run; unrelated owner fields remain unchanged."
+          }
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.search-jump",
+      "category": "search_jump",
+      "flow": "search_jump",
+      "description": "Search/list jump updates selection only through visible-navigation and focus ownership rules.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "list-jump-visible-target",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_LIST_JUMP"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.hidden-entry-visible-navigation",
+            "invariant.panel-local-focus-restore"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable across rebuild/rebind."
+            },
+            {
+              "domain_id": "identity.file.stable-key",
+              "expectation": "File identity remains durable across payload or view-shape changes."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "search-command-completion",
+          "transition_id": "transition.command-completion.user-command",
+          "stimulus": {
+            "event_id": "event.command-completion"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.panel-local-focus-restore",
+            "invariant.blocked-transition-determinism"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "target.modal-command.session",
+              "expectation": "Modal target generation validates before applying completion or dismissal."
+            },
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.showall-global-tagged-only",
+      "category": "display_mode",
+      "flow": "showall_global_tagged_only",
+      "description": "Toggle showall/global/tagged-only style filters without moving panel-local ownership into shared volume state.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "toggle-tagged-only",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_TOGGLE_TAGGED_MODE"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.shared-state-panel-local-isolation",
+            "invariant.hidden-entry-visible-navigation"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "state.visibility-filter.panel-volume",
+              "expectation": "Visibility/filter generation matches the selected panel after the transition."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "toggle-showall-global-projection",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_ASTERISK"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.shared-state-panel-local-isolation",
+            "invariant.render-projection-read-only"
+          ],
+          "diff_harness_ids": [
+            "harness.declared-write-set-diff",
+            "harness.render-projection-read-only-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "state.visibility-filter.panel-volume",
+              "expectation": "Visibility/filter generation matches the selected panel after the transition."
+            },
+            {
+              "domain_id": "generation.volume.shared-authority",
+              "expectation": "Volume generation advances only for declared shared-volume mutations."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.file-small-big-transitions",
+      "category": "directory_file_transition",
+      "flow": "file_small_big_transitions",
+      "description": "Move between small-file, big-file, and preview-shaped views without render-side ownership repair.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "toggle-file-mode",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_TOGGLE_MODE"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.panel-local-focus-restore",
+            "invariant.render-projection-read-only"
+          ],
+          "diff_harness_ids": [
+            "harness.declared-write-set-diff",
+            "harness.render-projection-read-only-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "identity.file.stable-key",
+              "expectation": "File identity remains durable across payload or view-shape changes."
+            },
+            {
+              "domain_id": "shape.panel.focus",
+              "expectation": "Preserve or rebind focus shape only through the transition result."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "view-preview-shape",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_VIEW_PREVIEW"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.panel-local-focus-restore",
+            "invariant.render-projection-read-only"
+          ],
+          "diff_harness_ids": [
+            "harness.declared-write-set-diff",
+            "harness.render-projection-read-only-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "identity.file.stable-key",
+              "expectation": "File identity remains durable across payload or view-shape changes."
+            },
+            {
+              "domain_id": "reflow.layout.projection",
+              "expectation": "Layout reflow generation is projection-only unless resize transition declares it."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.volume-cycling-release",
+      "category": "volume_lifecycle",
+      "flow": "volume_cycling_release",
+      "description": "Cycle and release volumes through shared lifecycle generation while each panel rebinds by identity.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "volume-next",
+          "transition_id": "transition.volume-operation.release-cycle",
+          "stimulus": {
+            "action_id": "ACTION_VOL_NEXT"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.shared-state-panel-local-isolation",
+            "invariant.viewport-identity-rebind"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "generation.volume.shared-authority",
+              "expectation": "Volume generation advances only for declared shared-volume mutations."
+            },
+            {
+              "domain_id": "lifecycle.volume.registry",
+              "expectation": "Volume lifecycle generation validates before rebinding panels."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "volume-release-event",
+          "transition_id": "transition.volume-operation.release-cycle",
+          "stimulus": {
+            "event_id": "event.volume-lifecycle"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.stale-snapshot-fail-closed",
+            "invariant.shared-state-panel-local-isolation"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.generation-mismatch-check"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.volume.shared-authority",
+              "expectation": "Volume generation advances only for declared shared-volume mutations."
+            },
+            {
+              "domain_id": "lifecycle.volume.registry",
+              "expectation": "Volume lifecycle generation validates before rebinding panels."
+            },
+            {
+              "domain_id": "state.topology.volume",
+              "expectation": "Topology generation advances only for declared topology changes."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.split-close-reopen",
+      "category": "layout_split",
+      "flow": "split_close_reopen",
+      "description": "Close and reopen split layout and prove panel snapshots survive layout projection changes.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "split-close",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_SPLIT_SCREEN"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.inactive-panel-frozen",
+            "invariant.panel-local-focus-restore",
+            "invariant.render-projection-read-only"
+          ],
+          "diff_harness_ids": [
+            "harness.declared-write-set-diff",
+            "harness.render-projection-read-only-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "shape.panel.focus",
+              "expectation": "Preserve or rebind focus shape only through the transition result."
+            },
+            {
+              "domain_id": "reflow.layout.projection",
+              "expectation": "Layout reflow generation is projection-only unless resize transition declares it."
+            }
+          ]
+        },
+        {
+          "ordinal": 2,
+          "step_id": "split-reopen",
+          "transition_id": "transition.keybinding.navigate-tree",
+          "stimulus": {
+            "action_id": "ACTION_SPLIT_SCREEN"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.inactive-panel-frozen",
+            "invariant.panel-local-focus-restore",
+            "invariant.viewport-identity-rebind"
+          ],
+          "diff_harness_ids": [
+            "harness.transition-before-after-snapshot",
+            "harness.declared-write-set-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."
+            },
+            {
+              "domain_id": "shape.panel.focus",
+              "expectation": "Preserve or rebind focus shape only through the transition result."
+            },
+            {
+              "domain_id": "reflow.layout.projection",
+              "expectation": "Layout reflow generation is projection-only unless resize transition declares it."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -19,6 +19,7 @@ DEFAULT_DISPATCH_SURFACES = REPO_ROOT / "docs" / "appstate_dispatch_surfaces.jso
 DEFAULT_INVARIANTS = REPO_ROOT / "docs" / "appstate_invariants.json"
 DEFAULT_GENERATION_DOMAINS = REPO_ROOT / "docs" / "appstate_generation_domains.json"
 DEFAULT_DIFF_HARNESS = REPO_ROOT / "docs" / "appstate_diff_harness.json"
+DEFAULT_TRANSITION_SEQUENCES = REPO_ROOT / "docs" / "appstate_transition_sequences.json"
 DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytree_defs.h"
 
 REQUIRED_TRANSITION_CATEGORIES = {
@@ -133,6 +134,34 @@ REQUIRED_DIFF_HARNESS_CATEGORIES = {
     "blocked_transition_no_unrelated_mutation",
 }
 
+REQUIRED_SEQUENCE_CATEGORIES = {
+    "directory_file_transition",
+    "display_mode",
+    "filesystem_mutation",
+    "layout_split",
+    "modal_command",
+    "panel_navigation",
+    "refresh_rebuild",
+    "search_jump",
+    "visibility_filter",
+    "volume_lifecycle",
+}
+
+REQUIRED_SEQUENCE_FLOWS = {
+    "dotfile_reveal_conceal",
+    "enter_directory_file_transition",
+    "esc_modal_dismissal",
+    "file_small_big_transitions",
+    "filesystem_mutation_result",
+    "refresh_rebuild",
+    "search_jump",
+    "showall_global_tagged_only",
+    "split_close_reopen",
+    "split_toggle_f8",
+    "tab_panel_switch",
+    "volume_cycling_release",
+}
+
 REQUIRED_DISPATCH_SURFACE_FIELDS = {
     "surface_id",
     "category",
@@ -209,6 +238,40 @@ REQUIRED_DIFF_HARNESS_FIELDS = {
     "migration_notes",
 }
 
+REQUIRED_SEQUENCE_FIELDS = {
+    "scenario_id",
+    "category",
+    "flow",
+    "description",
+    "steps",
+}
+
+REQUIRED_SEQUENCE_STEP_FIELDS = {
+    "ordinal",
+    "step_id",
+    "transition_id",
+    "stimulus",
+    "expected_result",
+    "invariant_ids",
+    "diff_harness_ids",
+    "generation_domain_expectations",
+}
+
+REQUIRED_GENERATION_EXPECTATION_FIELDS = {
+    "domain_id",
+    "expectation",
+}
+
+REQUIRED_FALLBACK_FIELDS = {
+    "outcome",
+    "allowed_mutation_scope",
+}
+
+REQUIRED_NO_UNRELATED_MUTATION_FIELDS = {
+    "diff_harness_id",
+    "expectation",
+}
+
 LIST_FIELDS = {
     "declared_write_set",
     "side_effects",
@@ -232,6 +295,11 @@ DIFF_HARNESS_LIST_FIELDS = {
     "invariant_ids",
     "generation_domain_ids",
     "migration_notes",
+}
+SEQUENCE_LIST_FIELDS = {
+    "invariant_ids",
+    "diff_harness_ids",
+    "generation_domain_expectations",
 }
 GENERATION_FIELD_RE = re.compile(r"\b(?:[A-Za-z0-9_]+\.)?[A-Za-z0-9_]+_generation\b")
 
@@ -420,6 +488,31 @@ def _collect_string_ids(doc: Any, *, collection_key: str, id_field: str) -> set[
         for value in [record.get(id_field)]
         if isinstance(value, str) and value.strip()
     }
+
+
+def _collect_transition_ids_by_string_id(
+    doc: Any, *, collection_key: str, id_field: str
+) -> dict[str, str]:
+    if not isinstance(doc, dict):
+        return {}
+    records = doc.get(collection_key)
+    if not isinstance(records, list):
+        return {}
+
+    transition_ids: dict[str, str] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        value = record.get(id_field)
+        transition_id = record.get("transition_id")
+        if (
+            isinstance(value, str)
+            and value.strip()
+            and isinstance(transition_id, str)
+            and transition_id.strip()
+        ):
+            transition_ids[value] = transition_id
+    return transition_ids
 
 
 def _validate_allowed_direct_writes(
@@ -1046,6 +1139,331 @@ def _validate_event_coverage(
     return failures
 
 
+def _validate_step_stimulus(
+    *,
+    stimulus: Any,
+    label: str,
+    transition_id: Any,
+    action_ids: set[str],
+    action_transition_ids: dict[str, str],
+    event_ids: set[str],
+    event_transition_ids: dict[str, str],
+) -> list[str]:
+    if not isinstance(stimulus, dict) or not stimulus:
+        return [f"{label}: stimulus must be a non-empty object"]
+
+    failures: list[str] = []
+    action_id = stimulus.get("action_id")
+    event_id = stimulus.get("event_id")
+    if action_id is None and event_id is None:
+        failures.append(f"{label}: stimulus must include action_id or event_id")
+
+    if action_id is not None:
+        if not isinstance(action_id, str) or not action_id.strip():
+            failures.append(f"{label}: stimulus.action_id must be a non-empty string")
+        elif action_id not in action_ids:
+            failures.append(f"{label}: stimulus.action_id references unknown action: {action_id}")
+        elif isinstance(transition_id, str) and transition_id.strip():
+            action_transition_id = action_transition_ids.get(action_id)
+            if action_transition_id != transition_id:
+                failures.append(
+                    f"{label}: stimulus.action_id {action_id} maps to transition_id "
+                    f"{action_transition_id}, not step.transition_id {transition_id}"
+                )
+
+    if event_id is not None:
+        if not isinstance(event_id, str) or not event_id.strip():
+            failures.append(f"{label}: stimulus.event_id must be a non-empty string")
+        elif event_id not in event_ids:
+            failures.append(f"{label}: stimulus.event_id references unknown event id: {event_id}")
+        elif isinstance(transition_id, str) and transition_id.strip():
+            event_transition_id = event_transition_ids.get(event_id)
+            if event_transition_id != transition_id:
+                failures.append(
+                    f"{label}: stimulus.event_id {event_id} maps to transition_id "
+                    f"{event_transition_id}, not step.transition_id {transition_id}"
+                )
+
+    return failures
+
+
+def _validate_step_reference_list(
+    *,
+    value: Any,
+    valid_ids: set[str],
+    label: str,
+    field: str,
+    reference_label: str,
+) -> list[str]:
+    failures = _validate_list_field(value=value, label=label, field=field)
+    if failures:
+        return failures
+
+    assert isinstance(value, list)
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        assert isinstance(item, str)
+        if item in seen:
+            failures.append(f"{label}: duplicate {field}[{index}]: {item}")
+        seen.add(item)
+        if item not in valid_ids:
+            failures.append(f"{label}: {field} references unknown {reference_label}: {item}")
+    return failures
+
+
+def _validate_generation_expectations(
+    *,
+    value: Any,
+    label: str,
+    generation_domain_ids: set[str],
+) -> list[str]:
+    if not isinstance(value, list) or not value:
+        return [f"{label}: generation_domain_expectations must be a non-empty list"]
+
+    failures: list[str] = []
+    seen: set[str] = set()
+    for index, record in enumerate(value):
+        expectation_label = f"{label}.generation_domain_expectations[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_GENERATION_EXPECTATION_FIELDS,
+                list_fields=set(),
+                label=expectation_label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+
+        domain_id = record.get("domain_id")
+        if isinstance(domain_id, str) and domain_id.strip():
+            if domain_id in seen:
+                failures.append(
+                    f"{expectation_label}: duplicate domain_id: {domain_id}"
+                )
+            seen.add(domain_id)
+            if domain_id not in generation_domain_ids:
+                failures.append(
+                    f"{expectation_label}: domain_id references unknown generation domain id: {domain_id}"
+                )
+
+    return failures
+
+
+def _requires_deterministic_fallback(record: dict[str, Any]) -> bool:
+    precondition = record.get("precondition")
+    expected_result = record.get("expected_result")
+    return (
+        precondition in {"generation_mismatch", "stale_snapshot"}
+        or expected_result == "fallback"
+    )
+
+
+def _validate_deterministic_fallback(
+    *,
+    record: dict[str, Any],
+    label: str,
+) -> list[str]:
+    fallback = record.get("deterministic_fallback")
+    if not isinstance(fallback, dict):
+        return [
+            f"{label}: stale-snapshot/generation-mismatch steps require deterministic_fallback"
+        ]
+    return _validate_required_fields(
+        record=fallback,
+        required_fields=REQUIRED_FALLBACK_FIELDS,
+        list_fields=set(),
+        label=f"{label}.deterministic_fallback",
+    )
+
+
+def _validate_no_unrelated_mutation(
+    *,
+    record: dict[str, Any],
+    label: str,
+    diff_harness_ids: set[str],
+) -> list[str]:
+    expectation = record.get("no_unrelated_mutation")
+    if not isinstance(expectation, dict):
+        return [
+            f"{label}: blocked/invalid steps require no_unrelated_mutation expectations"
+        ]
+
+    failures = _validate_required_fields(
+        record=expectation,
+        required_fields=REQUIRED_NO_UNRELATED_MUTATION_FIELDS,
+        list_fields=set(),
+        label=f"{label}.no_unrelated_mutation",
+    )
+    harness_id = expectation.get("diff_harness_id")
+    if isinstance(harness_id, str) and harness_id.strip() and harness_id not in diff_harness_ids:
+        failures.append(
+            f"{label}.no_unrelated_mutation: diff_harness_id references unknown diff harness id: {harness_id}"
+        )
+    return failures
+
+
+def _validate_appstate_transition_sequences(
+    *,
+    transition_sequences_doc: Any,
+    transition_sequences_path: Path,
+    transition_ids: dict[str, dict[str, Any]],
+    action_ids: set[str],
+    action_transition_ids: dict[str, str],
+    event_ids: set[str],
+    event_transition_ids: dict[str, str],
+    invariant_ids: set[str],
+    diff_harness_ids: set[str],
+    generation_domain_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(transition_sequences_doc, dict):
+        failures.append(f"{transition_sequences_path}: top-level value must be an object")
+        return failures
+
+    records = transition_sequences_doc.get("scenarios")
+    if not isinstance(records, list) or not records:
+        failures.append(f"{transition_sequences_path}: scenarios must be a non-empty list")
+        records = []
+
+    scenario_ids: set[str] = set()
+    covered_flows: set[str] = set()
+    for scenario_index, record in enumerate(records):
+        scenario_label = f"transition_sequence[{scenario_index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_SEQUENCE_FIELDS,
+                list_fields=set(),
+                label=scenario_label,
+            )
+        )
+        if not isinstance(record, dict):
+            continue
+
+        scenario_id = record.get("scenario_id")
+        if isinstance(scenario_id, str) and scenario_id.strip():
+            if scenario_id in scenario_ids:
+                failures.append(f"{scenario_label}: duplicate scenario_id: {scenario_id}")
+            scenario_ids.add(scenario_id)
+
+        category = record.get("category")
+        if isinstance(category, str) and category.strip():
+            if category not in REQUIRED_SEQUENCE_CATEGORIES:
+                failures.append(f"{scenario_label}: unknown category: {category}")
+
+        flow = record.get("flow")
+        if isinstance(flow, str) and flow.strip():
+            covered_flows.add(flow)
+            if flow not in REQUIRED_SEQUENCE_FLOWS:
+                failures.append(f"{scenario_label}: unknown flow: {flow}")
+
+        steps = record.get("steps")
+        if not isinstance(steps, list) or not steps:
+            failures.append(f"{scenario_label}: steps must be a non-empty list")
+            continue
+
+        ordinals: set[int] = set()
+        previous_ordinal = 0
+        for step_index, step in enumerate(steps):
+            label = f"{scenario_label}.step[{step_index}]"
+            failures.extend(
+                _validate_required_fields(
+                    record=step,
+                    required_fields=REQUIRED_SEQUENCE_STEP_FIELDS,
+                    list_fields=SEQUENCE_LIST_FIELDS - {"generation_domain_expectations"},
+                    label=label,
+                )
+            )
+            if not isinstance(step, dict):
+                continue
+
+            ordinal = step.get("ordinal")
+            if not isinstance(ordinal, int) or ordinal < 1:
+                failures.append(f"{label}: ordinal must be a positive integer")
+            else:
+                if ordinal in ordinals:
+                    failures.append(f"{label}: duplicate ordinal: {ordinal}")
+                if ordinal <= previous_ordinal:
+                    failures.append(f"{label}: ordinal must be greater than previous step ordinal")
+                ordinals.add(ordinal)
+                previous_ordinal = ordinal
+
+            transition_id = step.get("transition_id")
+            if isinstance(transition_id, str) and transition_id.strip():
+                if transition_id not in transition_ids:
+                    failures.append(
+                        f"{label}: transition_id references unknown transition id: {transition_id}"
+                    )
+
+            failures.extend(
+                _validate_step_stimulus(
+                    stimulus=step.get("stimulus"),
+                    label=label,
+                    transition_id=transition_id,
+                    action_ids=action_ids,
+                    action_transition_ids=action_transition_ids,
+                    event_ids=event_ids,
+                    event_transition_ids=event_transition_ids,
+                )
+            )
+            failures.extend(
+                _validate_step_reference_list(
+                    value=step.get("invariant_ids"),
+                    valid_ids=invariant_ids,
+                    label=label,
+                    field="invariant_ids",
+                    reference_label="invariant id",
+                )
+            )
+            failures.extend(
+                _validate_step_reference_list(
+                    value=step.get("diff_harness_ids"),
+                    valid_ids=diff_harness_ids,
+                    label=label,
+                    field="diff_harness_ids",
+                    reference_label="diff harness id",
+                )
+            )
+            failures.extend(
+                _validate_generation_expectations(
+                    value=step.get("generation_domain_expectations"),
+                    label=label,
+                    generation_domain_ids=generation_domain_ids,
+                )
+            )
+
+            expected_result = step.get("expected_result")
+            if (
+                isinstance(expected_result, str)
+                and expected_result.strip()
+                and expected_result not in {"allowed", "blocked", "fallback", "invalid"}
+            ):
+                failures.append(f"{label}: unknown expected_result: {expected_result}")
+
+            if _requires_deterministic_fallback(step):
+                failures.extend(
+                    _validate_deterministic_fallback(record=step, label=label)
+                )
+
+            if expected_result in {"blocked", "invalid"}:
+                failures.extend(
+                    _validate_no_unrelated_mutation(
+                        record=step,
+                        label=label,
+                        diff_harness_ids=diff_harness_ids,
+                    )
+                )
+
+    missing_flows = sorted(REQUIRED_SEQUENCE_FLOWS - covered_flows)
+    if missing_flows:
+        failures.append(
+            "transition sequences missing required flow(s): " + ", ".join(missing_flows)
+        )
+
+    return failures
+
+
 def validate_contract(
     transitions_path: Path,
     shims_path: Path,
@@ -1057,6 +1475,7 @@ def validate_contract(
     invariants_path: Path = DEFAULT_INVARIANTS,
     generation_domains_path: Path = DEFAULT_GENERATION_DOMAINS,
     diff_harness_path: Path = DEFAULT_DIFF_HARNESS,
+    transition_sequences_path: Path = DEFAULT_TRANSITION_SEQUENCES,
 ) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
@@ -1072,6 +1491,9 @@ def validate_contract(
         generation_domains_path
     )
     diff_harness_doc, diff_harness_load_failures = _load_json(diff_harness_path)
+    transition_sequences_doc, transition_sequences_load_failures = _load_json(
+        transition_sequences_path
+    )
     enum_actions, enum_failures = _parse_ytree_actions(actions_header_path)
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
@@ -1082,6 +1504,7 @@ def validate_contract(
     failures.extend(invariants_load_failures)
     failures.extend(generation_domains_load_failures)
     failures.extend(diff_harness_load_failures)
+    failures.extend(transition_sequences_load_failures)
     failures.extend(enum_failures)
     if failures:
         return failures
@@ -1292,6 +1715,11 @@ def validate_contract(
         collection_key="generation_domains",
         id_field="domain_id",
     )
+    diff_harness_ids = _collect_string_ids(
+        diff_harness_doc,
+        collection_key="diff_harness_checks",
+        id_field="harness_id",
+    )
     failures.extend(
         _validate_appstate_diff_harness(
             diff_harness_doc=diff_harness_doc,
@@ -1299,6 +1727,40 @@ def validate_contract(
             transition_ids=transition_ids,
             registered_owner_fields=registered_owner_fields,
             invariant_ids=invariant_ids,
+            generation_domain_ids=generation_domain_ids,
+        )
+    )
+    action_ids = _collect_string_ids(
+        action_coverage_doc,
+        collection_key="actions",
+        id_field="action",
+    )
+    action_transition_ids = _collect_transition_ids_by_string_id(
+        action_coverage_doc,
+        collection_key="actions",
+        id_field="action",
+    )
+    event_ids = _collect_string_ids(
+        event_coverage_doc,
+        collection_key="events",
+        id_field="event_id",
+    )
+    event_transition_ids = _collect_transition_ids_by_string_id(
+        event_coverage_doc,
+        collection_key="events",
+        id_field="event_id",
+    )
+    failures.extend(
+        _validate_appstate_transition_sequences(
+            transition_sequences_doc=transition_sequences_doc,
+            transition_sequences_path=transition_sequences_path,
+            transition_ids=transition_ids,
+            action_ids=action_ids,
+            action_transition_ids=action_transition_ids,
+            event_ids=event_ids,
+            event_transition_ids=event_transition_ids,
+            invariant_ids=invariant_ids,
+            diff_harness_ids=diff_harness_ids,
             generation_domain_ids=generation_domain_ids,
         )
     )
@@ -1321,6 +1783,9 @@ def main() -> int:
         "--generation-domains", type=Path, default=DEFAULT_GENERATION_DOMAINS
     )
     parser.add_argument("--diff-harness", type=Path, default=DEFAULT_DIFF_HARNESS)
+    parser.add_argument(
+        "--transition-sequences", type=Path, default=DEFAULT_TRANSITION_SEQUENCES
+    )
     parser.add_argument("--actions-header", type=Path, default=DEFAULT_ACTION_HEADER)
     args = parser.parse_args()
 
@@ -1335,6 +1800,7 @@ def main() -> int:
         args.invariants,
         args.generation_domains,
         args.diff_harness,
+        args.transition_sequences,
     )
     if failures:
         for failure in failures:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -21,6 +21,7 @@ REQUIRED_GENERATION_DOMAIN_CATEGORIES = sorted(
     guard.REQUIRED_GENERATION_DOMAIN_CATEGORIES
 )
 REQUIRED_DIFF_HARNESS_CATEGORIES = sorted(guard.REQUIRED_DIFF_HARNESS_CATEGORIES)
+REQUIRED_SEQUENCE_FLOWS = sorted(guard.REQUIRED_SEQUENCE_FLOWS)
 FIXTURE_ACTIONS = ["ACTION_NONE", "ACTION_MOVE_UP", "ACTION_USER_CMD"]
 REQUIRED_LIST_FIELD_CASES = [
     ("action", "declared_write_set", "action[0]"),
@@ -43,6 +44,16 @@ REQUIRED_LIST_FIELD_CASES = [
     ("diff_harness", "invariant_ids", "diff_harness_check[0]"),
     ("diff_harness", "generation_domain_ids", "diff_harness_check[0]"),
     ("diff_harness", "migration_notes", "diff_harness_check[0]"),
+    (
+        "transition_sequence_step",
+        "invariant_ids",
+        "transition_sequence[0].step[0]",
+    ),
+    (
+        "transition_sequence_step",
+        "diff_harness_ids",
+        "transition_sequence[0].step[0]",
+    ),
     ("shim", "invariant_checks", "shim[0]"),
     ("shim", "migration_notes", "shim[0]"),
 ]
@@ -232,6 +243,64 @@ def _diff_harness(
     }
 
 
+def _transition_sequence(
+    flow: str,
+    *,
+    scenario_id: str | None = None,
+    category: str = "layout_split",
+    steps: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "scenario_id": scenario_id or f"sequence.{flow}",
+        "category": category,
+        "flow": flow,
+        "description": "fixture transition sequence",
+        "steps": steps or [_sequence_step()],
+    }
+
+
+def _sequence_step(
+    *,
+    ordinal: int = 1,
+    transition_id: str = "transition.keybinding",
+    action_id: str = "ACTION_NONE",
+    event_id: str | None = None,
+    invariant_ids: list[str] | None = None,
+    diff_harness_ids: list[str] | None = None,
+    generation_domain_id: str = "domain.panel_generation",
+    expected_result: str = "allowed",
+) -> dict[str, object]:
+    stimulus: dict[str, object] = {"action_id": action_id}
+    if event_id is not None:
+        stimulus["event_id"] = event_id
+    return {
+        "ordinal": ordinal,
+        "step_id": f"step.{ordinal}",
+        "transition_id": transition_id,
+        "stimulus": stimulus,
+        "expected_result": expected_result,
+        "invariant_ids": invariant_ids or ["invariant.inactive_panel_frozen"],
+        "diff_harness_ids": diff_harness_ids
+        or ["harness.transition_before_after_snapshot"],
+        "generation_domain_expectations": [
+            {
+                "domain_id": generation_domain_id,
+                "expectation": "fixture expectation",
+            }
+        ],
+    }
+
+
+def _complete_transition_sequences() -> list[dict[str, object]]:
+    return [
+        _transition_sequence(
+            flow,
+            category="layout_split" if flow.startswith("split_") else "panel_navigation",
+        )
+        for flow in REQUIRED_SEQUENCE_FLOWS
+    ]
+
+
 def _owner_field(field: str = "field") -> dict[str, object]:
     return {
         "field": field,
@@ -256,9 +325,10 @@ def _write_fixture(
     invariants: list[dict[str, object]] | None = None,
     generation_domains: list[dict[str, object]] | None = None,
     diff_harness_checks: list[dict[str, object]] | None = None,
+    transition_sequences: list[dict[str, object]] | None = None,
     required_event_classes: list[str] | None = None,
     enum_actions: list[str] | None = None,
-) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
     action_coverage_path = tmp_path / "action_coverage.json"
@@ -268,6 +338,7 @@ def _write_fixture(
     invariants_path = tmp_path / "invariants.json"
     generation_domains_path = tmp_path / "generation_domains.json"
     diff_harness_path = tmp_path / "diff_harness.json"
+    transition_sequences_path = tmp_path / "transition_sequences.json"
     actions_header_path = tmp_path / "ytree_defs.h"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
     _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
@@ -324,6 +395,16 @@ def _write_fixture(
             }
         ),
     )
+    _write(
+        transition_sequences_path,
+        _jsonish(
+            {
+                "schema_version": 1,
+                "scenarios": transition_sequences
+                or _complete_transition_sequences(),
+            }
+        ),
+    )
     _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
     return (
         transitions_path,
@@ -336,6 +417,7 @@ def _write_fixture(
         invariants_path,
         generation_domains_path,
         diff_harness_path,
+        transition_sequences_path,
     )
 
 
@@ -403,14 +485,14 @@ def _complete_owner_fields() -> list[dict[str, object]]:
 
 
 def _validate(
-    paths: tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path],
+    paths: tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path],
 ) -> list[str]:
     return guard.validate_contract(*paths)
 
 
 def _fixture_with_list_field_value(
     tmp_path: Path, record_type: str, field: str, value: object
-) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions = _complete_transitions()
     shims = [_shim()]
     actions = _complete_actions()
@@ -420,6 +502,7 @@ def _fixture_with_list_field_value(
     invariants = _complete_invariants()
     generation_domains = _complete_generation_domains()
     diff_harness_checks = _complete_diff_harness_checks()
+    transition_sequences = _complete_transition_sequences()
     if record_type == "action":
         actions[0][field] = value
     elif record_type == "event":
@@ -438,6 +521,8 @@ def _fixture_with_list_field_value(
         invariants[0][field] = value
     elif record_type == "diff_harness":
         diff_harness_checks[0][field] = value
+    elif record_type == "transition_sequence_step":
+        transition_sequences[0]["steps"][0][field] = value
     else:
         raise AssertionError(f"unknown record type: {record_type}")
     return _write_fixture(
@@ -451,6 +536,7 @@ def _fixture_with_list_field_value(
         invariants=invariants,
         generation_domains=generation_domains,
         diff_harness_checks=diff_harness_checks,
+        transition_sequences=transition_sequences,
     )
 
 
@@ -549,6 +635,264 @@ def test_guard_accepts_diff_harness_registry_cli_override(tmp_path: Path) -> Non
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_guard_accepts_transition_sequence_registry_cli_override(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    override_path = tmp_path / "appstate_transition_sequences.json"
+    override_path.write_text(
+        (repo_root / "docs" / "appstate_transition_sequences.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    run = subprocess.run(
+        [
+            "python3",
+            "scripts/check_appstate_contract.py",
+            "--transition-sequences",
+            str(override_path),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_guard_fails_when_required_transition_sequence_field_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0].pop("description")
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0]" in failure
+        and "missing required field" in failure
+        and "description" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_duplicate_transition_sequence_ids(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[1]["scenario_id"] = transition_sequences[0]["scenario_id"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[1]" in failure and "duplicate scenario_id" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_transition_sequence_has_unknown_category(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["category"] = "unknown_sequence_category"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0]" in failure
+        and "unknown category" in failure
+        and "unknown_sequence_category" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_transition_sequence_has_unknown_flow(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["flow"] = "unknown_sequence_flow"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0]" in failure
+        and "unknown flow" in failure
+        and "unknown_sequence_flow" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_transition_sequence_steps_are_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"] = {}
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0]" in failure
+        and "steps must be a non-empty list" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_on_duplicate_transition_sequence_step_ordinal(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    duplicate_step = _sequence_step(ordinal=1)
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"] = [_sequence_step(ordinal=1), duplicate_step]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[1]" in failure
+        and "duplicate ordinal" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    (
+        ("transition_id", "transition.missing", "unknown transition id"),
+        ("stimulus", {"action_id": "ACTION_MISSING"}, "unknown action"),
+        ("stimulus", {"event_id": "event.missing"}, "unknown event id"),
+        ("invariant_ids", ["invariant.missing"], "unknown invariant id"),
+        ("diff_harness_ids", ["harness.missing"], "unknown diff harness id"),
+        (
+            "generation_domain_expectations",
+            [{"domain_id": "domain.missing", "expectation": "fixture"}],
+            "unknown generation domain id",
+        ),
+    ),
+)
+def test_guard_fails_on_unknown_transition_sequence_step_references(
+    tmp_path: Path, field: str, value: object, expected: str
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"][0][field] = value
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure and expected in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_transition_sequence_action_mismatches_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"][0]["transition_id"] = "transition.refresh_rebuild"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "stimulus.action_id" in failure
+        and "transition.keybinding" in failure
+        and "transition.refresh_rebuild" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_transition_sequence_event_mismatches_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"][0]["transition_id"] = "transition.refresh_rebuild"
+    transition_sequences[0]["steps"][0]["stimulus"] = {
+        "event_id": "event.modal_completion"
+    }
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "stimulus.event_id" in failure
+        and "transition.modal_action" in failure
+        and "transition.refresh_rebuild" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize("precondition", ("stale_snapshot", "generation_mismatch"))
+def test_guard_fails_when_transition_sequence_fallback_expectation_is_missing(
+    tmp_path: Path, precondition: str
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"][0]["precondition"] = precondition
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "require deterministic_fallback" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_blocked_transition_sequence_lacks_no_mutation_expectation(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"][0]["expected_result"] = "blocked"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "require no_unrelated_mutation" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_when_required_diff_harness_field_is_missing(


### PR DESCRIPTION
## Summary
- Adds a machine-readable AppState transition-sequence scenario registry for high-risk UI-affecting flows.
- Extends the AppState contract guard to validate ordered scenario steps, stimulus-to-transition alignment, invariant/diff-harness/generation references, and stale/blocked expectations.
- Adds guard tests for valid overrides and malformed or mismatched sequence metadata.

## Validation
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `git diff --check`
- `make qa-code-quality`
- `make clean && make` (passes with pre-existing warnings in unchanged runtime files)
