### PR TITLE
chore(appstate): anchor dispatch surface metadata

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -302,6 +302,8 @@ SEQUENCE_LIST_FIELDS = {
     "diff_harness_ids",
     "generation_domain_expectations",
 }
+DISPATCH_SURFACE_SOURCE_ROOT = REPO_ROOT / "src"
+ENTRY_SYMBOL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 GENERATION_FIELD_RE = re.compile(r"\b(?:[A-Za-z0-9_]+\.)?[A-Za-z0-9_]+_generation\b")
 
 
@@ -2795,7 +2797,14 @@ def _validate_source_path(value: Any, *, label: str) -> list[str]:
     ):
         return [f"{label}: source_path must be a relative repository path"]
 
-    if not (REPO_ROOT / source_path).is_file():
+    source_file = (REPO_ROOT / source_path).resolve()
+    source_root = DISPATCH_SURFACE_SOURCE_ROOT.resolve()
+    try:
+        source_file.relative_to(source_root)
+    except ValueError:
+        return [f"{label}: source_path must point inside src/: {source_path}"]
+
+    if not source_file.is_file():
         return [f"{label}: source_path does not exist: {source_path}"]
     return []
 
@@ -2813,6 +2822,36 @@ def _validate_entry_symbol_or_path(value: Any, *, label: str) -> list[str]:
         or re.search(r"\s", entry)
     ):
         return [f"{label}: entry_symbol_or_path is malformed: {entry}"]
+    return []
+
+
+def _entry_symbol_or_path_is_anchored(source: str, entry: str) -> bool:
+    if ENTRY_SYMBOL_RE.fullmatch(entry):
+        return (
+            re.search(
+                rf"(?<![A-Za-z0-9_]){re.escape(entry)}\s*\(",
+                source,
+            )
+            is not None
+        )
+    return entry in source
+
+
+def _validate_dispatch_surface_source_anchor(
+    *, source_path: str, entry_symbol_or_path: str, label: str
+) -> list[str]:
+    source_file = REPO_ROOT / source_path.strip()
+    entry = entry_symbol_or_path.strip()
+    try:
+        source = source_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{label}: source_path could not be read: {source_path}: {exc}"]
+
+    if not _entry_symbol_or_path_is_anchored(source, entry):
+        return [
+            f"{label}: entry_symbol_or_path not found in source_path "
+            f"{source_path}: {entry}"
+        ]
     return []
 
 
@@ -2880,12 +2919,27 @@ def _validate_dispatch_surfaces(
                     f"{label}: transition_id does not match a transition id: {transition_id}"
                 )
 
-        failures.extend(_validate_source_path(record.get("source_path"), label=label))
-        failures.extend(
-            _validate_entry_symbol_or_path(
-                record.get("entry_symbol_or_path"), label=label
-            )
+        source_path = record.get("source_path")
+        entry_symbol_or_path = record.get("entry_symbol_or_path")
+        source_failures = _validate_source_path(source_path, label=label)
+        entry_failures = _validate_entry_symbol_or_path(
+            entry_symbol_or_path, label=label
         )
+        failures.extend(source_failures)
+        failures.extend(entry_failures)
+        if (
+            not source_failures
+            and not entry_failures
+            and isinstance(source_path, str)
+            and isinstance(entry_symbol_or_path, str)
+        ):
+            failures.extend(
+                _validate_dispatch_surface_source_anchor(
+                    source_path=source_path,
+                    entry_symbol_or_path=entry_symbol_or_path,
+                    label=label,
+                )
+            )
 
     missing_categories = sorted(
         REQUIRED_DISPATCH_SURFACE_CATEGORIES - covered_categories

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -2880,6 +2880,47 @@ def test_guard_fails_on_malformed_dispatch_surface_source_path(
     )
 
 
+def test_guard_fails_when_dispatch_surface_source_path_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["source_path"] = "src/ui/missing_dispatch_surface.c"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "source_path does not exist" in failure
+        and "src/ui/missing_dispatch_surface.c" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_source_path_is_outside_src(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["source_path"] = "scripts/check_appstate_contract.py"
+    dispatch_surfaces[0]["entry_symbol_or_path"] = "validate_contract"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "source_path must point inside src/" in failure
+        and "scripts/check_appstate_contract.py" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_on_malformed_dispatch_surface_entry_symbol_or_path(
     tmp_path: Path,
 ) -> None:
@@ -2895,6 +2936,26 @@ def test_guard_fails_on_malformed_dispatch_surface_entry_symbol_or_path(
     assert any(
         "dispatch_surface[0]" in failure
         and "entry_symbol_or_path is malformed" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_entry_symbol_is_not_in_source(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["entry_symbol_or_path"] = "MissingDispatchSurfaceEntry"
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "entry_symbol_or_path not found in source_path" in failure
+        and "MissingDispatchSurfaceEntry" in failure
         for failure in failures
     )
 


### PR DESCRIPTION
## Summary
- Anchors AppState dispatch-surface metadata to real source files under the runtime source tree.
- Fails the contract guard when a registered dispatch entry no longer appears in its declared source file.
- Adds focused guard tests for missing source files, out-of-tree paths, and stale entry symbols.

## Validation
- Local AppState contract guard tests passed.
- Local contract guard, build, code-quality guard bundle, and whitespace check passed.

## Scope
- Guard/test scaffold only; no runtime transition execution behavior changes.
