### PR TITLE
chore(appstate): add shim registry lookup

### DIFF
--- a/include/ytree_appstate_actions.h
+++ b/include/ytree_appstate_actions.h
@@ -25,6 +25,20 @@ typedef struct {
   size_t declared_write_set_count;
 } AppStateTransitionMetadata;
 
+typedef struct {
+  const char *id;
+  const char *owner;
+  const char *old_authority_path;
+  const char *read_permission;
+  const char *write_permission;
+  const char *const *invariant_checks;
+  size_t invariant_check_count;
+  const char *removal_trigger;
+  const char *target_transition;
+  const char *follow_up_task;
+  const char *qa_enforcement;
+} AppStateCompatibilityShimMetadata;
+
 const AppStateActionTransitionMetadata *
 AppStateActionTransitionLookup(YtreeAction action);
 size_t AppStateActionTransitionCount(void);
@@ -32,5 +46,10 @@ const AppStateTransitionMetadata *
 AppStateTransitionLookup(const char *transition_id);
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index);
 size_t AppStateTransitionCount(void);
+const AppStateCompatibilityShimMetadata *
+AppStateCompatibilityShimLookup(const char *shim_id);
+const AppStateCompatibilityShimMetadata *
+AppStateCompatibilityShimAt(size_t index);
+size_t AppStateCompatibilityShimCount(void);
 
 #endif /* YTREE_APPSTATE_ACTIONS_H */

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -478,6 +478,78 @@ def _parse_runtime_transition_registry(
     return records, failures
 
 
+def _parse_runtime_shim_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    invariant_tables: dict[str, list[str]] = {}
+    invariant_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppStateCompatibilityShimInvariantChecks[0-9]+)\[\]\s*=\s*\{"
+        r"(?P<body>.*?)\};",
+        re.S,
+    )
+    for invariant_match in invariant_re.finditer(source):
+        invariant_tables[invariant_match.group(1)] = re.findall(
+            r'"([^"]+)"', invariant_match.group("body")
+        )
+
+    match = re.search(
+        r"kAppStateCompatibilityShims\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime compatibility shim registry"]
+
+    records: list[dict[str, Any]] = []
+    failures: list[str] = []
+    row_re = re.compile(
+        r"\{\s*\"(?P<id>[^\"]*)\"\s*,\s*\"(?P<owner>[^\"]*)\"\s*,"
+        r"\s*\"(?P<old_authority_path>[^\"]*)\"\s*,"
+        r"\s*\"(?P<read_permission>[^\"]*)\"\s*,"
+        r"\s*\"(?P<write_permission>[^\"]*)\"\s*,"
+        r"\s*(?P<invariants>kAppStateCompatibilityShimInvariantChecks[0-9]+)\s*,"
+        r"\s*sizeof\((?P=invariants)\)\s*/"
+        r"\s*sizeof\((?P=invariants)\[0\]\)\s*,"
+        r"\s*\"(?P<removal_trigger>[^\"]*)\"\s*,"
+        r"\s*\"(?P<target_transition>[^\"]*)\"\s*,"
+        r"\s*\"(?P<follow_up_task>[^\"]*)\"\s*,"
+        r"\s*\"(?P<qa_enforcement>[^\"]*)\"\s*\}",
+        re.S,
+    )
+    for index, row_match in enumerate(row_re.finditer(match.group("body"))):
+        invariant_table_name = row_match.group("invariants")
+        invariant_checks = invariant_tables.get(invariant_table_name)
+        if invariant_checks is None:
+            failures.append(
+                f"runtime_shim[{index}]: unknown invariant-check table: {invariant_table_name}"
+            )
+            invariant_checks = []
+        records.append(
+            {
+                "id": row_match.group("id"),
+                "owner": row_match.group("owner"),
+                "old_authority_path": row_match.group("old_authority_path"),
+                "read_permission": row_match.group("read_permission"),
+                "write_permission": row_match.group("write_permission"),
+                "invariant_checks": invariant_checks,
+                "removal_trigger": row_match.group("removal_trigger"),
+                "target_transition": row_match.group("target_transition"),
+                "follow_up_task": row_match.group("follow_up_task"),
+                "qa_enforcement": row_match.group("qa_enforcement"),
+            }
+        )
+
+    if not records:
+        failures.append(f"{runtime_path}: runtime compatibility shim registry must not be empty")
+    return records, failures
+
+
 def _validate_runtime_action_lookup(
     *,
     runtime_records: list[dict[str, str]],
@@ -597,6 +669,77 @@ def _validate_runtime_transition_registry(
     if missing_ids:
         failures.append(
             f"{runtime_path}: runtime transition registry missing transition id(s): "
+            + ", ".join(missing_ids)
+        )
+
+    return failures
+
+
+def _validate_runtime_shim_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    shim_records: list[Any],
+    runtime_transition_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    expected_shims = {
+        record["id"]: record
+        for record in shim_records
+        if isinstance(record, dict)
+        and isinstance(record.get("id"), str)
+        and record["id"].strip()
+    }
+    expected_ids = set(expected_shims)
+    covered_ids: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_shim[{index}]"
+        runtime_id = record["id"]
+        if runtime_id in covered_ids:
+            failures.append(f"{label}: duplicate runtime shim id: {runtime_id}")
+        covered_ids.add(runtime_id)
+
+        shim_record = expected_shims.get(runtime_id)
+        if shim_record is None:
+            failures.append(f"{label}: id does not match a shim id: {runtime_id}")
+        else:
+            for field in (
+                "owner",
+                "old_authority_path",
+                "read_permission",
+                "write_permission",
+                "invariant_checks",
+                "removal_trigger",
+                "target_transition",
+                "follow_up_task",
+                "qa_enforcement",
+            ):
+                if record.get(field) != shim_record.get(field):
+                    failures.append(
+                        f"{label}: runtime {field} does not match shim "
+                        f"{runtime_id}: {record.get(field)}"
+                    )
+
+        invariant_checks = record.get("invariant_checks")
+        if not isinstance(invariant_checks, list) or not invariant_checks:
+            failures.append(f"{label}: invariant_checks must be non-empty")
+
+        target_transition = record.get("target_transition")
+        if (
+            isinstance(target_transition, str)
+            and target_transition.strip()
+            and target_transition not in runtime_transition_ids
+        ):
+            failures.append(
+                f"{label}: target_transition does not match runtime transition "
+                f"registry: {target_transition}"
+            )
+
+    missing_ids = sorted(expected_ids - covered_ids)
+    if missing_ids:
+        failures.append(
+            f"{runtime_path}: runtime compatibility shim registry missing shim id(s): "
             + ", ".join(missing_ids)
         )
 
@@ -1719,6 +1862,9 @@ def validate_contract(
     runtime_transition_records, runtime_transition_failures = (
         _parse_runtime_transition_registry(action_runtime_path)
     )
+    runtime_shim_records, runtime_shim_failures = _parse_runtime_shim_registry(
+        action_runtime_path
+    )
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
@@ -1732,6 +1878,7 @@ def validate_contract(
     failures.extend(enum_failures)
     failures.extend(runtime_action_failures)
     failures.extend(runtime_transition_failures)
+    failures.extend(runtime_shim_failures)
     if failures:
         return failures
 
@@ -1842,6 +1989,16 @@ def validate_contract(
                 failures.append(
                     f"{label}: target_transition does not match a transition id: {target_transition}"
                 )
+    failures.extend(
+        _validate_runtime_shim_registry(
+            runtime_records=runtime_shim_records,
+            runtime_path=action_runtime_path,
+            shim_records=shims,
+            runtime_transition_ids={
+                record["id"] for record in runtime_transition_records
+            },
+        )
+    )
 
     if not isinstance(action_coverage_doc, dict):
         failures.append(f"{action_coverage_path}: top-level value must be an object")

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -86,6 +86,26 @@ static const char *const kAppStateTransitionWriteSet9[] = {
   "ctx.window_handles",
 };
 
+static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {
+  "YtreePanel(active).dotfile_visibility is authoritative",
+  "Inactive panel visibility is never overwritten from the mirror",
+};
+
+static const char *const kAppStateCompatibilityShimInvariantChecks1[] = {
+  "Raw index is never used while a stable identity key resolves",
+  "Generation mismatch forces rebind before dereference",
+};
+
+static const char *const kAppStateCompatibilityShimInvariantChecks2[] = {
+  "Panel focus_shape remains the restore authority",
+  "Session flag must not overwrite inactive panel shape",
+};
+
+static const char *const kAppStateCompatibilityShimInvariantChecks3[] = {
+  "Render projection is not restore authority",
+  "Temporary row math is discarded after draw",
+};
+
 static const AppStateTransitionMetadata kAppStateTransitions[] = {
   {"transition.keybinding.navigate-tree",
    "keybinding",
@@ -292,6 +312,57 @@ static const AppStateActionTransitionMetadata
   {ACTION_USER_CMD, "transition.command-completion.user-command", "command_completion"},
 };
 
+static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
+  {"shim.viewcontext-hide-dot-files",
+   "ViewContext derived mirror",
+   "ViewContext.hide_dot_files",
+   "Allowed only as a derived compatibility mirror for helpers that have not yet accepted YtreePanel dotfile visibility.",
+   "Write only when synchronizing from the active panel's authoritative dotfile_visibility during transition commit.",
+   kAppStateCompatibilityShimInvariantChecks0,
+   sizeof(kAppStateCompatibilityShimInvariantChecks0) /
+       sizeof(kAppStateCompatibilityShimInvariantChecks0[0]),
+   "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
+   "transition.keybinding.navigate-tree",
+   "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
+   "check_appstate_contract.py requires this shim to declare permissions, invariants, target transition, and removal trigger."},
+  {"shim.volume-saved-tree-index",
+   "Volume restore breadcrumb",
+   "Volume.saved_tree_index",
+   "Allowed only as a fallback breadcrumb when a stable path key has already failed to resolve.",
+   "Do not write as primary restore authority; future writes must update stable identity keys and generation metadata first.",
+   kAppStateCompatibilityShimInvariantChecks1,
+   sizeof(kAppStateCompatibilityShimInvariantChecks1) /
+       sizeof(kAppStateCompatibilityShimInvariantChecks1[0]),
+   "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
+   "transition.rebuild-rebind-callback.panel-anchor",
+   "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
+   "check_appstate_contract.py keeps this debt visible until runtime migration removes the shim."},
+  {"shim.focused-window-session-flag",
+   "ViewContext session routing",
+   "ViewContext.focused_window",
+   "Allowed for layout routing and footer context selection while AppState focus_shape migration is incomplete.",
+   "Write only from transition commit after the active panel focus_shape has been updated.",
+   kAppStateCompatibilityShimInvariantChecks2,
+   sizeof(kAppStateCompatibilityShimInvariantChecks2) /
+       sizeof(kAppStateCompatibilityShimInvariantChecks2[0]),
+   "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
+   "transition.keybinding.navigate-tree",
+   "Move focus-shape authority from session mirrors into panel-local transition records.",
+   "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
+  {"shim-render-derived-row-position",
+   "Render projection temporary",
+   "disp_begin_pos + cursor_pos render-derived lookup",
+   "Allowed only inside render projection or bounds-correction code after identity restore has run.",
+   "Never write authoritative selection from this calculation.",
+   kAppStateCompatibilityShimInvariantChecks3,
+   sizeof(kAppStateCompatibilityShimInvariantChecks3) /
+       sizeof(kAppStateCompatibilityShimInvariantChecks3[0]),
+   "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
+   "transition.render-reflow.project-state",
+   "Audit render/reflow call sites for projection-only behavior during runtime migration.",
+   "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage."},
+};
+
 size_t AppStateActionTransitionCount(void) {
   return sizeof(kAppStateActionTransitions) / sizeof(kAppStateActionTransitions[0]);
 }
@@ -300,11 +371,24 @@ size_t AppStateTransitionCount(void) {
   return sizeof(kAppStateTransitions) / sizeof(kAppStateTransitions[0]);
 }
 
+size_t AppStateCompatibilityShimCount(void) {
+  return sizeof(kAppStateCompatibilityShims) /
+         sizeof(kAppStateCompatibilityShims[0]);
+}
+
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
   if (index >= AppStateTransitionCount())
     return NULL;
 
   return &kAppStateTransitions[index];
+}
+
+const AppStateCompatibilityShimMetadata *
+AppStateCompatibilityShimAt(size_t index) {
+  if (index >= AppStateCompatibilityShimCount())
+    return NULL;
+
+  return &kAppStateCompatibilityShims[index];
 }
 
 const AppStateTransitionMetadata *
@@ -317,6 +401,21 @@ AppStateTransitionLookup(const char *transition_id) {
   for (index = 0; index < AppStateTransitionCount(); index++) {
     if (!strcmp(kAppStateTransitions[index].id, transition_id))
       return &kAppStateTransitions[index];
+  }
+
+  return NULL;
+}
+
+const AppStateCompatibilityShimMetadata *
+AppStateCompatibilityShimLookup(const char *shim_id) {
+  size_t index;
+
+  if (shim_id == NULL || shim_id[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateCompatibilityShimCount(); index++) {
+    if (!strcmp(kAppStateCompatibilityShims[index].id, shim_id))
+      return &kAppStateCompatibilityShims[index];
   }
 
   return NULL;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -27,6 +27,10 @@ static int CoreMainOpsReady(const CoreMainOps *ops) {
          ops->volume_free_all != NULL;
 }
 
+static int NonEmptyString(const char *value) {
+  return value != NULL && value[0] != '\0';
+}
+
 static int AppStateTransitionRegistryReady(void) {
   size_t index;
 
@@ -37,9 +41,9 @@ static int AppStateTransitionRegistryReady(void) {
     const AppStateTransitionMetadata *metadata = AppStateTransitionAt(index);
     size_t write_index;
 
-    if (metadata == NULL || metadata->id == NULL || metadata->id[0] == '\0' ||
-        metadata->category == NULL || metadata->category[0] == '\0' ||
-        metadata->owner == NULL || metadata->owner[0] == '\0' ||
+    if (metadata == NULL || !NonEmptyString(metadata->id) ||
+        !NonEmptyString(metadata->category) ||
+        !NonEmptyString(metadata->owner) ||
         metadata->declared_write_set == NULL ||
         metadata->declared_write_set_count == 0)
       return 0;
@@ -50,12 +54,59 @@ static int AppStateTransitionRegistryReady(void) {
          write_index++) {
       const char *field = metadata->declared_write_set[write_index];
 
-      if (field == NULL || field[0] == '\0')
+      if (!NonEmptyString(field))
         return 0;
     }
   }
 
   if (AppStateTransitionLookup("transition.__ytree_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
+static int AppStateCompatibilityShimsReady(void) {
+  size_t index;
+
+  if (AppStateCompatibilityShimCount() == 0)
+    return 0;
+
+  for (index = 0; index < AppStateCompatibilityShimCount(); index++) {
+    const AppStateCompatibilityShimMetadata *metadata =
+        AppStateCompatibilityShimAt(index);
+    size_t invariant_index;
+
+    if (metadata == NULL || !NonEmptyString(metadata->id) ||
+        !NonEmptyString(metadata->owner) ||
+        !NonEmptyString(metadata->old_authority_path) ||
+        !NonEmptyString(metadata->read_permission) ||
+        !NonEmptyString(metadata->write_permission) ||
+        metadata->invariant_checks == NULL ||
+        metadata->invariant_check_count == 0 ||
+        !NonEmptyString(metadata->removal_trigger) ||
+        !NonEmptyString(metadata->target_transition) ||
+        !NonEmptyString(metadata->follow_up_task) ||
+        !NonEmptyString(metadata->qa_enforcement))
+      return 0;
+    if (AppStateCompatibilityShimLookup(metadata->id) != metadata)
+      return 0;
+    if (AppStateTransitionLookup(metadata->target_transition) == NULL)
+      return 0;
+
+    for (invariant_index = 0;
+         invariant_index < metadata->invariant_check_count; invariant_index++) {
+      if (!NonEmptyString(metadata->invariant_checks[invariant_index]))
+        return 0;
+    }
+  }
+
+  if (AppStateCompatibilityShimAt(AppStateCompatibilityShimCount()) != NULL)
+    return 0;
+  if (AppStateCompatibilityShimLookup(NULL) != NULL)
+    return 0;
+  if (AppStateCompatibilityShimLookup("") != NULL)
+    return 0;
+  if (AppStateCompatibilityShimLookup("shim.__ytree_unknown__") != NULL)
     return 0;
 
   return 1;
@@ -72,9 +123,9 @@ static int AppStateActionTransitionsReady(void) {
     const AppStateTransitionMetadata *transition_metadata;
 
     action_metadata = AppStateActionTransitionLookup((YtreeAction)index);
-    if (action_metadata == NULL || action_metadata->transition_id == NULL ||
-        action_metadata->transition_id[0] == '\0' ||
-        action_metadata->category == NULL || action_metadata->category[0] == '\0')
+    if (action_metadata == NULL ||
+        !NonEmptyString(action_metadata->transition_id) ||
+        !NonEmptyString(action_metadata->category))
       return 0;
 
     transition_metadata =
@@ -161,6 +212,7 @@ int main(int argc, char **argv) {
   CoreMainOps_Register(&ctx);
   if (!CoreMainOpsReady(&ctx.core_main_ops) ||
       !AppStateTransitionRegistryReady() ||
+      !AppStateCompatibilityShimsReady() ||
       !AppStateActionTransitionsReady()) {
     fprintf(stderr, "EXIT: startup invariants not configured\n");
     exit(1);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -330,6 +330,7 @@ def _write_fixture(
     enum_actions: list[str] | None = None,
     runtime_actions: list[dict[str, object]] | None = None,
     runtime_transitions: list[dict[str, object]] | None = None,
+    runtime_shims: list[dict[str, object]] | None = None,
 ) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
@@ -414,6 +415,9 @@ def _write_fixture(
         _runtime_source(
             runtime_actions or _complete_actions(),
             runtime_transitions if runtime_transitions is not None else transitions,
+            runtime_shims
+            if runtime_shims is not None
+            else (shims if shims is not None else [_shim()]),
         ),
     )
     return (
@@ -444,7 +448,9 @@ def _enum_header(actions: list[str]) -> str:
 
 
 def _runtime_source(
-    actions: list[dict[str, object]], transitions: list[dict[str, object]]
+    actions: list[dict[str, object]],
+    transitions: list[dict[str, object]],
+    shims: list[dict[str, object]],
 ) -> str:
     transition_write_sets = []
     transition_rows = []
@@ -466,14 +472,45 @@ def _runtime_source(
             f"sizeof(kAppStateTransitionWriteSet{index}) / "
             f"sizeof(kAppStateTransitionWriteSet{index}[0])}},"
         )
+    shim_invariants = []
+    shim_rows = []
+    for index, record in enumerate(shims):
+        invariant_checks = record.get("invariant_checks")
+        if not isinstance(invariant_checks, list):
+            invariant_checks = []
+        invariant_rows = "\n".join(
+            f'  "{check}",' for check in invariant_checks if isinstance(check, str)
+        )
+        shim_invariants.append(
+            "static const char *const kAppStateCompatibilityShimInvariantChecks"
+            f"{index}[] = {{\n{invariant_rows}\n}};\n"
+        )
+        shim_rows.append(
+            f'  {{"{record.get("id", "")}", "{record.get("owner", "")}", '
+            f'"{record.get("old_authority_path", "")}", '
+            f'"{record.get("read_permission", "")}", '
+            f'"{record.get("write_permission", "")}", '
+            f"kAppStateCompatibilityShimInvariantChecks{index}, "
+            f"sizeof(kAppStateCompatibilityShimInvariantChecks{index}) / "
+            f"sizeof(kAppStateCompatibilityShimInvariantChecks{index}[0]), "
+            f'"{record.get("removal_trigger", "")}", '
+            f'"{record.get("target_transition", "")}", '
+            f'"{record.get("follow_up_task", "")}", '
+            f'"{record.get("qa_enforcement", "")}"}},'
+        )
     action_rows = "\n".join(
         f'  {{{record["action"]}, "{record["transition_id"]}", "{record["category"]}"}},'
         for record in actions
     )
     return (
         "".join(transition_write_sets)
+        + "".join(shim_invariants)
         + "static const AppStateTransitionMetadata kAppStateTransitions[] = {\n"
         + "\n".join(transition_rows)
+        + "\n};\n"
+        "static const AppStateCompatibilityShimMetadata "
+        "kAppStateCompatibilityShims[] = {\n"
+        + "\n".join(shim_rows)
         + "\n};\n"
         "static const AppStateActionTransitionMetadata\n"
         "    kAppStateActionTransitions[APPSTATE_ACTION_TRANSITION_COUNT] = {\n"
@@ -2041,6 +2078,130 @@ def test_guard_fails_when_shim_targets_unknown_transition(tmp_path: Path) -> Non
     assert any(
         "target_transition does not match a transition id" in failure
         and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_metadata_drifts(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim()]
+    runtime_shims[0]["owner"] = "different owner"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "runtime owner does not match shim" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_id_is_missing(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    second_shim = _shim()
+    second_shim["id"] = "shim.second"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        shims=[_shim(), second_shim],
+        runtime_shims=[_shim()],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime compatibility shim registry missing shim id" in failure
+        and "shim.second" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_id_is_extra(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    extra_shim = _shim()
+    extra_shim["id"] = "shim.extra"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=[_shim(), extra_shim],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[1]" in failure
+        and "id does not match a shim id" in failure
+        and "shim.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_target_transition_drifts(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim(target_transition="transition.render_reflow")]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "runtime target_transition does not match shim" in failure
+        and "transition.render_reflow" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_invariant_checks_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim()]
+    runtime_shims[0]["invariant_checks"] = []
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "invariant_checks must be non-empty" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_target_transition_is_not_runtime_registered(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transitions = [
+        record for record in transitions if record["id"] != "transition.keybinding"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=runtime_transitions,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "target_transition does not match runtime transition registry" in failure
+        and "transition.keybinding" in failure
         for failure in failures
     )
 


### PR DESCRIPTION
## Summary
- add a read-only AppState compatibility shim registry with lookup/count/index accessors
- validate shim metadata and transition linkage during startup
- extend the AppState contract guard and focused tests so runtime shim rows stay aligned with the documented shim registry

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `make qa-cppcheck && make qa-code-quality && git diff --check`
