### PR TITLE
chore(appstate): add transition sequence lookup

### DIFF
--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -119,6 +119,51 @@ typedef struct {
   size_t migration_note_count;
 } AppStateDiffHarnessMetadata;
 
+typedef struct {
+  const char *domain_id;
+  const char *expectation;
+} AppStateTransitionSequenceGenerationExpectationMetadata;
+
+typedef struct {
+  const char *diff_harness_id;
+  const char *expectation;
+} AppStateTransitionSequenceNoUnrelatedMutationMetadata;
+
+typedef struct {
+  const char *outcome;
+  const char *allowed_mutation_scope;
+} AppStateTransitionSequenceDeterministicFallbackMetadata;
+
+typedef struct {
+  size_t ordinal;
+  const char *step_id;
+  const char *transition_id;
+  const char *stimulus_action_id;
+  const char *stimulus_event_id;
+  const char *expected_result;
+  const char *const *invariant_ids;
+  size_t invariant_id_count;
+  const char *const *diff_harness_ids;
+  size_t diff_harness_id_count;
+  const AppStateTransitionSequenceGenerationExpectationMetadata
+      *generation_domain_expectations;
+  size_t generation_domain_expectation_count;
+  const AppStateTransitionSequenceNoUnrelatedMutationMetadata
+      *no_unrelated_mutation;
+  const char *precondition;
+  const AppStateTransitionSequenceDeterministicFallbackMetadata
+      *deterministic_fallback;
+} AppStateTransitionSequenceStepMetadata;
+
+typedef struct {
+  const char *scenario_id;
+  const char *category;
+  const char *flow;
+  const char *description;
+  const AppStateTransitionSequenceStepMetadata *steps;
+  size_t step_count;
+} AppStateTransitionSequenceMetadata;
+
 const AppStateActionTransitionMetadata *
 AppStateActionTransitionLookup(YtreeNovaAction action);
 size_t AppStateActionTransitionCount(void);
@@ -150,5 +195,10 @@ const AppStateDiffHarnessMetadata *
 AppStateDiffHarnessLookup(const char *harness_id);
 const AppStateDiffHarnessMetadata *AppStateDiffHarnessAt(size_t index);
 size_t AppStateDiffHarnessCount(void);
+const AppStateTransitionSequenceMetadata *
+AppStateTransitionSequenceLookup(const char *scenario_id);
+const AppStateTransitionSequenceMetadata *
+AppStateTransitionSequenceAt(size_t index);
+size_t AppStateTransitionSequenceCount(void);
 
 #endif /* YTNOVA_APPSTATE_ACTIONS_H */

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -1119,6 +1119,271 @@ def _parse_runtime_diff_harness_registry(
     return records, failures
 
 
+
+def _parse_runtime_nullable_string(value: str) -> str | None:
+    value = value.strip()
+    if value == "NULL":
+        return None
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        return value[1:-1]
+    return None
+
+
+def _parse_runtime_transition_sequence_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    failures: list[str] = []
+    string_arrays: dict[str, list[str]] = {}
+    string_array_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppStateTransitionSequenceStep(?:InvariantIds|DiffHarnessIds)[0-9]+_[0-9]+)"
+        r"\[\]\s*=\s*\{(?P<body>.*?)\};",
+        re.S,
+    )
+    for array_match in string_array_re.finditer(source):
+        table_name = array_match.group(1)
+        values, array_failures = _parse_string_initializer_array(
+            array_match.group("body"),
+            table_name,
+        )
+        string_arrays[table_name] = values
+        failures.extend(array_failures)
+
+    generation_expectations: dict[str, list[dict[str, str]]] = {}
+    generation_re = re.compile(
+        r"static\s+const\s+AppStateTransitionSequenceGenerationExpectationMetadata\s+"
+        r"(kAppStateTransitionSequenceStepGenerationExpectations[0-9]+_[0-9]+)"
+        r"\[\]\s*=\s*\{(?P<body>.*?)\};",
+        re.S,
+    )
+    generation_row_re = re.compile(
+        r"\{\s*\"(?P<domain_id>[^\"]*)\"\s*,\s*\"(?P<expectation>[^\"]*)\"\s*\}",
+        re.S,
+    )
+    for generation_match in generation_re.finditer(source):
+        table_name = generation_match.group(1)
+        rows, row_failures = _split_top_level_initializer_rows(
+            generation_match.group("body"),
+            table_name,
+        )
+        failures.extend(row_failures)
+        values: list[dict[str, str]] = []
+        for index, row in enumerate(rows):
+            row_match = generation_row_re.fullmatch(row.strip())
+            if row_match is None:
+                failures.append(
+                    f"{table_name}[{index}]: malformed generation expectation row: "
+                    f"{_compact_initializer_snippet(row)}"
+                )
+                continue
+            values.append(
+                {
+                    "domain_id": row_match.group("domain_id"),
+                    "expectation": row_match.group("expectation"),
+                }
+            )
+        generation_expectations[table_name] = values
+
+    no_unrelated_mutations: dict[str, dict[str, str]] = {}
+    no_unrelated_re = re.compile(
+        r"static\s+const\s+AppStateTransitionSequenceNoUnrelatedMutationMetadata\s+"
+        r"(kAppStateTransitionSequenceStepNoUnrelatedMutation[0-9]+_[0-9]+)"
+        r"\s*=\s*\{\s*\"(?P<diff_harness_id>[^\"]*)\"\s*,\s*"
+        r"\"(?P<expectation>[^\"]*)\"\s*\};",
+        re.S,
+    )
+    for no_unrelated_match in no_unrelated_re.finditer(source):
+        no_unrelated_mutations[no_unrelated_match.group(1)] = {
+            "diff_harness_id": no_unrelated_match.group("diff_harness_id"),
+            "expectation": no_unrelated_match.group("expectation"),
+        }
+
+    deterministic_fallbacks: dict[str, dict[str, str]] = {}
+    fallback_re = re.compile(
+        r"static\s+const\s+AppStateTransitionSequenceDeterministicFallbackMetadata\s+"
+        r"(kAppStateTransitionSequenceStepDeterministicFallback[0-9]+_[0-9]+)"
+        r"\s*=\s*\{\s*\"(?P<outcome>[^\"]*)\"\s*,\s*"
+        r"\"(?P<allowed_mutation_scope>[^\"]*)\"\s*\};",
+        re.S,
+    )
+    for fallback_match in fallback_re.finditer(source):
+        deterministic_fallbacks[fallback_match.group(1)] = {
+            "outcome": fallback_match.group("outcome"),
+            "allowed_mutation_scope": fallback_match.group("allowed_mutation_scope"),
+        }
+
+    step_arrays: dict[str, list[dict[str, Any]]] = {}
+    step_array_re = re.compile(
+        r"static\s+const\s+AppStateTransitionSequenceStepMetadata\s+"
+        r"(kAppStateTransitionSequenceSteps[0-9]+)\[\]\s*=\s*\{(?P<body>.*?)\};",
+        re.S,
+    )
+    step_row_re = re.compile(
+        r"\{\s*(?P<ordinal>[0-9]+)\s*,"
+        r"\s*\"(?P<step_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<transition_id>[^\"]*)\"\s*,"
+        r"\s*(?P<stimulus_action_id>NULL|\"[^\"]*\")\s*,"
+        r"\s*(?P<stimulus_event_id>NULL|\"[^\"]*\")\s*,"
+        r"\s*\"(?P<expected_result>[^\"]*)\"\s*,"
+        r"\s*(?P<invariant_ids>kAppStateTransitionSequenceStepInvariantIds[0-9]+_[0-9]+)\s*,"
+        r"\s*sizeof\((?P=invariant_ids)\)\s*/\s*sizeof\((?P=invariant_ids)\[0\]\)\s*,"
+        r"\s*(?P<diff_harness_ids>kAppStateTransitionSequenceStepDiffHarnessIds[0-9]+_[0-9]+)\s*,"
+        r"\s*sizeof\((?P=diff_harness_ids)\)\s*/\s*sizeof\((?P=diff_harness_ids)\[0\]\)\s*,"
+        r"\s*(?P<generation_domain_expectations>"
+        r"kAppStateTransitionSequenceStepGenerationExpectations[0-9]+_[0-9]+)\s*,"
+        r"\s*sizeof\((?P=generation_domain_expectations)\)\s*/"
+        r"\s*sizeof\((?P=generation_domain_expectations)\[0\]\)\s*,"
+        r"\s*(?P<no_unrelated_mutation>NULL|&?kAppStateTransitionSequenceStepNoUnrelatedMutation[0-9]+_[0-9]+)\s*,"
+        r"\s*(?P<precondition>NULL|\"[^\"]*\")\s*,"
+        r"\s*(?P<deterministic_fallback>NULL|&?kAppStateTransitionSequenceStepDeterministicFallback[0-9]+_[0-9]+)\s*\}",
+        re.S,
+    )
+    for step_array_match in step_array_re.finditer(source):
+        table_name = step_array_match.group(1)
+        rows, row_failures = _split_top_level_initializer_rows(
+            step_array_match.group("body"),
+            f"runtime_transition_sequence_step_array.{table_name}",
+        )
+        failures.extend(row_failures)
+        steps: list[dict[str, Any]] = []
+        for index, row in enumerate(rows):
+            row_match = step_row_re.fullmatch(row.strip())
+            if row_match is None:
+                failures.append(
+                    f"runtime_transition_sequence_step[{table_name}][{index}]: "
+                    f"malformed runtime transition sequence step row: "
+                    f"{_compact_initializer_snippet(row)}"
+                )
+                continue
+
+            invariant_table = row_match.group("invariant_ids")
+            diff_harness_table = row_match.group("diff_harness_ids")
+            generation_table = row_match.group("generation_domain_expectations")
+            no_unrelated_table = row_match.group("no_unrelated_mutation").lstrip("&")
+            fallback_table = row_match.group("deterministic_fallback").lstrip("&")
+
+            if invariant_table not in string_arrays:
+                failures.append(
+                    f"runtime_transition_sequence_step[{table_name}][{index}]: "
+                    f"unknown invariant_ids table: {invariant_table}"
+                )
+            if diff_harness_table not in string_arrays:
+                failures.append(
+                    f"runtime_transition_sequence_step[{table_name}][{index}]: "
+                    f"unknown diff_harness_ids table: {diff_harness_table}"
+                )
+            if generation_table not in generation_expectations:
+                failures.append(
+                    f"runtime_transition_sequence_step[{table_name}][{index}]: "
+                    "unknown generation_domain_expectations table: "
+                    f"{generation_table}"
+                )
+
+            no_unrelated = None
+            if no_unrelated_table != "NULL":
+                no_unrelated = no_unrelated_mutations.get(no_unrelated_table)
+                if no_unrelated is None:
+                    failures.append(
+                        f"runtime_transition_sequence_step[{table_name}][{index}]: "
+                        "unknown no_unrelated_mutation table: "
+                        f"{no_unrelated_table}"
+                    )
+            deterministic_fallback = None
+            if fallback_table != "NULL":
+                deterministic_fallback = deterministic_fallbacks.get(fallback_table)
+                if deterministic_fallback is None:
+                    failures.append(
+                        f"runtime_transition_sequence_step[{table_name}][{index}]: "
+                        "unknown deterministic_fallback table: "
+                        f"{fallback_table}"
+                    )
+
+            steps.append(
+                {
+                    "ordinal": int(row_match.group("ordinal")),
+                    "step_id": row_match.group("step_id"),
+                    "transition_id": row_match.group("transition_id"),
+                    "stimulus_action_id": _parse_runtime_nullable_string(
+                        row_match.group("stimulus_action_id")
+                    ),
+                    "stimulus_event_id": _parse_runtime_nullable_string(
+                        row_match.group("stimulus_event_id")
+                    ),
+                    "expected_result": row_match.group("expected_result"),
+                    "invariant_ids": string_arrays.get(invariant_table, []),
+                    "diff_harness_ids": string_arrays.get(diff_harness_table, []),
+                    "generation_domain_expectations": generation_expectations.get(
+                        generation_table,
+                        [],
+                    ),
+                    "no_unrelated_mutation": no_unrelated,
+                    "precondition": _parse_runtime_nullable_string(
+                        row_match.group("precondition")
+                    ),
+                    "deterministic_fallback": deterministic_fallback,
+                }
+            )
+        step_arrays[table_name] = steps
+
+    match = re.search(
+        r"kAppStateTransitionSequences\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime transition sequence registry"]
+
+    records: list[dict[str, Any]] = []
+    row_re = re.compile(
+        r"\{\s*\"(?P<scenario_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<category>[^\"]*)\"\s*,"
+        r"\s*\"(?P<flow>[^\"]*)\"\s*,"
+        r"\s*\"(?P<description>[^\"]*)\"\s*,"
+        r"\s*(?P<steps>kAppStateTransitionSequenceSteps[0-9]+)\s*,"
+        r"\s*sizeof\((?P=steps)\)\s*/\s*sizeof\((?P=steps)\[0\]\)\s*\}",
+        re.S,
+    )
+    rows, row_failures = _split_top_level_initializer_rows(
+        match.group("body"),
+        "runtime_transition_sequence",
+    )
+    failures.extend(row_failures)
+    for index, row in enumerate(rows):
+        row_match = row_re.fullmatch(row.strip())
+        if row_match is None:
+            failures.append(
+                f"runtime_transition_sequence[{index}]: malformed runtime transition "
+                f"sequence registry row: {_compact_initializer_snippet(row)}"
+            )
+            continue
+        steps_table = row_match.group("steps")
+        steps = step_arrays.get(steps_table)
+        if steps is None:
+            failures.append(
+                f"runtime_transition_sequence[{index}]: unknown steps table: {steps_table}"
+            )
+            steps = []
+        records.append(
+            {
+                "scenario_id": row_match.group("scenario_id"),
+                "category": row_match.group("category"),
+                "flow": row_match.group("flow"),
+                "description": row_match.group("description"),
+                "steps": steps,
+            }
+        )
+
+    if not records:
+        failures.append(
+            f"{runtime_path}: runtime transition sequence registry must not be empty"
+        )
+    return records, failures
+
 def _parse_runtime_shim_registry(
     runtime_path: Path,
 ) -> tuple[list[dict[str, Any]], list[str]]:
@@ -2979,6 +3244,260 @@ def _validate_appstate_transition_sequences(
     return failures
 
 
+
+def _normalize_transition_sequence_records(records: list[Any]) -> dict[str, dict[str, Any]]:
+    normalized: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        scenario_id = record.get("scenario_id")
+        if not isinstance(scenario_id, str) or not scenario_id.strip():
+            continue
+        steps: list[dict[str, Any]] = []
+        for step in record.get("steps", []):
+            if not isinstance(step, dict):
+                continue
+            stimulus = step.get("stimulus")
+            if not isinstance(stimulus, dict):
+                stimulus = {}
+            steps.append(
+                {
+                    "ordinal": step.get("ordinal"),
+                    "step_id": step.get("step_id"),
+                    "transition_id": step.get("transition_id"),
+                    "stimulus_action_id": stimulus.get("action_id"),
+                    "stimulus_event_id": stimulus.get("event_id"),
+                    "expected_result": step.get("expected_result"),
+                    "invariant_ids": step.get("invariant_ids"),
+                    "diff_harness_ids": step.get("diff_harness_ids"),
+                    "generation_domain_expectations": step.get(
+                        "generation_domain_expectations"
+                    ),
+                    "no_unrelated_mutation": step.get("no_unrelated_mutation"),
+                    "precondition": step.get("precondition"),
+                    "deterministic_fallback": step.get("deterministic_fallback"),
+                }
+            )
+        normalized[scenario_id] = {
+            "scenario_id": scenario_id,
+            "category": record.get("category"),
+            "flow": record.get("flow"),
+            "description": record.get("description"),
+            "steps": steps,
+        }
+    return normalized
+
+
+def _validate_runtime_transition_sequence_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    transition_sequence_records: list[Any],
+    runtime_transition_ids: set[str],
+    action_ids: set[str],
+    action_transition_ids: dict[str, str],
+    event_ids: set[str],
+    event_transition_ids: dict[str, str],
+    runtime_invariant_ids: set[str],
+    runtime_diff_harness_ids: set[str],
+    runtime_generation_domain_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    expected_sequences = _normalize_transition_sequence_records(
+        transition_sequence_records
+    )
+    expected_ids = set(expected_sequences)
+    covered_ids: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_transition_sequence[{index}]"
+        runtime_id = record.get("scenario_id")
+        if not isinstance(runtime_id, str) or not runtime_id.strip():
+            failures.append(f"{label}: scenario_id must be a non-empty string")
+            continue
+        if runtime_id in covered_ids:
+            failures.append(
+                f"{label}: duplicate runtime transition sequence scenario_id: {runtime_id}"
+            )
+        covered_ids.add(runtime_id)
+
+        expected_record = expected_sequences.get(runtime_id)
+        if expected_record is None:
+            failures.append(
+                f"{label}: scenario_id does not match a transition sequence: {runtime_id}"
+            )
+        else:
+            for field in ("category", "flow", "description", "steps"):
+                if record.get(field) != expected_record.get(field):
+                    failures.append(
+                        f"{label}: runtime {field} does not match transition "
+                        f"sequence {runtime_id}: {record.get(field)}"
+                    )
+
+        for field in ("category", "flow", "description"):
+            value = record.get(field)
+            if not isinstance(value, str) or not value.strip():
+                failures.append(f"{label}: {field} must be a non-empty string")
+
+        steps = record.get("steps")
+        if not isinstance(steps, list) or not steps:
+            failures.append(f"{label}: steps must be non-empty")
+            continue
+
+        previous_ordinal = 0
+        step_ids: set[str] = set()
+        ordinals: set[int] = set()
+        for step_index, step in enumerate(steps):
+            step_label = f"{label}.step[{step_index}]"
+            if not isinstance(step, dict):
+                failures.append(f"{step_label}: record must be an object")
+                continue
+
+            ordinal = step.get("ordinal")
+            if not isinstance(ordinal, int) or ordinal < 1:
+                failures.append(f"{step_label}: ordinal must be a positive integer")
+            else:
+                if ordinal in ordinals:
+                    failures.append(f"{step_label}: duplicate ordinal: {ordinal}")
+                if ordinal <= previous_ordinal:
+                    failures.append(
+                        f"{step_label}: ordinal must be greater than previous step ordinal"
+                    )
+                ordinals.add(ordinal)
+                previous_ordinal = ordinal
+
+            step_id = step.get("step_id")
+            if not isinstance(step_id, str) or not step_id.strip():
+                failures.append(f"{step_label}: step_id must be a non-empty string")
+            else:
+                if step_id in step_ids:
+                    failures.append(f"{step_label}: duplicate step_id: {step_id}")
+                step_ids.add(step_id)
+
+            transition_id = step.get("transition_id")
+            if not isinstance(transition_id, str) or not transition_id.strip():
+                failures.append(
+                    f"{step_label}: transition_id must be a non-empty string"
+                )
+            elif transition_id not in runtime_transition_ids:
+                failures.append(
+                    f"{step_label}: transition_id does not match runtime transition "
+                    f"registry: {transition_id}"
+                )
+
+            action_id = step.get("stimulus_action_id")
+            event_id = step.get("stimulus_event_id")
+            if action_id is None and event_id is None:
+                failures.append(
+                    f"{step_label}: stimulus must include action_id or event_id"
+                )
+            if action_id is not None:
+                if not isinstance(action_id, str) or not action_id.strip():
+                    failures.append(
+                        f"{step_label}: stimulus_action_id must be a non-empty string"
+                    )
+                elif action_id not in action_ids:
+                    failures.append(
+                        f"{step_label}: stimulus_action_id references unknown action: "
+                        f"{action_id}"
+                    )
+                elif isinstance(transition_id, str) and transition_id.strip():
+                    action_transition_id = action_transition_ids.get(action_id)
+                    if action_transition_id != transition_id:
+                        failures.append(
+                            f"{step_label}: stimulus_action_id {action_id} maps to "
+                            f"transition_id {action_transition_id}, not "
+                            f"step.transition_id {transition_id}"
+                        )
+            if event_id is not None:
+                if not isinstance(event_id, str) or not event_id.strip():
+                    failures.append(
+                        f"{step_label}: stimulus_event_id must be a non-empty string"
+                    )
+                elif event_id not in event_ids:
+                    failures.append(
+                        f"{step_label}: stimulus_event_id references unknown event id: "
+                        f"{event_id}"
+                    )
+                elif isinstance(transition_id, str) and transition_id.strip():
+                    event_transition_id = event_transition_ids.get(event_id)
+                    if event_transition_id != transition_id:
+                        failures.append(
+                            f"{step_label}: stimulus_event_id {event_id} maps to "
+                            f"transition_id {event_transition_id}, not "
+                            f"step.transition_id {transition_id}"
+                        )
+
+            for field, valid_ids, reference_label in (
+                ("invariant_ids", runtime_invariant_ids, "runtime invariant id"),
+                ("diff_harness_ids", runtime_diff_harness_ids, "runtime diff harness id"),
+            ):
+                values = step.get(field)
+                failures.extend(
+                    _validate_step_reference_list(
+                        value=values,
+                        valid_ids=valid_ids,
+                        label=step_label,
+                        field=field,
+                        reference_label=reference_label,
+                    )
+                )
+
+            failures.extend(
+                _validate_generation_expectations(
+                    value=step.get("generation_domain_expectations"),
+                    label=step_label,
+                    generation_domain_ids=runtime_generation_domain_ids,
+                )
+            )
+
+            expected_result = step.get("expected_result")
+            if not isinstance(expected_result, str) or not expected_result.strip():
+                failures.append(
+                    f"{step_label}: expected_result must be a non-empty string"
+                )
+            elif expected_result not in {"allowed", "blocked", "fallback", "invalid"}:
+                failures.append(
+                    f"{step_label}: unknown expected_result: {expected_result}"
+                )
+
+            precondition = step.get("precondition")
+            if precondition is not None and (
+                not isinstance(precondition, str) or not precondition.strip()
+            ):
+                failures.append(f"{step_label}: precondition must be non-empty")
+
+            if isinstance(step, dict) and _requires_deterministic_fallback(step):
+                failures.extend(
+                    _validate_deterministic_fallback(record=step, label=step_label)
+                )
+            fallback = step.get("deterministic_fallback")
+            if fallback is not None and not isinstance(fallback, dict):
+                failures.append(
+                    f"{step_label}: deterministic_fallback must be an object"
+                )
+
+            if expected_result in {"blocked", "invalid"}:
+                failures.extend(
+                    _validate_no_unrelated_mutation(
+                        record=step,
+                        label=step_label,
+                        diff_harness_ids=runtime_diff_harness_ids,
+                    )
+                )
+            no_unrelated = step.get("no_unrelated_mutation")
+            if no_unrelated is not None and not isinstance(no_unrelated, dict):
+                failures.append(f"{step_label}: no_unrelated_mutation must be an object")
+
+    missing_ids = sorted(expected_ids - covered_ids)
+    if missing_ids:
+        failures.append(
+            f"{runtime_path}: runtime transition sequence registry missing "
+            "scenario id(s): " + ", ".join(missing_ids)
+        )
+
+    return failures
+
 def validate_contract(
     transitions_path: Path,
     shims_path: Path,
@@ -3035,6 +3554,9 @@ def validate_contract(
     runtime_diff_harness_records, runtime_diff_harness_failures = (
         _parse_runtime_diff_harness_registry(action_runtime_path)
     )
+    runtime_transition_sequence_records, runtime_transition_sequence_failures = (
+        _parse_runtime_transition_sequence_registry(action_runtime_path)
+    )
     failures.extend(transition_load_failures)
     failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
@@ -3054,6 +3576,7 @@ def validate_contract(
     failures.extend(runtime_invariant_failures)
     failures.extend(runtime_generation_domain_failures)
     failures.extend(runtime_diff_harness_failures)
+    failures.extend(runtime_transition_sequence_failures)
     if failures:
         return failures
 
@@ -3430,6 +3953,35 @@ def validate_contract(
             invariant_ids=invariant_ids,
             diff_harness_ids=diff_harness_ids,
             generation_domain_ids=generation_domain_ids,
+        )
+    )
+    if isinstance(transition_sequences_doc, dict) and isinstance(
+        transition_sequences_doc.get("scenarios"), list
+    ):
+        transition_sequence_records = transition_sequences_doc["scenarios"]
+    else:
+        transition_sequence_records = []
+    failures.extend(
+        _validate_runtime_transition_sequence_registry(
+            runtime_records=runtime_transition_sequence_records,
+            runtime_path=action_runtime_path,
+            transition_sequence_records=transition_sequence_records,
+            runtime_transition_ids={
+                record["id"] for record in runtime_transition_records
+            },
+            action_ids=action_ids,
+            action_transition_ids=action_transition_ids,
+            event_ids=event_ids,
+            event_transition_ids=event_transition_ids,
+            runtime_invariant_ids={
+                record["invariant_id"] for record in runtime_invariant_records
+            },
+            runtime_diff_harness_ids={
+                record["harness_id"] for record in runtime_diff_harness_records
+            },
+            runtime_generation_domain_ids={
+                record["domain_id"] for record in runtime_generation_domain_records
+            },
         )
     )
 

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -1063,6 +1063,834 @@ static const AppStateDiffHarnessMetadata kAppStateDiffHarnesses[] = {
    kAppStateDiffHarnessMigrationNotes4,
    sizeof(kAppStateDiffHarnessMigrationNotes4) / sizeof(kAppStateDiffHarnessMigrationNotes4[0])},
 };
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds0_0[] = {
+  "invariant.inactive-panel-frozen",
+  "invariant.blocked-transition-determinism",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds0_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations0_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
+  {"reflow.layout.projection", "Layout reflow generation is projection-only unless resize transition declares it."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds0_1[] = {
+  "invariant.blocked-transition-determinism",
+  "invariant.inactive-panel-frozen",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds0_1[] = {
+  "harness.blocked-transition-no-unrelated-mutation",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations0_1[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"reflow.layout.projection", "Layout reflow generation is projection-only unless resize transition declares it."},
+};
+
+static const AppStateTransitionSequenceNoUnrelatedMutationMetadata kAppStateTransitionSequenceStepNoUnrelatedMutation0_1 = {"harness.blocked-transition-no-unrelated-mutation", "The blocked/invalid result may update only the declared diagnostic or dirty state and must not mutate unrelated owner fields."};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps0[] = {
+  {1,
+   "split-open",
+   "transition.keybinding.navigate-tree",
+   "ACTION_SPLIT_SCREEN",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds0_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds0_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds0_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds0_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds0_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds0_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations0_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations0_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations0_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "split-toggle-blocked-by-modal",
+   "transition.keybinding.navigate-tree",
+   "ACTION_SPLIT_SCREEN",
+   NULL,
+   "blocked",
+   kAppStateTransitionSequenceStepInvariantIds0_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds0_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds0_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds0_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds0_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds0_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations0_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations0_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations0_1[0]),
+   &kAppStateTransitionSequenceStepNoUnrelatedMutation0_1,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds1_0[] = {
+  "invariant.inactive-panel-frozen",
+  "invariant.panel-local-focus-restore",
+  "invariant.shared-state-panel-local-isolation",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds1_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations1_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds1_1[] = {
+  "invariant.inactive-panel-frozen",
+  "invariant.panel-local-focus-restore",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds1_1[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations1_1[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps1[] = {
+  {1,
+   "tab-to-inactive-panel",
+   "transition.keybinding.navigate-tree",
+   "ACTION_SWITCH_PANEL",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds1_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds1_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds1_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds1_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds1_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds1_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations1_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations1_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations1_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "tab-back-to-original-panel",
+   "transition.keybinding.navigate-tree",
+   "ACTION_SWITCH_PANEL",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds1_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds1_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds1_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds1_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds1_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds1_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations1_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations1_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations1_1[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds2_0[] = {
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.viewport-identity-rebind",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds2_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations2_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
+  {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds2_1[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.viewport-identity-rebind",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds2_1[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations2_1[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
+  {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps2[] = {
+  {1,
+   "enter-directory",
+   "transition.keybinding.navigate-tree",
+   "ACTION_ENTER",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds2_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds2_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds2_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds2_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds2_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds2_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations2_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations2_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations2_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "enter-file-target",
+   "transition.keybinding.navigate-tree",
+   "ACTION_TO_DIR",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds2_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds2_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds2_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds2_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds2_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds2_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations2_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations2_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations2_1[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds3_0[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.blocked-transition-determinism",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds3_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations3_0[] = {
+  {"target.modal-command.session", "Modal target generation validates before applying completion or dismissal."},
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps3[] = {
+  {1,
+   "active-modal-escape-dismiss",
+   "transition.modal-action.dismiss",
+   "ACTION_ESCAPE",
+   "event.modal-completion",
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds3_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds3_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds3_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds3_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds3_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds3_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations3_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations3_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations3_0[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds4_0[] = {
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.panel-local-focus-restore",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds4_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations4_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"state.visibility-filter.panel-volume", "Visibility/filter generation matches the selected panel after the transition."},
+  {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds4_1[] = {
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.viewport-identity-rebind",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds4_1[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations4_1[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"state.visibility-filter.panel-volume", "Visibility/filter generation matches the selected panel after the transition."},
+  {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps4[] = {
+  {1,
+   "reveal-dotfiles",
+   "transition.keybinding.navigate-tree",
+   "ACTION_TOGGLE_HIDDEN",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds4_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds4_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds4_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds4_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds4_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds4_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations4_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations4_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations4_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "conceal-dotfiles",
+   "transition.keybinding.navigate-tree",
+   "ACTION_TOGGLE_HIDDEN",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds4_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds4_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds4_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds4_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds4_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds4_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations4_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations4_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations4_1[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds5_0[] = {
+  "invariant.viewport-identity-rebind",
+  "invariant.shared-state-panel-local-isolation",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds5_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.generation-mismatch-check",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations5_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
+  {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
+  {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds5_1[] = {
+  "invariant.stale-snapshot-fail-closed",
+  "invariant.viewport-identity-rebind",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds5_1[] = {
+  "harness.generation-mismatch-check",
+  "harness.blocked-transition-no-unrelated-mutation",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations5_1[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
+  {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
+};
+
+static const AppStateTransitionSequenceDeterministicFallbackMetadata kAppStateTransitionSequenceStepDeterministicFallback5_1 = {"Fail closed to the nearest valid durable identity or preserve the prior valid selection without using stale rows.", "Only the registered fallback/no-op result may run; unrelated owner fields remain unchanged."};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps5[] = {
+  {1,
+   "manual-refresh",
+   "transition.refresh-rebuild.manual-refresh",
+   "ACTION_REFRESH",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds5_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds5_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds5_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds5_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds5_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds5_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations5_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations5_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations5_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "stale-snapshot-rebind",
+   "transition.rebuild-rebind-callback.panel-anchor",
+   NULL,
+   "event.rebuild-rebind-callback",
+   "fallback",
+   kAppStateTransitionSequenceStepInvariantIds5_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds5_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds5_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds5_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds5_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds5_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations5_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations5_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations5_1[0]),
+   NULL,
+   "stale_snapshot",
+   &kAppStateTransitionSequenceStepDeterministicFallback5_1},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds6_0[] = {
+  "invariant.viewport-identity-rebind",
+  "invariant.shared-state-panel-local-isolation",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds6_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.generation-mismatch-check",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations6_0[] = {
+  {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
+  {"state.topology.volume", "Topology generation advances only for declared topology changes."},
+  {"state.file-payload.volume", "File payload generation advances only for declared payload rebuilds."},
+  {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds6_1[] = {
+  "invariant.stale-snapshot-fail-closed",
+  "invariant.blocked-transition-determinism",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds6_1[] = {
+  "harness.generation-mismatch-check",
+  "harness.blocked-transition-no-unrelated-mutation",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations6_1[] = {
+  {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
+  {"state.topology.volume", "Topology generation advances only for declared topology changes."},
+  {"state.file-payload.volume", "File payload generation advances only for declared payload rebuilds."},
+};
+
+static const AppStateTransitionSequenceDeterministicFallbackMetadata kAppStateTransitionSequenceStepDeterministicFallback6_1 = {"Reject stale mutation result, request a registered refresh/rebind, and keep unrelated panel state unchanged.", "Only the registered fallback/no-op result may run; unrelated owner fields remain unchanged."};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps6[] = {
+  {1,
+   "delete-or-mkdir-result",
+   "transition.filesystem-mutation-result.mkdir-copy-delete",
+   NULL,
+   "event.filesystem-mutation-result",
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds6_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds6_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds6_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds6_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds6_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds6_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations6_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations6_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations6_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "mutation-generation-mismatch",
+   "transition.filesystem-mutation-result.mkdir-copy-delete",
+   "ACTION_CMD_D",
+   "event.filesystem-mutation-result",
+   "fallback",
+   kAppStateTransitionSequenceStepInvariantIds6_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds6_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds6_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds6_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds6_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds6_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations6_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations6_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations6_1[0]),
+   NULL,
+   "generation_mismatch",
+   &kAppStateTransitionSequenceStepDeterministicFallback6_1},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds7_0[] = {
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.panel-local-focus-restore",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds7_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations7_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
+  {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds7_1[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.blocked-transition-determinism",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds7_1[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations7_1[] = {
+  {"target.modal-command.session", "Modal target generation validates before applying completion or dismissal."},
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps7[] = {
+  {1,
+   "list-jump-visible-target",
+   "transition.keybinding.navigate-tree",
+   "ACTION_LIST_JUMP",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds7_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds7_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds7_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds7_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds7_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds7_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations7_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations7_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations7_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "search-command-completion",
+   "transition.command-completion.user-command",
+   NULL,
+   "event.command-completion",
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds7_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds7_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds7_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds7_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds7_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds7_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations7_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations7_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations7_1[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds8_0[] = {
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.hidden-entry-visible-navigation",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds8_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations8_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"state.visibility-filter.panel-volume", "Visibility/filter generation matches the selected panel after the transition."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds8_1[] = {
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.render-projection-read-only",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds8_1[] = {
+  "harness.declared-write-set-diff",
+  "harness.render-projection-read-only-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations8_1[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"state.visibility-filter.panel-volume", "Visibility/filter generation matches the selected panel after the transition."},
+  {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps8[] = {
+  {1,
+   "toggle-tagged-only",
+   "transition.keybinding.navigate-tree",
+   "ACTION_TOGGLE_TAGGED_MODE",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds8_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds8_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds8_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds8_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds8_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds8_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations8_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations8_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations8_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "toggle-showall-global-projection",
+   "transition.keybinding.navigate-tree",
+   "ACTION_ASTERISK",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds8_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds8_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds8_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds8_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds8_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds8_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations8_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations8_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations8_1[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds9_0[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.render-projection-read-only",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds9_0[] = {
+  "harness.declared-write-set-diff",
+  "harness.render-projection-read-only-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations9_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
+  {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds9_1[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.render-projection-read-only",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds9_1[] = {
+  "harness.declared-write-set-diff",
+  "harness.render-projection-read-only-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations9_1[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
+  {"reflow.layout.projection", "Layout reflow generation is projection-only unless resize transition declares it."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps9[] = {
+  {1,
+   "toggle-file-mode",
+   "transition.keybinding.navigate-tree",
+   "ACTION_TOGGLE_MODE",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds9_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds9_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds9_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds9_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds9_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds9_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations9_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations9_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations9_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "view-preview-shape",
+   "transition.keybinding.navigate-tree",
+   "ACTION_VIEW_PREVIEW",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds9_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds9_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds9_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds9_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds9_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds9_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations9_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations9_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations9_1[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds10_0[] = {
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.viewport-identity-rebind",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds10_0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations10_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
+  {"lifecycle.volume.registry", "Volume lifecycle generation validates before rebinding panels."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds10_1[] = {
+  "invariant.stale-snapshot-fail-closed",
+  "invariant.shared-state-panel-local-isolation",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds10_1[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.generation-mismatch-check",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations10_1[] = {
+  {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
+  {"lifecycle.volume.registry", "Volume lifecycle generation validates before rebinding panels."},
+  {"state.topology.volume", "Topology generation advances only for declared topology changes."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps10[] = {
+  {1,
+   "volume-next",
+   "transition.volume-operation.release-cycle",
+   "ACTION_VOL_NEXT",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds10_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds10_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds10_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds10_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds10_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds10_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations10_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations10_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations10_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "volume-release-event",
+   "transition.volume-operation.release-cycle",
+   NULL,
+   "event.volume-lifecycle",
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds10_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds10_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds10_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds10_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds10_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds10_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations10_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations10_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations10_1[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds11_0[] = {
+  "invariant.inactive-panel-frozen",
+  "invariant.panel-local-focus-restore",
+  "invariant.render-projection-read-only",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds11_0[] = {
+  "harness.declared-write-set-diff",
+  "harness.render-projection-read-only-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations11_0[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
+  {"reflow.layout.projection", "Layout reflow generation is projection-only unless resize transition declares it."},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds11_1[] = {
+  "invariant.inactive-panel-frozen",
+  "invariant.panel-local-focus-restore",
+  "invariant.viewport-identity-rebind",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds11_1[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations11_1[] = {
+  {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
+  {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
+  {"reflow.layout.projection", "Layout reflow generation is projection-only unless resize transition declares it."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps11[] = {
+  {1,
+   "split-close",
+   "transition.keybinding.navigate-tree",
+   "ACTION_SPLIT_SCREEN",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds11_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds11_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds11_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds11_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds11_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds11_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations11_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations11_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations11_0[0]),
+   NULL,
+   NULL,
+   NULL},
+  {2,
+   "split-reopen",
+   "transition.keybinding.navigate-tree",
+   "ACTION_SPLIT_SCREEN",
+   NULL,
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds11_1,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds11_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds11_1[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds11_1,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds11_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds11_1[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations11_1,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations11_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations11_1[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const AppStateTransitionSequenceMetadata kAppStateTransitionSequences[] = {
+  {"sequence.split-toggle-f8",
+   "layout_split",
+   "split_toggle_f8",
+   "Toggle split layout with F8 and prove inactive-panel and layout ownership after each transition.",
+   kAppStateTransitionSequenceSteps0,
+   sizeof(kAppStateTransitionSequenceSteps0) / sizeof(kAppStateTransitionSequenceSteps0[0])},
+  {"sequence.tab-panel-switch",
+   "panel_navigation",
+   "tab_panel_switch",
+   "Switch active panel with Tab while preserving inactive-panel cursor, viewport, and focus snapshots.",
+   kAppStateTransitionSequenceSteps1,
+   sizeof(kAppStateTransitionSequenceSteps1) / sizeof(kAppStateTransitionSequenceSteps1[0])},
+  {"sequence.enter-directory-file-transition",
+   "directory_file_transition",
+   "enter_directory_file_transition",
+   "Enter from tree/file targets and validate durable directory/file identity after each step.",
+   kAppStateTransitionSequenceSteps2,
+   sizeof(kAppStateTransitionSequenceSteps2) / sizeof(kAppStateTransitionSequenceSteps2[0])},
+  {"sequence.esc-modal-dismissal",
+   "modal_command",
+   "esc_modal_dismissal",
+   "Dismiss command/modal ownership through the registered modal transition and preserve panel-local state.",
+   kAppStateTransitionSequenceSteps3,
+   sizeof(kAppStateTransitionSequenceSteps3) / sizeof(kAppStateTransitionSequenceSteps3[0])},
+  {"sequence.dotfile-reveal-conceal",
+   "visibility_filter",
+   "dotfile_reveal_conceal",
+   "Reveal and conceal dotfiles without letting hidden entries become visible-navigation selections.",
+   kAppStateTransitionSequenceSteps4,
+   sizeof(kAppStateTransitionSequenceSteps4) / sizeof(kAppStateTransitionSequenceSteps4[0])},
+  {"sequence.refresh-rebuild",
+   "refresh_rebuild",
+   "refresh_rebuild",
+   "Refresh and rebuild with generation validation and deterministic stale-snapshot fail-closed behavior.",
+   kAppStateTransitionSequenceSteps5,
+   sizeof(kAppStateTransitionSequenceSteps5) / sizeof(kAppStateTransitionSequenceSteps5[0])},
+  {"sequence.filesystem-mutation-result",
+   "filesystem_mutation",
+   "filesystem_mutation_result",
+   "Apply filesystem mutation results through the registered result transition and validate generation mismatch fallback.",
+   kAppStateTransitionSequenceSteps6,
+   sizeof(kAppStateTransitionSequenceSteps6) / sizeof(kAppStateTransitionSequenceSteps6[0])},
+  {"sequence.search-jump",
+   "search_jump",
+   "search_jump",
+   "Search/list jump updates selection only through visible-navigation and focus ownership rules.",
+   kAppStateTransitionSequenceSteps7,
+   sizeof(kAppStateTransitionSequenceSteps7) / sizeof(kAppStateTransitionSequenceSteps7[0])},
+  {"sequence.showall-global-tagged-only",
+   "display_mode",
+   "showall_global_tagged_only",
+   "Toggle showall/global/tagged-only style filters without moving panel-local ownership into shared volume state.",
+   kAppStateTransitionSequenceSteps8,
+   sizeof(kAppStateTransitionSequenceSteps8) / sizeof(kAppStateTransitionSequenceSteps8[0])},
+  {"sequence.file-small-big-transitions",
+   "directory_file_transition",
+   "file_small_big_transitions",
+   "Move between small-file, big-file, and preview-shaped views without render-side ownership repair.",
+   kAppStateTransitionSequenceSteps9,
+   sizeof(kAppStateTransitionSequenceSteps9) / sizeof(kAppStateTransitionSequenceSteps9[0])},
+  {"sequence.volume-cycling-release",
+   "volume_lifecycle",
+   "volume_cycling_release",
+   "Cycle and release volumes through shared lifecycle generation while each panel rebinds by identity.",
+   kAppStateTransitionSequenceSteps10,
+   sizeof(kAppStateTransitionSequenceSteps10) / sizeof(kAppStateTransitionSequenceSteps10[0])},
+  {"sequence.split-close-reopen",
+   "layout_split",
+   "split_close_reopen",
+   "Close and reopen split layout and prove panel snapshots survive layout projection changes.",
+   kAppStateTransitionSequenceSteps11,
+   sizeof(kAppStateTransitionSequenceSteps11) / sizeof(kAppStateTransitionSequenceSteps11[0])},
+};
 static const char *const kAppStateDispatchSurfaceMigrationNotes0[] = {
   "Current input polling and key normalization feed controller dispatch; AppState mutation remains in downstream handlers until runtime transition objects are introduced.",
 };
@@ -1969,6 +2797,11 @@ size_t AppStateDiffHarnessCount(void) {
   return sizeof(kAppStateDiffHarnesses) / sizeof(kAppStateDiffHarnesses[0]);
 }
 
+size_t AppStateTransitionSequenceCount(void) {
+  return sizeof(kAppStateTransitionSequences) /
+         sizeof(kAppStateTransitionSequences[0]);
+}
+
 const AppStateOwnerFieldMetadata *AppStateOwnerFieldAt(size_t index) {
   if (index >= AppStateOwnerFieldCount())
     return NULL;
@@ -1989,6 +2822,14 @@ const AppStateDiffHarnessMetadata *AppStateDiffHarnessAt(size_t index) {
     return NULL;
 
   return &kAppStateDiffHarnesses[index];
+}
+
+const AppStateTransitionSequenceMetadata *
+AppStateTransitionSequenceAt(size_t index) {
+  if (index >= AppStateTransitionSequenceCount())
+    return NULL;
+
+  return &kAppStateTransitionSequences[index];
 }
 
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
@@ -2060,6 +2901,21 @@ AppStateDiffHarnessLookup(const char *harness_id) {
   for (index = 0; index < AppStateDiffHarnessCount(); index++) {
     if (!strcmp(kAppStateDiffHarnesses[index].harness_id, harness_id))
       return &kAppStateDiffHarnesses[index];
+  }
+
+  return NULL;
+}
+
+const AppStateTransitionSequenceMetadata *
+AppStateTransitionSequenceLookup(const char *scenario_id) {
+  size_t index;
+
+  if (scenario_id == NULL || scenario_id[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateTransitionSequenceCount(); index++) {
+    if (!strcmp(kAppStateTransitionSequences[index].scenario_id, scenario_id))
+      return &kAppStateTransitionSequences[index];
   }
 
   return NULL;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -45,6 +45,327 @@ static int NonEmptyStringList(const char *const *values, size_t count) {
   return 1;
 }
 
+static const struct {
+  const char *action_id;
+  YtreeNovaAction action;
+} kAppStateActionIds[] = {
+  {"ACTION_NONE", ACTION_NONE},
+  {"ACTION_MOVE_UP", ACTION_MOVE_UP},
+  {"ACTION_MOVE_DOWN", ACTION_MOVE_DOWN},
+  {"ACTION_MOVE_SIBLING_NEXT", ACTION_MOVE_SIBLING_NEXT},
+  {"ACTION_MOVE_SIBLING_PREV", ACTION_MOVE_SIBLING_PREV},
+  {"ACTION_MOVE_LEFT", ACTION_MOVE_LEFT},
+  {"ACTION_MOVE_RIGHT", ACTION_MOVE_RIGHT},
+  {"ACTION_PAGE_UP", ACTION_PAGE_UP},
+  {"ACTION_PAGE_DOWN", ACTION_PAGE_DOWN},
+  {"ACTION_HOME", ACTION_HOME},
+  {"ACTION_END", ACTION_END},
+  {"ACTION_TREE_EXPAND", ACTION_TREE_EXPAND},
+  {"ACTION_TREE_COLLAPSE", ACTION_TREE_COLLAPSE},
+  {"ACTION_TREE_EXPAND_ALL", ACTION_TREE_EXPAND_ALL},
+  {"ACTION_ENTER", ACTION_ENTER},
+  {"ACTION_ESCAPE", ACTION_ESCAPE},
+  {"ACTION_LOG", ACTION_LOG},
+  {"ACTION_QUIT", ACTION_QUIT},
+  {"ACTION_QUIT_DIR", ACTION_QUIT_DIR},
+  {"ACTION_TAG", ACTION_TAG},
+  {"ACTION_UNTAG", ACTION_UNTAG},
+  {"ACTION_TAG_ALL", ACTION_TAG_ALL},
+  {"ACTION_UNTAG_ALL", ACTION_UNTAG_ALL},
+  {"ACTION_TAG_REST", ACTION_TAG_REST},
+  {"ACTION_UNTAG_REST", ACTION_UNTAG_REST},
+  {"ACTION_FILTER", ACTION_FILTER},
+  {"ACTION_TOGGLE_MODE", ACTION_TOGGLE_MODE},
+  {"ACTION_REFRESH", ACTION_REFRESH},
+  {"ACTION_RESIZE", ACTION_RESIZE},
+  {"ACTION_VOL_MENU", ACTION_VOL_MENU},
+  {"ACTION_VOL_PREV", ACTION_VOL_PREV},
+  {"ACTION_VOL_NEXT", ACTION_VOL_NEXT},
+  {"ACTION_CMD_A", ACTION_CMD_A},
+  {"ACTION_CMD_B", ACTION_CMD_B},
+  {"ACTION_CMD_C", ACTION_CMD_C},
+  {"ACTION_CMD_D", ACTION_CMD_D},
+  {"ACTION_CMD_E", ACTION_CMD_E},
+  {"ACTION_CMD_G", ACTION_CMD_G},
+  {"ACTION_CMD_H", ACTION_CMD_H},
+  {"ACTION_CMD_I", ACTION_CMD_I},
+  {"ACTION_CMD_M", ACTION_CMD_M},
+  {"ACTION_CMD_O", ACTION_CMD_O},
+  {"ACTION_CMD_P", ACTION_CMD_P},
+  {"ACTION_CMD_R", ACTION_CMD_R},
+  {"ACTION_CMD_S", ACTION_CMD_S},
+  {"ACTION_CMD_V", ACTION_CMD_V},
+  {"ACTION_CMD_X", ACTION_CMD_X},
+  {"ACTION_CMD_Y", ACTION_CMD_Y},
+  {"ACTION_CMD_PRINT", ACTION_CMD_PRINT},
+  {"ACTION_TOGGLE_HIDDEN", ACTION_TOGGLE_HIDDEN},
+  {"ACTION_TOGGLE_COMPACT", ACTION_TOGGLE_COMPACT},
+  {"ACTION_CMD_MKFILE", ACTION_CMD_MKFILE},
+  {"ACTION_CMD_TAGGED_A", ACTION_CMD_TAGGED_A},
+  {"ACTION_CMD_TAGGED_C", ACTION_CMD_TAGGED_C},
+  {"ACTION_CMD_TAGGED_D", ACTION_CMD_TAGGED_D},
+  {"ACTION_CMD_TAGGED_G", ACTION_CMD_TAGGED_G},
+  {"ACTION_CMD_TAGGED_M", ACTION_CMD_TAGGED_M},
+  {"ACTION_CMD_TAGGED_O", ACTION_CMD_TAGGED_O},
+  {"ACTION_CMD_TAGGED_P", ACTION_CMD_TAGGED_P},
+  {"ACTION_CMD_TAGGED_R", ACTION_CMD_TAGGED_R},
+  {"ACTION_CMD_TAGGED_S", ACTION_CMD_TAGGED_S},
+  {"ACTION_CMD_TAGGED_V", ACTION_CMD_TAGGED_V},
+  {"ACTION_CMD_TAGGED_X", ACTION_CMD_TAGGED_X},
+  {"ACTION_CMD_TAGGED_Y", ACTION_CMD_TAGGED_Y},
+  {"ACTION_CMD_TAGGED_PRINT", ACTION_CMD_TAGGED_PRINT},
+  {"ACTION_LIST_JUMP", ACTION_LIST_JUMP},
+  {"ACTION_TO_DIR", ACTION_TO_DIR},
+  {"ACTION_TOGGLE_TAGGED_MODE", ACTION_TOGGLE_TAGGED_MODE},
+  {"ACTION_TOGGLE_STATS", ACTION_TOGGLE_STATS},
+  {"ACTION_ASTERISK", ACTION_ASTERISK},
+  {"ACTION_INVERT", ACTION_INVERT},
+  {"ACTION_SPLIT_SCREEN", ACTION_SPLIT_SCREEN},
+  {"ACTION_SWITCH_PANEL", ACTION_SWITCH_PANEL},
+  {"ACTION_VIEW_PREVIEW", ACTION_VIEW_PREVIEW},
+  {"ACTION_PREVIEW_SCROLL_UP", ACTION_PREVIEW_SCROLL_UP},
+  {"ACTION_PREVIEW_SCROLL_DOWN", ACTION_PREVIEW_SCROLL_DOWN},
+  {"ACTION_PREVIEW_HOME", ACTION_PREVIEW_HOME},
+  {"ACTION_PREVIEW_END", ACTION_PREVIEW_END},
+  {"ACTION_PREVIEW_PAGE_UP", ACTION_PREVIEW_PAGE_UP},
+  {"ACTION_PREVIEW_PAGE_DOWN", ACTION_PREVIEW_PAGE_DOWN},
+  {"ACTION_COMPARE_FILE", ACTION_COMPARE_FILE},
+  {"ACTION_COMPARE_DIR", ACTION_COMPARE_DIR},
+  {"ACTION_COMPARE_TREE", ACTION_COMPARE_TREE},
+  {"ACTION_EDIT_CONFIG", ACTION_EDIT_CONFIG},
+  {"ACTION_USER_CMD", ACTION_USER_CMD},
+};
+
+static const struct {
+  const char *event_id;
+  const char *transition_id;
+} kAppStateEventTransitionIds[] = {
+  {"event.terminal-resize-signal", "transition.terminal-signal-resize" },
+  {"event.refresh-rebuild", "transition.refresh-rebuild.manual-refresh" },
+  {"event.rebuild-rebind-callback", "transition.rebuild-rebind-callback.panel-anchor" },
+  {"event.filesystem-mutation-result", "transition.filesystem-mutation-result.mkdir-copy-delete" },
+  {"event.watcher-live-refresh", "transition.refresh-rebuild.manual-refresh" },
+  {"event.command-completion", "transition.command-completion.user-command" },
+  {"event.modal-completion", "transition.modal-action.dismiss" },
+  {"event.volume-lifecycle", "transition.volume-operation.release-cycle" },
+  {"event.render-reflow", "transition.render-reflow.project-state" },
+};
+
+
+static int StringListContains(const char *const *values, size_t count,
+                              const char *value) {
+  size_t index;
+
+  if (!NonEmptyString(value))
+    return 0;
+
+  for (index = 0; index < count; index++) {
+    if (NonEmptyString(values[index]) && strcmp(values[index], value) == 0)
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateExpectedResultValid(const char *expected_result) {
+  return strcmp(expected_result, "allowed") == 0 ||
+         strcmp(expected_result, "blocked") == 0 ||
+         strcmp(expected_result, "fallback") == 0 ||
+         strcmp(expected_result, "invalid") == 0;
+}
+
+static const AppStateActionTransitionMetadata *
+AppStateActionIdLookup(const char *action_id) {
+  size_t index;
+
+  if (!NonEmptyString(action_id))
+    return NULL;
+
+  for (index = 0; index < sizeof(kAppStateActionIds) / sizeof(kAppStateActionIds[0]);
+       index++) {
+    if (strcmp(kAppStateActionIds[index].action_id, action_id) == 0)
+      return AppStateActionTransitionLookup(kAppStateActionIds[index].action);
+  }
+
+  return NULL;
+}
+
+static const char *AppStateEventTransitionLookup(const char *event_id) {
+  size_t index;
+
+  if (!NonEmptyString(event_id))
+    return NULL;
+
+  for (index = 0;
+       index < sizeof(kAppStateEventTransitionIds) /
+                   sizeof(kAppStateEventTransitionIds[0]);
+       index++) {
+    if (strcmp(kAppStateEventTransitionIds[index].event_id, event_id) == 0)
+      return kAppStateEventTransitionIds[index].transition_id;
+  }
+
+  return NULL;
+}
+
+static int AppStateFallbackPreconditionValid(const char *precondition) {
+  if (precondition == NULL)
+    return 1;
+  if (!NonEmptyString(precondition))
+    return 0;
+  return strcmp(precondition, "generation_mismatch") == 0 ||
+         strcmp(precondition, "stale_snapshot") == 0;
+}
+
+static int AppStateTransitionSequenceStepReady(
+    const AppStateTransitionSequenceMetadata *sequence,
+    const AppStateTransitionSequenceStepMetadata *step, size_t step_index,
+    size_t previous_ordinal) {
+  size_t ref_index;
+
+  if (step == NULL || step->ordinal == 0 || step->ordinal <= previous_ordinal ||
+      !NonEmptyString(step->step_id) || !NonEmptyString(step->transition_id) ||
+      !NonEmptyString(step->expected_result) ||
+      !AppStateExpectedResultValid(step->expected_result) ||
+      AppStateTransitionLookup(step->transition_id) == NULL ||
+      !NonEmptyStringList(step->invariant_ids, step->invariant_id_count) ||
+      !NonEmptyStringList(step->diff_harness_ids, step->diff_harness_id_count) ||
+      step->generation_domain_expectations == NULL ||
+      step->generation_domain_expectation_count == 0 ||
+      !AppStateFallbackPreconditionValid(step->precondition))
+    return 0;
+
+  for (ref_index = 0; ref_index < step_index; ref_index++) {
+    if (strcmp(sequence->steps[ref_index].step_id, step->step_id) == 0)
+      return 0;
+  }
+
+  if (step->stimulus_action_id == NULL && step->stimulus_event_id == NULL)
+    return 0;
+  if (step->stimulus_action_id != NULL) {
+    const AppStateActionTransitionMetadata *action_metadata =
+        AppStateActionIdLookup(step->stimulus_action_id);
+
+    if (action_metadata == NULL ||
+        strcmp(action_metadata->transition_id, step->transition_id) != 0)
+      return 0;
+  }
+  if (step->stimulus_event_id != NULL) {
+    const char *event_transition =
+        AppStateEventTransitionLookup(step->stimulus_event_id);
+
+    if (event_transition == NULL || strcmp(event_transition, step->transition_id) != 0)
+      return 0;
+  }
+
+  for (ref_index = 0; ref_index < step->invariant_id_count; ref_index++) {
+    if (AppStateInvariantLookup(step->invariant_ids[ref_index]) == NULL)
+      return 0;
+    if (StringListContains(step->invariant_ids, ref_index,
+                           step->invariant_ids[ref_index]))
+      return 0;
+  }
+  for (ref_index = 0; ref_index < step->diff_harness_id_count; ref_index++) {
+    if (AppStateDiffHarnessLookup(step->diff_harness_ids[ref_index]) == NULL)
+      return 0;
+    if (StringListContains(step->diff_harness_ids, ref_index,
+                           step->diff_harness_ids[ref_index]))
+      return 0;
+  }
+  for (ref_index = 0; ref_index < step->generation_domain_expectation_count;
+       ref_index++) {
+    const AppStateTransitionSequenceGenerationExpectationMetadata *expectation =
+        &step->generation_domain_expectations[ref_index];
+    size_t previous_index;
+
+    if (!NonEmptyString(expectation->domain_id) ||
+        !NonEmptyString(expectation->expectation) ||
+        AppStateGenerationDomainLookup(expectation->domain_id) == NULL)
+      return 0;
+    for (previous_index = 0; previous_index < ref_index; previous_index++) {
+      if (strcmp(step->generation_domain_expectations[previous_index].domain_id,
+                 expectation->domain_id) == 0)
+        return 0;
+    }
+  }
+
+  if (strcmp(step->expected_result, "blocked") == 0 ||
+      strcmp(step->expected_result, "invalid") == 0) {
+    if (step->no_unrelated_mutation == NULL)
+      return 0;
+  }
+  if (step->no_unrelated_mutation != NULL) {
+    if (!NonEmptyString(step->no_unrelated_mutation->diff_harness_id) ||
+        !NonEmptyString(step->no_unrelated_mutation->expectation) ||
+        AppStateDiffHarnessLookup(step->no_unrelated_mutation->diff_harness_id) ==
+            NULL)
+      return 0;
+  }
+
+  if (step->precondition != NULL || strcmp(step->expected_result, "fallback") == 0) {
+    if (step->deterministic_fallback == NULL)
+      return 0;
+  }
+  if (step->deterministic_fallback != NULL) {
+    if (!NonEmptyString(step->deterministic_fallback->outcome) ||
+        !NonEmptyString(step->deterministic_fallback->allowed_mutation_scope))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int AppStateTransitionSequencesReady(void) {
+  size_t index;
+
+  if (AppStateTransitionSequenceCount() == 0)
+    return 0;
+
+  for (index = 0; index < AppStateTransitionSequenceCount(); index++) {
+    const AppStateTransitionSequenceMetadata *sequence =
+        AppStateTransitionSequenceAt(index);
+    size_t previous_index;
+    size_t step_index;
+    size_t previous_ordinal = 0;
+
+    if (sequence == NULL || !NonEmptyString(sequence->scenario_id) ||
+        !NonEmptyString(sequence->category) || !NonEmptyString(sequence->flow) ||
+        !NonEmptyString(sequence->description) || sequence->steps == NULL ||
+        sequence->step_count == 0)
+      return 0;
+    if (AppStateTransitionSequenceLookup(sequence->scenario_id) != sequence)
+      return 0;
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateTransitionSequenceMetadata *previous =
+          AppStateTransitionSequenceAt(previous_index);
+
+      if (previous == NULL ||
+          strcmp(previous->scenario_id, sequence->scenario_id) == 0)
+        return 0;
+    }
+
+    for (step_index = 0; step_index < sequence->step_count; step_index++) {
+      const AppStateTransitionSequenceStepMetadata *step =
+          &sequence->steps[step_index];
+
+      if (!AppStateTransitionSequenceStepReady(sequence, step, step_index,
+                                               previous_ordinal))
+        return 0;
+      previous_ordinal = step->ordinal;
+    }
+  }
+
+  if (AppStateTransitionSequenceAt(AppStateTransitionSequenceCount()) != NULL)
+    return 0;
+  if (AppStateTransitionSequenceLookup(NULL) != NULL)
+    return 0;
+  if (AppStateTransitionSequenceLookup("") != NULL)
+    return 0;
+  if (AppStateTransitionSequenceLookup("sequence.__ytnova_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
 static int AppStateInvariantDispatchSurfacesReady(
     const AppStateInvariantMetadata *metadata) {
   size_t note_index;
@@ -516,6 +837,7 @@ int main(int argc, char **argv) {
       !AppStateInvariantRegistryReady() ||
       !AppStateCompatibilityShimsReady() ||
       !AppStateDiffHarnessRegistryReady() ||
+      !AppStateTransitionSequencesReady() ||
       !AppStateActionTransitionsReady()) {
     fprintf(stderr, "EXIT: startup invariants not configured\n");
     exit(1);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import importlib.util
 import subprocess
 from pathlib import Path
@@ -336,6 +337,7 @@ def _write_fixture(
     runtime_owner_fields: list[dict[str, object]] | None = None,
     runtime_generation_domains: list[dict[str, object]] | None = None,
     runtime_diff_harness_checks: list[dict[str, object]] | None = None,
+    runtime_transition_sequences: list[dict[str, object]] | None = None,
 ) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
     transitions_path = tmp_path / "transitions.json"
     shims_path = tmp_path / "shims.json"
@@ -454,6 +456,13 @@ def _write_fixture(
                 if diff_harness_checks is not None
                 else _complete_diff_harness_checks()
             ),
+            runtime_transition_sequences
+            if runtime_transition_sequences is not None
+            else (
+                transition_sequences
+                if transition_sequences is not None
+                else _complete_transition_sequences()
+            ),
         ),
     )
     return (
@@ -492,6 +501,7 @@ def _runtime_source(
     invariants: list[dict[str, object]],
     generation_domains: list[dict[str, object]],
     diff_harness_checks: list[dict[str, object]],
+    transition_sequences: list[dict[str, object]],
 ) -> str:
     transition_write_sets = []
     transition_rows = []
@@ -735,6 +745,128 @@ def _runtime_source(
             f"sizeof(kAppStateDiffHarnessMigrationNotes{index}) / "
             f"sizeof(kAppStateDiffHarnessMigrationNotes{index}[0])}},"
         )
+    transition_sequence_arrays = []
+    transition_sequence_rows = []
+    for sequence_index, record in enumerate(transition_sequences):
+        steps = record.get("steps")
+        if not isinstance(steps, list):
+            steps = []
+        step_rows = []
+        for step_index, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            invariant_ids = step.get("invariant_ids")
+            if not isinstance(invariant_ids, list):
+                invariant_ids = []
+            sequence_invariant_rows = "\n".join(
+                f'  "{value}",' for value in invariant_ids if isinstance(value, str)
+            )
+            invariant_table = (
+                "kAppStateTransitionSequenceStepInvariantIds"
+                f"{sequence_index}_{step_index}"
+            )
+            transition_sequence_arrays.append(
+                f"static const char *const {invariant_table}[] = "
+                f"{{\n{sequence_invariant_rows}\n}};\n"
+            )
+            diff_harness_ids = step.get("diff_harness_ids")
+            if not isinstance(diff_harness_ids, list):
+                diff_harness_ids = []
+            diff_rows = "\n".join(
+                f'  "{value}",' for value in diff_harness_ids if isinstance(value, str)
+            )
+            diff_table = (
+                "kAppStateTransitionSequenceStepDiffHarnessIds"
+                f"{sequence_index}_{step_index}"
+            )
+            transition_sequence_arrays.append(
+                f"static const char *const {diff_table}[] = "
+                f"{{\n{diff_rows}\n}};\n"
+            )
+            expectations = step.get("generation_domain_expectations")
+            if not isinstance(expectations, list):
+                expectations = []
+            expectation_rows = "\n".join(
+                f'  {{"{expectation.get("domain_id", "")}", '
+                f'"{expectation.get("expectation", "")}"}},'
+                for expectation in expectations
+                if isinstance(expectation, dict)
+            )
+            expectation_table = (
+                "kAppStateTransitionSequenceStepGenerationExpectations"
+                f"{sequence_index}_{step_index}"
+            )
+            transition_sequence_arrays.append(
+                "static const "
+                "AppStateTransitionSequenceGenerationExpectationMetadata "
+                f"{expectation_table}[] = {{\n{expectation_rows}\n}};\n"
+            )
+            no_unrelated = step.get("no_unrelated_mutation")
+            if isinstance(no_unrelated, dict):
+                no_unrelated_table = (
+                    "kAppStateTransitionSequenceStepNoUnrelatedMutation"
+                    f"{sequence_index}_{step_index}"
+                )
+                transition_sequence_arrays.append(
+                    "static const "
+                    "AppStateTransitionSequenceNoUnrelatedMutationMetadata "
+                    f'{no_unrelated_table} = '
+                    f'{{"{no_unrelated.get("diff_harness_id", "")}", '
+                    f'"{no_unrelated.get("expectation", "")}"}};\n'
+                )
+                no_unrelated_ref = f"&{no_unrelated_table}"
+            else:
+                no_unrelated_ref = "NULL"
+            fallback = step.get("deterministic_fallback")
+            if isinstance(fallback, dict):
+                fallback_table = (
+                    "kAppStateTransitionSequenceStepDeterministicFallback"
+                    f"{sequence_index}_{step_index}"
+                )
+                transition_sequence_arrays.append(
+                    "static const "
+                    "AppStateTransitionSequenceDeterministicFallbackMetadata "
+                    f'{fallback_table} = '
+                    f'{{"{fallback.get("outcome", "")}", '
+                    f'"{fallback.get("allowed_mutation_scope", "")}"}};\n'
+                )
+                fallback_ref = f"&{fallback_table}"
+            else:
+                fallback_ref = "NULL"
+            stimulus = step.get("stimulus")
+            if not isinstance(stimulus, dict):
+                stimulus = {}
+            action_id = stimulus.get("action_id")
+            event_id = stimulus.get("event_id")
+            action_expr = f'"{action_id}"' if isinstance(action_id, str) else "NULL"
+            event_expr = f'"{event_id}"' if isinstance(event_id, str) else "NULL"
+            precondition = step.get("precondition")
+            precondition_expr = (
+                f'"{precondition}"' if isinstance(precondition, str) else "NULL"
+            )
+            step_rows.append(
+                f'  {{{step.get("ordinal", 0)}, "{step.get("step_id", "")}", '
+                f'"{step.get("transition_id", "")}", {action_expr}, {event_expr}, '
+                f'"{step.get("expected_result", "")}", '
+                f"{invariant_table}, sizeof({invariant_table}) / "
+                f"sizeof({invariant_table}[0]), "
+                f"{diff_table}, sizeof({diff_table}) / sizeof({diff_table}[0]), "
+                f"{expectation_table}, sizeof({expectation_table}) / "
+                f"sizeof({expectation_table}[0]), "
+                f"{no_unrelated_ref}, {precondition_expr}, {fallback_ref}}},"
+            )
+        steps_table = f"kAppStateTransitionSequenceSteps{sequence_index}"
+        transition_sequence_arrays.append(
+            "static const AppStateTransitionSequenceStepMetadata "
+            f"{steps_table}[] = {{\n" + "\n".join(step_rows) + "\n};\n"
+        )
+        transition_sequence_rows.append(
+            f'  {{"{record.get("scenario_id", "")}", '
+            f'"{record.get("category", "")}", '
+            f'"{record.get("flow", "")}", '
+            f'"{record.get("description", "")}", '
+            f"{steps_table}, sizeof({steps_table}) / sizeof({steps_table}[0])}},"
+        )
     action_rows = "\n".join(
         f'  {{{record["action"]}, "{record["transition_id"]}", "{record["category"]}"}},'
         for record in actions
@@ -770,6 +902,11 @@ def _runtime_source(
         + "\n};\n"
         "static const AppStateInvariantMetadata kAppStateInvariants[] = {\n"
         + "\n".join(invariant_rows)
+        + "\n};\n"
+        + "".join(transition_sequence_arrays)
+        + "static const AppStateTransitionSequenceMetadata "
+        "kAppStateTransitionSequences[] = {\n"
+        + "\n".join(transition_sequence_rows)
         + "\n};\n"
         "static const AppStateActionTransitionMetadata\n"
         "    kAppStateActionTransitions[APPSTATE_ACTION_TRANSITION_COUNT] = {\n"
@@ -1239,6 +1376,237 @@ def test_guard_fails_when_blocked_transition_sequence_lacks_no_mutation_expectat
         and "require no_unrelated_mutation" in failure
         for failure in failures
     )
+
+
+def test_guard_fails_when_runtime_transition_sequence_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    missing_id = transition_sequences[-1]["scenario_id"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transition_sequences=transition_sequences[:-1],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime transition sequence registry missing scenario id" in failure
+        and missing_id in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_is_extra(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transition_sequences = _complete_transition_sequences() + [
+        _transition_sequence("split_toggle_f8", scenario_id="sequence.extra")
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence" in failure
+        and "scenario_id does not match a transition sequence" in failure
+        and "sequence.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_is_duplicate(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences[1]["scenario_id"] = runtime_transition_sequences[0][
+        "scenario_id"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[1]" in failure
+        and "duplicate runtime transition sequence scenario_id" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_top_level_row_is_malformed(
+    tmp_path: Path,
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    runtime_path = paths[-1]
+    runtime_path.write_text(
+        runtime_path.read_text(encoding="utf-8").replace(
+            "static const AppStateTransitionSequenceMetadata "
+            "kAppStateTransitionSequences[] = {\n",
+            "static const AppStateTransitionSequenceMetadata "
+            "kAppStateTransitionSequences[] = {\n"
+            '  {"sequence.malformed"},\n',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0]" in failure
+        and "malformed runtime transition sequence registry row" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_step_row_is_malformed(
+    tmp_path: Path,
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    runtime_path = paths[-1]
+    runtime_path.write_text(
+        runtime_path.read_text(encoding="utf-8").replace(
+            "static const AppStateTransitionSequenceStepMetadata "
+            "kAppStateTransitionSequenceSteps0[] = {\n",
+            "static const AppStateTransitionSequenceStepMetadata "
+            "kAppStateTransitionSequenceSteps0[] = {\n"
+            '  {"step.malformed"},\n',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence_step[kAppStateTransitionSequenceSteps0][0]"
+        in failure
+        and "malformed runtime transition sequence step row" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_list_entry_is_malformed(
+    tmp_path: Path,
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    runtime_path = paths[-1]
+    runtime_path.write_text(
+        runtime_path.read_text(encoding="utf-8").replace(
+            "static const char *const kAppStateTransitionSequenceStepInvariantIds0_0[] = {\n"
+            '  "invariant.inactive_panel_frozen",',
+            "static const char *const kAppStateTransitionSequenceStepInvariantIds0_0[] = {\n"
+            "  NULL,\n"
+            '  "invariant.inactive_panel_frozen",',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateTransitionSequenceStepInvariantIds0_0[0]" in failure
+        and "malformed string literal entry" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    (
+        ("transition_id", "transition.missing", "runtime transition registry"),
+        ("stimulus", {"action_id": "ACTION_MISSING"}, "unknown action"),
+        ("stimulus", {"event_id": "event.missing"}, "unknown event id"),
+        ("invariant_ids", ["invariant.missing"], "runtime invariant id"),
+        ("diff_harness_ids", ["harness.missing"], "runtime diff harness id"),
+        (
+            "generation_domain_expectations",
+            [{"domain_id": "domain.missing", "expectation": "fixture"}],
+            "unknown generation domain id",
+        ),
+    ),
+)
+def test_guard_fails_on_runtime_transition_sequence_invalid_links(
+    tmp_path: Path, field: str, value: object, expected: str
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences[0]["steps"][0][field] = value
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0].step[0]" in failure
+        and expected in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_fallback_drifts(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    step = transition_sequences[0]["steps"][0]
+    step["precondition"] = "stale_snapshot"
+    step["expected_result"] = "fallback"
+    step["deterministic_fallback"] = {
+        "outcome": "restore stable identity",
+        "allowed_mutation_scope": "declared transition fields only",
+    }
+    runtime_transition_sequences = copy.deepcopy(transition_sequences)
+    runtime_transition_sequences[0]["steps"][0]["deterministic_fallback"][
+        "outcome"
+    ] = "different outcome"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        transition_sequences=transition_sequences,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0]" in failure
+        and "runtime steps does not match transition sequence" in failure
+        and "different outcome" in failure
+        for failure in failures
+    )
+
+
+def test_runtime_transition_sequence_lookup_fails_closed_in_startup_guard() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    header = (repo_root / "include" / "ytnova_appstate_actions.h").read_text(
+        encoding="utf-8"
+    )
+    source = (repo_root / "src" / "core" / "main.c").read_text(encoding="utf-8")
+
+    assert "AppStateTransitionSequenceCount(void)" in header
+    assert "AppStateTransitionSequenceAt(size_t index)" in header
+    assert "AppStateTransitionSequenceLookup(const char *scenario_id)" in header
+    assert "AppStateTransitionSequenceAt(AppStateTransitionSequenceCount())" in source
+    assert "AppStateTransitionSequenceLookup(NULL)" in source
+    assert 'AppStateTransitionSequenceLookup("")' in source
+    assert 'AppStateTransitionSequenceLookup("sequence.__ytnova_unknown__")' in source
 
 
 def test_guard_fails_when_required_diff_harness_field_is_missing(
@@ -3267,7 +3635,10 @@ def test_guard_fails_when_runtime_invariant_row_is_malformed(
         "sizeof(kAppStateInvariantMigrationNotes0) / "
         "sizeof(kAppStateInvariantMigrationNotes0[0])},"
     )
-    marker = "\n};\nstatic const AppStateActionTransitionMetadata"
+    marker = (
+        "\n};\n"
+        "static const char *const kAppStateTransitionSequenceStepInvariantIds0_0"
+    )
     runtime_path.write_text(
         source.replace(marker, f"\n{malformed_row}{marker}", 1),
         encoding="utf-8",


### PR DESCRIPTION
## Summary
- Add read-only runtime metadata for AppState transition-sequence scenarios and nested steps.
- Validate sequence metadata links against action, event, transition, invariant, diff-harness, and generation-domain registries.
- Extend the contract guard and focused tests so docs/runtime drift and malformed nested sequence metadata fail locally and in CI.

## Scope
- Runtime lookup/count/index scaffold only.
- No dynamic sequence execution, UI driving, transition-diff execution, snapshot capture, restore/render behavior changes, or UI state writes.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS, 255 passed.
- `make clean && make` — PASS with pre-existing compiler warnings.
- `make qa-cppcheck && make qa-code-quality && git diff --check && ./build/ytnova --version` — PASS.
