### PR TITLE
chore(appstate): add dispatch surface lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,3 @@ __pycache__/
 *.sh
 !scripts/**/*.sh
 !scripts/**/*.txt
-
-# Rebrand task deliverable

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,11 +27,13 @@ The alpha is published early so users and contributors can inspect the code, tes
 
 In short: the project is usable now, but not stable yet. Expect rough edges, occasional regressions, and evolving UX details until beta and then stable release.
 
-### Why refactor the existing code instead of writing a new one from scratch?
+### Why fork Ytree v2.10 instead of starting from scratch?
 
-The decision was made to modernize the existing codebase because YtreeNova is a known application with an established look and feel.
+YtreeNova began as a fork of Werner Bregulla’s Ytree v2.10. The original intention was to develop a major enhanced line from that codebase, but the project was renamed to YtreeNova to avoid confusion with Werner’s continuing Ytree 2.x work. The name keeps the Ytree lineage visible while the Nova suffix marks it as a separate enhanced fork rather than the next official Ytree release.
 
-Creating a new file manager from scratch would have resulted in a loss of identity and name recognition. By refactoring, we preserve the specific behavior and interface style of the original application while significantly enhancing the user experience and replacing the underlying architecture. This approach revitalizes the project without discarding its history.
+A clean-slate implementation could have copied the same UI/UX, but it would still have meant rebuilding existing behaviour before adding the missing features. Starting from Ytree preserved the working baseline and made it possible to focus on extending the program with split-screen workflows, integrated preview/autoview, archive-as-directory operations, and a more modular C99/POSIX codebase.
+
+Werner’s Ytree continues to value portability across a broad range of Unix systems, including older environments. YtreeNova currently targets contemporary POSIX-style Unix systems and, so far, has mainly been tested only on a small number of recent Linux distributions.
 
 ### Why is this not written in Rust?
 
@@ -47,15 +49,11 @@ YtreeNova only needs fast, reliable text/line-box terminal UI for file and VFS b
 
 ## Project Philosophy
 
-### Why modernize YtreeNova when UnixTree already exists?
+### How is YtreeNova different from UnixTree?
 
-While both projects aim to provide a file manager inspired by [XTree&trade;](https://www.xtreefanpage.org/x10dirja.htm), they represent solutions for different eras.
+YtreeNova and UnixTree are separate XTree&trade;-inspired projects with different histories, codebases, and design choices. They overlap in several user-facing goals, including logged-tree navigation, tagging, split-screen operation, preview/autoview, and archive handling, but they differ substantially in architecture and maintenance approach.
 
-`UnixTree` was built for a time when Unix systems were far more inconsistent. To stay portable, it evolved a project-specific internal ecosystem (`libecurses`, `libtcap`, custom term files, and related adaptations). That approach made sense then, but those methods are less common in mainstream Unix development today and can increase long-term maintenance, audit, and packaging effort.
-
-The goal of modernizing YtreeNova is to build for today’s open-source Unix systems. By using common libraries (`ncurses`, `libarchive`, `readline`) and keeping modules focused, YtreeNova becomes a lean, POSIX-compliant utility that is easier for new maintainers to understand, test, extend, audit, and package.
-
-### How do the architectures compare?
+#### How do the YtreeNova and UnixTree architectures compare?
 
 The difference lies in how they handle system dependencies:
 

--- a/etc/ytnova.conf
+++ b/etc/ytnova.conf
@@ -128,7 +128,7 @@ TAGGEDVIEWER=internal
 # WARN_COLOR=11,0     # Bright Yellow on Black (non-bright: 3,0)
 # ERR_COLOR=15,1      # Bright White on Red (non-bright: 7,1)
 
-# Example "Classic YtreeNova" color scheme
+# Example "Classic Blue" color scheme
 # DIR_COLOR=white,blue        # Directory text
 # HIDIR_COLOR=black,white     # Selected directory entry
 # WINDIR_COLOR=cyan,blue      # Directory window text/borders

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -26,6 +26,19 @@ typedef struct {
 } AppStateTransitionMetadata;
 
 typedef struct {
+  const char *surface_id;
+  const char *category;
+  const char *source_path;
+  const char *entry_symbol_or_path;
+  const char *transition_id;
+  const char *boundary_status;
+  const char *const *allowed_direct_writes;
+  size_t allowed_direct_write_count;
+  const char *const *migration_notes;
+  size_t migration_note_count;
+} AppStateDispatchSurfaceMetadata;
+
+typedef struct {
   const char *id;
   const char *owner;
   const char *old_authority_path;
@@ -63,6 +76,10 @@ const AppStateTransitionMetadata *
 AppStateTransitionLookup(const char *transition_id);
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index);
 size_t AppStateTransitionCount(void);
+const AppStateDispatchSurfaceMetadata *
+AppStateDispatchSurfaceLookup(const char *surface_id);
+const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index);
+size_t AppStateDispatchSurfaceCount(void);
 const AppStateCompatibilityShimMetadata *
 AppStateCompatibilityShimLookup(const char *shim_id);
 const AppStateCompatibilityShimMetadata *

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -619,6 +619,110 @@ def _parse_runtime_transition_registry(
     return records, failures
 
 
+def _parse_runtime_dispatch_surface_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    array_fields = {
+        "AllowedDirectWrites": "allowed_direct_writes",
+        "MigrationNotes": "migration_notes",
+    }
+    arrays: dict[str, list[str]] = {}
+    failures: list[str] = []
+    for table_prefix in array_fields:
+        array_re = re.compile(
+            r"static\s+const\s+char\s+\*const\s+"
+            rf"(kAppStateDispatchSurface{table_prefix}[0-9]+)\[\]\s*=\s*\{{"
+            r"(?P<body>.*?)\};",
+            re.S,
+        )
+        for array_match in array_re.finditer(source):
+            table_name = array_match.group(1)
+            values, array_failures = _parse_string_initializer_array(
+                array_match.group("body"),
+                table_name,
+            )
+            arrays[table_name] = values
+            failures.extend(array_failures)
+
+    match = re.search(
+        r"kAppStateDispatchSurfaces\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime dispatch surface registry"]
+
+    records: list[dict[str, Any]] = []
+    row_re = re.compile(
+        r"\{\s*\"(?P<surface_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<category>[^\"]*)\"\s*,"
+        r"\s*\"(?P<source_path>[^\"]*)\"\s*,"
+        r"\s*\"(?P<entry_symbol_or_path>[^\"]*)\"\s*,"
+        r"\s*\"(?P<transition_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<boundary_status>[^\"]*)\"\s*,"
+        r"\s*(?P<allowed_direct_writes>"
+        r"kAppStateDispatchSurfaceAllowedDirectWrites[0-9]+|NULL)\s*,"
+        r"\s*(?:(?P<allowed_direct_write_zero>0)|"
+        r"sizeof\((?P=allowed_direct_writes)\)\s*/"
+        r"\s*sizeof\((?P=allowed_direct_writes)\[0\]\))\s*,"
+        r"\s*(?P<migration_notes>kAppStateDispatchSurfaceMigrationNotes[0-9]+)\s*,"
+        r"\s*sizeof\((?P=migration_notes)\)\s*/"
+        r"\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
+        re.S,
+    )
+    rows, row_failures = _split_top_level_initializer_rows(
+        match.group("body"),
+        "runtime_dispatch_surface",
+    )
+    failures.extend(row_failures)
+    for index, row in enumerate(rows):
+        row_match = row_re.fullmatch(row.strip())
+        if row_match is None:
+            failures.append(
+                f"runtime_dispatch_surface[{index}]: malformed runtime dispatch "
+                f"surface registry row: {_compact_initializer_snippet(row)}"
+            )
+            continue
+        record: dict[str, Any] = {
+            "surface_id": row_match.group("surface_id"),
+            "category": row_match.group("category"),
+            "source_path": row_match.group("source_path"),
+            "entry_symbol_or_path": row_match.group("entry_symbol_or_path"),
+            "transition_id": row_match.group("transition_id"),
+            "boundary_status": row_match.group("boundary_status"),
+        }
+        for field in ("allowed_direct_writes", "migration_notes"):
+            table_name = row_match.group(field)
+            if table_name == "NULL":
+                values = []
+            else:
+                values = arrays.get(table_name)
+                if values is None:
+                    failures.append(
+                        f"runtime_dispatch_surface[{index}]: unknown {field} "
+                        f"table: {table_name}"
+                    )
+                    values = []
+            record[field] = values
+        if row_match.group("allowed_direct_writes") == "NULL" and not row_match.group(
+            "allowed_direct_write_zero"
+        ):
+            failures.append(
+                f"runtime_dispatch_surface[{index}]: NULL allowed_direct_writes "
+                "must have zero count"
+            )
+        records.append(record)
+
+    if not records:
+        failures.append(f"{runtime_path}: runtime dispatch surface registry must not be empty")
+    return records, failures
+
+
 def _parse_runtime_invariant_registry(
     runtime_path: Path,
 ) -> tuple[list[dict[str, Any]], list[str]]:
@@ -910,6 +1014,90 @@ def _validate_runtime_transition_registry(
         failures.append(
             f"{runtime_path}: runtime transition registry missing transition id(s): "
             + ", ".join(missing_ids)
+        )
+
+    return failures
+
+
+def _validate_runtime_dispatch_surface_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    dispatch_surface_records: list[Any],
+    runtime_transition_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    expected_surfaces = {
+        record["surface_id"]: record
+        for record in dispatch_surface_records
+        if isinstance(record, dict)
+        and isinstance(record.get("surface_id"), str)
+        and record["surface_id"].strip()
+    }
+    expected_ids = set(expected_surfaces)
+    covered_ids: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_dispatch_surface[{index}]"
+        runtime_id = record["surface_id"]
+        if runtime_id in covered_ids:
+            failures.append(f"{label}: duplicate runtime dispatch surface id: {runtime_id}")
+        covered_ids.add(runtime_id)
+
+        surface_record = expected_surfaces.get(runtime_id)
+        if surface_record is None:
+            failures.append(
+                f"{label}: surface_id does not match a dispatch surface id: {runtime_id}"
+            )
+        else:
+            for field in (
+                "category",
+                "source_path",
+                "entry_symbol_or_path",
+                "transition_id",
+                "boundary_status",
+                "allowed_direct_writes",
+                "migration_notes",
+            ):
+                if record.get(field) != surface_record.get(field):
+                    failures.append(
+                        f"{label}: runtime {field} does not match dispatch "
+                        f"surface {runtime_id}: {record.get(field)}"
+                    )
+
+        writes = record.get("allowed_direct_writes")
+        if not isinstance(writes, list):
+            failures.append(f"{label}: allowed_direct_writes must be a list")
+        else:
+            for write_index, write in enumerate(writes):
+                if not isinstance(write, str) or not write.strip():
+                    failures.append(
+                        f"{label}: allowed_direct_writes[{write_index}] "
+                        "must be a non-empty string"
+                    )
+
+        notes = record.get("migration_notes")
+        if not isinstance(notes, list) or not notes:
+            failures.append(f"{label}: migration_notes must be non-empty")
+        elif any(not isinstance(note, str) or not note.strip() for note in notes):
+            failures.append(f"{label}: migration_notes must contain non-empty strings")
+
+        transition_id = record.get("transition_id")
+        if (
+            isinstance(transition_id, str)
+            and transition_id.strip()
+            and transition_id not in runtime_transition_ids
+        ):
+            failures.append(
+                f"{label}: transition_id does not match runtime transition "
+                f"registry: {transition_id}"
+            )
+
+    missing_ids = sorted(expected_ids - covered_ids)
+    if missing_ids:
+        failures.append(
+            f"{runtime_path}: runtime dispatch surface registry missing "
+            "surface id(s): " + ", ".join(missing_ids)
         )
 
     return failures
@@ -2210,6 +2398,9 @@ def validate_contract(
     runtime_transition_records, runtime_transition_failures = (
         _parse_runtime_transition_registry(action_runtime_path)
     )
+    runtime_dispatch_surface_records, runtime_dispatch_surface_failures = (
+        _parse_runtime_dispatch_surface_registry(action_runtime_path)
+    )
     runtime_shim_records, runtime_shim_failures = _parse_runtime_shim_registry(
         action_runtime_path
     )
@@ -2229,6 +2420,7 @@ def validate_contract(
     failures.extend(enum_failures)
     failures.extend(runtime_action_failures)
     failures.extend(runtime_transition_failures)
+    failures.extend(runtime_dispatch_surface_failures)
     failures.extend(runtime_shim_failures)
     failures.extend(runtime_invariant_failures)
     if failures:
@@ -2447,11 +2639,28 @@ def validate_contract(
             registered_owner_fields=registered_owner_fields,
         )
     )
+    if isinstance(dispatch_surfaces_doc, dict) and isinstance(
+        dispatch_surfaces_doc.get("dispatch_surfaces"), list
+    ):
+        dispatch_surface_records = dispatch_surfaces_doc["dispatch_surfaces"]
+    else:
+        dispatch_surface_records = []
+    failures.extend(
+        _validate_runtime_dispatch_surface_registry(
+            runtime_records=runtime_dispatch_surface_records,
+            runtime_path=action_runtime_path,
+            dispatch_surface_records=dispatch_surface_records,
+            runtime_transition_ids={record["id"] for record in runtime_transition_records},
+        )
+    )
     dispatch_surface_ids = _collect_string_ids(
         dispatch_surfaces_doc,
         collection_key="dispatch_surfaces",
         id_field="surface_id",
     )
+    runtime_dispatch_surface_ids = {
+        record["surface_id"] for record in runtime_dispatch_surface_records
+    }
     failures.extend(
         _validate_invariants(
             invariants_doc=invariants_doc,
@@ -2473,7 +2682,7 @@ def validate_contract(
             runtime_path=action_runtime_path,
             invariant_records=invariant_records,
             runtime_transition_ids={record["id"] for record in runtime_transition_records},
-            dispatch_surface_ids=dispatch_surface_ids,
+            dispatch_surface_ids=runtime_dispatch_surface_ids,
         )
     )
     invariant_ids = _collect_string_ids(

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -86,6 +86,202 @@ static const char *const kAppStateTransitionWriteSet9[] = {
   "ctx.window_handles",
 };
 
+static const char *const kAppStateDispatchSurfaceMigrationNotes0[] = {
+  "Current input polling and key normalization feed controller dispatch; AppState mutation remains in downstream handlers until runtime transition objects are introduced.",
+};
+
+static const char *const kAppStateDispatchSurfaceAllowedDirectWrites1[] = {
+  "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.focus_shape",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes1[] = {
+  "Current directory-window switch dispatch owns tree navigation and focus updates; later migration should route each action through canonical transition boundaries.",
+};
+
+static const char *const kAppStateDispatchSurfaceAllowedDirectWrites2[] = {
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+  "panel.focus_shape",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes2[] = {
+  "Current file-window switch dispatch updates file selection and viewport state under the broad keybinding foundation record until file-specific transitions are split out.",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes3[] = {
+  "Current menu and modal choice completion returns a selected key to callers; AppState modal writes remain with the caller until modal transition boundaries are introduced.",
+};
+
+static const char *const kAppStateDispatchSurfaceAllowedDirectWrites4[] = {
+  "ctx.layout",
+  "ctx.window_handles",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes4[] = {
+  "Current resize dispatch converts KEY_RESIZE and resize_request state into controller refresh handling; signal-safe work must remain outside asynchronous handlers.",
+};
+
+static const char *const kAppStateDispatchSurfaceAllowedDirectWrites5[] = {
+  "volume.dir_tree",
+  "volume.logged_state",
+  "volume.volume_generation",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes5[] = {
+  "Current safe refresh saves state, rescans, restores, and rebinds panel anchors; migration must preserve that ordering at the transition boundary.",
+};
+
+static const char *const kAppStateDispatchSurfaceAllowedDirectWrites6[] = {
+  "volume.dir_tree",
+  "volume.payload_cache",
+  "volume.volume_generation",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "ctx.message_state",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes6[] = {
+  "Current filesystem command handlers refresh and rebind after successful mutations; only completed mutation results should commit AppState metadata.",
+};
+
+static const char *const kAppStateDispatchSurfaceAllowedDirectWrites7[] = {
+  "ctx.volumes_head",
+  "panel.volume_key",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes7[] = {
+  "Current loaded-volume selection and cycling update panel bindings directly; migration must preserve inactive panel restore records.",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes8[] = {
+  "Current watcher processing reports settled filesystem activity to input dispatch; topology mutation remains mapped to the broad refresh/rebuild transition.",
+};
+
+static const char *const kAppStateDispatchSurfaceMigrationNotes9[] = {
+  "Current render refresh projects settled state to ncurses windows; projection must not become selection, viewport, or topology authority.",
+};
+
+static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
+  {"surface.key-decode-input-dispatch",
+   "key_decode_input_dispatch",
+   "src/ui/key_engine.c",
+   "GetEventOrKey",
+   "transition.keybinding.navigate-tree",
+   "documented_foundation_only",
+   NULL,
+   0,
+   kAppStateDispatchSurfaceMigrationNotes0,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes0) / sizeof(kAppStateDispatchSurfaceMigrationNotes0[0])},
+  {"surface.directory-window-action-dispatch",
+   "directory_window_action_dispatch",
+   "src/ui/ctrl_dir.c",
+   "HandleDirWindow",
+   "transition.keybinding.navigate-tree",
+   "documented_foundation_only",
+   kAppStateDispatchSurfaceAllowedDirectWrites1,
+   sizeof(kAppStateDispatchSurfaceAllowedDirectWrites1) /
+       sizeof(kAppStateDispatchSurfaceAllowedDirectWrites1[0]),
+   kAppStateDispatchSurfaceMigrationNotes1,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes1) / sizeof(kAppStateDispatchSurfaceMigrationNotes1[0])},
+  {"surface.file-window-action-dispatch",
+   "file_window_action_dispatch",
+   "src/ui/ctrl_file.c",
+   "HandleFileWindow",
+   "transition.keybinding.navigate-tree",
+   "documented_foundation_only",
+   kAppStateDispatchSurfaceAllowedDirectWrites2,
+   sizeof(kAppStateDispatchSurfaceAllowedDirectWrites2) /
+       sizeof(kAppStateDispatchSurfaceAllowedDirectWrites2[0]),
+   kAppStateDispatchSurfaceMigrationNotes2,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes2) / sizeof(kAppStateDispatchSurfaceMigrationNotes2[0])},
+  {"surface.menu-modal-completion",
+   "menu_modal_completion",
+   "src/ui/key_engine.c",
+   "InputChoice",
+   "transition.modal-action.dismiss",
+   "documented_foundation_only",
+   NULL,
+   0,
+   kAppStateDispatchSurfaceMigrationNotes3,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes3) / sizeof(kAppStateDispatchSurfaceMigrationNotes3[0])},
+  {"surface.resize-signal-handling",
+   "resize_signal_handling",
+   "src/ui/key_engine.c",
+   "GetEventOrKey",
+   "transition.terminal-signal-resize",
+   "documented_foundation_only",
+   kAppStateDispatchSurfaceAllowedDirectWrites4,
+   sizeof(kAppStateDispatchSurfaceAllowedDirectWrites4) /
+       sizeof(kAppStateDispatchSurfaceAllowedDirectWrites4[0]),
+   kAppStateDispatchSurfaceMigrationNotes4,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes4) / sizeof(kAppStateDispatchSurfaceMigrationNotes4[0])},
+  {"surface.refresh-rebuild-rebind",
+   "refresh_rebuild_rebind",
+   "src/ui/dir_ops.c",
+   "RefreshTreeSafe",
+   "transition.refresh-rebuild.manual-refresh",
+   "documented_foundation_only",
+   kAppStateDispatchSurfaceAllowedDirectWrites5,
+   sizeof(kAppStateDispatchSurfaceAllowedDirectWrites5) /
+       sizeof(kAppStateDispatchSurfaceAllowedDirectWrites5[0]),
+   kAppStateDispatchSurfaceMigrationNotes5,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes5) / sizeof(kAppStateDispatchSurfaceMigrationNotes5[0])},
+  {"surface.filesystem-mutation-result",
+   "filesystem_mutation_result",
+   "src/ui/dir_ops.c",
+   "HandleDirMakeDirectory",
+   "transition.filesystem-mutation-result.mkdir-copy-delete",
+   "documented_foundation_only",
+   kAppStateDispatchSurfaceAllowedDirectWrites6,
+   sizeof(kAppStateDispatchSurfaceAllowedDirectWrites6) /
+       sizeof(kAppStateDispatchSurfaceAllowedDirectWrites6[0]),
+   kAppStateDispatchSurfaceMigrationNotes6,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes6) / sizeof(kAppStateDispatchSurfaceMigrationNotes6[0])},
+  {"surface.volume-operation",
+   "volume_operation",
+   "src/ui/volume_menu.c",
+   "SelectLoadedVolume",
+   "transition.volume-operation.release-cycle",
+   "documented_foundation_only",
+   kAppStateDispatchSurfaceAllowedDirectWrites7,
+   sizeof(kAppStateDispatchSurfaceAllowedDirectWrites7) /
+       sizeof(kAppStateDispatchSurfaceAllowedDirectWrites7[0]),
+   kAppStateDispatchSurfaceMigrationNotes7,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes7) / sizeof(kAppStateDispatchSurfaceMigrationNotes7[0])},
+  {"surface.watcher-live-refresh",
+   "watcher_live_refresh",
+   "src/fs/watcher.c",
+   "Watcher_ProcessEvents",
+   "transition.refresh-rebuild.manual-refresh",
+   "documented_foundation_only",
+   NULL,
+   0,
+   kAppStateDispatchSurfaceMigrationNotes8,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes8) / sizeof(kAppStateDispatchSurfaceMigrationNotes8[0])},
+  {"surface.render-reflow-projection",
+   "render_reflow_projection",
+   "src/ui/display.c",
+   "RefreshView",
+   "transition.render-reflow.project-state",
+   "documented_foundation_only",
+   NULL,
+   0,
+   kAppStateDispatchSurfaceMigrationNotes9,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes9) / sizeof(kAppStateDispatchSurfaceMigrationNotes9[0])},
+};
 static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {
   "YtreeNovaPanel(active).dotfile_visibility is authoritative",
   "Inactive panel visibility is never overwritten from the mirror",
@@ -771,6 +967,10 @@ size_t AppStateTransitionCount(void) {
   return sizeof(kAppStateTransitions) / sizeof(kAppStateTransitions[0]);
 }
 
+size_t AppStateDispatchSurfaceCount(void) {
+  return sizeof(kAppStateDispatchSurfaces) / sizeof(kAppStateDispatchSurfaces[0]);
+}
+
 size_t AppStateCompatibilityShimCount(void) {
   return sizeof(kAppStateCompatibilityShims) /
          sizeof(kAppStateCompatibilityShims[0]);
@@ -785,6 +985,13 @@ const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
     return NULL;
 
   return &kAppStateTransitions[index];
+}
+
+const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index) {
+  if (index >= AppStateDispatchSurfaceCount())
+    return NULL;
+
+  return &kAppStateDispatchSurfaces[index];
 }
 
 const AppStateCompatibilityShimMetadata *
@@ -812,6 +1019,21 @@ AppStateTransitionLookup(const char *transition_id) {
   for (index = 0; index < AppStateTransitionCount(); index++) {
     if (!strcmp(kAppStateTransitions[index].id, transition_id))
       return &kAppStateTransitions[index];
+  }
+
+  return NULL;
+}
+
+const AppStateDispatchSurfaceMetadata *
+AppStateDispatchSurfaceLookup(const char *surface_id) {
+  size_t index;
+
+  if (surface_id == NULL || surface_id[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateDispatchSurfaceCount(); index++) {
+    if (!strcmp(kAppStateDispatchSurfaces[index].surface_id, surface_id))
+      return &kAppStateDispatchSurfaces[index];
   }
 
   return NULL;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -98,6 +98,53 @@ static int AppStateTransitionRegistryReady(void) {
   return 1;
 }
 
+static int AppStateDispatchSurfaceWritesReady(
+    const AppStateDispatchSurfaceMetadata *metadata) {
+  if (metadata->allowed_direct_write_count == 0)
+    return metadata->allowed_direct_writes == NULL;
+
+  return NonEmptyStringList(metadata->allowed_direct_writes,
+                            metadata->allowed_direct_write_count);
+}
+
+static int AppStateDispatchSurfacesReady(void) {
+  size_t index;
+
+  if (AppStateDispatchSurfaceCount() == 0)
+    return 0;
+
+  for (index = 0; index < AppStateDispatchSurfaceCount(); index++) {
+    const AppStateDispatchSurfaceMetadata *metadata =
+        AppStateDispatchSurfaceAt(index);
+
+    if (metadata == NULL || !NonEmptyString(metadata->surface_id) ||
+        !NonEmptyString(metadata->category) ||
+        !NonEmptyString(metadata->source_path) ||
+        !NonEmptyString(metadata->entry_symbol_or_path) ||
+        !NonEmptyString(metadata->transition_id) ||
+        !NonEmptyString(metadata->boundary_status) ||
+        !AppStateDispatchSurfaceWritesReady(metadata) ||
+        !NonEmptyStringList(metadata->migration_notes,
+                            metadata->migration_note_count))
+      return 0;
+    if (AppStateDispatchSurfaceLookup(metadata->surface_id) != metadata)
+      return 0;
+    if (AppStateTransitionLookup(metadata->transition_id) == NULL)
+      return 0;
+  }
+
+  if (AppStateDispatchSurfaceAt(AppStateDispatchSurfaceCount()) != NULL)
+    return 0;
+  if (AppStateDispatchSurfaceLookup(NULL) != NULL)
+    return 0;
+  if (AppStateDispatchSurfaceLookup("") != NULL)
+    return 0;
+  if (AppStateDispatchSurfaceLookup("surface.__ytnova_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
 static int AppStateInvariantRegistryReady(void) {
   size_t index;
 
@@ -129,6 +176,13 @@ static int AppStateInvariantRegistryReady(void) {
          transition_index < metadata->transition_id_count; transition_index++) {
       if (AppStateTransitionLookup(metadata->transition_ids[transition_index]) ==
           NULL)
+        return 0;
+    }
+    for (transition_index = 0;
+         transition_index < metadata->dispatch_surface_id_count;
+         transition_index++) {
+      if (AppStateDispatchSurfaceLookup(
+              metadata->dispatch_surface_ids[transition_index]) == NULL)
         return 0;
     }
   }
@@ -292,6 +346,7 @@ int main(int argc, char **argv) {
   CoreMainOps_Register(&ctx);
   if (!CoreMainOpsReady(&ctx.core_main_ops) ||
       !AppStateTransitionRegistryReady() ||
+      !AppStateDispatchSurfacesReady() ||
       !AppStateInvariantRegistryReady() ||
       !AppStateCompatibilityShimsReady() ||
       !AppStateActionTransitionsReady()) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -330,6 +330,7 @@ def _write_fixture(
     enum_actions: list[str] | None = None,
     runtime_actions: list[dict[str, object]] | None = None,
     runtime_transitions: list[dict[str, object]] | None = None,
+    runtime_dispatch_surfaces: list[dict[str, object]] | None = None,
     runtime_shims: list[dict[str, object]] | None = None,
     runtime_invariants: list[dict[str, object]] | None = None,
 ) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
@@ -416,6 +417,13 @@ def _write_fixture(
         _runtime_source(
             runtime_actions or _complete_actions(),
             runtime_transitions if runtime_transitions is not None else transitions,
+            runtime_dispatch_surfaces
+            if runtime_dispatch_surfaces is not None
+            else (
+                dispatch_surfaces
+                if dispatch_surfaces is not None
+                else _complete_dispatch_surfaces()
+            ),
             runtime_shims
             if runtime_shims is not None
             else (shims if shims is not None else [_shim()]),
@@ -454,6 +462,7 @@ def _enum_header(actions: list[str]) -> str:
 def _runtime_source(
     actions: list[dict[str, object]],
     transitions: list[dict[str, object]],
+    dispatch_surfaces: list[dict[str, object]],
     shims: list[dict[str, object]],
     invariants: list[dict[str, object]],
 ) -> str:
@@ -476,6 +485,50 @@ def _runtime_source(
             f"kAppStateTransitionWriteSet{index}, "
             f"sizeof(kAppStateTransitionWriteSet{index}) / "
             f"sizeof(kAppStateTransitionWriteSet{index}[0])}},"
+        )
+    dispatch_surface_arrays = []
+    dispatch_surface_rows = []
+    for index, record in enumerate(dispatch_surfaces):
+        allowed_direct_writes = record.get("allowed_direct_writes")
+        if isinstance(allowed_direct_writes, list) and allowed_direct_writes:
+            write_rows = "\n".join(
+                f'  "{field}",'
+                for field in allowed_direct_writes
+                if isinstance(field, str)
+            )
+            dispatch_surface_arrays.append(
+                "static const char *const "
+                f"kAppStateDispatchSurfaceAllowedDirectWrites{index}[] = "
+                f"{{\n{write_rows}\n}};\n"
+            )
+            writes_table = f"kAppStateDispatchSurfaceAllowedDirectWrites{index}"
+            writes_count = (
+                f"sizeof({writes_table}) / "
+                f"sizeof({writes_table}[0])"
+            )
+        else:
+            writes_table = "NULL"
+            writes_count = "0"
+        migration_notes = record.get("migration_notes")
+        if not isinstance(migration_notes, list):
+            migration_notes = []
+        note_rows = "\n".join(
+            f'  "{note}",' for note in migration_notes if isinstance(note, str)
+        )
+        notes_table = f"kAppStateDispatchSurfaceMigrationNotes{index}"
+        dispatch_surface_arrays.append(
+            f"static const char *const {notes_table}[] = "
+            f"{{\n{note_rows}\n}};\n"
+        )
+        dispatch_surface_rows.append(
+            f'  {{"{record.get("surface_id", "")}", '
+            f'"{record.get("category", "")}", '
+            f'"{record.get("source_path", "")}", '
+            f'"{record.get("entry_symbol_or_path", "")}", '
+            f'"{record.get("transition_id", "")}", '
+            f'"{record.get("boundary_status", "")}", '
+            f"{writes_table}, {writes_count}, "
+            f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
     shim_invariants = []
     shim_rows = []
@@ -549,10 +602,15 @@ def _runtime_source(
     )
     return (
         "".join(transition_write_sets)
+        + "".join(dispatch_surface_arrays)
         + "".join(shim_invariants)
         + "".join(invariant_arrays)
         + "static const AppStateTransitionMetadata kAppStateTransitions[] = {\n"
         + "\n".join(transition_rows)
+        + "\n};\n"
+        "static const AppStateDispatchSurfaceMetadata "
+        "kAppStateDispatchSurfaces[] = {\n"
+        + "\n".join(dispatch_surface_rows)
         + "\n};\n"
         "static const AppStateCompatibilityShimMetadata "
         "kAppStateCompatibilityShims[] = {\n"
@@ -1766,6 +1824,137 @@ def test_guard_accepts_empty_dispatch_surface_allowed_writes(
     failures = _validate(paths)
 
     assert failures == []
+
+
+def test_guard_fails_when_runtime_dispatch_surface_metadata_drifts(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_dispatch_surfaces = _complete_dispatch_surfaces()
+    runtime_dispatch_surfaces[0]["category"] = "runtime_drift"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_dispatch_surfaces=runtime_dispatch_surfaces,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_dispatch_surface[0]" in failure
+        and "runtime category does not match dispatch surface" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_id_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_dispatch_surfaces = _complete_dispatch_surfaces()[1:]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_dispatch_surfaces=runtime_dispatch_surfaces,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime dispatch surface registry missing surface id(s)" in failure
+        and "surface.directory_window_action_dispatch" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_id_is_extra(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_dispatch_surfaces = _complete_dispatch_surfaces()
+    extra = dict(runtime_dispatch_surfaces[0])
+    extra["surface_id"] = "surface.extra"
+    runtime_dispatch_surfaces.append(extra)
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_dispatch_surfaces=runtime_dispatch_surfaces,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_dispatch_surface" in failure
+        and "does not match a dispatch surface id: surface.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_row_is_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(tmp_path, transitions=transitions)
+    runtime_path = paths[-1]
+    source = runtime_path.read_text(encoding="utf-8")
+    runtime_path.write_text(
+        source.replace('{"surface.key_decode_input_dispatch"', "{123", 1),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_dispatch_surface[3]" in failure
+        and "malformed runtime dispatch surface registry row" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_list_entry_is_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(tmp_path, transitions=transitions)
+    runtime_path = paths[-1]
+    source = runtime_path.read_text(encoding="utf-8")
+    runtime_path.write_text(
+        source.replace(
+            '"fixture coverage",',
+            "123,",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateDispatchSurfaceMigrationNotes0" in failure
+        and "malformed string literal entry" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_transition_is_not_registered(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_dispatch_surfaces = _complete_dispatch_surfaces()
+    runtime_dispatch_surfaces[0]["transition_id"] = "transition.missing"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_dispatch_surfaces=runtime_dispatch_surfaces,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_dispatch_surface[0]" in failure
+        and "transition_id does not match runtime transition registry" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_on_duplicate_owner_field_records(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds read-only runtime lookup metadata for AppState dispatch surfaces.
- Validates dispatch surface registry shape and transition linkage at startup.
- Extends the AppState contract guard/tests to catch runtime/docs drift and malformed registry entries.
- Includes small rebrand cleanup leftovers from main.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `make qa-cppcheck && make qa-code-quality && git diff --check`
