### PR TITLE
chore(appstate): require dispatch surface startup coverage

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -160,6 +160,19 @@ static const char *const kAppStateRequiredEventIds[] = {
   "event.render-reflow",
 };
 
+static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
+  "surface.key-decode-input-dispatch",
+  "surface.directory-window-action-dispatch",
+  "surface.file-window-action-dispatch",
+  "surface.menu-modal-completion",
+  "surface.resize-signal-handling",
+  "surface.refresh-rebuild-rebind",
+  "surface.filesystem-mutation-result",
+  "surface.volume-operation",
+  "surface.watcher-live-refresh",
+  "surface.render-reflow-projection",
+};
+
 static int StringListContains(const char *const *values, size_t count,
                               const char *value) {
   size_t index;
@@ -524,13 +537,17 @@ static int AppStateDispatchSurfaceWritesReady(
 
 static int AppStateDispatchSurfacesReady(void) {
   size_t index;
+  size_t required_surface_id_count =
+      sizeof(kAppStateRequiredDispatchSurfaceIds) /
+      sizeof(kAppStateRequiredDispatchSurfaceIds[0]);
 
-  if (AppStateDispatchSurfaceCount() == 0)
+  if (AppStateDispatchSurfaceCount() != required_surface_id_count)
     return 0;
 
   for (index = 0; index < AppStateDispatchSurfaceCount(); index++) {
     const AppStateDispatchSurfaceMetadata *metadata =
         AppStateDispatchSurfaceAt(index);
+    size_t previous_index;
 
     if (metadata == NULL || !NonEmptyString(metadata->surface_id) ||
         !NonEmptyString(metadata->category) ||
@@ -545,6 +562,21 @@ static int AppStateDispatchSurfacesReady(void) {
     if (AppStateDispatchSurfaceLookup(metadata->surface_id) != metadata)
       return 0;
     if (AppStateTransitionLookup(metadata->transition_id) == NULL)
+      return 0;
+
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateDispatchSurfaceMetadata *previous =
+          AppStateDispatchSurfaceAt(previous_index);
+
+      if (previous == NULL ||
+          strcmp(previous->surface_id, metadata->surface_id) == 0)
+        return 0;
+    }
+  }
+
+  for (index = 0; index < required_surface_id_count; index++) {
+    if (AppStateDispatchSurfaceLookup(
+            kAppStateRequiredDispatchSurfaceIds[index]) == NULL)
       return 0;
   }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4555,3 +4555,45 @@ def test_runtime_event_coverage_startup_requires_documented_event_ids() -> None:
     assert table_failures == []
     assert set(table_ids) == required_ids
     assert "AppStateRequiredEventIdCovered(kAppStateRequiredEventIds[index])" in source
+
+
+def test_runtime_dispatch_surface_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateDispatchSurfaceAt(AppStateDispatchSurfaceCount()) != NULL" in source
+    assert 'AppStateDispatchSurfaceLookup("surface.__ytnova_unknown__") != NULL' in source
+    assert "AppStateDispatchSurfaceCount() != required_surface_id_count" in source
+    assert "previous_index < index" in source
+    assert "strcmp(previous->surface_id, metadata->surface_id) == 0" in source
+    assert "!AppStateDispatchSurfacesReady()" in source
+
+
+def test_runtime_dispatch_surface_startup_requires_documented_surface_ids() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    dispatch_doc, dispatch_failures = guard._load_json(guard.DEFAULT_DISPATCH_SURFACES)
+    required_ids = guard._collect_string_ids(
+        dispatch_doc,
+        collection_key="dispatch_surfaces",
+        id_field="surface_id",
+    )
+    required_table = re.search(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"kAppStateRequiredDispatchSurfaceIds\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+
+    assert dispatch_failures == []
+    assert required_table is not None
+    table_ids, table_failures = guard._parse_string_initializer_array(
+        required_table.group("body"),
+        "kAppStateRequiredDispatchSurfaceIds",
+    )
+    assert table_failures == []
+    assert set(table_ids) == required_ids
+    assert re.search(
+        r"AppStateDispatchSurfaceLookup\(\s*"
+        r"kAppStateRequiredDispatchSurfaceIds\[index\]\s*\)",
+        source,
+        re.S,
+    )


### PR DESCRIPTION
## Summary
- Requires startup validation to cover every documented AppState dispatch-surface ID.
- Fails closed for missing, renamed, or duplicate runtime dispatch-surface IDs.
- Adds focused guard tests proving the required startup table matches the dispatch-surface registry.

## Validation
- Local AppState contract guard tests passed.
- Local contract guard, build, code-quality guard bundle, and whitespace check passed.

## Scope
- Startup guard/test scaffold only; no user-visible transition execution behavior changes.
