### PR TITLE
chore(appstate): require diff harness startup coverage

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -191,6 +191,14 @@ static const char *const kAppStateRequiredInvariantIds[] = {
   "invariant.blocked-transition-determinism",
 };
 
+static const char *const kAppStateRequiredDiffHarnessIds[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.declared-write-set-diff",
+  "harness.render-projection-read-only-diff",
+  "harness.generation-mismatch-check",
+  "harness.blocked-transition-no-unrelated-mutation",
+};
+
 static int StringListContains(const char *const *values, size_t count,
                               const char *value) {
   size_t index;
@@ -967,14 +975,18 @@ static int AppStateActionCoverageReady(void) {
 
 static int AppStateDiffHarnessRegistryReady(void) {
   size_t index;
+  size_t required_diff_harness_id_count =
+      sizeof(kAppStateRequiredDiffHarnessIds) /
+      sizeof(kAppStateRequiredDiffHarnessIds[0]);
 
-  if (AppStateDiffHarnessCount() == 0)
+  if (AppStateDiffHarnessCount() != required_diff_harness_id_count)
     return 0;
 
   for (index = 0; index < AppStateDiffHarnessCount(); index++) {
     const AppStateDiffHarnessMetadata *metadata =
         AppStateDiffHarnessAt(index);
     size_t ref_index;
+    size_t previous_index;
 
     if (metadata == NULL || !NonEmptyString(metadata->harness_id) ||
         !NonEmptyString(metadata->check_category) ||
@@ -999,6 +1011,15 @@ static int AppStateDiffHarnessRegistryReady(void) {
     if (AppStateDiffHarnessLookup(metadata->harness_id) != metadata)
       return 0;
 
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateDiffHarnessMetadata *previous =
+          AppStateDiffHarnessAt(previous_index);
+
+      if (previous == NULL ||
+          strcmp(previous->harness_id, metadata->harness_id) == 0)
+        return 0;
+    }
+
     for (ref_index = 0; ref_index < metadata->transition_id_count;
          ref_index++) {
       if (AppStateTransitionLookup(metadata->transition_ids[ref_index]) ==
@@ -1022,6 +1043,12 @@ static int AppStateDiffHarnessRegistryReady(void) {
               metadata->generation_domain_ids[ref_index]) == NULL)
         return 0;
     }
+  }
+
+  for (index = 0; index < required_diff_harness_id_count; index++) {
+    if (AppStateDiffHarnessLookup(kAppStateRequiredDiffHarnessIds[index]) ==
+        NULL)
+      return 0;
   }
 
   if (AppStateDiffHarnessAt(AppStateDiffHarnessCount()) != NULL)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4687,3 +4687,55 @@ def test_runtime_shim_startup_requires_documented_shim_ids() -> None:
         source,
         re.S,
     )
+
+
+def test_runtime_diff_harness_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateDiffHarnessAt(AppStateDiffHarnessCount()) != NULL" in source
+    assert 'AppStateDiffHarnessLookup("harness.__ytnova_unknown__") != NULL' in source
+    assert "AppStateDiffHarnessLookup(NULL) != NULL" in source
+    assert 'AppStateDiffHarnessLookup("") != NULL' in source
+    assert "AppStateDiffHarnessCount() != required_diff_harness_id_count" in source
+    assert "previous_index < index" in source
+    assert "strcmp(previous->harness_id, metadata->harness_id) == 0" in source
+    assert "AppStateTransitionLookup(metadata->transition_ids[ref_index])" in source
+    assert "AppStateOwnerFieldLookup(metadata->owner_field_refs[ref_index])" in source
+    assert "AppStateInvariantLookup(metadata->invariant_ids[ref_index])" in source
+    assert (
+        "AppStateGenerationDomainLookup(\n"
+        "              metadata->generation_domain_ids[ref_index])"
+        in source
+    )
+    assert "!AppStateDiffHarnessRegistryReady()" in source
+
+
+def test_runtime_diff_harness_startup_requires_documented_harness_ids() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    diff_doc, diff_failures = guard._load_json(guard.DEFAULT_DIFF_HARNESS)
+    required_ids = guard._collect_string_ids(
+        diff_doc,
+        collection_key="diff_harness_checks",
+        id_field="harness_id",
+    )
+    required_table = re.search(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"kAppStateRequiredDiffHarnessIds\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+
+    assert diff_failures == []
+    assert required_table is not None
+    table_ids, table_failures = guard._parse_string_initializer_array(
+        required_table.group("body"),
+        "kAppStateRequiredDiffHarnessIds",
+    )
+    assert table_failures == []
+    assert set(table_ids) == required_ids
+    assert re.search(
+        r"AppStateDiffHarnessLookup\(\s*"
+        r"kAppStateRequiredDiffHarnessIds\[index\]\s*\)",
+        source,
+        re.S,
+    )


### PR DESCRIPTION
## Summary
- adds startup fail-closed coverage for the documented AppState diff harness registry
- verifies required harness IDs stay synchronized with `docs/appstate_diff_harness.json`
- extends the AppState contract guard tests for diff harness startup coverage

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'diff_harness and startup'`
- `pytest -q tests/test_appstate_contract_guard.py`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
