### PR TITLE
chore(appstate): add owner field lookup

### DIFF
--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -69,6 +69,17 @@ typedef struct {
   size_t migration_note_count;
 } AppStateInvariantMetadata;
 
+typedef struct {
+  const char *field;
+  const char *owner_region;
+  const char *canonical_owner;
+  const char *runtime_carrier;
+  const char *mutation_rule;
+  const char *migration_status;
+  const char *const *invariant_checks;
+  size_t invariant_check_count;
+} AppStateOwnerFieldMetadata;
+
 const AppStateActionTransitionMetadata *
 AppStateActionTransitionLookup(YtreeNovaAction action);
 size_t AppStateActionTransitionCount(void);
@@ -89,5 +100,8 @@ const AppStateInvariantMetadata *
 AppStateInvariantLookup(const char *invariant_id);
 const AppStateInvariantMetadata *AppStateInvariantAt(size_t index);
 size_t AppStateInvariantCount(void);
+const AppStateOwnerFieldMetadata *AppStateOwnerFieldLookup(const char *field);
+const AppStateOwnerFieldMetadata *AppStateOwnerFieldAt(size_t index);
+size_t AppStateOwnerFieldCount(void);
 
 #endif /* YTNOVA_APPSTATE_ACTIONS_H */

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -619,6 +619,91 @@ def _parse_runtime_transition_registry(
     return records, failures
 
 
+def _parse_runtime_owner_field_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    invariant_tables: dict[str, list[str]] = {}
+    failures: list[str] = []
+    invariant_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppStateOwnerFieldInvariantChecks[0-9]+)\[\]\s*=\s*\{"
+        r"(?P<body>.*?)\};",
+        re.S,
+    )
+    for invariant_match in invariant_re.finditer(source):
+        table_name = invariant_match.group(1)
+        values, array_failures = _parse_string_initializer_array(
+            invariant_match.group("body"),
+            table_name,
+        )
+        invariant_tables[table_name] = values
+        failures.extend(array_failures)
+
+    match = re.search(
+        r"kAppStateOwnerFields\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime owner field registry"]
+
+    records: list[dict[str, Any]] = []
+    row_re = re.compile(
+        r"\{\s*\"(?P<field>[^\"]*)\"\s*,"
+        r"\s*\"(?P<owner_region>[^\"]*)\"\s*,"
+        r"\s*\"(?P<canonical_owner>[^\"]*)\"\s*,"
+        r"\s*\"(?P<runtime_carrier>[^\"]*)\"\s*,"
+        r"\s*\"(?P<mutation_rule>[^\"]*)\"\s*,"
+        r"\s*\"(?P<migration_status>[^\"]*)\"\s*,"
+        r"\s*(?P<invariant_checks>kAppStateOwnerFieldInvariantChecks[0-9]+)\s*,"
+        r"\s*sizeof\((?P=invariant_checks)\)\s*/"
+        r"\s*sizeof\((?P=invariant_checks)\[0\]\)\s*\}",
+        re.S,
+    )
+    rows, row_failures = _split_top_level_initializer_rows(
+        match.group("body"),
+        "runtime_owner_field",
+    )
+    failures.extend(row_failures)
+    for index, row in enumerate(rows):
+        row_match = row_re.fullmatch(row.strip())
+        if row_match is None:
+            failures.append(
+                f"runtime_owner_field[{index}]: malformed runtime owner field "
+                f"registry row: {_compact_initializer_snippet(row)}"
+            )
+            continue
+
+        table_name = row_match.group("invariant_checks")
+        invariant_checks = invariant_tables.get(table_name)
+        if invariant_checks is None:
+            failures.append(
+                f"runtime_owner_field[{index}]: unknown invariant_checks "
+                f"table: {table_name}"
+            )
+            invariant_checks = []
+        records.append(
+            {
+                "field": row_match.group("field"),
+                "owner_region": row_match.group("owner_region"),
+                "canonical_owner": row_match.group("canonical_owner"),
+                "runtime_carrier": row_match.group("runtime_carrier"),
+                "mutation_rule": row_match.group("mutation_rule"),
+                "migration_status": row_match.group("migration_status"),
+                "invariant_checks": invariant_checks,
+            }
+        )
+
+    if not records:
+        failures.append(f"{runtime_path}: runtime owner field registry must not be empty")
+    return records, failures
+
+
 def _parse_runtime_dispatch_surface_registry(
     runtime_path: Path,
 ) -> tuple[list[dict[str, Any]], list[str]]:
@@ -1014,6 +1099,69 @@ def _validate_runtime_transition_registry(
         failures.append(
             f"{runtime_path}: runtime transition registry missing transition id(s): "
             + ", ".join(missing_ids)
+        )
+
+    return failures
+
+
+def _validate_runtime_owner_field_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    owner_field_records: list[Any],
+) -> list[str]:
+    failures: list[str] = []
+    expected_owner_fields = {
+        record["field"]: record
+        for record in owner_field_records
+        if isinstance(record, dict)
+        and isinstance(record.get("field"), str)
+        and record["field"].strip()
+    }
+    expected_fields = set(expected_owner_fields)
+    covered_fields: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_owner_field[{index}]"
+        runtime_field = record["field"]
+        if runtime_field in covered_fields:
+            failures.append(f"{label}: duplicate runtime owner field: {runtime_field}")
+        covered_fields.add(runtime_field)
+
+        owner_field_record = expected_owner_fields.get(runtime_field)
+        if owner_field_record is None:
+            failures.append(
+                f"{label}: field does not match an owner field: {runtime_field}"
+            )
+        else:
+            for field in REQUIRED_OWNER_FIELDS:
+                if record.get(field) != owner_field_record.get(field):
+                    failures.append(
+                        f"{label}: runtime {field} does not match owner field "
+                        f"{runtime_field}: {record.get(field)}"
+                    )
+
+        for field in sorted(REQUIRED_OWNER_FIELDS - {"invariant_checks"}):
+            value = record.get(field)
+            if not isinstance(value, str) or not value.strip():
+                failures.append(f"{label}: {field} must be a non-empty string")
+
+        invariant_checks = record.get("invariant_checks")
+        if not isinstance(invariant_checks, list) or not invariant_checks:
+            failures.append(f"{label}: invariant_checks must be non-empty")
+        else:
+            for check_index, check in enumerate(invariant_checks):
+                if not isinstance(check, str) or not check.strip():
+                    failures.append(
+                        f"{label}: invariant_checks[{check_index}] "
+                        "must be a non-empty string"
+                    )
+
+    missing_fields = sorted(expected_fields - covered_fields)
+    if missing_fields:
+        failures.append(
+            f"{runtime_path}: runtime owner field registry missing field(s): "
+            + ", ".join(missing_fields)
         )
 
     return failures
@@ -2398,6 +2546,9 @@ def validate_contract(
     runtime_transition_records, runtime_transition_failures = (
         _parse_runtime_transition_registry(action_runtime_path)
     )
+    runtime_owner_field_records, runtime_owner_field_failures = (
+        _parse_runtime_owner_field_registry(action_runtime_path)
+    )
     runtime_dispatch_surface_records, runtime_dispatch_surface_failures = (
         _parse_runtime_dispatch_surface_registry(action_runtime_path)
     )
@@ -2420,6 +2571,7 @@ def validate_contract(
     failures.extend(enum_failures)
     failures.extend(runtime_action_failures)
     failures.extend(runtime_transition_failures)
+    failures.extend(runtime_owner_field_failures)
     failures.extend(runtime_dispatch_surface_failures)
     failures.extend(runtime_shim_failures)
     failures.extend(runtime_invariant_failures)
@@ -2431,6 +2583,19 @@ def validate_contract(
         owner_fields_path=owner_fields_path,
     )
     failures.extend(owner_field_failures)
+    if isinstance(owner_fields_doc, dict) and isinstance(
+        owner_fields_doc.get("owner_fields"), list
+    ):
+        owner_field_records = owner_fields_doc["owner_fields"]
+    else:
+        owner_field_records = []
+    failures.extend(
+        _validate_runtime_owner_field_registry(
+            runtime_records=runtime_owner_field_records,
+            runtime_path=action_runtime_path,
+            owner_field_records=owner_field_records,
+        )
+    )
 
     if not isinstance(transitions_doc, dict):
         failures.append(f"{transitions_path}: top-level value must be an object")

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -86,6 +86,274 @@ static const char *const kAppStateTransitionWriteSet9[] = {
   "ctx.window_handles",
 };
 
+static const char *const kAppStateOwnerFieldInvariantChecks0[] = {
+  "Active panel changes must preserve inactive panel-local records.",
+  "Panel routing must resolve to an existing YtreeNovaPanel carrier before render projection.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks1[] = {
+  "Command completion must not mutate panel or volume fields outside the declared follow-up transition.",
+  "Command failure or cancellation must preserve authoritative panel and volume state.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks2[] = {
+  "Blocked transitions may write message state only when needed for outcome clarity.",
+  "Message writes must not imply filesystem or panel state success.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks3[] = {
+  "Modal dismissal must leave underlying panel and volume authority unchanged unless declared.",
+  "Destructive confirmations must remain explicit and default-safe.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks4[] = {
+  "Pending transitions must name a registered transition before later mutation.",
+  "Queueing a transition must not advance panel or volume generations by itself.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks5[] = {
+  "Releasing a volume must not leave active or inactive panels with stale volume pointers.",
+  "Volume registry changes must rebind affected panels through stable identity or deterministic fallback.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks6[] = {
+  "Resize handling must not choose a new authoritative selection from rendered rows.",
+  "Layout changes alone must not advance volume_generation.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks7[] = {
+  "Render invalidation writes must not mutate selection, focus, or identity state.",
+  "Render projection may clear only surfaces produced from settled AppState records.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks8[] = {
+  "Ncurses window recreation must happen outside signal handlers.",
+  "Window handles must not become restore authority for panel selection or viewport state.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks9[] = {
+  "File selection identity must be path/name based, not a stale FileEntry pointer.",
+  "Inactive panel file selection must remain frozen across active-only actions.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks10[] = {
+  "File viewport correction must preserve the stored selection when it remains visible.",
+  "Render paths may compute temporary file projection without overwriting this origin.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks11[] = {
+  "Reactivation must restore the recorded tree/small-file/big-file shape directly.",
+  "Focus shape changes must not import the inactive panel's state.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks12[] = {
+  "Render projection alone must not advance panel_generation.",
+  "Snapshot restore must compare panel_generation before applying saved state.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks13[] = {
+  "Restore snapshots must use stable identities plus generation validation.",
+  "Stale snapshots must fail closed through the deterministic fallback order.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks14[] = {
+  "Tree cursor position is interpreted against visible rows, not raw topology indices.",
+  "Inactive panel cursor must remain unchanged unless the transition explicitly targets that panel.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks15[] = {
+  "Tree selection identity must be stable and path based within the current volume namespace.",
+  "Selection restore must not derive authority from disp_begin_pos plus cursor_pos.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks16[] = {
+  "Hidden dotfile visibility must not cause extra viewport shifts when selection remains visible.",
+  "Render-side temporary placement must not overwrite the saved viewport origin.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks17[] = {
+  "Panel volume binding must point to an existing volume/archive namespace or deterministic fallback.",
+  "A panel must not import the opposite panel's volume-specific snapshot.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks18[] = {
+  "Shared topology changes must re-anchor each panel by its own stable identity.",
+  "Topology mutation must advance volume_generation before restore consumers observe it.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks19[] = {
+  "Logged state is shared topology and must not store panel-local cursor or tag authority.",
+  "Unlogged placeholders must not degrade a frozen file-view anchor without rebind or payload reload.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks20[] = {
+  "Payload cache changes must not overwrite panel-local file selection identity.",
+  "Mutation-result commits must distinguish filesystem side effects from AppState metadata updates.",
+};
+static const char *const kAppStateOwnerFieldInvariantChecks21[] = {
+  "Render projection alone must not advance volume_generation.",
+  "Generation mismatch must force stable-identity re-resolution before snapshot restore.",
+};
+
+static const AppStateOwnerFieldMetadata kAppStateOwnerFields[] = {
+  {"ctx.active",
+   "ctx/session state",
+   "ViewContext.session routing",
+   "ViewContext.active",
+   "May change only during an allowed panel-routing or volume/menu transition commit.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks0,
+   sizeof(kAppStateOwnerFieldInvariantChecks0) / sizeof(kAppStateOwnerFieldInvariantChecks0[0])},
+  {"ctx.command_state",
+   "ctx/session state",
+   "ViewContext.command_region",
+   "ViewContext command state fields",
+   "May change only through command start/completion/cancel transitions.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks1,
+   sizeof(kAppStateOwnerFieldInvariantChecks1) / sizeof(kAppStateOwnerFieldInvariantChecks1[0])},
+  {"ctx.message_state",
+   "ctx/session state",
+   "ViewContext.message_region",
+   "ViewContext message/footer state fields",
+   "May change only through transitions that declare user-visible outcome or constraint messaging.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks2,
+   sizeof(kAppStateOwnerFieldInvariantChecks2) / sizeof(kAppStateOwnerFieldInvariantChecks2[0])},
+  {"ctx.modal_state",
+   "ctx/session state",
+   "ViewContext.modal_region",
+   "ViewContext modal/dialog state fields",
+   "May change only when entering, completing, or dismissing a registered modal transition.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks3,
+   sizeof(kAppStateOwnerFieldInvariantChecks3) / sizeof(kAppStateOwnerFieldInvariantChecks3[0])},
+  {"ctx.pending_transition",
+   "ctx/session state",
+   "ViewContext.transition_queue",
+   "ViewContext pending transition marker",
+   "May be queued only by transitions that declare a deterministic follow-up boundary.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks4,
+   sizeof(kAppStateOwnerFieldInvariantChecks4) / sizeof(kAppStateOwnerFieldInvariantChecks4[0])},
+  {"ctx.volumes_head",
+   "volume/shared topology and payload state",
+   "ViewContext.volume_registry",
+   "ViewContext.volumes_head",
+   "May change only through volume lifecycle transitions that validate panel bindings.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks5,
+   sizeof(kAppStateOwnerFieldInvariantChecks5) / sizeof(kAppStateOwnerFieldInvariantChecks5[0])},
+  {"ctx.layout",
+   "render/projection/invalidation state",
+   "ViewContext.layout_region",
+   "ViewContext layout geometry fields",
+   "May change only during resize/reflow transitions executed in the main loop.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks6,
+   sizeof(kAppStateOwnerFieldInvariantChecks6) / sizeof(kAppStateOwnerFieldInvariantChecks6[0])},
+  {"ctx.render_dirty_flags",
+   "render/projection/invalidation state",
+   "ViewContext.render_region",
+   "ViewContext render invalidation fields",
+   "May change only when a transition marks or clears declared projection surfaces.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks7,
+   sizeof(kAppStateOwnerFieldInvariantChecks7) / sizeof(kAppStateOwnerFieldInvariantChecks7[0])},
+  {"ctx.window_handles",
+   "render/projection/invalidation state",
+   "ViewContext ncurses window/layout handles",
+   "ViewContext window handle fields",
+   "May change only during main-loop layout/reflow or render projection setup.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks8,
+   sizeof(kAppStateOwnerFieldInvariantChecks8) / sizeof(kAppStateOwnerFieldInvariantChecks8[0])},
+  {"panel.file_selection_key",
+   "panel-local state",
+   "YtreeNovaPanel.file identity owner",
+   "YtreeNovaPanel file selection identity fields",
+   "May change only for the targeted panel through navigation, restore, or rebind transitions.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks9,
+   sizeof(kAppStateOwnerFieldInvariantChecks9) / sizeof(kAppStateOwnerFieldInvariantChecks9[0])},
+  {"panel.file_viewport_origin",
+   "panel-local state",
+   "YtreeNovaPanel.file viewport owner",
+   "YtreeNovaPanel file viewport fields",
+   "May change only for the targeted panel when navigation, bounds correction, or reflow declares it.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks10,
+   sizeof(kAppStateOwnerFieldInvariantChecks10) / sizeof(kAppStateOwnerFieldInvariantChecks10[0])},
+  {"panel.focus_shape",
+   "panel-local state",
+   "YtreeNovaPanel.focus owner",
+   "YtreeNovaPanel focus/window-shape fields",
+   "May change only during allowed focus, modal restore, split, or file/tree transition commits.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks11,
+   sizeof(kAppStateOwnerFieldInvariantChecks11) / sizeof(kAppStateOwnerFieldInvariantChecks11[0])},
+  {"panel.panel_generation",
+   "panel-local state",
+   "YtreeNovaPanel.generation owner",
+   "YtreeNovaPanel panel generation field",
+   "May increment only when panel-local restore authority changes.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks12,
+   sizeof(kAppStateOwnerFieldInvariantChecks12) / sizeof(kAppStateOwnerFieldInvariantChecks12[0])},
+  {"panel.restore_snapshot",
+   "panel-local state",
+   "YtreeNovaPanel.restore snapshot owner",
+   "YtreeNovaPanel restore snapshot fields",
+   "May change only through snapshot capture, rebind, fallback, or volume-binding transitions.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks13,
+   sizeof(kAppStateOwnerFieldInvariantChecks13) / sizeof(kAppStateOwnerFieldInvariantChecks13[0])},
+  {"panel.tree_cursor_pos",
+   "panel-local state",
+   "YtreeNovaPanel.tree cursor owner",
+   "YtreeNovaPanel tree cursor field",
+   "May change only for the targeted panel during tree navigation or rebind/fallback transitions.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks14,
+   sizeof(kAppStateOwnerFieldInvariantChecks14) / sizeof(kAppStateOwnerFieldInvariantChecks14[0])},
+  {"panel.tree_selection_key",
+   "panel-local state",
+   "YtreeNovaPanel.tree selection owner",
+   "YtreeNovaPanel tree selection identity fields",
+   "May change only through tree navigation, restore, or topology rebind transitions for the targeted panel.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks15,
+   sizeof(kAppStateOwnerFieldInvariantChecks15) / sizeof(kAppStateOwnerFieldInvariantChecks15[0])},
+  {"panel.tree_viewport_origin",
+   "panel-local state",
+   "YtreeNovaPanel.tree viewport owner",
+   "YtreeNovaPanel tree viewport fields",
+   "May change only when navigation, bounds correction, resize, or rebind declares viewport mutation.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks16,
+   sizeof(kAppStateOwnerFieldInvariantChecks16) / sizeof(kAppStateOwnerFieldInvariantChecks16[0])},
+  {"panel.volume_key",
+   "panel-local state",
+   "YtreeNovaPanel.volume binding owner",
+   "YtreeNovaPanel volume binding fields",
+   "May change only through volume selection, cycle, release, or restore transitions.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks17,
+   sizeof(kAppStateOwnerFieldInvariantChecks17) / sizeof(kAppStateOwnerFieldInvariantChecks17[0])},
+  {"volume.dir_tree",
+   "volume/shared topology and payload state",
+   "Volume.topology owner",
+   "Volume directory tree fields",
+   "May change only through logging, rebuild, refresh, release, or completed filesystem mutation transitions.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks18,
+   sizeof(kAppStateOwnerFieldInvariantChecks18) / sizeof(kAppStateOwnerFieldInvariantChecks18[0])},
+  {"volume.logged_state",
+   "volume/shared topology and payload state",
+   "Volume.logged topology owner",
+   "Volume logged/unlogged directory state",
+   "May change only through explicit log, relog, release, collapse, refresh, or rebuild transitions.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks19,
+   sizeof(kAppStateOwnerFieldInvariantChecks19) / sizeof(kAppStateOwnerFieldInvariantChecks19[0])},
+  {"volume.payload_cache",
+   "volume/shared topology and payload state",
+   "Volume.payload cache owner",
+   "Volume file payload/statistics cache fields",
+   "May change only through payload load, refresh, archive, or completed filesystem mutation transitions.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks20,
+   sizeof(kAppStateOwnerFieldInvariantChecks20) / sizeof(kAppStateOwnerFieldInvariantChecks20[0])},
+  {"volume.volume_generation",
+   "volume/shared topology and payload state",
+   "Volume.generation owner",
+   "Volume topology/payload generation field",
+   "May increment only when shared topology, payload identity, logged state, or namespace mapping changes.",
+   "documented_foundation_only",
+   kAppStateOwnerFieldInvariantChecks21,
+   sizeof(kAppStateOwnerFieldInvariantChecks21) / sizeof(kAppStateOwnerFieldInvariantChecks21[0])},
+};
+
 static const char *const kAppStateDispatchSurfaceMigrationNotes0[] = {
   "Current input polling and key normalization feed controller dispatch; AppState mutation remains in downstream handlers until runtime transition objects are introduced.",
 };
@@ -980,6 +1248,17 @@ size_t AppStateInvariantCount(void) {
   return sizeof(kAppStateInvariants) / sizeof(kAppStateInvariants[0]);
 }
 
+size_t AppStateOwnerFieldCount(void) {
+  return sizeof(kAppStateOwnerFields) / sizeof(kAppStateOwnerFields[0]);
+}
+
+const AppStateOwnerFieldMetadata *AppStateOwnerFieldAt(size_t index) {
+  if (index >= AppStateOwnerFieldCount())
+    return NULL;
+
+  return &kAppStateOwnerFields[index];
+}
+
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
   if (index >= AppStateTransitionCount())
     return NULL;
@@ -1007,6 +1286,21 @@ const AppStateInvariantMetadata *AppStateInvariantAt(size_t index) {
     return NULL;
 
   return &kAppStateInvariants[index];
+}
+
+const AppStateOwnerFieldMetadata *
+AppStateOwnerFieldLookup(const char *field) {
+  size_t index;
+
+  if (field == NULL || field[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateOwnerFieldCount(); index++) {
+    if (!strcmp(kAppStateOwnerFields[index].field, field))
+      return &kAppStateOwnerFields[index];
+  }
+
+  return NULL;
 }
 
 const AppStateTransitionMetadata *

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -64,6 +64,40 @@ static int AppStateInvariantDispatchSurfacesReady(
   return 0;
 }
 
+static int AppStateOwnerFieldsReady(void) {
+  size_t index;
+
+  if (AppStateOwnerFieldCount() == 0)
+    return 0;
+
+  for (index = 0; index < AppStateOwnerFieldCount(); index++) {
+    const AppStateOwnerFieldMetadata *metadata = AppStateOwnerFieldAt(index);
+
+    if (metadata == NULL || !NonEmptyString(metadata->field) ||
+        !NonEmptyString(metadata->owner_region) ||
+        !NonEmptyString(metadata->canonical_owner) ||
+        !NonEmptyString(metadata->runtime_carrier) ||
+        !NonEmptyString(metadata->mutation_rule) ||
+        !NonEmptyString(metadata->migration_status) ||
+        !NonEmptyStringList(metadata->invariant_checks,
+                            metadata->invariant_check_count))
+      return 0;
+    if (AppStateOwnerFieldLookup(metadata->field) != metadata)
+      return 0;
+  }
+
+  if (AppStateOwnerFieldAt(AppStateOwnerFieldCount()) != NULL)
+    return 0;
+  if (AppStateOwnerFieldLookup(NULL) != NULL)
+    return 0;
+  if (AppStateOwnerFieldLookup("") != NULL)
+    return 0;
+  if (AppStateOwnerFieldLookup("field.__ytnova_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
 static int AppStateTransitionRegistryReady(void) {
   size_t index;
 
@@ -345,6 +379,7 @@ int main(int argc, char **argv) {
   memset(&ctx, 0, sizeof(ViewContext));
   CoreMainOps_Register(&ctx);
   if (!CoreMainOpsReady(&ctx.core_main_ops) ||
+      !AppStateOwnerFieldsReady() ||
       !AppStateTransitionRegistryReady() ||
       !AppStateDispatchSurfacesReady() ||
       !AppStateInvariantRegistryReady() ||

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -333,6 +333,7 @@ def _write_fixture(
     runtime_dispatch_surfaces: list[dict[str, object]] | None = None,
     runtime_shims: list[dict[str, object]] | None = None,
     runtime_invariants: list[dict[str, object]] | None = None,
+    runtime_owner_fields: list[dict[str, object]] | None = None,
 ) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
@@ -417,6 +418,13 @@ def _write_fixture(
         _runtime_source(
             runtime_actions or _complete_actions(),
             runtime_transitions if runtime_transitions is not None else transitions,
+            runtime_owner_fields
+            if runtime_owner_fields is not None
+            else (
+                owner_fields
+                if owner_fields is not None
+                else _complete_owner_fields()
+            ),
             runtime_dispatch_surfaces
             if runtime_dispatch_surfaces is not None
             else (
@@ -462,6 +470,7 @@ def _enum_header(actions: list[str]) -> str:
 def _runtime_source(
     actions: list[dict[str, object]],
     transitions: list[dict[str, object]],
+    owner_fields: list[dict[str, object]],
     dispatch_surfaces: list[dict[str, object]],
     shims: list[dict[str, object]],
     invariants: list[dict[str, object]],
@@ -485,6 +494,29 @@ def _runtime_source(
             f"kAppStateTransitionWriteSet{index}, "
             f"sizeof(kAppStateTransitionWriteSet{index}) / "
             f"sizeof(kAppStateTransitionWriteSet{index}[0])}},"
+        )
+    owner_field_arrays = []
+    owner_field_rows = []
+    for index, record in enumerate(owner_fields):
+        invariant_checks = record.get("invariant_checks")
+        if not isinstance(invariant_checks, list):
+            invariant_checks = []
+        invariant_rows = "\n".join(
+            f'  "{check}",' for check in invariant_checks if isinstance(check, str)
+        )
+        checks_table = f"kAppStateOwnerFieldInvariantChecks{index}"
+        owner_field_arrays.append(
+            f"static const char *const {checks_table}[] = "
+            f"{{\n{invariant_rows}\n}};\n"
+        )
+        owner_field_rows.append(
+            f'  {{"{record.get("field", "")}", '
+            f'"{record.get("owner_region", "")}", '
+            f'"{record.get("canonical_owner", "")}", '
+            f'"{record.get("runtime_carrier", "")}", '
+            f'"{record.get("mutation_rule", "")}", '
+            f'"{record.get("migration_status", "")}", '
+            f"{checks_table}, sizeof({checks_table}) / sizeof({checks_table}[0])}},"
         )
     dispatch_surface_arrays = []
     dispatch_surface_rows = []
@@ -602,11 +634,15 @@ def _runtime_source(
     )
     return (
         "".join(transition_write_sets)
+        + "".join(owner_field_arrays)
         + "".join(dispatch_surface_arrays)
         + "".join(shim_invariants)
         + "".join(invariant_arrays)
         + "static const AppStateTransitionMetadata kAppStateTransitions[] = {\n"
         + "\n".join(transition_rows)
+        + "\n};\n"
+        "static const AppStateOwnerFieldMetadata kAppStateOwnerFields[] = {\n"
+        + "\n".join(owner_field_rows)
         + "\n};\n"
         "static const AppStateDispatchSurfaceMetadata "
         "kAppStateDispatchSurfaces[] = {\n"
@@ -1998,6 +2034,155 @@ def test_guard_fails_on_malformed_owner_invariant_checks(tmp_path: Path) -> None
         "owner_field[0]" in failure
         and "invariant_checks" in failure
         and "must be non-empty" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_owner_field_record_is_malformed(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    owner_fields = _complete_owner_fields()
+    malformed_owner_fields: list[object] = [123, owner_fields[1]]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        owner_fields=malformed_owner_fields,  # type: ignore[arg-type]
+        runtime_owner_fields=_complete_owner_fields(),
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "owner_field[0]" in failure and "record must be an object" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_owner_field_metadata_drifts(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_owner_fields = _complete_owner_fields()
+    runtime_owner_fields[0]["canonical_owner"] = "runtime drift"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_owner_fields=runtime_owner_fields,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_owner_field[0]" in failure
+        and "runtime canonical_owner does not match owner field" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_owner_field_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    owner_fields = _complete_owner_fields()
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_owner_fields=owner_fields[1:],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime owner field registry missing field" in failure
+        and owner_fields[0]["field"] in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_owner_field_is_extra(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    extra = _owner_field("field.extra")
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_owner_fields=_complete_owner_fields() + [extra],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_owner_field" in failure
+        and "field does not match an owner field: field.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_owner_field_is_duplicated(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_owner_fields = _complete_owner_fields()
+    runtime_owner_fields[1]["field"] = runtime_owner_fields[0]["field"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_owner_fields=runtime_owner_fields,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_owner_field[1]" in failure
+        and "duplicate runtime owner field" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_owner_field_row_is_malformed(
+    tmp_path: Path,
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    runtime_path = paths[-1]
+    source = runtime_path.read_text(encoding="utf-8")
+    runtime_path.write_text(
+        source.replace('{"field",', "{NULL,", 1),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_owner_field[0]" in failure
+        and "malformed runtime owner field registry row" in failure
+        and "NULL" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_owner_field_list_entry_is_malformed(
+    tmp_path: Path,
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    runtime_path = paths[-1]
+    source = runtime_path.read_text(encoding="utf-8")
+    runtime_path.write_text(
+        source.replace(
+            'static const char *const kAppStateOwnerFieldInvariantChecks0[] = {\n'
+            '  "fixture invariant",',
+            "static const char *const kAppStateOwnerFieldInvariantChecks0[] = {\n"
+            "  NULL,",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateOwnerFieldInvariantChecks0[0]" in failure
+        and "malformed string literal entry" in failure
+        and "NULL" in failure
         for failure in failures
     )
 


### PR DESCRIPTION
## Summary
- Adds read-only runtime lookup metadata for AppState owner fields.
- Validates owner-field registry shape at startup.
- Extends the AppState contract guard/tests to catch runtime/docs drift and malformed owner-field metadata.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `make qa-cppcheck && make qa-code-quality && git diff --check`
