### PR TITLE
chore(appstate): add transition registry lookup

### DIFF
--- a/include/ytree_appstate_actions.h
+++ b/include/ytree_appstate_actions.h
@@ -17,8 +17,20 @@ typedef struct {
   const char *category;
 } AppStateActionTransitionMetadata;
 
+typedef struct {
+  const char *id;
+  const char *category;
+  const char *owner;
+  const char *const *declared_write_set;
+  size_t declared_write_set_count;
+} AppStateTransitionMetadata;
+
 const AppStateActionTransitionMetadata *
 AppStateActionTransitionLookup(YtreeAction action);
 size_t AppStateActionTransitionCount(void);
+const AppStateTransitionMetadata *
+AppStateTransitionLookup(const char *transition_id);
+const AppStateTransitionMetadata *AppStateTransitionAt(size_t index);
+size_t AppStateTransitionCount(void);
 
 #endif /* YTREE_APPSTATE_ACTIONS_H */

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -421,6 +421,63 @@ def _parse_runtime_action_transitions(
     return records, []
 
 
+def _parse_runtime_transition_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    write_sets: dict[str, list[str]] = {}
+    write_set_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppStateTransitionWriteSet[0-9]+)\[\]\s*=\s*\{(?P<body>.*?)\};",
+        re.S,
+    )
+    for write_set_match in write_set_re.finditer(source):
+        write_sets[write_set_match.group(1)] = re.findall(
+            r'"([^"]+)"', write_set_match.group("body")
+        )
+
+    match = re.search(
+        r"kAppStateTransitions\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime transition registry"]
+
+    records: list[dict[str, Any]] = []
+    failures: list[str] = []
+    row_re = re.compile(
+        r"\{\s*\"([^\"]+)\"\s*,\s*\"([^\"]+)\"\s*,\s*\"([^\"]+)\"\s*,"
+        r"\s*(?P<write_set>kAppStateTransitionWriteSet[0-9]+)\s*,"
+        r"\s*sizeof\((?P=write_set)\)\s*/\s*sizeof\((?P=write_set)\[0\]\)\s*\}",
+        re.S,
+    )
+    for index, row_match in enumerate(row_re.finditer(match.group("body"))):
+        write_set_name = row_match.group("write_set")
+        declared_write_set = write_sets.get(write_set_name)
+        if declared_write_set is None:
+            failures.append(
+                f"runtime_transition[{index}]: unknown write-set table: {write_set_name}"
+            )
+            declared_write_set = []
+        records.append(
+            {
+                "id": row_match.group(1),
+                "category": row_match.group(2),
+                "owner": row_match.group(3),
+                "declared_write_set": declared_write_set,
+            }
+        )
+
+    if not records:
+        failures.append(f"{runtime_path}: runtime transition registry must not be empty")
+    return records, failures
+
+
 def _validate_runtime_action_lookup(
     *,
     runtime_records: list[dict[str, str]],
@@ -428,6 +485,7 @@ def _validate_runtime_action_lookup(
     enum_actions: list[str],
     action_coverage_by_action: dict[str, dict[str, Any]],
     transition_ids: dict[str, dict[str, Any]],
+    runtime_transition_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
     expected_actions = set(enum_actions)
@@ -453,6 +511,11 @@ def _validate_runtime_action_lookup(
         if transition_record is None:
             failures.append(
                 f"{label}: transition_id does not match a transition id: {transition_id}"
+            )
+        if transition_id not in runtime_transition_ids:
+            failures.append(
+                f"{label}: transition_id does not match runtime transition "
+                f"registry: {transition_id}"
             )
 
         category = record["category"]
@@ -486,6 +549,55 @@ def _validate_runtime_action_lookup(
         failures.append(
             f"{runtime_path}: runtime action lookup missing YtreeAction enum member(s): "
             + ", ".join(missing_actions)
+        )
+
+    return failures
+
+
+def _validate_runtime_transition_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    transition_ids: dict[str, dict[str, Any]],
+    registered_owner_fields: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    expected_ids = set(transition_ids)
+    covered_ids: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_transition[{index}]"
+        runtime_id = record["id"]
+        if runtime_id in covered_ids:
+            failures.append(f"{label}: duplicate runtime transition id: {runtime_id}")
+        covered_ids.add(runtime_id)
+
+        matrix_record = transition_ids.get(runtime_id)
+        if matrix_record is None:
+            failures.append(
+                f"{label}: id does not match a transition matrix id: {runtime_id}"
+            )
+        else:
+            for field in ("category", "owner", "declared_write_set"):
+                if record.get(field) != matrix_record.get(field):
+                    failures.append(
+                        f"{label}: runtime {field} does not match transition "
+                        f"{runtime_id}: {record.get(field)}"
+                    )
+
+        failures.extend(
+            _validate_registered_write_set(
+                record=record,
+                registered_fields=registered_owner_fields,
+                label=label,
+            )
+        )
+
+    missing_ids = sorted(expected_ids - covered_ids)
+    if missing_ids:
+        failures.append(
+            f"{runtime_path}: runtime transition registry missing transition id(s): "
+            + ", ".join(missing_ids)
         )
 
     return failures
@@ -1604,6 +1716,9 @@ def validate_contract(
     runtime_action_records, runtime_action_failures = _parse_runtime_action_transitions(
         action_runtime_path
     )
+    runtime_transition_records, runtime_transition_failures = (
+        _parse_runtime_transition_registry(action_runtime_path)
+    )
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
@@ -1616,6 +1731,7 @@ def validate_contract(
     failures.extend(transition_sequences_load_failures)
     failures.extend(enum_failures)
     failures.extend(runtime_action_failures)
+    failures.extend(runtime_transition_failures)
     if failures:
         return failures
 
@@ -1670,6 +1786,14 @@ def validate_contract(
             "transition matrix missing required category/categories: "
             + ", ".join(missing_categories)
         )
+    failures.extend(
+        _validate_runtime_transition_registry(
+            runtime_records=runtime_transition_records,
+            runtime_path=action_runtime_path,
+            transition_ids=transition_ids,
+            registered_owner_fields=registered_owner_fields,
+        )
+    )
 
     generation_owner_fields, generation_domain_failures = _validate_generation_domains(
         generation_domains_doc=generation_domains_doc,
@@ -1794,6 +1918,7 @@ def validate_contract(
             enum_actions=enum_actions,
             action_coverage_by_action=action_coverage_by_action,
             transition_ids=transition_ids,
+            runtime_transition_ids={record["id"] for record in runtime_transition_records},
         )
     )
 

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6,8 +6,138 @@
  ***************************************************************************/
 
 #include "ytree_appstate_actions.h"
+#include <string.h>
 
 enum { APPSTATE_ACTION_TRANSITION_COUNT = ACTION_USER_CMD + 1 };
+
+static const char *const kAppStateTransitionWriteSet0[] = {
+  "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.focus_shape",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateTransitionWriteSet1[] = {
+  "ctx.active",
+  "panel.volume_key",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateTransitionWriteSet2[] = {
+  "ctx.modal_state",
+  "ctx.message_state",
+  "panel.focus_shape",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateTransitionWriteSet3[] = {
+  "volume.dir_tree",
+  "volume.logged_state",
+  "volume.volume_generation",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateTransitionWriteSet4[] = {
+  "ctx.volumes_head",
+  "panel.volume_key",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateTransitionWriteSet5[] = {
+  "ctx.layout",
+  "ctx.window_handles",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateTransitionWriteSet6[] = {
+  "volume.dir_tree",
+  "volume.payload_cache",
+  "volume.volume_generation",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "ctx.message_state",
+};
+
+static const char *const kAppStateTransitionWriteSet7[] = {
+  "ctx.command_state",
+  "ctx.message_state",
+  "ctx.pending_transition",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateTransitionWriteSet8[] = {
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateTransitionWriteSet9[] = {
+  "ctx.render_dirty_flags",
+  "ctx.window_handles",
+};
+
+static const AppStateTransitionMetadata kAppStateTransitions[] = {
+  {"transition.keybinding.navigate-tree",
+   "keybinding",
+   "YtreePanel(active)",
+   kAppStateTransitionWriteSet0,
+   sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0])},
+  {"transition.menu-action.volume-select",
+   "menu_action",
+   "ViewContext(session routing) and YtreePanel(active)",
+   kAppStateTransitionWriteSet1,
+   sizeof(kAppStateTransitionWriteSet1) / sizeof(kAppStateTransitionWriteSet1[0])},
+  {"transition.modal-action.dismiss",
+   "modal_action",
+   "ViewContext.modal_region",
+   kAppStateTransitionWriteSet2,
+   sizeof(kAppStateTransitionWriteSet2) / sizeof(kAppStateTransitionWriteSet2[0])},
+  {"transition.refresh-rebuild.manual-refresh",
+   "refresh_rebuild",
+   "Volume(shared topology)",
+   kAppStateTransitionWriteSet3,
+   sizeof(kAppStateTransitionWriteSet3) / sizeof(kAppStateTransitionWriteSet3[0])},
+  {"transition.volume-operation.release-cycle",
+   "volume_operation",
+   "ViewContext.volume_registry and YtreePanel(active)",
+   kAppStateTransitionWriteSet4,
+   sizeof(kAppStateTransitionWriteSet4) / sizeof(kAppStateTransitionWriteSet4[0])},
+  {"transition.terminal-signal-resize",
+   "terminal_signal_or_resize",
+   "ViewContext.layout_region",
+   kAppStateTransitionWriteSet5,
+   sizeof(kAppStateTransitionWriteSet5) / sizeof(kAppStateTransitionWriteSet5[0])},
+  {"transition.filesystem-mutation-result.mkdir-copy-delete",
+   "filesystem_mutation_result",
+   "Volume(shared topology) plus YtreePanel(active) for active selection",
+   kAppStateTransitionWriteSet6,
+   sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0])},
+  {"transition.command-completion.user-command",
+   "command_completion",
+   "ViewContext.command_region",
+   kAppStateTransitionWriteSet7,
+   sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0])},
+  {"transition.rebuild-rebind-callback.panel-anchor",
+   "rebuild_rebind_callback",
+   "YtreePanel(affected) and Volume(current)",
+   kAppStateTransitionWriteSet8,
+   sizeof(kAppStateTransitionWriteSet8) / sizeof(kAppStateTransitionWriteSet8[0])},
+  {"transition.render-reflow.project-state",
+   "render_reflow",
+   "ViewContext.render_region",
+   kAppStateTransitionWriteSet9,
+   sizeof(kAppStateTransitionWriteSet9) / sizeof(kAppStateTransitionWriteSet9[0])},
+};
 
 static const AppStateActionTransitionMetadata
     kAppStateActionTransitions[APPSTATE_ACTION_TRANSITION_COUNT] = {
@@ -164,6 +294,32 @@ static const AppStateActionTransitionMetadata
 
 size_t AppStateActionTransitionCount(void) {
   return sizeof(kAppStateActionTransitions) / sizeof(kAppStateActionTransitions[0]);
+}
+
+size_t AppStateTransitionCount(void) {
+  return sizeof(kAppStateTransitions) / sizeof(kAppStateTransitions[0]);
+}
+
+const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
+  if (index >= AppStateTransitionCount())
+    return NULL;
+
+  return &kAppStateTransitions[index];
+}
+
+const AppStateTransitionMetadata *
+AppStateTransitionLookup(const char *transition_id) {
+  size_t index;
+
+  if (transition_id == NULL || transition_id[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateTransitionCount(); index++) {
+    if (!strcmp(kAppStateTransitions[index].id, transition_id))
+      return &kAppStateTransitions[index];
+  }
+
+  return NULL;
 }
 
 const AppStateActionTransitionMetadata *

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -27,6 +27,40 @@ static int CoreMainOpsReady(const CoreMainOps *ops) {
          ops->volume_free_all != NULL;
 }
 
+static int AppStateTransitionRegistryReady(void) {
+  size_t index;
+
+  if (AppStateTransitionCount() == 0)
+    return 0;
+
+  for (index = 0; index < AppStateTransitionCount(); index++) {
+    const AppStateTransitionMetadata *metadata = AppStateTransitionAt(index);
+    size_t write_index;
+
+    if (metadata == NULL || metadata->id == NULL || metadata->id[0] == '\0' ||
+        metadata->category == NULL || metadata->category[0] == '\0' ||
+        metadata->owner == NULL || metadata->owner[0] == '\0' ||
+        metadata->declared_write_set == NULL ||
+        metadata->declared_write_set_count == 0)
+      return 0;
+    if (AppStateTransitionLookup(metadata->id) != metadata)
+      return 0;
+
+    for (write_index = 0; write_index < metadata->declared_write_set_count;
+         write_index++) {
+      const char *field = metadata->declared_write_set[write_index];
+
+      if (field == NULL || field[0] == '\0')
+        return 0;
+    }
+  }
+
+  if (AppStateTransitionLookup("transition.__ytree_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
 static int AppStateActionTransitionsReady(void) {
   size_t index;
 
@@ -34,7 +68,20 @@ static int AppStateActionTransitionsReady(void) {
     return 0;
 
   for (index = 0; index < AppStateActionTransitionCount(); index++) {
-    if (AppStateActionTransitionLookup((YtreeAction)index) == NULL)
+    const AppStateActionTransitionMetadata *action_metadata;
+    const AppStateTransitionMetadata *transition_metadata;
+
+    action_metadata = AppStateActionTransitionLookup((YtreeAction)index);
+    if (action_metadata == NULL || action_metadata->transition_id == NULL ||
+        action_metadata->transition_id[0] == '\0' ||
+        action_metadata->category == NULL || action_metadata->category[0] == '\0')
+      return 0;
+
+    transition_metadata =
+        AppStateTransitionLookup(action_metadata->transition_id);
+    if (transition_metadata == NULL)
+      return 0;
+    if (strcmp(action_metadata->category, transition_metadata->category) != 0)
       return 0;
   }
 
@@ -113,6 +160,7 @@ int main(int argc, char **argv) {
   memset(&ctx, 0, sizeof(ViewContext));
   CoreMainOps_Register(&ctx);
   if (!CoreMainOpsReady(&ctx.core_main_ops) ||
+      !AppStateTransitionRegistryReady() ||
       !AppStateActionTransitionsReady()) {
     fprintf(stderr, "EXIT: startup invariants not configured\n");
     exit(1);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -329,6 +329,7 @@ def _write_fixture(
     required_event_classes: list[str] | None = None,
     enum_actions: list[str] | None = None,
     runtime_actions: list[dict[str, object]] | None = None,
+    runtime_transitions: list[dict[str, object]] | None = None,
 ) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
@@ -408,7 +409,13 @@ def _write_fixture(
         ),
     )
     _write(actions_header_path, _enum_header(enum_actions or FIXTURE_ACTIONS))
-    _write(action_runtime_path, _runtime_source(runtime_actions or _complete_actions()))
+    _write(
+        action_runtime_path,
+        _runtime_source(
+            runtime_actions or _complete_actions(),
+            runtime_transitions if runtime_transitions is not None else transitions,
+        ),
+    )
     return (
         transitions_path,
         shims_path,
@@ -436,15 +443,41 @@ def _enum_header(actions: list[str]) -> str:
     return f"typedef enum {{\n{members}\n}} YtreeAction;\n"
 
 
-def _runtime_source(actions: list[dict[str, object]]) -> str:
-    rows = "\n".join(
+def _runtime_source(
+    actions: list[dict[str, object]], transitions: list[dict[str, object]]
+) -> str:
+    transition_write_sets = []
+    transition_rows = []
+    for index, record in enumerate(transitions):
+        declared_write_set = record.get("declared_write_set")
+        if not isinstance(declared_write_set, list):
+            declared_write_set = []
+        write_set_rows = "\n".join(
+            f'  "{field}",' for field in declared_write_set if isinstance(field, str)
+        )
+        transition_write_sets.append(
+            "static const char *const kAppStateTransitionWriteSet"
+            f"{index}[] = {{\n{write_set_rows}\n}};\n"
+        )
+        transition_rows.append(
+            f'  {{"{record.get("id", "")}", "{record.get("category", "")}", '
+            f'"{record.get("owner", "")}", '
+            f"kAppStateTransitionWriteSet{index}, "
+            f"sizeof(kAppStateTransitionWriteSet{index}) / "
+            f"sizeof(kAppStateTransitionWriteSet{index}[0])}},"
+        )
+    action_rows = "\n".join(
         f'  {{{record["action"]}, "{record["transition_id"]}", "{record["category"]}"}},'
         for record in actions
     )
     return (
+        "".join(transition_write_sets)
+        + "static const AppStateTransitionMetadata kAppStateTransitions[] = {\n"
+        + "\n".join(transition_rows)
+        + "\n};\n"
         "static const AppStateActionTransitionMetadata\n"
         "    kAppStateActionTransitions[APPSTATE_ACTION_TRANSITION_COUNT] = {\n"
-        f"{rows}\n"
+        f"{action_rows}\n"
         "};\n"
     )
 
@@ -2035,6 +2068,123 @@ def test_guard_fails_when_action_coverage_has_extra_unknown_action(tmp_path: Pat
 
     assert any(
         "unknown YtreeAction enum member" in failure and "ACTION_NOT_IN_ENUM" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_registry_is_missing_matrix_id(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=transitions[:-1],
+    )
+
+    failures = _validate(paths)
+
+    missing_id = transitions[-1]["id"]
+    assert any(
+        "runtime transition registry missing transition id" in failure
+        and missing_id in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_action_lookup_references_missing_runtime_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transitions = [
+        record for record in transitions if record["id"] != "transition.keybinding"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=runtime_transitions,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_action[0]" in failure
+        and "transition_id does not match runtime transition registry" in failure
+        and "transition.keybinding" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_registry_has_extra_id(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transitions = transitions + [
+        _transition("keybinding", "transition.runtime.extra")
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=runtime_transitions,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition" in failure
+        and "id does not match a transition matrix id" in failure
+        and "transition.runtime.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_registry_mismatches_matrix(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transitions = [dict(record) for record in transitions]
+    runtime_transitions[0]["category"] = "render_reflow"
+    runtime_transitions[1]["owner"] = "different owner"
+    runtime_transitions[2]["declared_write_set"] = ["panel.tree_selection_key"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=runtime_transitions,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime category does not match transition" in failure
+        for failure in failures
+    )
+    assert any(
+        "runtime owner does not match transition" in failure for failure in failures
+    )
+    assert any(
+        "runtime declared_write_set does not match transition" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_registry_uses_unknown_write_field(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transitions = [dict(record) for record in transitions]
+    runtime_transitions[0]["declared_write_set"] = ["field.not_registered"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=runtime_transitions,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition[0]" in failure
+        and "declared_write_set references unregistered owner field" in failure
+        and "field.not_registered" in failure
         for failure in failures
     )
 


### PR DESCRIPTION
## Summary
- add a read-only AppState transition registry with lookup/count/index accessors
- validate action transition metadata against the runtime transition registry during startup
- extend the AppState contract guard and focused tests so registry rows stay aligned with the transition matrix

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `make qa-cppcheck && make qa-code-quality && git diff --check`
