### PR TITLE
chore(appstate): add generation domain lookup

### DIFF
--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -80,6 +80,23 @@ typedef struct {
   size_t invariant_check_count;
 } AppStateOwnerFieldMetadata;
 
+typedef struct {
+  const char *domain_id;
+  const char *category;
+  const char *owner_region;
+  const char *generation_owner_field;
+  const char *const *identity_fields;
+  size_t identity_field_count;
+  const char *const *advances_on_transition_ids;
+  size_t advances_on_transition_id_count;
+  const char *stale_snapshot_policy;
+  const char *fail_closed_fallback;
+  const char *restore_boundary;
+  const char *enforcement_status;
+  const char *const *migration_notes;
+  size_t migration_note_count;
+} AppStateGenerationDomainMetadata;
+
 const AppStateActionTransitionMetadata *
 AppStateActionTransitionLookup(YtreeNovaAction action);
 size_t AppStateActionTransitionCount(void);
@@ -103,5 +120,9 @@ size_t AppStateInvariantCount(void);
 const AppStateOwnerFieldMetadata *AppStateOwnerFieldLookup(const char *field);
 const AppStateOwnerFieldMetadata *AppStateOwnerFieldAt(size_t index);
 size_t AppStateOwnerFieldCount(void);
+const AppStateGenerationDomainMetadata *
+AppStateGenerationDomainLookup(const char *domain_id);
+const AppStateGenerationDomainMetadata *AppStateGenerationDomainAt(size_t index);
+size_t AppStateGenerationDomainCount(void);
 
 #endif /* YTNOVA_APPSTATE_ACTIONS_H */

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -907,6 +907,107 @@ def _parse_runtime_invariant_registry(
     return records, failures
 
 
+def _parse_runtime_generation_domain_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    array_fields = {
+        "IdentityFields": "identity_fields",
+        "AdvancesOnTransitionIds": "advances_on_transition_ids",
+        "MigrationNotes": "migration_notes",
+    }
+    arrays: dict[str, list[str]] = {}
+    failures: list[str] = []
+    for table_prefix in array_fields:
+        array_re = re.compile(
+            r"static\s+const\s+char\s+\*const\s+"
+            rf"(kAppStateGenerationDomain{table_prefix}[0-9]+)\[\]\s*=\s*\{{"
+            r"(?P<body>.*?)\};",
+            re.S,
+        )
+        for array_match in array_re.finditer(source):
+            table_name = array_match.group(1)
+            values, array_failures = _parse_string_initializer_array(
+                array_match.group("body"),
+                table_name,
+            )
+            arrays[table_name] = values
+            failures.extend(array_failures)
+
+    match = re.search(
+        r"kAppStateGenerationDomains\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime generation domain registry"]
+
+    records: list[dict[str, Any]] = []
+    row_re = re.compile(
+        r"\{\s*\"(?P<domain_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<category>[^\"]*)\"\s*,"
+        r"\s*\"(?P<owner_region>[^\"]*)\"\s*,"
+        r"\s*\"(?P<generation_owner_field>[^\"]*)\"\s*,"
+        r"\s*(?P<identity_fields>kAppStateGenerationDomainIdentityFields[0-9]+)\s*,"
+        r"\s*sizeof\((?P=identity_fields)\)\s*/"
+        r"\s*sizeof\((?P=identity_fields)\[0\]\)\s*,"
+        r"\s*(?P<advances_on_transition_ids>"
+        r"kAppStateGenerationDomainAdvancesOnTransitionIds[0-9]+)\s*,"
+        r"\s*sizeof\((?P=advances_on_transition_ids)\)\s*/"
+        r"\s*sizeof\((?P=advances_on_transition_ids)\[0\]\)\s*,"
+        r"\s*\"(?P<stale_snapshot_policy>[^\"]*)\"\s*,"
+        r"\s*\"(?P<fail_closed_fallback>[^\"]*)\"\s*,"
+        r"\s*\"(?P<restore_boundary>[^\"]*)\"\s*,"
+        r"\s*\"(?P<enforcement_status>[^\"]*)\"\s*,"
+        r"\s*(?P<migration_notes>kAppStateGenerationDomainMigrationNotes[0-9]+)\s*,"
+        r"\s*sizeof\((?P=migration_notes)\)\s*/"
+        r"\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
+        re.S,
+    )
+    rows, row_failures = _split_top_level_initializer_rows(
+        match.group("body"),
+        "runtime_generation_domain",
+    )
+    failures.extend(row_failures)
+    for index, row in enumerate(rows):
+        row_match = row_re.fullmatch(row.strip())
+        if row_match is None:
+            failures.append(
+                f"runtime_generation_domain[{index}]: malformed runtime generation "
+                f"domain registry row: {_compact_initializer_snippet(row)}"
+            )
+            continue
+        record: dict[str, Any] = {
+            "domain_id": row_match.group("domain_id"),
+            "category": row_match.group("category"),
+            "owner_region": row_match.group("owner_region"),
+            "generation_owner_field": row_match.group("generation_owner_field"),
+            "stale_snapshot_policy": row_match.group("stale_snapshot_policy"),
+            "fail_closed_fallback": row_match.group("fail_closed_fallback"),
+            "restore_boundary": row_match.group("restore_boundary"),
+            "enforcement_status": row_match.group("enforcement_status"),
+        }
+        for table_prefix, field in array_fields.items():
+            table_name = row_match.group(field)
+            values = arrays.get(table_name)
+            if values is None:
+                failures.append(
+                    f"runtime_generation_domain[{index}]: unknown {field} "
+                    f"table: {table_name}"
+                )
+                values = []
+            record[field] = values
+        records.append(record)
+
+    if not records:
+        failures.append(f"{runtime_path}: runtime generation domain registry must not be empty")
+    return records, failures
+
+
 def _parse_runtime_shim_registry(
     runtime_path: Path,
 ) -> tuple[list[dict[str, Any]], list[str]]:
@@ -1354,6 +1455,140 @@ def _validate_runtime_invariant_registry(
         failures.append(
             f"{runtime_path}: runtime invariant registry missing invariant id(s): "
             + ", ".join(missing_ids)
+        )
+
+    return failures
+
+
+def _validate_runtime_generation_domain_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    generation_domain_records: list[Any],
+    runtime_owner_fields: set[str],
+    runtime_transition_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    expected_domains = {
+        record["domain_id"]: record
+        for record in generation_domain_records
+        if isinstance(record, dict)
+        and isinstance(record.get("domain_id"), str)
+        and record["domain_id"].strip()
+    }
+    expected_ids = set(expected_domains)
+    covered_ids: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_generation_domain[{index}]"
+        runtime_id = record["domain_id"]
+        if runtime_id in covered_ids:
+            failures.append(
+                f"{label}: duplicate runtime generation domain id: {runtime_id}"
+            )
+        covered_ids.add(runtime_id)
+
+        domain_record = expected_domains.get(runtime_id)
+        if domain_record is None:
+            failures.append(
+                f"{label}: domain_id does not match a generation domain id: {runtime_id}"
+            )
+        else:
+            for field in (
+                "category",
+                "owner_region",
+                "generation_owner_field",
+                "identity_fields",
+                "advances_on_transition_ids",
+                "stale_snapshot_policy",
+                "fail_closed_fallback",
+                "restore_boundary",
+                "enforcement_status",
+                "migration_notes",
+            ):
+                if record.get(field) != domain_record.get(field):
+                    failures.append(
+                        f"{label}: runtime {field} does not match generation "
+                        f"domain {runtime_id}: {record.get(field)}"
+                    )
+
+        for field in (
+            "domain_id",
+            "category",
+            "owner_region",
+            "generation_owner_field",
+            "stale_snapshot_policy",
+            "fail_closed_fallback",
+            "restore_boundary",
+            "enforcement_status",
+        ):
+            value = record.get(field)
+            if not isinstance(value, str) or not value.strip():
+                failures.append(f"{label}: {field} must be a non-empty string")
+
+        for field in ("identity_fields", "migration_notes"):
+            values = record.get(field)
+            if not isinstance(values, list) or not values:
+                failures.append(f"{label}: {field} must be non-empty")
+                continue
+            for value_index, value in enumerate(values):
+                if not isinstance(value, str) or not value.strip():
+                    failures.append(
+                        f"{label}: {field}[{value_index}] must be a non-empty string"
+                    )
+
+        transition_refs = record.get("advances_on_transition_ids")
+        if not isinstance(transition_refs, list):
+            failures.append(f"{label}: advances_on_transition_ids must be a list")
+        else:
+            for transition_index, transition_id in enumerate(transition_refs):
+                if not isinstance(transition_id, str) or not transition_id.strip():
+                    failures.append(
+                        f"{label}: advances_on_transition_ids[{transition_index}] "
+                        "must be a non-empty string"
+                    )
+
+        generation_owner_field = record.get("generation_owner_field")
+        if (
+            isinstance(generation_owner_field, str)
+            and generation_owner_field.strip()
+            and generation_owner_field not in runtime_owner_fields
+        ):
+            failures.append(
+                f"{label}: generation_owner_field does not match runtime owner "
+                f"field registry: {generation_owner_field}"
+            )
+
+        identity_fields = record.get("identity_fields")
+        if isinstance(identity_fields, list):
+            for field in identity_fields:
+                if (
+                    isinstance(field, str)
+                    and field.strip()
+                    and field not in runtime_owner_fields
+                ):
+                    failures.append(
+                        f"{label}: identity_fields does not match runtime owner "
+                        f"field registry: {field}"
+                    )
+
+        if isinstance(transition_refs, list):
+            for transition_id in transition_refs:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in runtime_transition_ids
+                ):
+                    failures.append(
+                        f"{label}: advances_on_transition_ids does not match "
+                        f"runtime transition registry: {transition_id}"
+                    )
+
+    missing_ids = sorted(expected_ids - covered_ids)
+    if missing_ids:
+        failures.append(
+            f"{runtime_path}: runtime generation domain registry missing "
+            "domain id(s): " + ", ".join(missing_ids)
         )
 
     return failures
@@ -2558,6 +2793,9 @@ def validate_contract(
     runtime_invariant_records, runtime_invariant_failures = (
         _parse_runtime_invariant_registry(action_runtime_path)
     )
+    runtime_generation_domain_records, runtime_generation_domain_failures = (
+        _parse_runtime_generation_domain_registry(action_runtime_path)
+    )
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
@@ -2575,6 +2813,7 @@ def validate_contract(
     failures.extend(runtime_dispatch_surface_failures)
     failures.extend(runtime_shim_failures)
     failures.extend(runtime_invariant_failures)
+    failures.extend(runtime_generation_domain_failures)
     if failures:
         return failures
 
@@ -2658,6 +2897,25 @@ def validate_contract(
         registered_owner_fields=registered_owner_fields,
     )
     failures.extend(generation_domain_failures)
+    if isinstance(generation_domains_doc, dict) and isinstance(
+        generation_domains_doc.get("generation_domains"), list
+    ):
+        generation_domain_records = generation_domains_doc["generation_domains"]
+    else:
+        generation_domain_records = []
+    failures.extend(
+        _validate_runtime_generation_domain_registry(
+            runtime_records=runtime_generation_domain_records,
+            runtime_path=action_runtime_path,
+            generation_domain_records=generation_domain_records,
+            runtime_owner_fields={
+                record["field"] for record in runtime_owner_field_records
+            },
+            runtime_transition_ids={
+                record["id"] for record in runtime_transition_records
+            },
+        )
+    )
     failures.extend(
         _validate_transition_generation_effects(
             transitions=transitions,

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -354,6 +354,388 @@ static const AppStateOwnerFieldMetadata kAppStateOwnerFields[] = {
    sizeof(kAppStateOwnerFieldInvariantChecks21) / sizeof(kAppStateOwnerFieldInvariantChecks21[0])},
 };
 
+static const char *const kAppStateGenerationDomainIdentityFields0[] = {
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.focus_shape",
+  "panel.restore_snapshot",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds0[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.menu-action.volume-select",
+  "transition.modal-action.dismiss",
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.terminal-signal-resize",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes0[] = {
+  "Runtime panel_generation is still documented foundation; later runtime migration must wire this field to the canonical panel UI state record.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields1[] = {
+  "ctx.volumes_head",
+  "volume.dir_tree",
+  "volume.logged_state",
+  "volume.payload_cache",
+  "panel.volume_key",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds1[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes1[] = {
+  "Runtime volume_generation is still documented foundation; later runtime migration must attach it to Volume topology and payload commits.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields2[] = {
+  "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "volume.dir_tree",
+  "volume.logged_state",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds2[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.volume-operation.release-cycle",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes2[] = {
+  "Directory identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative invalidation owner for topology changes.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields3[] = {
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+  "volume.payload_cache",
+  "volume.dir_tree",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds3[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes3[] = {
+  "File identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative owner for payload and namespace invalidation.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields4[] = {
+  "panel.focus_shape",
+  "panel.restore_snapshot",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds4[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.modal-action.dismiss",
+  "transition.menu-action.volume-select",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes4[] = {
+  "Focus-shape invalidation is represented by panel.panel_generation until a narrower runtime focus-shape generation exists.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields5[] = {
+  "ctx.modal_state",
+  "ctx.command_state",
+  "ctx.pending_transition",
+  "ctx.message_state",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds5[] = {
+  "transition.modal-action.dismiss",
+  "transition.command-completion.user-command",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes5[] = {
+  "No dedicated ctx command/modal generation exists yet; panel.panel_generation is the closest guard for command paths that restore focus or queue panel-local follow-up work.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields6[] = {
+  "panel.tree_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+  "volume.logged_state",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds6[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.keybinding.navigate-tree",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes6[] = {
+  "Dedicated filter and dotfile visibility owner fields are not registered yet; panel.panel_generation is the closest panel-local invalidation owner.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields7[] = {
+  "volume.dir_tree",
+  "volume.logged_state",
+  "ctx.volumes_head",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds7[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes7[] = {
+  "Topology generation is represented by volume.volume_generation until runtime Volume commit hooks are migrated.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields8[] = {
+  "volume.payload_cache",
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds8[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes8[] = {
+  "File payload invalidation uses volume.volume_generation until a narrower payload generation field is registered.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields9[] = {
+  "ctx.volumes_head",
+  "panel.volume_key",
+  "panel.restore_snapshot",
+  "volume.logged_state",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds9[] = {
+  "transition.volume-operation.release-cycle",
+  "transition.menu-action.volume-select",
+  "transition.refresh-rebuild.manual-refresh",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes9[] = {
+  "Volume lifecycle has no separate registry generation yet; volume.volume_generation is the closest shared invalidation owner while ctx.volumes_head remains the registry identity field.",
+};
+
+static const char *const kAppStateGenerationDomainIdentityFields10[] = {
+  "ctx.layout",
+  "ctx.window_handles",
+  "ctx.render_dirty_flags",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+};
+
+static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds10[] = {
+  "transition.terminal-signal-resize",
+};
+
+static const char *const kAppStateGenerationDomainMigrationNotes10[] = {
+  "Render projection itself is read-only/projection-only and does not advance generations; terminal resize uses panel.panel_generation only when saved viewport origins are corrected.",
+};
+
+static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
+  {"generation.panel.local-authority",
+   "panel_generation",
+   "panel-local state",
+   "panel.panel_generation",
+   kAppStateGenerationDomainIdentityFields0,
+   sizeof(kAppStateGenerationDomainIdentityFields0) /
+       sizeof(kAppStateGenerationDomainIdentityFields0[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds0,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds0) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds0[0]),
+   "Reject snapshots whose saved panel_generation does not match the panel-local generation marker before restore authority is applied.",
+   "Re-resolve by stable identity, then nearest visible ancestor, next visible sibling, previous visible sibling, and finally root visible node.",
+   "Canonical panel-anchor restore helpers commit panel-local selection, viewport, focus shape, and snapshot generation together.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes0,
+   sizeof(kAppStateGenerationDomainMigrationNotes0) /
+       sizeof(kAppStateGenerationDomainMigrationNotes0[0])},
+  {"generation.volume.shared-authority",
+   "volume_generation",
+   "volume/shared topology and payload state",
+   "volume.volume_generation",
+   kAppStateGenerationDomainIdentityFields1,
+   sizeof(kAppStateGenerationDomainIdentityFields1) /
+       sizeof(kAppStateGenerationDomainIdentityFields1[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds1,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds1) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds1[0]),
+   "Treat any saved volume_generation mismatch as stale and require topology/payload identity re-resolution before panel snapshots are reused.",
+   "Keep the previous settled topology on blocked transitions; after invalidation, rebind panels through stable identities or fall back to root visible node.",
+   "Refresh/rebuild and mutation-result commits advance volume generation before panel restore consumers can observe the changed volume.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes1,
+   sizeof(kAppStateGenerationDomainMigrationNotes1) /
+       sizeof(kAppStateGenerationDomainMigrationNotes1[0])},
+  {"identity.directory.stable-key",
+   "directory_identity",
+   "panel-local state plus volume/shared topology and payload state",
+   "volume.volume_generation",
+   kAppStateGenerationDomainIdentityFields2,
+   sizeof(kAppStateGenerationDomainIdentityFields2) /
+       sizeof(kAppStateGenerationDomainIdentityFields2[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds2,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds2) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds2[0]),
+   "Directory snapshots must compare stable path identity against the current volume generation before row or cursor state is trusted.",
+   "Exact directory identity, nearest visible ancestor, next visible sibling, previous visible sibling, then root visible node.",
+   "Directory rebind runs through panel-anchor helpers after the shared topology generation has settled.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes2,
+   sizeof(kAppStateGenerationDomainMigrationNotes2) /
+       sizeof(kAppStateGenerationDomainMigrationNotes2[0])},
+  {"identity.file.stable-key",
+   "file_identity",
+   "panel-local state plus volume/shared topology and payload state",
+   "volume.volume_generation",
+   kAppStateGenerationDomainIdentityFields3,
+   sizeof(kAppStateGenerationDomainIdentityFields3) /
+       sizeof(kAppStateGenerationDomainIdentityFields3[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds3,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds3) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds3[0]),
+   "File snapshots must revalidate path/name identity and payload membership when volume generation changes.",
+   "Preserve the directory anchor when possible and choose a valid visible file only after exact file identity is unavailable.",
+   "File identity restore is committed with the panel snapshot after topology or payload mutation has settled.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes3,
+   sizeof(kAppStateGenerationDomainMigrationNotes3) /
+       sizeof(kAppStateGenerationDomainMigrationNotes3[0])},
+  {"shape.panel.focus",
+   "focus_shape",
+   "panel-local state",
+   "panel.panel_generation",
+   kAppStateGenerationDomainIdentityFields4,
+   sizeof(kAppStateGenerationDomainIdentityFields4) /
+       sizeof(kAppStateGenerationDomainIdentityFields4[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds4,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds4) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds4[0]),
+   "Saved focus shape is stale when panel_generation differs and must not be restored by transient render shape.",
+   "Restore the recorded panel shape directly or keep the current settled shape without rendering an intermediate guess.",
+   "Modal dismissal, panel reactivation, and rebind callbacks commit focus shape only through panel-local state.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes4,
+   sizeof(kAppStateGenerationDomainMigrationNotes4) /
+       sizeof(kAppStateGenerationDomainMigrationNotes4[0])},
+  {"target.modal-command.session",
+   "modal_command_target",
+   "ctx/session state",
+   "panel.panel_generation",
+   kAppStateGenerationDomainIdentityFields5,
+   sizeof(kAppStateGenerationDomainIdentityFields5) /
+       sizeof(kAppStateGenerationDomainIdentityFields5[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds5,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds5) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds5[0]),
+   "Modal and command targets may write panel or volume state only through a declared follow-up transition boundary.",
+   "On blocked or failed command completion, preserve authoritative panel and volume state and write only declared message/modal fields.",
+   "Modal dismissal and command completion settle session state before any panel restore or refresh follow-up observes the result.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes5,
+   sizeof(kAppStateGenerationDomainMigrationNotes5) /
+       sizeof(kAppStateGenerationDomainMigrationNotes5[0])},
+  {"state.visibility-filter.panel-volume",
+   "visibility_filter_state",
+   "panel-local state plus volume/shared topology and payload state",
+   "panel.panel_generation",
+   kAppStateGenerationDomainIdentityFields6,
+   sizeof(kAppStateGenerationDomainIdentityFields6) /
+       sizeof(kAppStateGenerationDomainIdentityFields6[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds6,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds6) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds6[0]),
+   "Visibility/filter changes that alter rendered rows invalidate saved panel anchors before any snapshot can be reused.",
+   "Rebind visible identity through the deterministic fallback order rather than deriving from hidden or filtered row indexes.",
+   "Visibility-filter commits update panel generation before rebind and render projection.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes6,
+   sizeof(kAppStateGenerationDomainMigrationNotes6) /
+       sizeof(kAppStateGenerationDomainMigrationNotes6[0])},
+  {"state.topology.volume",
+   "topology_state",
+   "volume/shared topology and payload state",
+   "volume.volume_generation",
+   kAppStateGenerationDomainIdentityFields7,
+   sizeof(kAppStateGenerationDomainIdentityFields7) /
+       sizeof(kAppStateGenerationDomainIdentityFields7[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds7,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds7) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds7[0]),
+   "Topology snapshots are invalid after any volume_generation advance and must be rebuilt or rebound by identity.",
+   "Blocked topology changes retain the previous settled tree; completed invalidation falls back panel anchors only after exact identity fails.",
+   "Topology rebuild commits settle volume.dir_tree and volume.logged_state before panel rebind callbacks run.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes7,
+   sizeof(kAppStateGenerationDomainMigrationNotes7) /
+       sizeof(kAppStateGenerationDomainMigrationNotes7[0])},
+  {"state.file-payload.volume",
+   "file_payload_state",
+   "volume/shared topology and payload state",
+   "volume.volume_generation",
+   kAppStateGenerationDomainIdentityFields8,
+   sizeof(kAppStateGenerationDomainIdentityFields8) /
+       sizeof(kAppStateGenerationDomainIdentityFields8[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds8,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds8) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds8[0]),
+   "Payload cache identity must be revalidated on generation mismatch before saved file selection is restored.",
+   "If payload cannot be loaded safely, preserve directory selection and leave file authority unchanged or empty according to current AppState.",
+   "Payload changes settle in Volume before panel file anchors are rebound.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes8,
+   sizeof(kAppStateGenerationDomainMigrationNotes8) /
+       sizeof(kAppStateGenerationDomainMigrationNotes8[0])},
+  {"lifecycle.volume.registry",
+   "volume_lifecycle",
+   "ctx/session state plus volume/shared topology and payload state",
+   "volume.volume_generation",
+   kAppStateGenerationDomainIdentityFields9,
+   sizeof(kAppStateGenerationDomainIdentityFields9) /
+       sizeof(kAppStateGenerationDomainIdentityFields9[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds9,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds9) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds9[0]),
+   "Panel volume bindings must resolve to an existing volume identity before per-volume snapshots can be restored.",
+   "Do not orphan panel bindings; use deterministic volume fallback and then panel identity fallback after release or cycle invalidation.",
+   "Volume lifecycle transitions update registry/binding state before panel-local restore snapshots are applied.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes9,
+   sizeof(kAppStateGenerationDomainMigrationNotes9) /
+       sizeof(kAppStateGenerationDomainMigrationNotes9[0])},
+  {"reflow.layout.projection",
+   "layout_reflow",
+   "render/projection/invalidation state",
+   "panel.panel_generation",
+   kAppStateGenerationDomainIdentityFields10,
+   sizeof(kAppStateGenerationDomainIdentityFields10) /
+       sizeof(kAppStateGenerationDomainIdentityFields10[0]),
+   kAppStateGenerationDomainAdvancesOnTransitionIds10,
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds10) /
+       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds10[0]),
+   "Layout reflow must project from settled AppState and may advance panel generation only for viewport bounds correction.",
+   "If safe projection cannot be computed, degrade or skip render without choosing new authoritative identities.",
+   "Resize handling runs in the main loop and commits any viewport correction before render projection.",
+   "documented_foundation_only",
+   kAppStateGenerationDomainMigrationNotes10,
+   sizeof(kAppStateGenerationDomainMigrationNotes10) /
+       sizeof(kAppStateGenerationDomainMigrationNotes10[0])},
+};
 static const char *const kAppStateDispatchSurfaceMigrationNotes0[] = {
   "Current input polling and key normalization feed controller dispatch; AppState mutation remains in downstream handlers until runtime transition objects are introduced.",
 };
@@ -1252,11 +1634,23 @@ size_t AppStateOwnerFieldCount(void) {
   return sizeof(kAppStateOwnerFields) / sizeof(kAppStateOwnerFields[0]);
 }
 
+size_t AppStateGenerationDomainCount(void) {
+  return sizeof(kAppStateGenerationDomains) / sizeof(kAppStateGenerationDomains[0]);
+}
+
 const AppStateOwnerFieldMetadata *AppStateOwnerFieldAt(size_t index) {
   if (index >= AppStateOwnerFieldCount())
     return NULL;
 
   return &kAppStateOwnerFields[index];
+}
+
+const AppStateGenerationDomainMetadata *
+AppStateGenerationDomainAt(size_t index) {
+  if (index >= AppStateGenerationDomainCount())
+    return NULL;
+
+  return &kAppStateGenerationDomains[index];
 }
 
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
@@ -1298,6 +1692,21 @@ AppStateOwnerFieldLookup(const char *field) {
   for (index = 0; index < AppStateOwnerFieldCount(); index++) {
     if (!strcmp(kAppStateOwnerFields[index].field, field))
       return &kAppStateOwnerFields[index];
+  }
+
+  return NULL;
+}
+
+const AppStateGenerationDomainMetadata *
+AppStateGenerationDomainLookup(const char *domain_id) {
+  size_t index;
+
+  if (domain_id == NULL || domain_id[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateGenerationDomainCount(); index++) {
+    if (!strcmp(kAppStateGenerationDomains[index].domain_id, domain_id))
+      return &kAppStateGenerationDomains[index];
   }
 
   return NULL;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -132,6 +132,65 @@ static int AppStateTransitionRegistryReady(void) {
   return 1;
 }
 
+static int AppStateGenerationDomainsReady(void) {
+  size_t index;
+
+  if (AppStateGenerationDomainCount() == 0)
+    return 0;
+
+  for (index = 0; index < AppStateGenerationDomainCount(); index++) {
+    const AppStateGenerationDomainMetadata *metadata =
+        AppStateGenerationDomainAt(index);
+    size_t field_index;
+    size_t transition_index;
+
+    if (metadata == NULL || !NonEmptyString(metadata->domain_id) ||
+        !NonEmptyString(metadata->category) ||
+        !NonEmptyString(metadata->owner_region) ||
+        !NonEmptyString(metadata->generation_owner_field) ||
+        !NonEmptyString(metadata->stale_snapshot_policy) ||
+        !NonEmptyString(metadata->fail_closed_fallback) ||
+        !NonEmptyString(metadata->restore_boundary) ||
+        !NonEmptyString(metadata->enforcement_status) ||
+        !NonEmptyStringList(metadata->identity_fields,
+                            metadata->identity_field_count) ||
+        !NonEmptyStringList(metadata->advances_on_transition_ids,
+                            metadata->advances_on_transition_id_count) ||
+        !NonEmptyStringList(metadata->migration_notes,
+                            metadata->migration_note_count))
+      return 0;
+    if (AppStateGenerationDomainLookup(metadata->domain_id) != metadata)
+      return 0;
+    if (AppStateOwnerFieldLookup(metadata->generation_owner_field) == NULL)
+      return 0;
+
+    for (field_index = 0; field_index < metadata->identity_field_count;
+         field_index++) {
+      if (AppStateOwnerFieldLookup(metadata->identity_fields[field_index]) ==
+          NULL)
+        return 0;
+    }
+    for (transition_index = 0;
+         transition_index < metadata->advances_on_transition_id_count;
+         transition_index++) {
+      if (AppStateTransitionLookup(
+              metadata->advances_on_transition_ids[transition_index]) == NULL)
+        return 0;
+    }
+  }
+
+  if (AppStateGenerationDomainAt(AppStateGenerationDomainCount()) != NULL)
+    return 0;
+  if (AppStateGenerationDomainLookup(NULL) != NULL)
+    return 0;
+  if (AppStateGenerationDomainLookup("") != NULL)
+    return 0;
+  if (AppStateGenerationDomainLookup("generation.__ytnova_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
 static int AppStateDispatchSurfaceWritesReady(
     const AppStateDispatchSurfaceMetadata *metadata) {
   if (metadata->allowed_direct_write_count == 0)
@@ -381,6 +440,7 @@ int main(int argc, char **argv) {
   if (!CoreMainOpsReady(&ctx.core_main_ops) ||
       !AppStateOwnerFieldsReady() ||
       !AppStateTransitionRegistryReady() ||
+      !AppStateGenerationDomainsReady() ||
       !AppStateDispatchSurfacesReady() ||
       !AppStateInvariantRegistryReady() ||
       !AppStateCompatibilityShimsReady() ||

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -334,6 +334,7 @@ def _write_fixture(
     runtime_shims: list[dict[str, object]] | None = None,
     runtime_invariants: list[dict[str, object]] | None = None,
     runtime_owner_fields: list[dict[str, object]] | None = None,
+    runtime_generation_domains: list[dict[str, object]] | None = None,
 ) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
@@ -438,6 +439,13 @@ def _write_fixture(
             runtime_invariants
             if runtime_invariants is not None
             else (invariants if invariants is not None else _complete_invariants()),
+            runtime_generation_domains
+            if runtime_generation_domains is not None
+            else (
+                generation_domains
+                if generation_domains is not None
+                else _complete_generation_domains()
+            ),
         ),
     )
     return (
@@ -474,6 +482,7 @@ def _runtime_source(
     dispatch_surfaces: list[dict[str, object]],
     shims: list[dict[str, object]],
     invariants: list[dict[str, object]],
+    generation_domains: list[dict[str, object]],
 ) -> str:
     transition_write_sets = []
     transition_rows = []
@@ -628,6 +637,44 @@ def _runtime_source(
             f"sizeof(kAppStateInvariantMigrationNotes{index}) / "
             f"sizeof(kAppStateInvariantMigrationNotes{index}[0])}},"
         )
+    generation_domain_arrays = []
+    generation_domain_rows = []
+    generation_domain_list_fields = (
+        ("identity_fields", "IdentityFields"),
+        ("advances_on_transition_ids", "AdvancesOnTransitionIds"),
+        ("migration_notes", "MigrationNotes"),
+    )
+    for index, record in enumerate(generation_domains):
+        for field, prefix in generation_domain_list_fields:
+            values = record.get(field)
+            if not isinstance(values, list):
+                values = []
+            rows = "\n".join(
+                f'  "{value}",' for value in values if isinstance(value, str)
+            )
+            generation_domain_arrays.append(
+                f"static const char *const kAppStateGenerationDomain{prefix}{index}[] "
+                f"= {{\n{rows}\n}};\n"
+            )
+        generation_domain_rows.append(
+            f'  {{"{record.get("domain_id", "")}", '
+            f'"{record.get("category", "")}", '
+            f'"{record.get("owner_region", "")}", '
+            f'"{record.get("generation_owner_field", "")}", '
+            f"kAppStateGenerationDomainIdentityFields{index}, "
+            f"sizeof(kAppStateGenerationDomainIdentityFields{index}) / "
+            f"sizeof(kAppStateGenerationDomainIdentityFields{index}[0]), "
+            f"kAppStateGenerationDomainAdvancesOnTransitionIds{index}, "
+            f"sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds{index}) / "
+            f"sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds{index}[0]), "
+            f'"{record.get("stale_snapshot_policy", "")}", '
+            f'"{record.get("fail_closed_fallback", "")}", '
+            f'"{record.get("restore_boundary", "")}", '
+            f'"{record.get("enforcement_status", "")}", '
+            f"kAppStateGenerationDomainMigrationNotes{index}, "
+            f"sizeof(kAppStateGenerationDomainMigrationNotes{index}) / "
+            f"sizeof(kAppStateGenerationDomainMigrationNotes{index}[0])}},"
+        )
     action_rows = "\n".join(
         f'  {{{record["action"]}, "{record["transition_id"]}", "{record["category"]}"}},'
         for record in actions
@@ -638,6 +685,7 @@ def _runtime_source(
         + "".join(dispatch_surface_arrays)
         + "".join(shim_invariants)
         + "".join(invariant_arrays)
+        + "".join(generation_domain_arrays)
         + "static const AppStateTransitionMetadata kAppStateTransitions[] = {\n"
         + "\n".join(transition_rows)
         + "\n};\n"
@@ -651,6 +699,10 @@ def _runtime_source(
         "static const AppStateCompatibilityShimMetadata "
         "kAppStateCompatibilityShims[] = {\n"
         + "\n".join(shim_rows)
+        + "\n};\n"
+        "static const AppStateGenerationDomainMetadata "
+        "kAppStateGenerationDomains[] = {\n"
+        + "\n".join(generation_domain_rows)
         + "\n};\n"
         "static const AppStateInvariantMetadata kAppStateInvariants[] = {\n"
         + "\n".join(invariant_rows)
@@ -1469,6 +1521,209 @@ def test_guard_accepts_empty_generation_domain_advances_with_projection_note(
     failures = _validate(paths)
 
     assert failures == []
+
+
+def test_guard_fails_when_runtime_generation_domain_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()[1:]
+    missing_domain_id = _complete_generation_domains()[0]["domain_id"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime generation domain registry missing domain id(s)" in failure
+        and missing_domain_id in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_is_extra(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()
+    runtime_generation_domains.append(
+        _generation_domain("panel_generation", "domain.extra")
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain" in failure
+        and "domain_id does not match a generation domain id" in failure
+        and "domain.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_is_duplicate(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()
+    runtime_generation_domains[1]["domain_id"] = runtime_generation_domains[0][
+        "domain_id"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain[1]" in failure
+        and "duplicate runtime generation domain id" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_row_is_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(tmp_path, transitions=transitions)
+    runtime_path = paths[-1]
+    runtime_path.write_text(
+        runtime_path.read_text(encoding="utf-8").replace(
+            "static const AppStateGenerationDomainMetadata "
+            "kAppStateGenerationDomains[] = {\n",
+            "static const AppStateGenerationDomainMetadata "
+            "kAppStateGenerationDomains[] = {\n"
+            '  {"domain.malformed"},\n',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and "malformed runtime generation domain registry row" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_list_entry_is_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(tmp_path, transitions=transitions)
+    runtime_path = paths[-1]
+    runtime_path.write_text(
+        runtime_path.read_text(encoding="utf-8").replace(
+            'static const char *const kAppStateGenerationDomainIdentityFields0[] '
+            '= {\n  "field",\n};',
+            "static const char *const kAppStateGenerationDomainIdentityFields0[] "
+            "= {\n  123,\n};",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateGenerationDomainIdentityFields0[0]" in failure
+        and "malformed string literal entry" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_owner_link_is_invalid(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()
+    runtime_generation_domains[0]["generation_owner_field"] = "field.missing"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and "generation_owner_field does not match runtime owner field registry"
+        in failure
+        and "field.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_transition_link_is_invalid(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()
+    runtime_generation_domains[0]["advances_on_transition_ids"] = [
+        "transition.missing"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and "advances_on_transition_ids does not match runtime transition registry"
+        in failure
+        and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_stale_boundary_fields_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()
+    runtime_generation_domains[0]["stale_snapshot_policy"] = "changed stale policy"
+    runtime_generation_domains[0]["fail_closed_fallback"] = "changed fallback"
+    runtime_generation_domains[0]["restore_boundary"] = "changed boundary"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and "runtime stale_snapshot_policy does not match generation domain"
+        in failure
+        for failure in failures
+    )
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and "runtime fail_closed_fallback does not match generation domain" in failure
+        for failure in failures
+    )
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and "runtime restore_boundary does not match generation domain" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_when_generation_effect_names_unregistered_generation_field(


### PR DESCRIPTION
## Summary
- Adds read-only runtime lookup metadata for AppState generation domains.
- Validates generation-domain registry shape, owner-field linkage, transition linkage, and stale-snapshot boundary fields at startup.
- Extends the AppState contract guard/tests to catch runtime/docs drift, malformed metadata, and invalid generation-domain linkage.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `make qa-cppcheck && make qa-code-quality && git diff --check`
