### PR TITLE
chore(appstate): add event coverage lookup

### DIFF
--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -31,6 +31,22 @@ typedef struct {
 } AppStateActionCoverageMetadata;
 
 typedef struct {
+  const char *event_id;
+  const char *event_class;
+  const char *transition_id;
+  const char *category;
+  const char *source;
+  const char *owner;
+  const char *const *declared_write_set;
+  size_t declared_write_set_count;
+  const char *boundary_status;
+  const char *const *trigger_paths;
+  size_t trigger_path_count;
+  const char *const *migration_notes;
+  size_t migration_note_count;
+} AppStateEventCoverageMetadata;
+
+typedef struct {
   const char *id;
   const char *category;
   const char *owner;
@@ -184,6 +200,10 @@ const AppStateActionCoverageMetadata *
 AppStateActionCoverageLookup(YtreeNovaAction action);
 const AppStateActionCoverageMetadata *AppStateActionCoverageAt(size_t index);
 size_t AppStateActionCoverageCount(void);
+const AppStateEventCoverageMetadata *
+AppStateEventCoverageLookup(const char *event_id);
+const AppStateEventCoverageMetadata *AppStateEventCoverageAt(size_t index);
+size_t AppStateEventCoverageCount(void);
 const AppStateTransitionMetadata *
 AppStateTransitionLookup(const char *transition_id);
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index);

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -675,6 +675,110 @@ def _parse_runtime_action_coverage_registry(
     return records, failures
 
 
+def _parse_runtime_event_coverage_registry(
+    runtime_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = runtime_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{runtime_path}: failed to read: {exc}"]
+
+    failures: list[str] = []
+    arrays: dict[str, list[str]] = {}
+    array_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppState(?:TransitionWriteSet|EventCoverageTriggerPaths|EventCoverageMigrationNotes)[0-9]+)"
+        r"\[\]\s*=\s*\{(?P<body>.*?)\};",
+        re.S,
+    )
+    for array_match in array_re.finditer(source):
+        table_name = array_match.group(1)
+        values, array_failures = _parse_string_initializer_array(
+            array_match.group("body"),
+            table_name,
+        )
+        arrays[table_name] = values
+        failures.extend(array_failures)
+
+    match = re.search(
+        r"kAppStateEventCoverages\s*\[[^\]]*\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        return [], [f"{runtime_path}: failed to find runtime event coverage registry"]
+
+    records: list[dict[str, Any]] = []
+    row_re = re.compile(
+        r"\{\s*\"(?P<event_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<event_class>[^\"]*)\"\s*,"
+        r"\s*\"(?P<transition_id>[^\"]*)\"\s*,"
+        r"\s*\"(?P<category>[^\"]*)\"\s*,"
+        r"\s*\"(?P<source>[^\"]*)\"\s*,"
+        r"\s*\"(?P<owner>[^\"]*)\"\s*,"
+        r"\s*(?P<write_set>kAppStateTransitionWriteSet[0-9]+)\s*,"
+        r"\s*sizeof\((?P=write_set)\)\s*/\s*sizeof\((?P=write_set)\[0\]\)\s*,"
+        r"\s*\"(?P<boundary_status>[^\"]*)\"\s*,"
+        r"\s*(?P<trigger_paths>kAppStateEventCoverageTriggerPaths[0-9]+)\s*,"
+        r"\s*sizeof\((?P=trigger_paths)\)\s*/\s*sizeof\((?P=trigger_paths)\[0\]\)\s*,"
+        r"\s*(?P<migration_notes>kAppStateEventCoverageMigrationNotes[0-9]+)\s*,"
+        r"\s*sizeof\((?P=migration_notes)\)\s*/\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
+        re.S,
+    )
+    rows, row_failures = _split_top_level_initializer_rows(
+        match.group("body"),
+        "runtime_event_coverage",
+    )
+    failures.extend(row_failures)
+    for index, row in enumerate(rows):
+        row_match = row_re.fullmatch(row.strip())
+        if row_match is None:
+            failures.append(
+                f"runtime_event_coverage[{index}]: malformed runtime event "
+                f"coverage row: {_compact_initializer_snippet(row)}"
+            )
+            continue
+        write_set = arrays.get(row_match.group("write_set"))
+        trigger_paths = arrays.get(row_match.group("trigger_paths"))
+        migration_notes = arrays.get(row_match.group("migration_notes"))
+        if write_set is None:
+            failures.append(
+                f"runtime_event_coverage[{index}]: unknown declared-write-set table: "
+                f"{row_match.group('write_set')}"
+            )
+            write_set = []
+        if trigger_paths is None:
+            failures.append(
+                f"runtime_event_coverage[{index}]: unknown trigger-paths table: "
+                f"{row_match.group('trigger_paths')}"
+            )
+            trigger_paths = []
+        if migration_notes is None:
+            failures.append(
+                f"runtime_event_coverage[{index}]: unknown migration-notes table: "
+                f"{row_match.group('migration_notes')}"
+            )
+            migration_notes = []
+        records.append(
+            {
+                "event_id": row_match.group("event_id"),
+                "event_class": row_match.group("event_class"),
+                "transition_id": row_match.group("transition_id"),
+                "category": row_match.group("category"),
+                "source": row_match.group("source"),
+                "owner": row_match.group("owner"),
+                "declared_write_set": write_set,
+                "boundary_status": row_match.group("boundary_status"),
+                "trigger_paths": trigger_paths,
+                "migration_notes": migration_notes,
+            }
+        )
+
+    if not records:
+        failures.append(f"{runtime_path}: runtime event coverage registry must not be empty")
+    return records, failures
+
+
 def _parse_runtime_transition_registry(
     runtime_path: Path,
 ) -> tuple[list[dict[str, Any]], list[str]]:
@@ -3073,6 +3177,81 @@ def _validate_transition_generation_effects(
     return failures
 
 
+def _validate_runtime_event_coverage_registry(
+    *,
+    runtime_records: list[dict[str, Any]],
+    runtime_path: Path,
+    event_coverage_doc: Any,
+    transition_ids: dict[str, dict[str, Any]],
+    runtime_transition_ids: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    doc_records = event_coverage_doc.get("events") if isinstance(event_coverage_doc, dict) else []
+    event_by_id = {
+        record.get("event_id"): record
+        for record in doc_records
+        if isinstance(record, dict) and isinstance(record.get("event_id"), str)
+    }
+    expected_ids = set(event_by_id)
+    covered_ids: set[str] = set()
+    covered_classes: set[str] = set()
+
+    for index, record in enumerate(runtime_records):
+        label = f"runtime_event_coverage[{index}]"
+        failures.extend(
+            _validate_required_fields(
+                record=record,
+                required_fields=REQUIRED_EVENT_FIELDS,
+                list_fields=EVENT_LIST_FIELDS,
+                label=label,
+            )
+        )
+        event_id = record.get("event_id")
+        if isinstance(event_id, str) and event_id.strip():
+            if event_id in covered_ids:
+                failures.append(f"{label}: duplicate event_id: {event_id}")
+            covered_ids.add(event_id)
+            doc_record = event_by_id.get(event_id)
+            if doc_record is None:
+                failures.append(f"{label}: runtime event coverage missing from docs: {event_id}")
+            else:
+                for field in REQUIRED_EVENT_FIELDS:
+                    if record.get(field) != doc_record.get(field):
+                        failures.append(f"{label}: {field} does not match docs for {event_id}")
+        event_class = record.get("event_class")
+        if isinstance(event_class, str) and event_class.strip():
+            if event_class in covered_classes:
+                failures.append(f"{label}: duplicate event_class: {event_class}")
+            covered_classes.add(event_class)
+            if event_class not in REQUIRED_EVENT_CLASSES:
+                failures.append(f"{label}: unknown event_class: {event_class}")
+        transition_id = record.get("transition_id")
+        transition_record = transition_ids.get(transition_id) if isinstance(transition_id, str) else None
+        if transition_record is None:
+            failures.append(f"{label}: transition_id does not match a transition id: {transition_id}")
+        elif transition_id not in runtime_transition_ids:
+            failures.append(f"{label}: transition_id missing from runtime transition registry: {transition_id}")
+        else:
+            if record.get("category") != transition_record.get("category"):
+                failures.append(f"{label}: category does not match transition {transition_id}: {record.get('category')}")
+            if record.get("declared_write_set") != transition_record.get("declared_write_set"):
+                failures.append(f"{label}: declared_write_set does not match transition {transition_id}")
+
+    missing_ids = sorted(expected_ids - covered_ids)
+    if missing_ids:
+        failures.append(
+            f"{runtime_path}: runtime event coverage missing event id(s): "
+            + ", ".join(missing_ids)
+        )
+    missing_classes = sorted(REQUIRED_EVENT_CLASSES - covered_classes)
+    if missing_classes:
+        failures.append(
+            f"{runtime_path}: runtime event coverage missing event_class(es): "
+            + ", ".join(missing_classes)
+        )
+    return failures
+
+
 def _validate_event_coverage(
     *,
     event_coverage_doc: Any,
@@ -3783,6 +3962,9 @@ def validate_contract(
     runtime_action_coverage_records, runtime_action_coverage_failures = (
         _parse_runtime_action_coverage_registry(action_runtime_path)
     )
+    runtime_event_coverage_records, runtime_event_coverage_failures = (
+        _parse_runtime_event_coverage_registry(action_runtime_path)
+    )
     runtime_transition_records, runtime_transition_failures = (
         _parse_runtime_transition_registry(action_runtime_path)
     )
@@ -3820,6 +4002,7 @@ def validate_contract(
     failures.extend(enum_failures)
     failures.extend(runtime_action_failures)
     failures.extend(runtime_action_coverage_failures)
+    failures.extend(runtime_event_coverage_failures)
     failures.extend(runtime_transition_failures)
     failures.extend(runtime_owner_field_failures)
     failures.extend(runtime_dispatch_surface_failures)
@@ -4080,6 +4263,15 @@ def validate_contract(
             event_coverage_path=event_coverage_path,
             transition_ids=transition_ids,
             registered_owner_fields=registered_owner_fields,
+        )
+    )
+    failures.extend(
+        _validate_runtime_event_coverage_registry(
+            runtime_records=runtime_event_coverage_records,
+            runtime_path=action_runtime_path,
+            event_coverage_doc=event_coverage_doc,
+            transition_ids=transition_ids,
+            runtime_transition_ids={record["id"] for record in runtime_transition_records},
         )
     )
     failures.extend(

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -10,7 +10,8 @@
 
 enum {
   APPSTATE_ACTION_TRANSITION_COUNT = ACTION_USER_CMD + 1,
-  APPSTATE_ACTION_COVERAGE_COUNT = ACTION_USER_CMD + 1
+  APPSTATE_ACTION_COVERAGE_COUNT = ACTION_USER_CMD + 1,
+  APPSTATE_EVENT_COVERAGE_COUNT = 9
 };
 
 static const char *const kAppStateTransitionWriteSet0[] = {
@@ -2715,6 +2716,198 @@ static const AppStateActionTransitionMetadata
    "command_completion"},
   {ACTION_USER_CMD, "transition.command-completion.user-command", "command_completion"},
 };
+static const char *const kAppStateEventCoverageTriggerPaths0[] = {
+  "Signal flag set outside curses work",
+  "Main-loop resize/reflow handling",
+};
+static const char *const kAppStateEventCoverageMigrationNotes0[] = {
+  "Signal handlers may only set flags; resize commits through the main-loop transition boundary.",
+};
+static const char *const kAppStateEventCoverageTriggerPaths1[] = {
+  "Manual refresh command",
+  "Explicit relog of the current path",
+};
+static const char *const kAppStateEventCoverageMigrationNotes1[] = {
+  "Rebuild must settle topology, advance generation, then rebind panels by stable identity.",
+};
+static const char *const kAppStateEventCoverageTriggerPaths2[] = {
+  "Post-refresh restore",
+  "Post-mutation restore",
+  "Visibility or topology generation mismatch rebind",
+};
+static const char *const kAppStateEventCoverageMigrationNotes2[] = {
+  "Callback coverage points to the existing rebuild/rebind transition rather than inventing a separate runtime event.",
+};
+static const char *const kAppStateEventCoverageTriggerPaths3[] = {
+  "Create directory result",
+  "Copy or move result",
+  "Delete or chmod-like result",
+};
+static const char *const kAppStateEventCoverageMigrationNotes3[] = {
+  "Command side effects remain outside AppState commit; only completed results may update AppState metadata.",
+};
+static const char *const kAppStateEventCoverageTriggerPaths4[] = {
+  "Watcher notification",
+  "Live refresh scheduling",
+  "Settled topology refresh",
+};
+static const char *const kAppStateEventCoverageMigrationNotes4[] = {
+  "Watcher/live-refresh intentionally maps to the broad refresh_rebuild transition until a dedicated watcher runtime boundary exists.",
+};
+static const char *const kAppStateEventCoverageTriggerPaths5[] = {
+  "External command completion",
+  "User command menu completion",
+  "Command failure or cancellation outcome",
+};
+static const char *const kAppStateEventCoverageMigrationNotes5[] = {
+  "Command completion may schedule refresh only when the command contract declares filesystem impact.",
+};
+static const char *const kAppStateEventCoverageTriggerPaths6[] = {
+  "Modal Enter completion",
+  "Modal Esc cancellation",
+  "Neutral dialog dismissal",
+};
+static const char *const kAppStateEventCoverageMigrationNotes6[] = {
+  "Modal completion maps to the modal_action dismiss record while destructive confirmations remain governed by their own command transitions.",
+};
+static const char *const kAppStateEventCoverageTriggerPaths7[] = {
+  "Cycle loaded volume",
+  "Release volume",
+  "Bind active panel to selected volume",
+};
+static const char *const kAppStateEventCoverageMigrationNotes7[] = {
+  "Lifecycle coverage keeps inactive panels from inheriting stale volume pointers during migration.",
+};
+static const char *const kAppStateEventCoverageTriggerPaths8[] = {
+  "Render dirty flag projection",
+  "Layout reflow projection",
+  "doupdate-ready render tick",
+};
+static const char *const kAppStateEventCoverageMigrationNotes8[] = {
+  "Render/reflow is projection-only and must not become restore authority.",
+};
+
+static const AppStateEventCoverageMetadata
+    kAppStateEventCoverages[APPSTATE_EVENT_COVERAGE_COUNT] = {
+  {"event.terminal-resize-signal",
+   "terminal_resize_signal",
+   "transition.terminal-signal-resize",
+   "terminal_signal_or_resize",
+   "SIGWINCH flag handling and resize polling in the main loop",
+   "ViewContext.layout_region",
+   kAppStateTransitionWriteSet5,
+   sizeof(kAppStateTransitionWriteSet5) / sizeof(kAppStateTransitionWriteSet5[0]),
+   "covered_by_transition_record",
+   kAppStateEventCoverageTriggerPaths0,
+   sizeof(kAppStateEventCoverageTriggerPaths0) / sizeof(kAppStateEventCoverageTriggerPaths0[0]),
+   kAppStateEventCoverageMigrationNotes0,
+   sizeof(kAppStateEventCoverageMigrationNotes0) / sizeof(kAppStateEventCoverageMigrationNotes0[0])},
+  {"event.refresh-rebuild",
+   "refresh_rebuild",
+   "transition.refresh-rebuild.manual-refresh",
+   "refresh_rebuild",
+   "Manual refresh, explicit relog, or declared refresh boundary",
+   "Volume(shared topology)",
+   kAppStateTransitionWriteSet3,
+   sizeof(kAppStateTransitionWriteSet3) / sizeof(kAppStateTransitionWriteSet3[0]),
+   "covered_by_transition_record",
+   kAppStateEventCoverageTriggerPaths1,
+   sizeof(kAppStateEventCoverageTriggerPaths1) / sizeof(kAppStateEventCoverageTriggerPaths1[0]),
+   kAppStateEventCoverageMigrationNotes1,
+   sizeof(kAppStateEventCoverageMigrationNotes1) / sizeof(kAppStateEventCoverageMigrationNotes1[0])},
+  {"event.rebuild-rebind-callback",
+   "rebuild_rebind_callback",
+   "transition.rebuild-rebind-callback.panel-anchor",
+   "rebuild_rebind_callback",
+   "Post-rebuild panel anchor re-resolution callback",
+   "YtreeNovaPanel(affected) and Volume(current)",
+   kAppStateTransitionWriteSet8,
+   sizeof(kAppStateTransitionWriteSet8) / sizeof(kAppStateTransitionWriteSet8[0]),
+   "covered_by_transition_record",
+   kAppStateEventCoverageTriggerPaths2,
+   sizeof(kAppStateEventCoverageTriggerPaths2) / sizeof(kAppStateEventCoverageTriggerPaths2[0]),
+   kAppStateEventCoverageMigrationNotes2,
+   sizeof(kAppStateEventCoverageMigrationNotes2) / sizeof(kAppStateEventCoverageMigrationNotes2[0])},
+  {"event.filesystem-mutation-result",
+   "filesystem_mutation_result",
+   "transition.filesystem-mutation-result.mkdir-copy-delete",
+   "filesystem_mutation_result",
+   "Completed filesystem mutation command result",
+   "Volume(shared topology) plus YtreeNovaPanel(active) for active selection",
+   kAppStateTransitionWriteSet6,
+   sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
+   "covered_by_transition_record",
+   kAppStateEventCoverageTriggerPaths3,
+   sizeof(kAppStateEventCoverageTriggerPaths3) / sizeof(kAppStateEventCoverageTriggerPaths3[0]),
+   kAppStateEventCoverageMigrationNotes3,
+   sizeof(kAppStateEventCoverageMigrationNotes3) / sizeof(kAppStateEventCoverageMigrationNotes3[0])},
+  {"event.watcher-live-refresh",
+   "watcher_live_refresh",
+   "transition.refresh-rebuild.manual-refresh",
+   "refresh_rebuild",
+   "Filesystem watcher or live-refresh notification after debounce/settle",
+   "Volume(shared topology)",
+   kAppStateTransitionWriteSet3,
+   sizeof(kAppStateTransitionWriteSet3) / sizeof(kAppStateTransitionWriteSet3[0]),
+   "mapped_to_existing_broad_transition",
+   kAppStateEventCoverageTriggerPaths4,
+   sizeof(kAppStateEventCoverageTriggerPaths4) / sizeof(kAppStateEventCoverageTriggerPaths4[0]),
+   kAppStateEventCoverageMigrationNotes4,
+   sizeof(kAppStateEventCoverageMigrationNotes4) / sizeof(kAppStateEventCoverageMigrationNotes4[0])},
+  {"event.command-completion",
+   "command_completion",
+   "transition.command-completion.user-command",
+   "command_completion",
+   "External or user command exit-status completion",
+   "ViewContext.command_region",
+   kAppStateTransitionWriteSet7,
+   sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0]),
+   "covered_by_transition_record",
+   kAppStateEventCoverageTriggerPaths5,
+   sizeof(kAppStateEventCoverageTriggerPaths5) / sizeof(kAppStateEventCoverageTriggerPaths5[0]),
+   kAppStateEventCoverageMigrationNotes5,
+   sizeof(kAppStateEventCoverageMigrationNotes5) / sizeof(kAppStateEventCoverageMigrationNotes5[0])},
+  {"event.modal-completion",
+   "modal_completion",
+   "transition.modal-action.dismiss",
+   "modal_action",
+   "Modal prompt, menu, or dialog completion",
+   "ViewContext.modal_region",
+   kAppStateTransitionWriteSet2,
+   sizeof(kAppStateTransitionWriteSet2) / sizeof(kAppStateTransitionWriteSet2[0]),
+   "mapped_to_existing_broad_transition",
+   kAppStateEventCoverageTriggerPaths6,
+   sizeof(kAppStateEventCoverageTriggerPaths6) / sizeof(kAppStateEventCoverageTriggerPaths6[0]),
+   kAppStateEventCoverageMigrationNotes6,
+   sizeof(kAppStateEventCoverageMigrationNotes6) / sizeof(kAppStateEventCoverageMigrationNotes6[0])},
+  {"event.volume-lifecycle",
+   "volume_lifecycle",
+   "transition.volume-operation.release-cycle",
+   "volume_operation",
+   "Volume cycle, release, or loaded-volume selection lifecycle event",
+   "ViewContext.volume_registry and YtreeNovaPanel(active)",
+   kAppStateTransitionWriteSet4,
+   sizeof(kAppStateTransitionWriteSet4) / sizeof(kAppStateTransitionWriteSet4[0]),
+   "covered_by_transition_record",
+   kAppStateEventCoverageTriggerPaths7,
+   sizeof(kAppStateEventCoverageTriggerPaths7) / sizeof(kAppStateEventCoverageTriggerPaths7[0]),
+   kAppStateEventCoverageMigrationNotes7,
+   sizeof(kAppStateEventCoverageMigrationNotes7) / sizeof(kAppStateEventCoverageMigrationNotes7[0])},
+  {"event.render-reflow",
+   "render_reflow",
+   "transition.render-reflow.project-state",
+   "render_reflow",
+   "Render invalidation projection and doupdate-ready reflow",
+   "ViewContext.render_region",
+   kAppStateTransitionWriteSet9,
+   sizeof(kAppStateTransitionWriteSet9) / sizeof(kAppStateTransitionWriteSet9[0]),
+   "covered_by_transition_record",
+   kAppStateEventCoverageTriggerPaths8,
+   sizeof(kAppStateEventCoverageTriggerPaths8) / sizeof(kAppStateEventCoverageTriggerPaths8[0]),
+   kAppStateEventCoverageMigrationNotes8,
+   sizeof(kAppStateEventCoverageMigrationNotes8) / sizeof(kAppStateEventCoverageMigrationNotes8[0])},
+};
+
 static const char *const kAppStateActionCoverageMigrationNotes0[] = {
   "Covered by the current keybinding foundation record until runtime transition objects are split per action.",
 };
@@ -3654,6 +3847,10 @@ size_t AppStateActionCoverageCount(void) {
   return sizeof(kAppStateActionCoverages) / sizeof(kAppStateActionCoverages[0]);
 }
 
+size_t AppStateEventCoverageCount(void) {
+  return sizeof(kAppStateEventCoverages) / sizeof(kAppStateEventCoverages[0]);
+}
+
 size_t AppStateTransitionCount(void) {
   return sizeof(kAppStateTransitions) / sizeof(kAppStateTransitions[0]);
 }
@@ -3723,6 +3920,13 @@ const AppStateActionCoverageMetadata *AppStateActionCoverageAt(size_t index) {
     return NULL;
 
   return &kAppStateActionCoverages[index];
+}
+
+const AppStateEventCoverageMetadata *AppStateEventCoverageAt(size_t index) {
+  if (index >= AppStateEventCoverageCount())
+    return NULL;
+
+  return &kAppStateEventCoverages[index];
 }
 
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
@@ -3900,4 +4104,19 @@ AppStateActionCoverageLookup(YtreeNovaAction action) {
     return NULL;
 
   return metadata;
+}
+
+const AppStateEventCoverageMetadata *
+AppStateEventCoverageLookup(const char *event_id) {
+  size_t index;
+
+  if (event_id == NULL || event_id[0] == '\0')
+    return NULL;
+
+  for (index = 0; index < AppStateEventCoverageCount(); index++) {
+    if (!strcmp(kAppStateEventCoverages[index].event_id, event_id))
+      return &kAppStateEventCoverages[index];
+  }
+
+  return NULL;
 }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -136,21 +136,29 @@ static const struct {
   {"ACTION_USER_CMD", ACTION_USER_CMD},
 };
 
-static const struct {
-  const char *event_id;
-  const char *transition_id;
-} kAppStateEventTransitionIds[] = {
-  {"event.terminal-resize-signal", "transition.terminal-signal-resize" },
-  {"event.refresh-rebuild", "transition.refresh-rebuild.manual-refresh" },
-  {"event.rebuild-rebind-callback", "transition.rebuild-rebind-callback.panel-anchor" },
-  {"event.filesystem-mutation-result", "transition.filesystem-mutation-result.mkdir-copy-delete" },
-  {"event.watcher-live-refresh", "transition.refresh-rebuild.manual-refresh" },
-  {"event.command-completion", "transition.command-completion.user-command" },
-  {"event.modal-completion", "transition.modal-action.dismiss" },
-  {"event.volume-lifecycle", "transition.volume-operation.release-cycle" },
-  {"event.render-reflow", "transition.render-reflow.project-state" },
+static const char *const kAppStateRequiredEventClasses[] = {
+  "terminal_resize_signal",
+  "refresh_rebuild",
+  "rebuild_rebind_callback",
+  "filesystem_mutation_result",
+  "watcher_live_refresh",
+  "command_completion",
+  "modal_completion",
+  "volume_lifecycle",
+  "render_reflow",
 };
 
+static const char *const kAppStateRequiredEventIds[] = {
+  "event.terminal-resize-signal",
+  "event.refresh-rebuild",
+  "event.rebuild-rebind-callback",
+  "event.filesystem-mutation-result",
+  "event.watcher-live-refresh",
+  "event.command-completion",
+  "event.modal-completion",
+  "event.volume-lifecycle",
+  "event.render-reflow",
+};
 
 static int StringListContains(const char *const *values, size_t count,
                               const char *value) {
@@ -191,20 +199,13 @@ AppStateActionIdLookup(const char *action_id) {
 }
 
 static const char *AppStateEventTransitionLookup(const char *event_id) {
-  size_t index;
+  const AppStateEventCoverageMetadata *coverage =
+      AppStateEventCoverageLookup(event_id);
 
-  if (!NonEmptyString(event_id))
+  if (coverage == NULL)
     return NULL;
 
-  for (index = 0;
-       index < sizeof(kAppStateEventTransitionIds) /
-                   sizeof(kAppStateEventTransitionIds[0]);
-       index++) {
-    if (strcmp(kAppStateEventTransitionIds[index].event_id, event_id) == 0)
-      return kAppStateEventTransitionIds[index].transition_id;
-  }
-
-  return NULL;
+  return coverage->transition_id;
 }
 
 static int AppStateFallbackPreconditionValid(const char *precondition) {
@@ -704,6 +705,115 @@ static int AppStateActionCoverageWriteSetMatches(
   return 1;
 }
 
+static int AppStateEventCoverageWriteSetMatches(
+    const AppStateEventCoverageMetadata *coverage,
+    const AppStateTransitionMetadata *transition) {
+  size_t index;
+
+  if (coverage->declared_write_set_count != transition->declared_write_set_count)
+    return 0;
+
+  for (index = 0; index < coverage->declared_write_set_count; index++) {
+    if (strcmp(coverage->declared_write_set[index],
+               transition->declared_write_set[index]) != 0)
+      return 0;
+  }
+
+  return 1;
+}
+
+static int AppStateRequiredEventClassCovered(const char *event_class) {
+  size_t index;
+
+  for (index = 0; index < AppStateEventCoverageCount(); index++) {
+    const AppStateEventCoverageMetadata *coverage = AppStateEventCoverageAt(index);
+
+    if (coverage != NULL && strcmp(coverage->event_class, event_class) == 0)
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateRequiredEventIdCovered(const char *event_id) {
+  return AppStateEventCoverageLookup(event_id) != NULL;
+}
+
+static int AppStateEventCoverageReady(void) {
+  size_t index;
+  size_t required_class_count =
+      sizeof(kAppStateRequiredEventClasses) /
+      sizeof(kAppStateRequiredEventClasses[0]);
+  size_t required_event_id_count =
+      sizeof(kAppStateRequiredEventIds) / sizeof(kAppStateRequiredEventIds[0]);
+
+  if (AppStateEventCoverageCount() != required_class_count ||
+      AppStateEventCoverageCount() != required_event_id_count)
+    return 0;
+
+  for (index = 0; index < AppStateEventCoverageCount(); index++) {
+    const AppStateEventCoverageMetadata *coverage;
+    const AppStateTransitionMetadata *transition;
+    size_t previous_index;
+
+    coverage = AppStateEventCoverageAt(index);
+    if (coverage == NULL || !NonEmptyString(coverage->event_id) ||
+        !NonEmptyString(coverage->event_class) ||
+        !NonEmptyString(coverage->transition_id) ||
+        !NonEmptyString(coverage->category) || !NonEmptyString(coverage->source) ||
+        !NonEmptyString(coverage->owner) ||
+        !NonEmptyString(coverage->boundary_status) ||
+        !NonEmptyStringList(coverage->declared_write_set,
+                            coverage->declared_write_set_count) ||
+        !NonEmptyStringList(coverage->trigger_paths,
+                            coverage->trigger_path_count) ||
+        !NonEmptyStringList(coverage->migration_notes,
+                            coverage->migration_note_count))
+      return 0;
+    if (AppStateEventCoverageLookup(coverage->event_id) != coverage)
+      return 0;
+
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateEventCoverageMetadata *previous =
+          AppStateEventCoverageAt(previous_index);
+
+      if (previous == NULL ||
+          strcmp(previous->event_id, coverage->event_id) == 0 ||
+          strcmp(previous->event_class, coverage->event_class) == 0)
+        return 0;
+    }
+
+    transition = AppStateTransitionLookup(coverage->transition_id);
+    if (transition == NULL)
+      return 0;
+    if (strcmp(coverage->category, transition->category) != 0)
+      return 0;
+    if (!AppStateEventCoverageWriteSetMatches(coverage, transition))
+      return 0;
+  }
+
+  for (index = 0; index < required_class_count; index++) {
+    if (!AppStateRequiredEventClassCovered(kAppStateRequiredEventClasses[index]))
+      return 0;
+  }
+
+  for (index = 0; index < required_event_id_count; index++) {
+    if (!AppStateRequiredEventIdCovered(kAppStateRequiredEventIds[index]))
+      return 0;
+  }
+
+  if (AppStateEventCoverageAt(AppStateEventCoverageCount()) != NULL)
+    return 0;
+  if (AppStateEventCoverageLookup(NULL) != NULL)
+    return 0;
+  if (AppStateEventCoverageLookup("") != NULL)
+    return 0;
+  if (AppStateEventCoverageLookup("event.__ytnova_unknown__") != NULL)
+    return 0;
+
+  return 1;
+}
+
 static int AppStateActionCoverageReady(void) {
   size_t index;
   size_t action_id_count =
@@ -923,6 +1033,7 @@ int main(int argc, char **argv) {
       !AppStateDiffHarnessRegistryReady() ||
       !AppStateTransitionSequencesReady() ||
       !AppStateActionCoverageReady() ||
+      !AppStateEventCoverageReady() ||
       !AppStateActionTransitionsReady()) {
     fprintf(stderr, "EXIT: startup invariants not configured\n");
     exit(1);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import re
 import subprocess
 from pathlib import Path
 
@@ -143,7 +144,7 @@ def _event(
         "declared_write_set": ["field"],
         "boundary_status": "test",
         "trigger_paths": ["fixture trigger"],
-        "migration_notes": ["fixture coverage"],
+        "migration_notes": ["fixture event coverage"],
     }
 
 
@@ -331,6 +332,7 @@ def _write_fixture(
     enum_actions: list[str] | None = None,
     runtime_actions: list[dict[str, object]] | None = None,
     runtime_action_coverages: list[dict[str, object]] | None = None,
+    runtime_events: list[dict[str, object]] | None = None,
     runtime_transitions: list[dict[str, object]] | None = None,
     runtime_dispatch_surfaces: list[dict[str, object]] | None = None,
     runtime_shims: list[dict[str, object]] | None = None,
@@ -425,6 +427,9 @@ def _write_fixture(
             runtime_action_coverages
             if runtime_action_coverages is not None
             else (actions if actions is not None else _complete_actions()),
+            runtime_events
+            if runtime_events is not None
+            else (events if events is not None else _complete_events()),
             runtime_transitions if runtime_transitions is not None else transitions,
             runtime_owner_fields
             if runtime_owner_fields is not None
@@ -499,6 +504,7 @@ def _enum_header(actions: list[str]) -> str:
 def _runtime_source(
     actions: list[dict[str, object]],
     action_coverages: list[dict[str, object]],
+    events: list[dict[str, object]],
     transitions: list[dict[str, object]],
     owner_fields: list[dict[str, object]],
     dispatch_surfaces: list[dict[str, object]],
@@ -560,6 +566,46 @@ def _runtime_source(
             f"{write_set_table}, sizeof({write_set_table}) / "
             f"sizeof({write_set_table}[0]), "
             f'"{record.get("boundary_status", "")}", '
+            f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
+        )
+    event_coverage_arrays = []
+    event_coverage_rows = []
+    transition_index_by_id = {
+        str(record.get("id", "")): index for index, record in enumerate(transitions)
+    }
+    for index, record in enumerate(events):
+        trigger_paths = record.get("trigger_paths")
+        if not isinstance(trigger_paths, list):
+            trigger_paths = []
+        trigger_rows = "\n".join(
+            f'  "{trigger}",' for trigger in trigger_paths if isinstance(trigger, str)
+        )
+        trigger_table = f"kAppStateEventCoverageTriggerPaths{index}"
+        event_coverage_arrays.append(
+            f"static const char *const {trigger_table}[] = "
+            f"{{\n{trigger_rows}\n}};\n"
+        )
+        migration_notes = record.get("migration_notes")
+        if not isinstance(migration_notes, list):
+            migration_notes = []
+        note_rows = "\n".join(
+            f'  "{note}",' for note in migration_notes if isinstance(note, str)
+        )
+        notes_table = f"kAppStateEventCoverageMigrationNotes{index}"
+        event_coverage_arrays.append(
+            f"static const char *const {notes_table}[] = "
+            f"{{\n{note_rows}\n}};\n"
+        )
+        transition_index = transition_index_by_id.get(str(record.get("transition_id", "")), 0)
+        write_set_table = f"kAppStateTransitionWriteSet{transition_index}"
+        event_coverage_rows.append(
+            f'  {{"{record.get("event_id", "")}", "{record.get("event_class", "")}", '
+            f'"{record.get("transition_id", "")}", "{record.get("category", "")}", '
+            f'"{record.get("source", "")}", "{record.get("owner", "")}", '
+            f"{write_set_table}, sizeof({write_set_table}) / "
+            f"sizeof({write_set_table}[0]), "
+            f'"{record.get("boundary_status", "")}", '
+            f"{trigger_table}, sizeof({trigger_table}) / sizeof({trigger_table}[0]), "
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
     owner_field_arrays = []
@@ -913,6 +959,7 @@ def _runtime_source(
     return (
         "".join(transition_write_sets)
         + "".join(action_coverage_arrays)
+        + "".join(event_coverage_arrays)
         + "".join(owner_field_arrays)
         + "".join(dispatch_surface_arrays)
         + "".join(shim_invariants)
@@ -955,6 +1002,10 @@ def _runtime_source(
         "static const AppStateActionCoverageMetadata\n"
         "    kAppStateActionCoverages[APPSTATE_ACTION_COVERAGE_COUNT] = {\n"
         + "\n".join(action_coverage_rows)
+        + "\n};\n"
+        "static const AppStateEventCoverageMetadata\n"
+        "    kAppStateEventCoverages[APPSTATE_EVENT_COVERAGE_COUNT] = {\n"
+        + "\n".join(event_coverage_rows)
         + "\n};\n"
     )
 
@@ -4292,3 +4343,154 @@ def test_guard_fails_when_action_transition_table_drifts_from_coverage(
         and "ACTION_NONE" in failure
         for failure in failures
     )
+
+
+def _event_runtime_records_and_failures(runtime_path: Path = guard.DEFAULT_ACTION_RUNTIME):
+    return guard._parse_runtime_event_coverage_registry(runtime_path)
+
+
+def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
+    transitions_doc, transition_failures = guard._load_json(guard.DEFAULT_TRANSITIONS)
+    event_doc, event_failures = guard._load_json(guard.DEFAULT_EVENT_COVERAGE)
+    runtime_transitions, runtime_transition_failures = guard._parse_runtime_transition_registry(
+        runtime_path
+    )
+    runtime_events, runtime_event_failures = guard._parse_runtime_event_coverage_registry(
+        runtime_path
+    )
+    transition_ids = {
+        record["id"]: record for record in transitions_doc.get("transitions", [])
+    }
+    return (
+        transition_failures
+        + event_failures
+        + runtime_transition_failures
+        + runtime_event_failures
+        + guard._validate_runtime_event_coverage_registry(
+            runtime_records=runtime_events,
+            runtime_path=runtime_path,
+            event_coverage_doc=event_doc,
+            transition_ids=transition_ids,
+            runtime_transition_ids={record["id"] for record in runtime_transitions},
+        )
+    )
+
+
+def _mutated_event_runtime(tmp_path: Path, old: str, new: str) -> Path:
+    runtime_path = tmp_path / "appstate_actions.c"
+    source = guard.DEFAULT_ACTION_RUNTIME.read_text(encoding="utf-8")
+    assert old in source
+    runtime_path.write_text(source.replace(old, new, 1), encoding="utf-8")
+    return runtime_path
+
+
+def test_runtime_event_coverage_registry_matches_docs() -> None:
+    records, parse_failures = _event_runtime_records_and_failures()
+
+    assert parse_failures == []
+    assert {record["event_id"] for record in records} == guard._collect_string_ids(
+        guard._load_json(guard.DEFAULT_EVENT_COVERAGE)[0],
+        collection_key="events",
+        id_field="event_id",
+    )
+    assert _event_runtime_validation_failures(guard.DEFAULT_ACTION_RUNTIME) == []
+
+
+def test_runtime_event_coverage_detects_doc_drift(tmp_path: Path) -> None:
+    runtime_path = _mutated_event_runtime(
+        tmp_path,
+        '"event.render-reflow",\n   "render_reflow"',
+        '"event.render-reflow-runtime",\n   "render_reflow"',
+    )
+
+    failures = _event_runtime_validation_failures(runtime_path)
+
+    assert any("runtime event coverage missing from docs" in failure for failure in failures)
+    assert any("runtime event coverage missing event id(s)" in failure for failure in failures)
+
+
+def test_runtime_event_coverage_detects_duplicate_and_missing_classes(
+    tmp_path: Path,
+) -> None:
+    runtime_path = _mutated_event_runtime(
+        tmp_path,
+        '"event.render-reflow",\n   "render_reflow"',
+        '"event.render-reflow",\n   "modal_completion"',
+    )
+
+    failures = _event_runtime_validation_failures(runtime_path)
+
+    assert any("duplicate event_class: modal_completion" in failure for failure in failures)
+    assert any("missing event_class(es): render_reflow" in failure for failure in failures)
+
+
+def test_runtime_event_coverage_detects_invalid_transition_linkage(
+    tmp_path: Path,
+) -> None:
+    runtime_path = _mutated_event_runtime(
+        tmp_path,
+        '"event.render-reflow",\n   "render_reflow",\n   "transition.render-reflow.project-state"',
+        '"event.render-reflow",\n   "render_reflow",\n   "transition.render-reflow.unknown"',
+    )
+
+    failures = _event_runtime_validation_failures(runtime_path)
+
+    assert any("transition_id does not match a transition id" in failure for failure in failures)
+
+
+def test_runtime_event_coverage_detects_write_set_drift(tmp_path: Path) -> None:
+    runtime_path = _mutated_event_runtime(
+        tmp_path,
+        "   kAppStateTransitionWriteSet9,\n   sizeof(kAppStateTransitionWriteSet9) / sizeof(kAppStateTransitionWriteSet9[0]),\n   \"covered_by_transition_record\",\n   kAppStateEventCoverageTriggerPaths8",
+        "   kAppStateTransitionWriteSet0,\n   sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),\n   \"covered_by_transition_record\",\n   kAppStateEventCoverageTriggerPaths8",
+    )
+
+    failures = _event_runtime_validation_failures(runtime_path)
+
+    assert any("declared_write_set does not match transition" in failure for failure in failures)
+
+
+def test_runtime_event_coverage_detects_malformed_lists(tmp_path: Path) -> None:
+    runtime_path = _mutated_event_runtime(
+        tmp_path,
+        '"Signal flag set outside curses work",',
+        '"",',
+    )
+
+    failures = _event_runtime_validation_failures(runtime_path)
+
+    assert any("trigger_paths" in failure for failure in failures)
+
+
+def test_runtime_event_coverage_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateEventCoverageAt(AppStateEventCoverageCount()) != NULL" in source
+    assert 'AppStateEventCoverageLookup("event.__ytnova_unknown__") != NULL' in source
+    assert "!AppStateEventCoverageReady()" in source
+
+
+def test_runtime_event_coverage_startup_requires_documented_event_ids() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    event_doc, event_failures = guard._load_json(guard.DEFAULT_EVENT_COVERAGE)
+    required_ids = guard._collect_string_ids(
+        event_doc,
+        collection_key="events",
+        id_field="event_id",
+    )
+    required_table = re.search(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"kAppStateRequiredEventIds\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+
+    assert event_failures == []
+    assert required_table is not None
+    table_ids, table_failures = guard._parse_string_initializer_array(
+        required_table.group("body"),
+        "kAppStateRequiredEventIds",
+    )
+    assert table_failures == []
+    assert set(table_ids) == required_ids
+    assert "AppStateRequiredEventIdCovered(kAppStateRequiredEventIds[index])" in source


### PR DESCRIPTION
## Summary
- Adds a read-only runtime lookup for AppState event-coverage metadata.
- Validates documented event IDs and classes against transition metadata at startup.
- Extends the contract guard and focused tests so non-key UI-affecting event coverage stays synchronized.

## Validation
- Local targeted AppState guard passed.
- Local build, cppcheck, code-quality guard bundle, whitespace check, and version smoke passed.

## Scope
- Lookup/guard scaffold only; no user-visible transition execution behavior changes.
