### PR TITLE
chore(appstate): require shim startup coverage

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -173,6 +173,13 @@ static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
   "surface.render-reflow-projection",
 };
 
+static const char *const kAppStateRequiredShimIds[] = {
+  "shim.viewcontext-hide-dot-files",
+  "shim.volume-saved-tree-index",
+  "shim.focused-window-session-flag",
+  "shim-render-derived-row-position",
+};
+
 static const char *const kAppStateRequiredInvariantIds[] = {
   "invariant.inactive-panel-frozen",
   "invariant.render-projection-read-only",
@@ -676,14 +683,17 @@ static int AppStateInvariantRegistryReady(void) {
 
 static int AppStateCompatibilityShimsReady(void) {
   size_t index;
+  size_t required_shim_id_count =
+      sizeof(kAppStateRequiredShimIds) / sizeof(kAppStateRequiredShimIds[0]);
 
-  if (AppStateCompatibilityShimCount() == 0)
+  if (AppStateCompatibilityShimCount() != required_shim_id_count)
     return 0;
 
   for (index = 0; index < AppStateCompatibilityShimCount(); index++) {
     const AppStateCompatibilityShimMetadata *metadata =
         AppStateCompatibilityShimAt(index);
     size_t invariant_index;
+    size_t previous_index;
 
     if (metadata == NULL || !NonEmptyString(metadata->id) ||
         !NonEmptyString(metadata->owner) ||
@@ -702,11 +712,25 @@ static int AppStateCompatibilityShimsReady(void) {
     if (AppStateTransitionLookup(metadata->target_transition) == NULL)
       return 0;
 
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateCompatibilityShimMetadata *previous =
+          AppStateCompatibilityShimAt(previous_index);
+
+      if (previous == NULL || strcmp(previous->id, metadata->id) == 0)
+        return 0;
+    }
+
     for (invariant_index = 0;
          invariant_index < metadata->invariant_check_count; invariant_index++) {
       if (!NonEmptyString(metadata->invariant_checks[invariant_index]))
         return 0;
     }
+  }
+
+  for (index = 0; index < required_shim_id_count; index++) {
+    if (AppStateCompatibilityShimLookup(kAppStateRequiredShimIds[index]) ==
+        NULL)
+      return 0;
   }
 
   if (AppStateCompatibilityShimAt(AppStateCompatibilityShimCount()) != NULL)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4639,3 +4639,51 @@ def test_runtime_invariant_startup_requires_documented_invariant_ids() -> None:
         source,
         re.S,
     )
+
+
+def test_runtime_shim_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert (
+        "AppStateCompatibilityShimAt(AppStateCompatibilityShimCount()) != NULL"
+        in source
+    )
+    assert (
+        'AppStateCompatibilityShimLookup("shim.__ytnova_unknown__") != NULL'
+        in source
+    )
+    assert "AppStateCompatibilityShimCount() != required_shim_id_count" in source
+    assert "previous_index < index" in source
+    assert "strcmp(previous->id, metadata->id) == 0" in source
+    assert "!AppStateCompatibilityShimsReady()" in source
+
+
+def test_runtime_shim_startup_requires_documented_shim_ids() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    shim_doc, shim_failures = guard._load_json(guard.DEFAULT_SHIMS)
+    required_ids = guard._collect_string_ids(
+        shim_doc,
+        collection_key="shims",
+        id_field="id",
+    )
+    required_table = re.search(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"kAppStateRequiredShimIds\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+
+    assert shim_failures == []
+    assert required_table is not None
+    table_ids, table_failures = guard._parse_string_initializer_array(
+        required_table.group("body"),
+        "kAppStateRequiredShimIds",
+    )
+    assert table_failures == []
+    assert set(table_ids) == required_ids
+    assert re.search(
+        r"AppStateCompatibilityShimLookup\(\s*"
+        r"kAppStateRequiredShimIds\[index\]\s*\)",
+        source,
+        re.S,
+    )


### PR DESCRIPTION
## Summary
- Requires startup validation to cover every documented AppState compatibility shim ID.
- Fails closed for missing, renamed, or duplicate runtime shim IDs.
- Adds focused guard tests proving the required startup table matches the shim registry.

## Validation
- Local AppState contract guard tests passed.
- Local contract guard, build, code-quality guard bundle, and whitespace check passed.

## Scope
- Startup guard/test scaffold only; no user-visible transition execution behavior changes.
