### PR TITLE
chore(appstate): require invariant startup coverage

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -173,6 +173,17 @@ static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
   "surface.render-reflow-projection",
 };
 
+static const char *const kAppStateRequiredInvariantIds[] = {
+  "invariant.inactive-panel-frozen",
+  "invariant.render-projection-read-only",
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.panel-local-focus-restore",
+  "invariant.viewport-identity-rebind",
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.stale-snapshot-fail-closed",
+  "invariant.blocked-transition-determinism",
+};
+
 static int StringListContains(const char *const *values, size_t count,
                               const char *value) {
   size_t index;
@@ -594,13 +605,16 @@ static int AppStateDispatchSurfacesReady(void) {
 
 static int AppStateInvariantRegistryReady(void) {
   size_t index;
+  size_t required_invariant_id_count = sizeof(kAppStateRequiredInvariantIds) /
+                                       sizeof(kAppStateRequiredInvariantIds[0]);
 
-  if (AppStateInvariantCount() == 0)
+  if (AppStateInvariantCount() != required_invariant_id_count)
     return 0;
 
   for (index = 0; index < AppStateInvariantCount(); index++) {
     const AppStateInvariantMetadata *metadata = AppStateInvariantAt(index);
     size_t transition_index;
+    size_t previous_index;
 
     if (metadata == NULL || !NonEmptyString(metadata->invariant_id) ||
         !NonEmptyString(metadata->category) ||
@@ -619,6 +633,15 @@ static int AppStateInvariantRegistryReady(void) {
     if (AppStateInvariantLookup(metadata->invariant_id) != metadata)
       return 0;
 
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateInvariantMetadata *previous =
+          AppStateInvariantAt(previous_index);
+
+      if (previous == NULL ||
+          strcmp(previous->invariant_id, metadata->invariant_id) == 0)
+        return 0;
+    }
+
     for (transition_index = 0;
          transition_index < metadata->transition_id_count; transition_index++) {
       if (AppStateTransitionLookup(metadata->transition_ids[transition_index]) ==
@@ -632,6 +655,11 @@ static int AppStateInvariantRegistryReady(void) {
               metadata->dispatch_surface_ids[transition_index]) == NULL)
         return 0;
     }
+  }
+
+  for (index = 0; index < required_invariant_id_count; index++) {
+    if (AppStateInvariantLookup(kAppStateRequiredInvariantIds[index]) == NULL)
+      return 0;
   }
 
   if (AppStateInvariantAt(AppStateInvariantCount()) != NULL)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4597,3 +4597,45 @@ def test_runtime_dispatch_surface_startup_requires_documented_surface_ids() -> N
         source,
         re.S,
     )
+
+
+def test_runtime_invariant_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateInvariantAt(AppStateInvariantCount()) != NULL" in source
+    assert 'AppStateInvariantLookup("invariant.__ytnova_unknown__") != NULL' in source
+    assert "AppStateInvariantCount() != required_invariant_id_count" in source
+    assert "previous_index < index" in source
+    assert "strcmp(previous->invariant_id, metadata->invariant_id) == 0" in source
+    assert "!AppStateInvariantRegistryReady()" in source
+
+
+def test_runtime_invariant_startup_requires_documented_invariant_ids() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    invariant_doc, invariant_failures = guard._load_json(guard.DEFAULT_INVARIANTS)
+    required_ids = guard._collect_string_ids(
+        invariant_doc,
+        collection_key="invariants",
+        id_field="invariant_id",
+    )
+    required_table = re.search(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"kAppStateRequiredInvariantIds\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+
+    assert invariant_failures == []
+    assert required_table is not None
+    table_ids, table_failures = guard._parse_string_initializer_array(
+        required_table.group("body"),
+        "kAppStateRequiredInvariantIds",
+    )
+    assert table_failures == []
+    assert set(table_ids) == required_ids
+    assert re.search(
+        r"AppStateInvariantLookup\(\s*"
+        r"kAppStateRequiredInvariantIds\[index\]\s*\)",
+        source,
+        re.S,
+    )


### PR DESCRIPTION
## Summary
- Requires startup validation to cover every documented AppState invariant ID.
- Fails closed for missing, renamed, or duplicate runtime invariant IDs.
- Adds focused guard tests proving the required startup table matches the invariant registry.

## Validation
- Local AppState contract guard tests passed.
- Local contract guard, build, code-quality guard bundle, and whitespace check passed.

## Scope
- Startup guard/test scaffold only; no user-visible transition execution behavior changes.
