### PR TITLE
chore(appstate): add invariant registry lookup

### DIFF
--- a/include/ytree_appstate_actions.h
+++ b/include/ytree_appstate_actions.h
@@ -39,6 +39,23 @@ typedef struct {
   const char *qa_enforcement;
 } AppStateCompatibilityShimMetadata;
 
+typedef struct {
+  const char *invariant_id;
+  const char *category;
+  const char *owner_region;
+  const char *const *protected_fields;
+  size_t protected_field_count;
+  const char *const *transition_ids;
+  size_t transition_id_count;
+  const char *const *dispatch_surface_ids;
+  size_t dispatch_surface_id_count;
+  const char *failure_mode;
+  const char *enforcement_status;
+  const char *test_strategy;
+  const char *const *migration_notes;
+  size_t migration_note_count;
+} AppStateInvariantMetadata;
+
 const AppStateActionTransitionMetadata *
 AppStateActionTransitionLookup(YtreeAction action);
 size_t AppStateActionTransitionCount(void);
@@ -51,5 +68,9 @@ AppStateCompatibilityShimLookup(const char *shim_id);
 const AppStateCompatibilityShimMetadata *
 AppStateCompatibilityShimAt(size_t index);
 size_t AppStateCompatibilityShimCount(void);
+const AppStateInvariantMetadata *
+AppStateInvariantLookup(const char *invariant_id);
+const AppStateInvariantMetadata *AppStateInvariantAt(size_t index);
+size_t AppStateInvariantCount(void);
 
 #endif /* YTREE_APPSTATE_ACTIONS_H */

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -387,6 +387,147 @@ def _parse_ytree_actions(header_path: Path) -> tuple[list[str], list[str]]:
     return actions, []
 
 
+def _compact_initializer_snippet(row: str) -> str:
+    snippet = re.sub(r"\s+", " ", row).strip()
+    if len(snippet) > 160:
+        return snippet[:157] + "..."
+    return snippet
+
+
+def _split_top_level_initializer_rows(
+    body: str,
+    label: str,
+) -> tuple[list[str], list[str]]:
+    rows: list[str] = []
+    failures: list[str] = []
+    index = 0
+    while index < len(body):
+        while index < len(body) and body[index] in " \t\r\n,":
+            index += 1
+        if index >= len(body):
+            break
+        if body[index] != "{":
+            start = index
+            while index < len(body) and body[index] not in ",\n":
+                index += 1
+            failures.append(
+                f"{label}: unexpected content outside initializer row: "
+                f"{_compact_initializer_snippet(body[start:index])}"
+            )
+            continue
+
+        start = index
+        depth = 0
+        in_string = False
+        escaped = False
+        while index < len(body):
+            char = body[index]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+            else:
+                if char == '"':
+                    in_string = True
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        index += 1
+                        rows.append(body[start:index])
+                        break
+            index += 1
+        else:
+            failures.append(
+                f"{label}[{len(rows)}]: unterminated initializer row: "
+                f"{_compact_initializer_snippet(body[start:])}"
+            )
+            break
+
+    return rows, failures
+
+
+def _parse_string_initializer_array(
+    body: str,
+    table_name: str,
+) -> tuple[list[str], list[str]]:
+    values: list[str] = []
+    failures: list[str] = []
+    index = 0
+    entry_index = 0
+    while index < len(body):
+        while index < len(body) and body[index] in " \t\r\n":
+            index += 1
+        if index >= len(body):
+            break
+
+        start = index
+        if body[index] == ",":
+            failures.append(
+                f"{table_name}[{entry_index}]: malformed string literal entry: "
+                f"{_compact_initializer_snippet(body[start:index + 1])}"
+            )
+            index += 1
+            entry_index += 1
+            continue
+        if body[index] != '"':
+            while index < len(body) and body[index] != ",":
+                index += 1
+            failures.append(
+                f"{table_name}[{entry_index}]: malformed string literal entry: "
+                f"{_compact_initializer_snippet(body[start:index])}"
+            )
+            if index < len(body) and body[index] == ",":
+                index += 1
+            entry_index += 1
+            continue
+
+        index += 1
+        value_start = index
+        escaped = False
+        while index < len(body):
+            char = body[index]
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                break
+            index += 1
+        else:
+            failures.append(
+                f"{table_name}[{entry_index}]: unterminated string literal entry: "
+                f"{_compact_initializer_snippet(body[start:])}"
+            )
+            break
+
+        value = body[value_start:index]
+        index += 1
+        while index < len(body) and body[index] in " \t\r\n":
+            index += 1
+        if index < len(body) and body[index] != ",":
+            while index < len(body) and body[index] not in ",\n":
+                index += 1
+            failures.append(
+                f"{table_name}[{entry_index}]: malformed string literal entry: "
+                f"{_compact_initializer_snippet(body[start:index])}"
+            )
+            if index < len(body) and body[index] == ",":
+                index += 1
+            entry_index += 1
+            continue
+        if index < len(body) and body[index] == ",":
+            index += 1
+        values.append(value)
+        entry_index += 1
+
+    return values, failures
+
+
 def _parse_runtime_action_transitions(
     runtime_path: Path,
 ) -> tuple[list[dict[str, str]], list[str]]:
@@ -475,6 +616,105 @@ def _parse_runtime_transition_registry(
 
     if not records:
         failures.append(f"{runtime_path}: runtime transition registry must not be empty")
+    return records, failures
+
+
+def _parse_runtime_invariant_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    array_fields = {
+        "ProtectedFields": "protected_fields",
+        "TransitionIds": "transition_ids",
+        "DispatchSurfaceIds": "dispatch_surface_ids",
+        "MigrationNotes": "migration_notes",
+    }
+    arrays: dict[str, list[str]] = {}
+    failures: list[str] = []
+    for table_prefix in array_fields:
+        array_re = re.compile(
+            r"static\s+const\s+char\s+\*const\s+"
+            rf"(kAppStateInvariant{table_prefix}[0-9]+)\[\]\s*=\s*\{{"
+            r"(?P<body>.*?)\};",
+            re.S,
+        )
+        for array_match in array_re.finditer(source):
+            table_name = array_match.group(1)
+            values, array_failures = _parse_string_initializer_array(
+                array_match.group("body"),
+                table_name,
+            )
+            arrays[table_name] = values
+            failures.extend(array_failures)
+
+    match = re.search(
+        r"kAppStateInvariants\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime invariant registry"]
+
+    records: list[dict[str, Any]] = []
+    row_re = re.compile(
+        r"\{\s*\"(?P<invariant_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<category>[^\"]*)\"\s*,"
+        r"\s*\"(?P<owner_region>[^\"]*)\"\s*,"
+        r"\s*(?P<protected_fields>kAppStateInvariantProtectedFields[0-9]+)\s*,"
+        r"\s*sizeof\((?P=protected_fields)\)\s*/"
+        r"\s*sizeof\((?P=protected_fields)\[0\]\)\s*,"
+        r"\s*(?P<transition_ids>kAppStateInvariantTransitionIds[0-9]+)\s*,"
+        r"\s*sizeof\((?P=transition_ids)\)\s*/"
+        r"\s*sizeof\((?P=transition_ids)\[0\]\)\s*,"
+        r"\s*(?P<dispatch_surface_ids>kAppStateInvariantDispatchSurfaceIds[0-9]+)\s*,"
+        r"\s*sizeof\((?P=dispatch_surface_ids)\)\s*/"
+        r"\s*sizeof\((?P=dispatch_surface_ids)\[0\]\)\s*,"
+        r"\s*\"(?P<failure_mode>[^\"]*)\"\s*,"
+        r"\s*\"(?P<enforcement_status>[^\"]*)\"\s*,"
+        r"\s*\"(?P<test_strategy>[^\"]*)\"\s*,"
+        r"\s*(?P<migration_notes>kAppStateInvariantMigrationNotes[0-9]+)\s*,"
+        r"\s*sizeof\((?P=migration_notes)\)\s*/"
+        r"\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
+        re.S,
+    )
+    rows, row_failures = _split_top_level_initializer_rows(
+        match.group("body"),
+        "runtime_invariant",
+    )
+    failures.extend(row_failures)
+    for index, row in enumerate(rows):
+        row_match = row_re.fullmatch(row.strip())
+        if row_match is None:
+            failures.append(
+                f"runtime_invariant[{index}]: malformed runtime invariant "
+                f"registry row: {_compact_initializer_snippet(row)}"
+            )
+            continue
+        record: dict[str, Any] = {
+            "invariant_id": row_match.group("invariant_id"),
+            "category": row_match.group("category"),
+            "owner_region": row_match.group("owner_region"),
+            "failure_mode": row_match.group("failure_mode"),
+            "enforcement_status": row_match.group("enforcement_status"),
+            "test_strategy": row_match.group("test_strategy"),
+        }
+        for table_prefix, field in array_fields.items():
+            table_name = row_match.group(field)
+            values = arrays.get(table_name)
+            if values is None:
+                failures.append(
+                    f"runtime_invariant[{index}]: unknown {field} table: {table_name}"
+                )
+                values = []
+            record[field] = values
+        records.append(record)
+
+    if not records:
+        failures.append(f"{runtime_path}: runtime invariant registry must not be empty")
     return records, failures
 
 
@@ -669,6 +909,114 @@ def _validate_runtime_transition_registry(
     if missing_ids:
         failures.append(
             f"{runtime_path}: runtime transition registry missing transition id(s): "
+            + ", ".join(missing_ids)
+        )
+
+    return failures
+
+
+def _validate_runtime_invariant_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    invariant_records: list[Any],
+    runtime_transition_ids: set[str],
+    dispatch_surface_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    expected_invariants = {
+        record["invariant_id"]: record
+        for record in invariant_records
+        if isinstance(record, dict)
+        and isinstance(record.get("invariant_id"), str)
+        and record["invariant_id"].strip()
+    }
+    expected_ids = set(expected_invariants)
+    covered_ids: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_invariant[{index}]"
+        runtime_id = record["invariant_id"]
+        if runtime_id in covered_ids:
+            failures.append(f"{label}: duplicate runtime invariant id: {runtime_id}")
+        covered_ids.add(runtime_id)
+
+        invariant_record = expected_invariants.get(runtime_id)
+        if invariant_record is None:
+            failures.append(f"{label}: invariant_id does not match an invariant id: {runtime_id}")
+        else:
+            for field in (
+                "category",
+                "owner_region",
+                "protected_fields",
+                "transition_ids",
+                "dispatch_surface_ids",
+                "failure_mode",
+                "enforcement_status",
+                "test_strategy",
+                "migration_notes",
+            ):
+                if record.get(field) != invariant_record.get(field):
+                    failures.append(
+                        f"{label}: runtime {field} does not match invariant "
+                        f"{runtime_id}: {record.get(field)}"
+                    )
+
+        for field in (
+            "protected_fields",
+            "transition_ids",
+            "migration_notes",
+        ):
+            values = record.get(field)
+            if not isinstance(values, list) or not values:
+                failures.append(f"{label}: {field} must be non-empty")
+
+        runtime_surface_refs = record.get("dispatch_surface_ids")
+        if not isinstance(runtime_surface_refs, list):
+            failures.append(f"{label}: dispatch_surface_ids must be non-empty")
+        elif not runtime_surface_refs:
+            migration_notes = record.get("migration_notes")
+            has_cross_cutting_note = (
+                isinstance(migration_notes, list)
+                and any(
+                    isinstance(note, str)
+                    and "cross-cutting" in note.lower()
+                    for note in migration_notes
+                )
+            )
+            if not has_cross_cutting_note:
+                failures.append(f"{label}: dispatch_surface_ids must be non-empty")
+
+        transition_refs = record.get("transition_ids")
+        if isinstance(transition_refs, list):
+            for transition_id in transition_refs:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in runtime_transition_ids
+                ):
+                    failures.append(
+                        f"{label}: transition_ids does not match runtime transition "
+                        f"registry: {transition_id}"
+                    )
+
+        surface_refs = record.get("dispatch_surface_ids")
+        if isinstance(surface_refs, list):
+            for surface_id in surface_refs:
+                if (
+                    isinstance(surface_id, str)
+                    and surface_id.strip()
+                    and surface_id not in dispatch_surface_ids
+                ):
+                    failures.append(
+                        f"{label}: dispatch_surface_ids references unknown dispatch "
+                        f"surface id: {surface_id}"
+                    )
+
+    missing_ids = sorted(expected_ids - covered_ids)
+    if missing_ids:
+        failures.append(
+            f"{runtime_path}: runtime invariant registry missing invariant id(s): "
             + ", ".join(missing_ids)
         )
 
@@ -1865,6 +2213,9 @@ def validate_contract(
     runtime_shim_records, runtime_shim_failures = _parse_runtime_shim_registry(
         action_runtime_path
     )
+    runtime_invariant_records, runtime_invariant_failures = (
+        _parse_runtime_invariant_registry(action_runtime_path)
+    )
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
@@ -1879,6 +2230,7 @@ def validate_contract(
     failures.extend(runtime_action_failures)
     failures.extend(runtime_transition_failures)
     failures.extend(runtime_shim_failures)
+    failures.extend(runtime_invariant_failures)
     if failures:
         return failures
 
@@ -2106,6 +2458,21 @@ def validate_contract(
             invariants_path=invariants_path,
             transition_ids=transition_ids,
             registered_owner_fields=registered_owner_fields,
+            dispatch_surface_ids=dispatch_surface_ids,
+        )
+    )
+    if isinstance(invariants_doc, dict) and isinstance(
+        invariants_doc.get("invariants"), list
+    ):
+        invariant_records = invariants_doc["invariants"]
+    else:
+        invariant_records = []
+    failures.extend(
+        _validate_runtime_invariant_registry(
+            runtime_records=runtime_invariant_records,
+            runtime_path=action_runtime_path,
+            invariant_records=invariant_records,
+            runtime_transition_ids={record["id"] for record in runtime_transition_records},
             dispatch_surface_ids=dispatch_surface_ids,
         )
     )

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -106,6 +106,406 @@ static const char *const kAppStateCompatibilityShimInvariantChecks3[] = {
   "Temporary row math is discarded after draw",
 };
 
+static const char *const kAppStateInvariantProtectedFields0[] = {
+  "ctx.active",
+  "panel.volume_key",
+  "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+  "panel.focus_shape",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateInvariantTransitionIds0[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.menu-action.volume-select",
+  "transition.modal-action.dismiss",
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.terminal-signal-resize",
+};
+
+static const char *const kAppStateInvariantDispatchSurfaceIds0[] = {
+  "surface.directory-window-action-dispatch",
+  "surface.file-window-action-dispatch",
+  "surface.menu-modal-completion",
+  "surface.refresh-rebuild-rebind",
+  "surface.volume-operation",
+  "surface.resize-signal-handling",
+};
+
+static const char *const kAppStateInvariantMigrationNotes0[] = {
+  "Future dynamic tests should distinguish shared topology mirroring from inactive panel-local mutation.",
+};
+
+static const char *const kAppStateInvariantProtectedFields1[] = {
+  "ctx.layout",
+  "ctx.render_dirty_flags",
+  "ctx.window_handles",
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.focus_shape",
+  "panel.panel_generation",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateInvariantTransitionIds1[] = {
+  "transition.render-reflow.project-state",
+  "transition.terminal-signal-resize",
+};
+
+static const char *const kAppStateInvariantDispatchSurfaceIds1[] = {
+  "surface.render-reflow-projection",
+  "surface.resize-signal-handling",
+};
+
+static const char *const kAppStateInvariantMigrationNotes1[] = {
+  "Runtime migration must keep ncurses drawing and temporary row calculations from becoming restore authority.",
+};
+
+static const char *const kAppStateInvariantProtectedFields2[] = {
+  "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "volume.dir_tree",
+  "volume.logged_state",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateInvariantTransitionIds2[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateInvariantDispatchSurfaceIds2[] = {
+  "surface.directory-window-action-dispatch",
+  "surface.refresh-rebuild-rebind",
+  "surface.watcher-live-refresh",
+};
+
+static const char *const kAppStateInvariantMigrationNotes2[] = {
+  "Hidden-entry checks must use stable identity and visibility metadata rather than stale row positions.",
+};
+
+static const char *const kAppStateInvariantProtectedFields3[] = {
+  "ctx.modal_state",
+  "panel.focus_shape",
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateInvariantTransitionIds3[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.menu-action.volume-select",
+  "transition.modal-action.dismiss",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateInvariantDispatchSurfaceIds3[] = {
+  "surface.directory-window-action-dispatch",
+  "surface.file-window-action-dispatch",
+  "surface.menu-modal-completion",
+  "surface.volume-operation",
+};
+
+static const char *const kAppStateInvariantMigrationNotes3[] = {
+  "Compatibility session mirrors may shadow focus only after the panel-local owner has committed the transition.",
+};
+
+static const char *const kAppStateInvariantProtectedFields4[] = {
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "volume.dir_tree",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateInvariantTransitionIds4[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.terminal-signal-resize",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateInvariantDispatchSurfaceIds4[] = {
+  "surface.refresh-rebuild-rebind",
+  "surface.resize-signal-handling",
+  "surface.filesystem-mutation-result",
+  "surface.watcher-live-refresh",
+};
+
+static const char *const kAppStateInvariantMigrationNotes4[] = {
+  "Canonical restore helpers must remain the only authority for rebind after topology or layout invalidation.",
+};
+
+static const char *const kAppStateInvariantProtectedFields5[] = {
+  "ctx.active",
+  "ctx.volumes_head",
+  "panel.volume_key",
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.focus_shape",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "volume.dir_tree",
+  "volume.logged_state",
+  "volume.payload_cache",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateInvariantTransitionIds5[] = {
+  "transition.menu-action.volume-select",
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+};
+
+static const char *const kAppStateInvariantDispatchSurfaceIds5[] = {
+  "surface.volume-operation",
+  "surface.refresh-rebuild-rebind",
+  "surface.filesystem-mutation-result",
+  "surface.watcher-live-refresh",
+};
+
+static const char *const kAppStateInvariantMigrationNotes5[] = {
+  "Shared topology mirroring must be followed by panel-local rebind rather than copying active panel state into inactive panels.",
+};
+
+static const char *const kAppStateInvariantProtectedFields6[] = {
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "volume.dir_tree",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateInvariantTransitionIds6[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateInvariantDispatchSurfaceIds6[] = {
+  "surface.refresh-rebuild-rebind",
+  "surface.volume-operation",
+  "surface.filesystem-mutation-result",
+  "surface.watcher-live-refresh",
+};
+
+static const char *const kAppStateInvariantMigrationNotes6[] = {
+  "Generation validation must happen before any restore snapshot is applied to a panel record.",
+};
+
+static const char *const kAppStateInvariantProtectedFields7[] = {
+  "ctx.command_state",
+  "ctx.message_state",
+  "ctx.modal_state",
+  "ctx.pending_transition",
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "volume.dir_tree",
+  "volume.payload_cache",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateInvariantTransitionIds7[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.menu-action.volume-select",
+  "transition.modal-action.dismiss",
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.terminal-signal-resize",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.command-completion.user-command",
+  "transition.rebuild-rebind-callback.panel-anchor",
+  "transition.render-reflow.project-state",
+};
+
+static const char *const kAppStateInvariantDispatchSurfaceIds7[] = {
+  "surface.key-decode-input-dispatch",
+  "surface.directory-window-action-dispatch",
+  "surface.file-window-action-dispatch",
+  "surface.menu-modal-completion",
+  "surface.resize-signal-handling",
+  "surface.refresh-rebuild-rebind",
+  "surface.filesystem-mutation-result",
+  "surface.volume-operation",
+  "surface.watcher-live-refresh",
+  "surface.render-reflow-projection",
+};
+
+static const char *const kAppStateInvariantMigrationNotes7[] = {
+  "Blocked outcomes are cross-cutting across all registered transition and dispatch surfaces but are listed explicitly here for guard traceability.",
+};
+
+static const AppStateInvariantMetadata kAppStateInvariants[] = {
+  {"invariant.inactive-panel-frozen",
+   "inactive_panel_frozen",
+   "panel-local state",
+   kAppStateInvariantProtectedFields0,
+   sizeof(kAppStateInvariantProtectedFields0) /
+       sizeof(kAppStateInvariantProtectedFields0[0]),
+   kAppStateInvariantTransitionIds0,
+   sizeof(kAppStateInvariantTransitionIds0) /
+       sizeof(kAppStateInvariantTransitionIds0[0]),
+   kAppStateInvariantDispatchSurfaceIds0,
+   sizeof(kAppStateInvariantDispatchSurfaceIds0) /
+       sizeof(kAppStateInvariantDispatchSurfaceIds0[0]),
+   "Fail if an active-only transition mutates inactive panel-local identity, viewport, focus, restore, or generation fields outside an explicitly targeted transition.",
+   "documented_foundation_only",
+   "State-sequence harness snapshots both panels before each active-panel transition and compares inactive panel fields after allowed and blocked outcomes.",
+   kAppStateInvariantMigrationNotes0,
+   sizeof(kAppStateInvariantMigrationNotes0) /
+       sizeof(kAppStateInvariantMigrationNotes0[0])},
+  {"invariant.render-projection-read-only",
+   "render_projection_read_only",
+   "render/projection/invalidation state",
+   kAppStateInvariantProtectedFields1,
+   sizeof(kAppStateInvariantProtectedFields1) /
+       sizeof(kAppStateInvariantProtectedFields1[0]),
+   kAppStateInvariantTransitionIds1,
+   sizeof(kAppStateInvariantTransitionIds1) /
+       sizeof(kAppStateInvariantTransitionIds1[0]),
+   kAppStateInvariantDispatchSurfaceIds1,
+   sizeof(kAppStateInvariantDispatchSurfaceIds1) /
+       sizeof(kAppStateInvariantDispatchSurfaceIds1[0]),
+   "Fail if render or reflow chooses new authoritative selection, focus, viewport, panel generation, or volume generation from projected rows or window geometry.",
+   "documented_foundation_only",
+   "Transition-diff harness runs render/reflow passes after settled transitions and verifies only declared render projection fields change.",
+   kAppStateInvariantMigrationNotes1,
+   sizeof(kAppStateInvariantMigrationNotes1) /
+       sizeof(kAppStateInvariantMigrationNotes1[0])},
+  {"invariant.hidden-entry-visible-navigation",
+   "hidden_entry_visible_navigation",
+   "panel-local state",
+   kAppStateInvariantProtectedFields2,
+   sizeof(kAppStateInvariantProtectedFields2) /
+       sizeof(kAppStateInvariantProtectedFields2[0]),
+   kAppStateInvariantTransitionIds2,
+   sizeof(kAppStateInvariantTransitionIds2) /
+       sizeof(kAppStateInvariantTransitionIds2[0]),
+   kAppStateInvariantDispatchSurfaceIds2,
+   sizeof(kAppStateInvariantDispatchSurfaceIds2) /
+       sizeof(kAppStateInvariantDispatchSurfaceIds2[0]),
+   "Fail if visible navigation lands on a hidden entry or resurrects a concealed identity after visibility/topology changes.",
+   "documented_foundation_only",
+   "Generated navigation sequences toggle visibility, rebuild, and move through visible rows while asserting the selected identity remains visible or falls back deterministically.",
+   kAppStateInvariantMigrationNotes2,
+   sizeof(kAppStateInvariantMigrationNotes2) /
+       sizeof(kAppStateInvariantMigrationNotes2[0])},
+  {"invariant.panel-local-focus-restore",
+   "panel_local_focus_restore",
+   "panel-local state",
+   kAppStateInvariantProtectedFields3,
+   sizeof(kAppStateInvariantProtectedFields3) /
+       sizeof(kAppStateInvariantProtectedFields3[0]),
+   kAppStateInvariantTransitionIds3,
+   sizeof(kAppStateInvariantTransitionIds3) /
+       sizeof(kAppStateInvariantTransitionIds3[0]),
+   kAppStateInvariantDispatchSurfaceIds3,
+   sizeof(kAppStateInvariantDispatchSurfaceIds3) /
+       sizeof(kAppStateInvariantDispatchSurfaceIds3[0]),
+   "Fail if focus restoration imports another panel's shape, briefly renders a different shape, or restores focus from session mirrors instead of panel-local records.",
+   "documented_foundation_only",
+   "Sequence tests alternate modal dismissal, Tab/F8-style routing, and file/tree transitions while asserting each panel restores its own recorded focus shape.",
+   kAppStateInvariantMigrationNotes3,
+   sizeof(kAppStateInvariantMigrationNotes3) /
+       sizeof(kAppStateInvariantMigrationNotes3[0])},
+  {"invariant.viewport-identity-rebind",
+   "viewport_identity_rebind",
+   "panel-local state",
+   kAppStateInvariantProtectedFields4,
+   sizeof(kAppStateInvariantProtectedFields4) /
+       sizeof(kAppStateInvariantProtectedFields4[0]),
+   kAppStateInvariantTransitionIds4,
+   sizeof(kAppStateInvariantTransitionIds4) /
+       sizeof(kAppStateInvariantTransitionIds4[0]),
+   kAppStateInvariantDispatchSurfaceIds4,
+   sizeof(kAppStateInvariantDispatchSurfaceIds4) /
+       sizeof(kAppStateInvariantDispatchSurfaceIds4[0]),
+   "Fail if rebuild, mutation, or resize restores viewport from raw rows when the stable identity is still visible or before deterministic fallback order is exhausted.",
+   "documented_foundation_only",
+   "Snapshot/diff tests rebuild or resize around stable directory and file identities, then assert exact rebind when visible and deterministic fallback otherwise.",
+   kAppStateInvariantMigrationNotes4,
+   sizeof(kAppStateInvariantMigrationNotes4) /
+       sizeof(kAppStateInvariantMigrationNotes4[0])},
+  {"invariant.shared-state-panel-local-isolation",
+   "shared_state_panel_local_isolation",
+   "volume/shared topology and payload state",
+   kAppStateInvariantProtectedFields5,
+   sizeof(kAppStateInvariantProtectedFields5) /
+       sizeof(kAppStateInvariantProtectedFields5[0]),
+   kAppStateInvariantTransitionIds5,
+   sizeof(kAppStateInvariantTransitionIds5) /
+       sizeof(kAppStateInvariantTransitionIds5[0]),
+   kAppStateInvariantDispatchSurfaceIds5,
+   sizeof(kAppStateInvariantDispatchSurfaceIds5) /
+       sizeof(kAppStateInvariantDispatchSurfaceIds5[0]),
+   "Fail if shared volume topology or registry changes overwrite panel-local selection, focus, tags, viewport, or restore snapshots by shared index or pointer aliasing.",
+   "documented_foundation_only",
+   "Split-panel sequences share a volume, mutate shared topology, and verify each panel rebinds through its own identity without cross-panel field drift.",
+   kAppStateInvariantMigrationNotes5,
+   sizeof(kAppStateInvariantMigrationNotes5) /
+       sizeof(kAppStateInvariantMigrationNotes5[0])},
+  {"invariant.stale-snapshot-fail-closed",
+   "stale_snapshot_fail_closed",
+   "panel-local state",
+   kAppStateInvariantProtectedFields6,
+   sizeof(kAppStateInvariantProtectedFields6) /
+       sizeof(kAppStateInvariantProtectedFields6[0]),
+   kAppStateInvariantTransitionIds6,
+   sizeof(kAppStateInvariantTransitionIds6) /
+       sizeof(kAppStateInvariantTransitionIds6[0]),
+   kAppStateInvariantDispatchSurfaceIds6,
+   sizeof(kAppStateInvariantDispatchSurfaceIds6) /
+       sizeof(kAppStateInvariantDispatchSurfaceIds6[0]),
+   "Fail if a generation mismatch reuses stale DirEntry/FileEntry pointers, stale flat-list rows, or stale snapshot payloads instead of exact rebind or deterministic fallback.",
+   "documented_foundation_only",
+   "Harness corrupts or invalidates saved generations around rebuild/mutation transitions and asserts stale snapshots fail closed without unrelated mutation.",
+   kAppStateInvariantMigrationNotes6,
+   sizeof(kAppStateInvariantMigrationNotes6) /
+       sizeof(kAppStateInvariantMigrationNotes6[0])},
+  {"invariant.blocked-transition-determinism",
+   "blocked_transition_determinism",
+   "ctx/session state",
+   kAppStateInvariantProtectedFields7,
+   sizeof(kAppStateInvariantProtectedFields7) /
+       sizeof(kAppStateInvariantProtectedFields7[0]),
+   kAppStateInvariantTransitionIds7,
+   sizeof(kAppStateInvariantTransitionIds7) /
+       sizeof(kAppStateInvariantTransitionIds7[0]),
+   kAppStateInvariantDispatchSurfaceIds7,
+   sizeof(kAppStateInvariantDispatchSurfaceIds7) /
+       sizeof(kAppStateInvariantDispatchSurfaceIds7[0]),
+   "Fail if a blocked or invalid transition partially mutates authoritative panel/volume state, advances generations, performs hidden side effects, or chooses a non-deterministic fallback.",
+   "documented_foundation_only",
+   "Negative state-sequence tests force guard failures and unavailable targets, then assert no unrelated owner fields differ and any message/modal output is declared.",
+   kAppStateInvariantMigrationNotes7,
+   sizeof(kAppStateInvariantMigrationNotes7) /
+       sizeof(kAppStateInvariantMigrationNotes7[0])},
+};
+
 static const AppStateTransitionMetadata kAppStateTransitions[] = {
   {"transition.keybinding.navigate-tree",
    "keybinding",
@@ -376,6 +776,10 @@ size_t AppStateCompatibilityShimCount(void) {
          sizeof(kAppStateCompatibilityShims[0]);
 }
 
+size_t AppStateInvariantCount(void) {
+  return sizeof(kAppStateInvariants) / sizeof(kAppStateInvariants[0]);
+}
+
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
   if (index >= AppStateTransitionCount())
     return NULL;
@@ -389,6 +793,13 @@ AppStateCompatibilityShimAt(size_t index) {
     return NULL;
 
   return &kAppStateCompatibilityShims[index];
+}
+
+const AppStateInvariantMetadata *AppStateInvariantAt(size_t index) {
+  if (index >= AppStateInvariantCount())
+    return NULL;
+
+  return &kAppStateInvariants[index];
 }
 
 const AppStateTransitionMetadata *
@@ -416,6 +827,21 @@ AppStateCompatibilityShimLookup(const char *shim_id) {
   for (index = 0; index < AppStateCompatibilityShimCount(); index++) {
     if (!strcmp(kAppStateCompatibilityShims[index].id, shim_id))
       return &kAppStateCompatibilityShims[index];
+  }
+
+  return NULL;
+}
+
+const AppStateInvariantMetadata *
+AppStateInvariantLookup(const char *invariant_id) {
+  size_t index;
+
+  if (invariant_id == NULL || invariant_id[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateInvariantCount(); index++) {
+    if (!strcmp(kAppStateInvariants[index].invariant_id, invariant_id))
+      return &kAppStateInvariants[index];
   }
 
   return NULL;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -31,6 +31,39 @@ static int NonEmptyString(const char *value) {
   return value != NULL && value[0] != '\0';
 }
 
+static int NonEmptyStringList(const char *const *values, size_t count) {
+  size_t index;
+
+  if (values == NULL || count == 0)
+    return 0;
+
+  for (index = 0; index < count; index++) {
+    if (!NonEmptyString(values[index]))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int AppStateInvariantDispatchSurfacesReady(
+    const AppStateInvariantMetadata *metadata) {
+  size_t note_index;
+
+  if (metadata->dispatch_surface_ids == NULL)
+    return 0;
+  if (metadata->dispatch_surface_id_count > 0)
+    return NonEmptyStringList(metadata->dispatch_surface_ids,
+                              metadata->dispatch_surface_id_count);
+
+  for (note_index = 0; note_index < metadata->migration_note_count;
+       note_index++) {
+    if (strstr(metadata->migration_notes[note_index], "cross-cutting") != NULL)
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateTransitionRegistryReady(void) {
   size_t index;
 
@@ -60,6 +93,53 @@ static int AppStateTransitionRegistryReady(void) {
   }
 
   if (AppStateTransitionLookup("transition.__ytree_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
+static int AppStateInvariantRegistryReady(void) {
+  size_t index;
+
+  if (AppStateInvariantCount() == 0)
+    return 0;
+
+  for (index = 0; index < AppStateInvariantCount(); index++) {
+    const AppStateInvariantMetadata *metadata = AppStateInvariantAt(index);
+    size_t transition_index;
+
+    if (metadata == NULL || !NonEmptyString(metadata->invariant_id) ||
+        !NonEmptyString(metadata->category) ||
+        !NonEmptyString(metadata->owner_region) ||
+        !NonEmptyString(metadata->failure_mode) ||
+        !NonEmptyString(metadata->enforcement_status) ||
+        !NonEmptyString(metadata->test_strategy) ||
+        !NonEmptyStringList(metadata->protected_fields,
+                            metadata->protected_field_count) ||
+        !NonEmptyStringList(metadata->transition_ids,
+                            metadata->transition_id_count) ||
+        !NonEmptyStringList(metadata->migration_notes,
+                            metadata->migration_note_count) ||
+        !AppStateInvariantDispatchSurfacesReady(metadata))
+      return 0;
+    if (AppStateInvariantLookup(metadata->invariant_id) != metadata)
+      return 0;
+
+    for (transition_index = 0;
+         transition_index < metadata->transition_id_count; transition_index++) {
+      if (AppStateTransitionLookup(metadata->transition_ids[transition_index]) ==
+          NULL)
+        return 0;
+    }
+  }
+
+  if (AppStateInvariantAt(AppStateInvariantCount()) != NULL)
+    return 0;
+  if (AppStateInvariantLookup(NULL) != NULL)
+    return 0;
+  if (AppStateInvariantLookup("") != NULL)
+    return 0;
+  if (AppStateInvariantLookup("invariant.__ytree_unknown__") != NULL)
     return 0;
 
   return 1;
@@ -212,6 +292,7 @@ int main(int argc, char **argv) {
   CoreMainOps_Register(&ctx);
   if (!CoreMainOpsReady(&ctx.core_main_ops) ||
       !AppStateTransitionRegistryReady() ||
+      !AppStateInvariantRegistryReady() ||
       !AppStateCompatibilityShimsReady() ||
       !AppStateActionTransitionsReady()) {
     fprintf(stderr, "EXIT: startup invariants not configured\n");

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -331,6 +331,7 @@ def _write_fixture(
     runtime_actions: list[dict[str, object]] | None = None,
     runtime_transitions: list[dict[str, object]] | None = None,
     runtime_shims: list[dict[str, object]] | None = None,
+    runtime_invariants: list[dict[str, object]] | None = None,
 ) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
@@ -418,6 +419,9 @@ def _write_fixture(
             runtime_shims
             if runtime_shims is not None
             else (shims if shims is not None else [_shim()]),
+            runtime_invariants
+            if runtime_invariants is not None
+            else (invariants if invariants is not None else _complete_invariants()),
         ),
     )
     return (
@@ -451,6 +455,7 @@ def _runtime_source(
     actions: list[dict[str, object]],
     transitions: list[dict[str, object]],
     shims: list[dict[str, object]],
+    invariants: list[dict[str, object]],
 ) -> str:
     transition_write_sets = []
     transition_rows = []
@@ -498,6 +503,46 @@ def _runtime_source(
             f'"{record.get("follow_up_task", "")}", '
             f'"{record.get("qa_enforcement", "")}"}},'
         )
+    invariant_arrays = []
+    invariant_rows = []
+    invariant_list_fields = (
+        ("protected_fields", "ProtectedFields"),
+        ("transition_ids", "TransitionIds"),
+        ("dispatch_surface_ids", "DispatchSurfaceIds"),
+        ("migration_notes", "MigrationNotes"),
+    )
+    for index, record in enumerate(invariants):
+        for field, prefix in invariant_list_fields:
+            values = record.get(field)
+            if not isinstance(values, list):
+                values = []
+            rows = "\n".join(
+                f'  "{value}",' for value in values if isinstance(value, str)
+            )
+            invariant_arrays.append(
+                f"static const char *const kAppStateInvariant{prefix}{index}[] "
+                f"= {{\n{rows}\n}};\n"
+            )
+        invariant_rows.append(
+            f'  {{"{record.get("invariant_id", "")}", '
+            f'"{record.get("category", "")}", '
+            f'"{record.get("owner_region", "")}", '
+            f"kAppStateInvariantProtectedFields{index}, "
+            f"sizeof(kAppStateInvariantProtectedFields{index}) / "
+            f"sizeof(kAppStateInvariantProtectedFields{index}[0]), "
+            f"kAppStateInvariantTransitionIds{index}, "
+            f"sizeof(kAppStateInvariantTransitionIds{index}) / "
+            f"sizeof(kAppStateInvariantTransitionIds{index}[0]), "
+            f"kAppStateInvariantDispatchSurfaceIds{index}, "
+            f"sizeof(kAppStateInvariantDispatchSurfaceIds{index}) / "
+            f"sizeof(kAppStateInvariantDispatchSurfaceIds{index}[0]), "
+            f'"{record.get("failure_mode", "")}", '
+            f'"{record.get("enforcement_status", "")}", '
+            f'"{record.get("test_strategy", "")}", '
+            f"kAppStateInvariantMigrationNotes{index}, "
+            f"sizeof(kAppStateInvariantMigrationNotes{index}) / "
+            f"sizeof(kAppStateInvariantMigrationNotes{index}[0])}},"
+        )
     action_rows = "\n".join(
         f'  {{{record["action"]}, "{record["transition_id"]}", "{record["category"]}"}},'
         for record in actions
@@ -505,12 +550,16 @@ def _runtime_source(
     return (
         "".join(transition_write_sets)
         + "".join(shim_invariants)
+        + "".join(invariant_arrays)
         + "static const AppStateTransitionMetadata kAppStateTransitions[] = {\n"
         + "\n".join(transition_rows)
         + "\n};\n"
         "static const AppStateCompatibilityShimMetadata "
         "kAppStateCompatibilityShims[] = {\n"
         + "\n".join(shim_rows)
+        + "\n};\n"
+        "static const AppStateInvariantMetadata kAppStateInvariants[] = {\n"
+        + "\n".join(invariant_rows)
         + "\n};\n"
         "static const AppStateActionTransitionMetadata\n"
         "    kAppStateActionTransitions[APPSTATE_ACTION_TRANSITION_COUNT] = {\n"
@@ -2201,6 +2250,197 @@ def test_guard_fails_when_runtime_shim_target_transition_is_not_runtime_register
     assert any(
         "runtime_shim[0]" in failure
         and "target_transition does not match runtime transition registry" in failure
+        and "transition.keybinding" in failure
+        for failure in failures
+    )
+
+def test_guard_fails_when_runtime_invariant_metadata_drifts(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    runtime_invariants = _complete_invariants()
+    runtime_invariants[0]["protected_fields"] = ["field"]
+    runtime_invariants[1]["migration_notes"] = ["different note"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_invariant[0]" in failure
+        and "runtime protected_fields does not match invariant" in failure
+        for failure in failures
+    )
+    assert any(
+        "runtime_invariant[1]" in failure
+        and "runtime migration_notes does not match invariant" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_id_is_missing(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    missing_id = invariants[-1]["invariant_id"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=invariants[:-1],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime invariant registry missing invariant id" in failure
+        and missing_id in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_id_is_extra(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    extra_invariant = _invariant("inactive_panel_frozen", "invariant.extra")
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=_complete_invariants() + [extra_invariant],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_invariant" in failure
+        and "invariant_id does not match an invariant id" in failure
+        and "invariant.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_row_is_malformed(
+    tmp_path: Path,
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    runtime_path = paths[-1]
+    source = runtime_path.read_text(encoding="utf-8")
+    malformed_row = (
+        '  {NULL, "inactive_panel_frozen", "YtreePanel(inactive)", '
+        "kAppStateInvariantProtectedFields0, "
+        "sizeof(kAppStateInvariantProtectedFields0) / "
+        "sizeof(kAppStateInvariantProtectedFields0[0]), "
+        "kAppStateInvariantTransitionIds0, "
+        "sizeof(kAppStateInvariantTransitionIds0) / "
+        "sizeof(kAppStateInvariantTransitionIds0[0]), "
+        "kAppStateInvariantDispatchSurfaceIds0, "
+        "sizeof(kAppStateInvariantDispatchSurfaceIds0) / "
+        "sizeof(kAppStateInvariantDispatchSurfaceIds0[0]), "
+        '"stale selection", "guard", "contract guard", '
+        "kAppStateInvariantMigrationNotes0, "
+        "sizeof(kAppStateInvariantMigrationNotes0) / "
+        "sizeof(kAppStateInvariantMigrationNotes0[0])},"
+    )
+    marker = "\n};\nstatic const AppStateActionTransitionMetadata"
+    runtime_path.write_text(
+        source.replace(marker, f"\n{malformed_row}{marker}", 1),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_invariant[" in failure
+        and "malformed runtime invariant registry row" in failure
+        and "NULL" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_list_entry_is_malformed(
+    tmp_path: Path,
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    runtime_path = paths[-1]
+    source = runtime_path.read_text(encoding="utf-8")
+    marker = (
+        "static const char *const kAppStateInvariantProtectedFields0[] = {\n"
+        '  "field",'
+    )
+    mutated_marker = marker.replace('  "field",', '  NULL,\n  "field",')
+    runtime_path.write_text(
+        source.replace(marker, mutated_marker, 1),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateInvariantProtectedFields0[0]" in failure
+        and "malformed string literal entry" in failure
+        and "NULL" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_id_is_duplicated(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_invariants = _complete_invariants()
+    runtime_invariants[1]["invariant_id"] = runtime_invariants[0]["invariant_id"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_invariant[1]" in failure
+        and "duplicate runtime invariant id" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_transition_ids_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_invariants = _complete_invariants()
+    runtime_invariants[0]["transition_ids"] = []
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_invariant[0]" in failure
+        and "transition_ids must be non-empty" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_transition_is_not_runtime_registered(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transitions = [
+        record for record in transitions if record["id"] != "transition.keybinding"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=runtime_transitions,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_invariant[0]" in failure
+        and "transition_ids does not match runtime transition registry" in failure
         and "transition.keybinding" in failure
         for failure in failures
     )


### PR DESCRIPTION
## Summary
- Adds read-only runtime lookup metadata for AppState invariants.
- Validates invariant registry shape and transition linkage during startup.
- Extends the AppState contract guard and focused tests to catch runtime/docs drift and malformed registry entries.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS, 209 passed
- `make clean && make` — PASS with pre-existing warnings in unchanged files
- `make qa-cppcheck && make qa-code-quality && git diff --check` — PASS
