### PR TITLE
chore(appstate): add diff harness lookup

### DIFF
--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -97,6 +97,28 @@ typedef struct {
   size_t migration_note_count;
 } AppStateGenerationDomainMetadata;
 
+typedef struct {
+  const char *harness_id;
+  const char *check_category;
+  const char *const *snapshot_phases;
+  size_t snapshot_phase_count;
+  const char *const *snapshot_regions;
+  size_t snapshot_region_count;
+  const char *const *transition_ids;
+  size_t transition_id_count;
+  const char *const *owner_field_refs;
+  size_t owner_field_ref_count;
+  const char *const *invariant_ids;
+  size_t invariant_id_count;
+  const char *const *generation_domain_ids;
+  size_t generation_domain_id_count;
+  const char *expected_behavior;
+  const char *failure_mode;
+  const char *enforcement_status;
+  const char *const *migration_notes;
+  size_t migration_note_count;
+} AppStateDiffHarnessMetadata;
+
 const AppStateActionTransitionMetadata *
 AppStateActionTransitionLookup(YtreeNovaAction action);
 size_t AppStateActionTransitionCount(void);
@@ -124,5 +146,9 @@ const AppStateGenerationDomainMetadata *
 AppStateGenerationDomainLookup(const char *domain_id);
 const AppStateGenerationDomainMetadata *AppStateGenerationDomainAt(size_t index);
 size_t AppStateGenerationDomainCount(void);
+const AppStateDiffHarnessMetadata *
+AppStateDiffHarnessLookup(const char *harness_id);
+const AppStateDiffHarnessMetadata *AppStateDiffHarnessAt(size_t index);
+size_t AppStateDiffHarnessCount(void);
 
 #endif /* YTNOVA_APPSTATE_ACTIONS_H */

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -1008,6 +1008,117 @@ def _parse_runtime_generation_domain_registry(
     return records, failures
 
 
+def _parse_runtime_diff_harness_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    array_fields = {
+        "SnapshotPhases": "snapshot_phases",
+        "SnapshotRegions": "snapshot_regions",
+        "TransitionIds": "transition_ids",
+        "OwnerFieldRefs": "owner_field_refs",
+        "InvariantIds": "invariant_ids",
+        "GenerationDomainIds": "generation_domain_ids",
+        "MigrationNotes": "migration_notes",
+    }
+    arrays: dict[str, list[str]] = {}
+    failures: list[str] = []
+    for table_prefix in array_fields:
+        array_re = re.compile(
+            r"static\s+const\s+char\s+\*const\s+"
+            rf"(kAppStateDiffHarness{table_prefix}[0-9]+)\[\]\s*=\s*\{{"
+            r"(?P<body>.*?)\};",
+            re.S,
+        )
+        for array_match in array_re.finditer(source):
+            table_name = array_match.group(1)
+            values, array_failures = _parse_string_initializer_array(
+                array_match.group("body"),
+                table_name,
+            )
+            arrays[table_name] = values
+            failures.extend(array_failures)
+
+    match = re.search(
+        r"kAppStateDiffHarnesses\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime diff harness registry"]
+
+    records: list[dict[str, Any]] = []
+    row_re = re.compile(
+        r"\{\s*\"(?P<harness_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<check_category>[^\"]*)\"\s*,"
+        r"\s*(?P<snapshot_phases>kAppStateDiffHarnessSnapshotPhases[0-9]+)\s*,"
+        r"\s*sizeof\((?P=snapshot_phases)\)\s*/"
+        r"\s*sizeof\((?P=snapshot_phases)\[0\]\)\s*,"
+        r"\s*(?P<snapshot_regions>kAppStateDiffHarnessSnapshotRegions[0-9]+)\s*,"
+        r"\s*sizeof\((?P=snapshot_regions)\)\s*/"
+        r"\s*sizeof\((?P=snapshot_regions)\[0\]\)\s*,"
+        r"\s*(?P<transition_ids>kAppStateDiffHarnessTransitionIds[0-9]+)\s*,"
+        r"\s*sizeof\((?P=transition_ids)\)\s*/"
+        r"\s*sizeof\((?P=transition_ids)\[0\]\)\s*,"
+        r"\s*(?P<owner_field_refs>kAppStateDiffHarnessOwnerFieldRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=owner_field_refs)\)\s*/"
+        r"\s*sizeof\((?P=owner_field_refs)\[0\]\)\s*,"
+        r"\s*(?P<invariant_ids>kAppStateDiffHarnessInvariantIds[0-9]+)\s*,"
+        r"\s*sizeof\((?P=invariant_ids)\)\s*/"
+        r"\s*sizeof\((?P=invariant_ids)\[0\]\)\s*,"
+        r"\s*(?P<generation_domain_ids>"
+        r"kAppStateDiffHarnessGenerationDomainIds[0-9]+)\s*,"
+        r"\s*sizeof\((?P=generation_domain_ids)\)\s*/"
+        r"\s*sizeof\((?P=generation_domain_ids)\[0\]\)\s*,"
+        r"\s*\"(?P<expected_behavior>[^\"]*)\"\s*,"
+        r"\s*\"(?P<failure_mode>[^\"]*)\"\s*,"
+        r"\s*\"(?P<enforcement_status>[^\"]*)\"\s*,"
+        r"\s*(?P<migration_notes>kAppStateDiffHarnessMigrationNotes[0-9]+)\s*,"
+        r"\s*sizeof\((?P=migration_notes)\)\s*/"
+        r"\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
+        re.S,
+    )
+    rows, row_failures = _split_top_level_initializer_rows(
+        match.group("body"),
+        "runtime_diff_harness",
+    )
+    failures.extend(row_failures)
+    for index, row in enumerate(rows):
+        row_match = row_re.fullmatch(row.strip())
+        if row_match is None:
+            failures.append(
+                f"runtime_diff_harness[{index}]: malformed runtime diff harness "
+                f"registry row: {_compact_initializer_snippet(row)}"
+            )
+            continue
+        record: dict[str, Any] = {
+            "harness_id": row_match.group("harness_id"),
+            "check_category": row_match.group("check_category"),
+            "expected_behavior": row_match.group("expected_behavior"),
+            "failure_mode": row_match.group("failure_mode"),
+            "enforcement_status": row_match.group("enforcement_status"),
+        }
+        for table_prefix, field in array_fields.items():
+            table_name = row_match.group(field)
+            values = arrays.get(table_name)
+            if values is None:
+                failures.append(
+                    f"runtime_diff_harness[{index}]: unknown {field} "
+                    f"table: {table_name}"
+                )
+                values = []
+            record[field] = values
+        records.append(record)
+
+    if not records:
+        failures.append(f"{runtime_path}: runtime diff harness registry must not be empty")
+    return records, failures
+
+
 def _parse_runtime_shim_registry(
     runtime_path: Path,
 ) -> tuple[list[dict[str, Any]], list[str]]:
@@ -1589,6 +1700,131 @@ def _validate_runtime_generation_domain_registry(
         failures.append(
             f"{runtime_path}: runtime generation domain registry missing "
             "domain id(s): " + ", ".join(missing_ids)
+        )
+
+    return failures
+
+
+def _validate_runtime_diff_harness_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    diff_harness_records: list[Any],
+    runtime_transition_ids: set[str],
+    runtime_owner_fields: set[str],
+    runtime_invariant_ids: set[str],
+    runtime_generation_domain_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    expected_harnesses = {
+        record["harness_id"]: record
+        for record in diff_harness_records
+        if isinstance(record, dict)
+        and isinstance(record.get("harness_id"), str)
+        and record["harness_id"].strip()
+    }
+    expected_ids = set(expected_harnesses)
+    covered_ids: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_diff_harness[{index}]"
+        runtime_id = record["harness_id"]
+        if runtime_id in covered_ids:
+            failures.append(f"{label}: duplicate runtime diff harness id: {runtime_id}")
+        covered_ids.add(runtime_id)
+
+        harness_record = expected_harnesses.get(runtime_id)
+        if harness_record is None:
+            failures.append(
+                f"{label}: harness_id does not match a diff harness id: {runtime_id}"
+            )
+        else:
+            for field in REQUIRED_DIFF_HARNESS_FIELDS:
+                if record.get(field) != harness_record.get(field):
+                    failures.append(
+                        f"{label}: runtime {field} does not match diff harness "
+                        f"{runtime_id}: {record.get(field)}"
+                    )
+
+        for field in (
+            "harness_id",
+            "check_category",
+            "expected_behavior",
+            "failure_mode",
+            "enforcement_status",
+        ):
+            value = record.get(field)
+            if not isinstance(value, str) or not value.strip():
+                failures.append(f"{label}: {field} must be a non-empty string")
+
+        for field in DIFF_HARNESS_LIST_FIELDS:
+            values = record.get(field)
+            if not isinstance(values, list) or not values:
+                failures.append(f"{label}: {field} must be non-empty")
+                continue
+            for value_index, value in enumerate(values):
+                if not isinstance(value, str) or not value.strip():
+                    failures.append(
+                        f"{label}: {field}[{value_index}] must be a non-empty string"
+                    )
+
+        transition_refs = record.get("transition_ids")
+        if isinstance(transition_refs, list):
+            for transition_id in transition_refs:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in runtime_transition_ids
+                ):
+                    failures.append(
+                        f"{label}: transition_ids does not match runtime transition "
+                        f"registry: {transition_id}"
+                    )
+
+        owner_field_refs = record.get("owner_field_refs")
+        if isinstance(owner_field_refs, list):
+            for field in owner_field_refs:
+                if (
+                    isinstance(field, str)
+                    and field.strip()
+                    and field not in runtime_owner_fields
+                ):
+                    failures.append(
+                        f"{label}: owner_field_refs does not match runtime owner "
+                        f"field registry: {field}"
+                    )
+
+        invariant_refs = record.get("invariant_ids")
+        if isinstance(invariant_refs, list):
+            for invariant_id in invariant_refs:
+                if (
+                    isinstance(invariant_id, str)
+                    and invariant_id.strip()
+                    and invariant_id not in runtime_invariant_ids
+                ):
+                    failures.append(
+                        f"{label}: invariant_ids does not match runtime invariant "
+                        f"registry: {invariant_id}"
+                    )
+
+        generation_domain_refs = record.get("generation_domain_ids")
+        if isinstance(generation_domain_refs, list):
+            for domain_id in generation_domain_refs:
+                if (
+                    isinstance(domain_id, str)
+                    and domain_id.strip()
+                    and domain_id not in runtime_generation_domain_ids
+                ):
+                    failures.append(
+                        f"{label}: generation_domain_ids does not match runtime "
+                        f"generation domain registry: {domain_id}"
+                    )
+
+    missing_ids = sorted(expected_ids - covered_ids)
+    if missing_ids:
+        failures.append(
+            f"{runtime_path}: runtime diff harness registry missing harness id(s): "
+            + ", ".join(missing_ids)
         )
 
     return failures
@@ -2796,6 +3032,9 @@ def validate_contract(
     runtime_generation_domain_records, runtime_generation_domain_failures = (
         _parse_runtime_generation_domain_registry(action_runtime_path)
     )
+    runtime_diff_harness_records, runtime_diff_harness_failures = (
+        _parse_runtime_diff_harness_registry(action_runtime_path)
+    )
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
@@ -2814,6 +3053,7 @@ def validate_contract(
     failures.extend(runtime_shim_failures)
     failures.extend(runtime_invariant_failures)
     failures.extend(runtime_generation_domain_failures)
+    failures.extend(runtime_diff_harness_failures)
     if failures:
         return failures
 
@@ -3131,6 +3371,31 @@ def validate_contract(
             registered_owner_fields=registered_owner_fields,
             invariant_ids=invariant_ids,
             generation_domain_ids=generation_domain_ids,
+        )
+    )
+    if isinstance(diff_harness_doc, dict) and isinstance(
+        diff_harness_doc.get("diff_harness_checks"), list
+    ):
+        diff_harness_records = diff_harness_doc["diff_harness_checks"]
+    else:
+        diff_harness_records = []
+    failures.extend(
+        _validate_runtime_diff_harness_registry(
+            runtime_records=runtime_diff_harness_records,
+            runtime_path=action_runtime_path,
+            diff_harness_records=diff_harness_records,
+            runtime_transition_ids={
+                record["id"] for record in runtime_transition_records
+            },
+            runtime_owner_fields={
+                record["field"] for record in runtime_owner_field_records
+            },
+            runtime_invariant_ids={
+                record["invariant_id"] for record in runtime_invariant_records
+            },
+            runtime_generation_domain_ids={
+                record["domain_id"] for record in runtime_generation_domain_records
+            },
         )
     )
     action_ids = _collect_string_ids(

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -736,6 +736,333 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    sizeof(kAppStateGenerationDomainMigrationNotes10) /
        sizeof(kAppStateGenerationDomainMigrationNotes10[0])},
 };
+
+static const char *const kAppStateDiffHarnessSnapshotPhases0[] = {
+  "before_guard",
+  "after_allowed_or_blocked_result",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotRegions0[] = {
+  "ctx/session state",
+  "panel-local state",
+  "volume/shared topology and payload state",
+  "render/projection/invalidation state",
+};
+
+static const char *const kAppStateDiffHarnessTransitionIds0[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+
+static const char *const kAppStateDiffHarnessOwnerFieldRefs0[] = {
+  "ctx.active",
+  "ctx.volumes_head",
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+  "volume.dir_tree",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateDiffHarnessInvariantIds0[] = {
+  "invariant.inactive-panel-frozen",
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.viewport-identity-rebind",
+};
+
+static const char *const kAppStateDiffHarnessGenerationDomainIds0[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+};
+
+static const char *const kAppStateDiffHarnessMigrationNotes0[] = {
+  "This registry entry defines the machine-readable coverage target; no runtime C runner exists in this unit.",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotPhases1[] = {
+  "before_transition",
+  "after_transition_commit",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotRegions1[] = {
+  "ctx/session state",
+  "panel-local state",
+  "volume/shared topology and payload state",
+};
+
+static const char *const kAppStateDiffHarnessTransitionIds1[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.menu-action.volume-select",
+  "transition.modal-action.dismiss",
+  "transition.command-completion.user-command",
+};
+
+static const char *const kAppStateDiffHarnessOwnerFieldRefs1[] = {
+  "ctx.command_state",
+  "ctx.message_state",
+  "ctx.modal_state",
+  "ctx.pending_transition",
+  "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.focus_shape",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateDiffHarnessInvariantIds1[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.shared-state-panel-local-isolation",
+};
+
+static const char *const kAppStateDiffHarnessGenerationDomainIds1[] = {
+  "generation.panel.local-authority",
+  "shape.panel.focus",
+  "target.modal-command.session",
+};
+
+static const char *const kAppStateDiffHarnessMigrationNotes1[] = {
+  "Runtime migration should derive concrete field comparisons from docs/appstate_transition_matrix.json declared_write_set records.",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotPhases2[] = {
+  "before_render_projection",
+  "after_render_projection",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotRegions2[] = {
+  "panel-local state",
+  "volume/shared topology and payload state",
+  "render/projection/invalidation state",
+};
+
+static const char *const kAppStateDiffHarnessTransitionIds2[] = {
+  "transition.render-reflow.project-state",
+};
+
+static const char *const kAppStateDiffHarnessOwnerFieldRefs2[] = {
+  "ctx.render_dirty_flags",
+  "ctx.window_handles",
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.focus_shape",
+  "panel.panel_generation",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateDiffHarnessInvariantIds2[] = {
+  "invariant.render-projection-read-only",
+  "invariant.inactive-panel-frozen",
+};
+
+static const char *const kAppStateDiffHarnessGenerationDomainIds2[] = {
+  "reflow.layout.projection",
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+};
+
+static const char *const kAppStateDiffHarnessMigrationNotes2[] = {
+  "Dirty-flag clearing and window-handle staging remain named so the future harness can distinguish projection bookkeeping from selection authority.",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotPhases3[] = {
+  "saved_snapshot",
+  "current_authority",
+  "restore_attempt_result",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotRegions3[] = {
+  "panel-local state",
+  "volume/shared topology and payload state",
+};
+
+static const char *const kAppStateDiffHarnessTransitionIds3[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+  "transition.terminal-signal-resize",
+};
+
+static const char *const kAppStateDiffHarnessOwnerFieldRefs3[] = {
+  "panel.restore_snapshot",
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.panel_generation",
+  "volume.dir_tree",
+  "volume.payload_cache",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateDiffHarnessInvariantIds3[] = {
+  "invariant.stale-snapshot-fail-closed",
+  "invariant.viewport-identity-rebind",
+  "invariant.hidden-entry-visible-navigation",
+};
+
+static const char *const kAppStateDiffHarnessGenerationDomainIds3[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+  "state.topology.volume",
+  "state.file-payload.volume",
+};
+
+static const char *const kAppStateDiffHarnessMigrationNotes3[] = {
+  "The future runner should seed mismatched saved/current generations to verify deterministic restore fallback.",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotPhases4[] = {
+  "before_guard",
+  "after_blocked_result",
+};
+
+static const char *const kAppStateDiffHarnessSnapshotRegions4[] = {
+  "ctx/session state",
+  "panel-local state",
+  "volume/shared topology and payload state",
+};
+
+static const char *const kAppStateDiffHarnessTransitionIds4[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.modal-action.dismiss",
+  "transition.volume-operation.release-cycle",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.command-completion.user-command",
+};
+
+static const char *const kAppStateDiffHarnessOwnerFieldRefs4[] = {
+  "ctx.message_state",
+  "ctx.modal_state",
+  "panel.volume_key",
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.panel_generation",
+  "volume.dir_tree",
+  "volume.volume_generation",
+};
+
+static const char *const kAppStateDiffHarnessInvariantIds4[] = {
+  "invariant.blocked-transition-determinism",
+  "invariant.inactive-panel-frozen",
+  "invariant.shared-state-panel-local-isolation",
+};
+
+static const char *const kAppStateDiffHarnessGenerationDomainIds4[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "lifecycle.volume.registry",
+  "target.modal-command.session",
+};
+
+static const char *const kAppStateDiffHarnessMigrationNotes4[] = {
+  "Concrete blocked-result allowances should be derived from the target transition's blocked_result and declared_write_set records.",
+};
+
+static const AppStateDiffHarnessMetadata kAppStateDiffHarnesses[] = {
+  {"harness.transition-before-after-snapshot",
+   "transition_before_after_snapshot",
+   kAppStateDiffHarnessSnapshotPhases0,
+   sizeof(kAppStateDiffHarnessSnapshotPhases0) / sizeof(kAppStateDiffHarnessSnapshotPhases0[0]),
+   kAppStateDiffHarnessSnapshotRegions0,
+   sizeof(kAppStateDiffHarnessSnapshotRegions0) / sizeof(kAppStateDiffHarnessSnapshotRegions0[0]),
+   kAppStateDiffHarnessTransitionIds0,
+   sizeof(kAppStateDiffHarnessTransitionIds0) / sizeof(kAppStateDiffHarnessTransitionIds0[0]),
+   kAppStateDiffHarnessOwnerFieldRefs0,
+   sizeof(kAppStateDiffHarnessOwnerFieldRefs0) / sizeof(kAppStateDiffHarnessOwnerFieldRefs0[0]),
+   kAppStateDiffHarnessInvariantIds0,
+   sizeof(kAppStateDiffHarnessInvariantIds0) / sizeof(kAppStateDiffHarnessInvariantIds0[0]),
+   kAppStateDiffHarnessGenerationDomainIds0,
+   sizeof(kAppStateDiffHarnessGenerationDomainIds0) / sizeof(kAppStateDiffHarnessGenerationDomainIds0[0]),
+   "A later dynamic harness snapshots every referenced AppState region before guard evaluation and after the transition result, then compares only authoritative state owned by the registered transition boundary.",
+   "Any unclassified region change, stale snapshot reuse, or missing before/after phase is reported as a transition contract violation.",
+   "documented_foundation_only",
+   kAppStateDiffHarnessMigrationNotes0,
+   sizeof(kAppStateDiffHarnessMigrationNotes0) / sizeof(kAppStateDiffHarnessMigrationNotes0[0])},
+  {"harness.declared-write-set-diff",
+   "declared_write_set_diff",
+   kAppStateDiffHarnessSnapshotPhases1,
+   sizeof(kAppStateDiffHarnessSnapshotPhases1) / sizeof(kAppStateDiffHarnessSnapshotPhases1[0]),
+   kAppStateDiffHarnessSnapshotRegions1,
+   sizeof(kAppStateDiffHarnessSnapshotRegions1) / sizeof(kAppStateDiffHarnessSnapshotRegions1[0]),
+   kAppStateDiffHarnessTransitionIds1,
+   sizeof(kAppStateDiffHarnessTransitionIds1) / sizeof(kAppStateDiffHarnessTransitionIds1[0]),
+   kAppStateDiffHarnessOwnerFieldRefs1,
+   sizeof(kAppStateDiffHarnessOwnerFieldRefs1) / sizeof(kAppStateDiffHarnessOwnerFieldRefs1[0]),
+   kAppStateDiffHarnessInvariantIds1,
+   sizeof(kAppStateDiffHarnessInvariantIds1) / sizeof(kAppStateDiffHarnessInvariantIds1[0]),
+   kAppStateDiffHarnessGenerationDomainIds1,
+   sizeof(kAppStateDiffHarnessGenerationDomainIds1) / sizeof(kAppStateDiffHarnessGenerationDomainIds1[0]),
+   "The after snapshot may differ from the before snapshot only in owner fields named by the transition's declared_write_set or by an explicitly registered follow-up transition.",
+   "A changed owner field outside the registered write set is rejected as an undeclared AppState mutation.",
+   "documented_foundation_only",
+   kAppStateDiffHarnessMigrationNotes1,
+   sizeof(kAppStateDiffHarnessMigrationNotes1) / sizeof(kAppStateDiffHarnessMigrationNotes1[0])},
+  {"harness.render-projection-read-only-diff",
+   "render_projection_read_only_diff",
+   kAppStateDiffHarnessSnapshotPhases2,
+   sizeof(kAppStateDiffHarnessSnapshotPhases2) / sizeof(kAppStateDiffHarnessSnapshotPhases2[0]),
+   kAppStateDiffHarnessSnapshotRegions2,
+   sizeof(kAppStateDiffHarnessSnapshotRegions2) / sizeof(kAppStateDiffHarnessSnapshotRegions2[0]),
+   kAppStateDiffHarnessTransitionIds2,
+   sizeof(kAppStateDiffHarnessTransitionIds2) / sizeof(kAppStateDiffHarnessTransitionIds2[0]),
+   kAppStateDiffHarnessOwnerFieldRefs2,
+   sizeof(kAppStateDiffHarnessOwnerFieldRefs2) / sizeof(kAppStateDiffHarnessOwnerFieldRefs2[0]),
+   kAppStateDiffHarnessInvariantIds2,
+   sizeof(kAppStateDiffHarnessInvariantIds2) / sizeof(kAppStateDiffHarnessInvariantIds2[0]),
+   kAppStateDiffHarnessGenerationDomainIds2,
+   sizeof(kAppStateDiffHarnessGenerationDomainIds2) / sizeof(kAppStateDiffHarnessGenerationDomainIds2[0]),
+   "Render/reflow projection may consume settled AppState and stage terminal output, but it must not mutate authoritative selection, identity, focus, or generation fields.",
+   "Any authoritative owner or generation delta produced by render projection is rejected as render-state leakage into AppState authority.",
+   "documented_foundation_only",
+   kAppStateDiffHarnessMigrationNotes2,
+   sizeof(kAppStateDiffHarnessMigrationNotes2) / sizeof(kAppStateDiffHarnessMigrationNotes2[0])},
+  {"harness.generation-mismatch-check",
+   "generation_mismatch_check",
+   kAppStateDiffHarnessSnapshotPhases3,
+   sizeof(kAppStateDiffHarnessSnapshotPhases3) / sizeof(kAppStateDiffHarnessSnapshotPhases3[0]),
+   kAppStateDiffHarnessSnapshotRegions3,
+   sizeof(kAppStateDiffHarnessSnapshotRegions3) / sizeof(kAppStateDiffHarnessSnapshotRegions3[0]),
+   kAppStateDiffHarnessTransitionIds3,
+   sizeof(kAppStateDiffHarnessTransitionIds3) / sizeof(kAppStateDiffHarnessTransitionIds3[0]),
+   kAppStateDiffHarnessOwnerFieldRefs3,
+   sizeof(kAppStateDiffHarnessOwnerFieldRefs3) / sizeof(kAppStateDiffHarnessOwnerFieldRefs3[0]),
+   kAppStateDiffHarnessInvariantIds3,
+   sizeof(kAppStateDiffHarnessInvariantIds3) / sizeof(kAppStateDiffHarnessInvariantIds3[0]),
+   kAppStateDiffHarnessGenerationDomainIds3,
+   sizeof(kAppStateDiffHarnessGenerationDomainIds3) / sizeof(kAppStateDiffHarnessGenerationDomainIds3[0]),
+   "Saved panel or volume snapshots whose generation markers mismatch current authority must be rejected or rebound through stable identity fallback before any restore commit.",
+   "Reusing stale row, pointer, or payload identity after a generation mismatch is rejected as a fail-closed violation.",
+   "documented_foundation_only",
+   kAppStateDiffHarnessMigrationNotes3,
+   sizeof(kAppStateDiffHarnessMigrationNotes3) / sizeof(kAppStateDiffHarnessMigrationNotes3[0])},
+  {"harness.blocked-transition-no-unrelated-mutation",
+   "blocked_transition_no_unrelated_mutation",
+   kAppStateDiffHarnessSnapshotPhases4,
+   sizeof(kAppStateDiffHarnessSnapshotPhases4) / sizeof(kAppStateDiffHarnessSnapshotPhases4[0]),
+   kAppStateDiffHarnessSnapshotRegions4,
+   sizeof(kAppStateDiffHarnessSnapshotRegions4) / sizeof(kAppStateDiffHarnessSnapshotRegions4[0]),
+   kAppStateDiffHarnessTransitionIds4,
+   sizeof(kAppStateDiffHarnessTransitionIds4) / sizeof(kAppStateDiffHarnessTransitionIds4[0]),
+   kAppStateDiffHarnessOwnerFieldRefs4,
+   sizeof(kAppStateDiffHarnessOwnerFieldRefs4) / sizeof(kAppStateDiffHarnessOwnerFieldRefs4[0]),
+   kAppStateDiffHarnessInvariantIds4,
+   sizeof(kAppStateDiffHarnessInvariantIds4) / sizeof(kAppStateDiffHarnessInvariantIds4[0]),
+   kAppStateDiffHarnessGenerationDomainIds4,
+   sizeof(kAppStateDiffHarnessGenerationDomainIds4) / sizeof(kAppStateDiffHarnessGenerationDomainIds4[0]),
+   "A blocked transition may report only the registered user-visible failure state and must leave unrelated owner fields and all unaffected generations byte-for-byte unchanged.",
+   "Any unrelated owner-field or generation delta after a blocked result is rejected as nondeterministic blocked-transition mutation.",
+   "documented_foundation_only",
+   kAppStateDiffHarnessMigrationNotes4,
+   sizeof(kAppStateDiffHarnessMigrationNotes4) / sizeof(kAppStateDiffHarnessMigrationNotes4[0])},
+};
 static const char *const kAppStateDispatchSurfaceMigrationNotes0[] = {
   "Current input polling and key normalization feed controller dispatch; AppState mutation remains in downstream handlers until runtime transition objects are introduced.",
 };
@@ -1638,6 +1965,10 @@ size_t AppStateGenerationDomainCount(void) {
   return sizeof(kAppStateGenerationDomains) / sizeof(kAppStateGenerationDomains[0]);
 }
 
+size_t AppStateDiffHarnessCount(void) {
+  return sizeof(kAppStateDiffHarnesses) / sizeof(kAppStateDiffHarnesses[0]);
+}
+
 const AppStateOwnerFieldMetadata *AppStateOwnerFieldAt(size_t index) {
   if (index >= AppStateOwnerFieldCount())
     return NULL;
@@ -1651,6 +1982,13 @@ AppStateGenerationDomainAt(size_t index) {
     return NULL;
 
   return &kAppStateGenerationDomains[index];
+}
+
+const AppStateDiffHarnessMetadata *AppStateDiffHarnessAt(size_t index) {
+  if (index >= AppStateDiffHarnessCount())
+    return NULL;
+
+  return &kAppStateDiffHarnesses[index];
 }
 
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
@@ -1707,6 +2045,21 @@ AppStateGenerationDomainLookup(const char *domain_id) {
   for (index = 0; index < AppStateGenerationDomainCount(); index++) {
     if (!strcmp(kAppStateGenerationDomains[index].domain_id, domain_id))
       return &kAppStateGenerationDomains[index];
+  }
+
+  return NULL;
+}
+
+const AppStateDiffHarnessMetadata *
+AppStateDiffHarnessLookup(const char *harness_id) {
+  size_t index;
+
+  if (harness_id == NULL || harness_id[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateDiffHarnessCount(); index++) {
+    if (!strcmp(kAppStateDiffHarnesses[index].harness_id, harness_id))
+      return &kAppStateDiffHarnesses[index];
   }
 
   return NULL;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -366,6 +366,77 @@ static int AppStateActionTransitionsReady(void) {
   return 1;
 }
 
+static int AppStateDiffHarnessRegistryReady(void) {
+  size_t index;
+
+  if (AppStateDiffHarnessCount() == 0)
+    return 0;
+
+  for (index = 0; index < AppStateDiffHarnessCount(); index++) {
+    const AppStateDiffHarnessMetadata *metadata =
+        AppStateDiffHarnessAt(index);
+    size_t ref_index;
+
+    if (metadata == NULL || !NonEmptyString(metadata->harness_id) ||
+        !NonEmptyString(metadata->check_category) ||
+        !NonEmptyStringList(metadata->snapshot_phases,
+                            metadata->snapshot_phase_count) ||
+        !NonEmptyStringList(metadata->snapshot_regions,
+                            metadata->snapshot_region_count) ||
+        !NonEmptyStringList(metadata->transition_ids,
+                            metadata->transition_id_count) ||
+        !NonEmptyStringList(metadata->owner_field_refs,
+                            metadata->owner_field_ref_count) ||
+        !NonEmptyStringList(metadata->invariant_ids,
+                            metadata->invariant_id_count) ||
+        !NonEmptyStringList(metadata->generation_domain_ids,
+                            metadata->generation_domain_id_count) ||
+        !NonEmptyString(metadata->expected_behavior) ||
+        !NonEmptyString(metadata->failure_mode) ||
+        !NonEmptyString(metadata->enforcement_status) ||
+        !NonEmptyStringList(metadata->migration_notes,
+                            metadata->migration_note_count))
+      return 0;
+    if (AppStateDiffHarnessLookup(metadata->harness_id) != metadata)
+      return 0;
+
+    for (ref_index = 0; ref_index < metadata->transition_id_count;
+         ref_index++) {
+      if (AppStateTransitionLookup(metadata->transition_ids[ref_index]) ==
+          NULL)
+        return 0;
+    }
+    for (ref_index = 0; ref_index < metadata->owner_field_ref_count;
+         ref_index++) {
+      if (AppStateOwnerFieldLookup(metadata->owner_field_refs[ref_index]) ==
+          NULL)
+        return 0;
+    }
+    for (ref_index = 0; ref_index < metadata->invariant_id_count;
+         ref_index++) {
+      if (AppStateInvariantLookup(metadata->invariant_ids[ref_index]) == NULL)
+        return 0;
+    }
+    for (ref_index = 0; ref_index < metadata->generation_domain_id_count;
+         ref_index++) {
+      if (AppStateGenerationDomainLookup(
+              metadata->generation_domain_ids[ref_index]) == NULL)
+        return 0;
+    }
+  }
+
+  if (AppStateDiffHarnessAt(AppStateDiffHarnessCount()) != NULL)
+    return 0;
+  if (AppStateDiffHarnessLookup(NULL) != NULL)
+    return 0;
+  if (AppStateDiffHarnessLookup("") != NULL)
+    return 0;
+  if (AppStateDiffHarnessLookup("harness.__ytnova_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
 static void SigIntHandler(int sig) {
   (void)sig;
   ytnova_shutdown_flag = 1;
@@ -444,6 +515,7 @@ int main(int argc, char **argv) {
       !AppStateDispatchSurfacesReady() ||
       !AppStateInvariantRegistryReady() ||
       !AppStateCompatibilityShimsReady() ||
+      !AppStateDiffHarnessRegistryReady() ||
       !AppStateActionTransitionsReady()) {
     fprintf(stderr, "EXIT: startup invariants not configured\n");
     exit(1);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -335,6 +335,7 @@ def _write_fixture(
     runtime_invariants: list[dict[str, object]] | None = None,
     runtime_owner_fields: list[dict[str, object]] | None = None,
     runtime_generation_domains: list[dict[str, object]] | None = None,
+    runtime_diff_harness_checks: list[dict[str, object]] | None = None,
 ) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
@@ -446,6 +447,13 @@ def _write_fixture(
                 if generation_domains is not None
                 else _complete_generation_domains()
             ),
+            runtime_diff_harness_checks
+            if runtime_diff_harness_checks is not None
+            else (
+                diff_harness_checks
+                if diff_harness_checks is not None
+                else _complete_diff_harness_checks()
+            ),
         ),
     )
     return (
@@ -483,6 +491,7 @@ def _runtime_source(
     shims: list[dict[str, object]],
     invariants: list[dict[str, object]],
     generation_domains: list[dict[str, object]],
+    diff_harness_checks: list[dict[str, object]],
 ) -> str:
     transition_write_sets = []
     transition_rows = []
@@ -675,6 +684,57 @@ def _runtime_source(
             f"sizeof(kAppStateGenerationDomainMigrationNotes{index}) / "
             f"sizeof(kAppStateGenerationDomainMigrationNotes{index}[0])}},"
         )
+    diff_harness_arrays = []
+    diff_harness_rows = []
+    diff_harness_list_fields = (
+        ("snapshot_phases", "SnapshotPhases"),
+        ("snapshot_regions", "SnapshotRegions"),
+        ("transition_ids", "TransitionIds"),
+        ("owner_field_refs", "OwnerFieldRefs"),
+        ("invariant_ids", "InvariantIds"),
+        ("generation_domain_ids", "GenerationDomainIds"),
+        ("migration_notes", "MigrationNotes"),
+    )
+    for index, record in enumerate(diff_harness_checks):
+        for field, prefix in diff_harness_list_fields:
+            values = record.get(field)
+            if not isinstance(values, list):
+                values = []
+            rows = "\n".join(
+                f'  "{value}",' for value in values if isinstance(value, str)
+            )
+            diff_harness_arrays.append(
+                f"static const char *const kAppStateDiffHarness{prefix}{index}[] "
+                f"= {{\n{rows}\n}};\n"
+            )
+        diff_harness_rows.append(
+            f'  {{"{record.get("harness_id", "")}", '
+            f'"{record.get("check_category", "")}", '
+            f"kAppStateDiffHarnessSnapshotPhases{index}, "
+            f"sizeof(kAppStateDiffHarnessSnapshotPhases{index}) / "
+            f"sizeof(kAppStateDiffHarnessSnapshotPhases{index}[0]), "
+            f"kAppStateDiffHarnessSnapshotRegions{index}, "
+            f"sizeof(kAppStateDiffHarnessSnapshotRegions{index}) / "
+            f"sizeof(kAppStateDiffHarnessSnapshotRegions{index}[0]), "
+            f"kAppStateDiffHarnessTransitionIds{index}, "
+            f"sizeof(kAppStateDiffHarnessTransitionIds{index}) / "
+            f"sizeof(kAppStateDiffHarnessTransitionIds{index}[0]), "
+            f"kAppStateDiffHarnessOwnerFieldRefs{index}, "
+            f"sizeof(kAppStateDiffHarnessOwnerFieldRefs{index}) / "
+            f"sizeof(kAppStateDiffHarnessOwnerFieldRefs{index}[0]), "
+            f"kAppStateDiffHarnessInvariantIds{index}, "
+            f"sizeof(kAppStateDiffHarnessInvariantIds{index}) / "
+            f"sizeof(kAppStateDiffHarnessInvariantIds{index}[0]), "
+            f"kAppStateDiffHarnessGenerationDomainIds{index}, "
+            f"sizeof(kAppStateDiffHarnessGenerationDomainIds{index}) / "
+            f"sizeof(kAppStateDiffHarnessGenerationDomainIds{index}[0]), "
+            f'"{record.get("expected_behavior", "")}", '
+            f'"{record.get("failure_mode", "")}", '
+            f'"{record.get("enforcement_status", "")}", '
+            f"kAppStateDiffHarnessMigrationNotes{index}, "
+            f"sizeof(kAppStateDiffHarnessMigrationNotes{index}) / "
+            f"sizeof(kAppStateDiffHarnessMigrationNotes{index}[0])}},"
+        )
     action_rows = "\n".join(
         f'  {{{record["action"]}, "{record["transition_id"]}", "{record["category"]}"}},'
         for record in actions
@@ -686,6 +746,7 @@ def _runtime_source(
         + "".join(shim_invariants)
         + "".join(invariant_arrays)
         + "".join(generation_domain_arrays)
+        + "".join(diff_harness_arrays)
         + "static const AppStateTransitionMetadata kAppStateTransitions[] = {\n"
         + "\n".join(transition_rows)
         + "\n};\n"
@@ -703,6 +764,9 @@ def _runtime_source(
         "static const AppStateGenerationDomainMetadata "
         "kAppStateGenerationDomains[] = {\n"
         + "\n".join(generation_domain_rows)
+        + "\n};\n"
+        "static const AppStateDiffHarnessMetadata kAppStateDiffHarnesses[] = {\n"
+        + "\n".join(diff_harness_rows)
         + "\n};\n"
         "static const AppStateInvariantMetadata kAppStateInvariants[] = {\n"
         + "\n".join(invariant_rows)
@@ -1307,6 +1371,241 @@ def test_guard_fails_when_diff_harness_references_unknown_generation_domain(
         and "domain.missing" in failure
         for failure in failures
     )
+
+
+def test_guard_fails_when_runtime_diff_harness_is_missing(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()[1:]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime diff harness registry missing harness id(s)" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_diff_harness_is_extra(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    extra = dict(runtime_diff_harness_checks[0])
+    extra["harness_id"] = "harness.extra"
+    runtime_diff_harness_checks.append(extra)
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_diff_harness" in failure
+        and "harness_id does not match a diff harness id" in failure
+        and "harness.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_diff_harness_is_duplicate(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    runtime_diff_harness_checks[1]["harness_id"] = runtime_diff_harness_checks[0][
+        "harness_id"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any("duplicate runtime diff harness id" in failure for failure in failures)
+
+
+def test_guard_fails_when_runtime_diff_harness_drifts_from_docs(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    runtime_diff_harness_checks[0]["expected_behavior"] = "runtime drift"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_diff_harness[0]" in failure
+        and "runtime expected_behavior does not match diff harness" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_diff_harness_row_is_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(tmp_path, transitions=transitions)
+    runtime_path = paths[-1]
+    runtime_path.write_text(
+        runtime_path.read_text(encoding="utf-8").replace(
+            '"blocked_transition_no_unrelated_mutation", '
+            "kAppStateDiffHarnessSnapshotPhases0",
+            '"blocked_transition_no_unrelated_mutation", '
+            "kAppStateDiffHarnessMissing0",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_diff_harness[0]" in failure
+        and "malformed runtime diff harness registry row" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_diff_harness_list_entry_is_malformed(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(tmp_path, transitions=transitions)
+    runtime_path = paths[-1]
+    runtime_path.write_text(
+        runtime_path.read_text(encoding="utf-8").replace(
+            'static const char *const kAppStateDiffHarnessSnapshotPhases0[] '
+            '= {\n  "before",',
+            'static const char *const kAppStateDiffHarnessSnapshotPhases0[] '
+            '= {\n  ,',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateDiffHarnessSnapshotPhases0[0]" in failure
+        and "malformed string literal entry" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    (
+        (
+            "transition_ids",
+            ["transition.missing"],
+            "transition_ids does not match runtime transition registry",
+        ),
+        (
+            "owner_field_refs",
+            ["field.missing"],
+            "owner_field_refs does not match runtime owner field registry",
+        ),
+        (
+            "invariant_ids",
+            ["invariant.missing"],
+            "invariant_ids does not match runtime invariant registry",
+        ),
+        (
+            "generation_domain_ids",
+            ["domain.missing"],
+            "generation_domain_ids does not match runtime generation domain registry",
+        ),
+    ),
+)
+def test_guard_fails_on_runtime_diff_harness_invalid_linkage(
+    tmp_path: Path, field: str, value: list[str], expected: str
+) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    runtime_diff_harness_checks[0][field] = value
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_diff_harness[0]" in failure
+        and expected in failure
+        and value[0] in failure
+        for failure in failures
+    )
+
+
+def test_runtime_diff_harness_lookup_fails_closed(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "diff_harness_lookup_probe.c"
+    binary = tmp_path / "diff_harness_lookup_probe"
+    probe.write_text(
+        """
+#include "ytnova_appstate_actions.h"
+
+int main(void) {
+  const AppStateDiffHarnessMetadata *metadata;
+
+  if (AppStateDiffHarnessCount() == 0)
+    return 1;
+  if (AppStateDiffHarnessAt(AppStateDiffHarnessCount()) != 0)
+    return 2;
+  if (AppStateDiffHarnessLookup(0) != 0)
+    return 3;
+  if (AppStateDiffHarnessLookup("") != 0)
+    return 4;
+  if (AppStateDiffHarnessLookup("harness.__ytnova_unknown__") != 0)
+    return 5;
+
+  metadata = AppStateDiffHarnessAt(0);
+  if (metadata == 0)
+    return 6;
+  if (AppStateDiffHarnessLookup(metadata->harness_id) != metadata)
+    return 7;
+  return 0;
+}
+""",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            "gcc",
+            "-std=c99",
+            "-Iinclude",
+            str(probe),
+            "src/core/appstate_actions.c",
+            "-o",
+            str(binary),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0, build.stdout + build.stderr
+    run = subprocess.run(
+        [str(binary)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
 
 
 def test_guard_fails_when_required_generation_domain_category_is_missing(


### PR DESCRIPTION
## Summary
- Add read-only runtime metadata for AppState transition-diff harness checks.
- Validate diff-harness metadata links against transition, owner-field, invariant, and generation-domain registries.
- Extend the contract guard and focused tests so docs/runtime drift fails locally and in CI.

## Scope
- Runtime lookup/count/index scaffold only.
- No dynamic transition-diff execution, snapshot capture, restore/render behavior changes, or UI state writes.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS, 241 passed.
- `make clean && make` — PASS with pre-existing compiler warnings.
- `make qa-cppcheck && make qa-code-quality && git diff --check` — PASS.
