### PR TITLE
chore(appstate): require owner startup coverage

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -160,6 +160,31 @@ static const char *const kAppStateRequiredEventIds[] = {
   "event.render-reflow",
 };
 
+static const char *const kAppStateRequiredOwnerFieldIds[] = {
+  "ctx.active",
+  "ctx.command_state",
+  "ctx.message_state",
+  "ctx.modal_state",
+  "ctx.pending_transition",
+  "ctx.volumes_head",
+  "ctx.layout",
+  "ctx.render_dirty_flags",
+  "ctx.window_handles",
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+  "panel.focus_shape",
+  "panel.panel_generation",
+  "panel.restore_snapshot",
+  "panel.tree_cursor_pos",
+  "panel.tree_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.volume_key",
+  "volume.dir_tree",
+  "volume.logged_state",
+  "volume.payload_cache",
+  "volume.volume_generation",
+};
+
 static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
   "surface.key-decode-input-dispatch",
   "surface.directory-window-action-dispatch",
@@ -451,12 +476,16 @@ static int AppStateInvariantDispatchSurfacesReady(
 
 static int AppStateOwnerFieldsReady(void) {
   size_t index;
+  size_t required_owner_field_id_count =
+      sizeof(kAppStateRequiredOwnerFieldIds) /
+      sizeof(kAppStateRequiredOwnerFieldIds[0]);
 
-  if (AppStateOwnerFieldCount() == 0)
+  if (AppStateOwnerFieldCount() != required_owner_field_id_count)
     return 0;
 
   for (index = 0; index < AppStateOwnerFieldCount(); index++) {
     const AppStateOwnerFieldMetadata *metadata = AppStateOwnerFieldAt(index);
+    size_t previous_index;
 
     if (metadata == NULL || !NonEmptyString(metadata->field) ||
         !NonEmptyString(metadata->owner_region) ||
@@ -468,6 +497,19 @@ static int AppStateOwnerFieldsReady(void) {
                             metadata->invariant_check_count))
       return 0;
     if (AppStateOwnerFieldLookup(metadata->field) != metadata)
+      return 0;
+
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateOwnerFieldMetadata *previous =
+          AppStateOwnerFieldAt(previous_index);
+
+      if (previous == NULL || strcmp(previous->field, metadata->field) == 0)
+        return 0;
+    }
+  }
+
+  for (index = 0; index < required_owner_field_id_count; index++) {
+    if (AppStateOwnerFieldLookup(kAppStateRequiredOwnerFieldIds[index]) == NULL)
       return 0;
   }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4629,6 +4629,53 @@ def test_runtime_event_coverage_startup_requires_documented_event_ids() -> None:
     assert "AppStateRequiredEventIdCovered(kAppStateRequiredEventIds[index])" in source
 
 
+def test_runtime_owner_field_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateOwnerFieldAt(AppStateOwnerFieldCount()) != NULL" in source
+    assert "AppStateOwnerFieldLookup(NULL) != NULL" in source
+    assert 'AppStateOwnerFieldLookup("") != NULL' in source
+    assert 'AppStateOwnerFieldLookup("field.__ytnova_unknown__") != NULL' in source
+    assert "AppStateOwnerFieldCount() != required_owner_field_id_count" in source
+    assert "metadata == NULL || !NonEmptyString(metadata->field)" in source
+    assert "previous_index < index" in source
+    assert "strcmp(previous->field, metadata->field) == 0" in source
+    assert "AppStateOwnerFieldLookup(kAppStateRequiredOwnerFieldIds[index])" in source
+    assert "!AppStateOwnerFieldsReady()" in source
+
+
+def test_runtime_owner_field_startup_requires_documented_field_ids() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    owner_doc, owner_failures = guard._load_json(guard.DEFAULT_OWNER_FIELDS)
+    required_ids = guard._collect_string_ids(
+        owner_doc,
+        collection_key="owner_fields",
+        id_field="field",
+    )
+    required_table = re.search(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"kAppStateRequiredOwnerFieldIds\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+
+    assert owner_failures == []
+    assert required_table is not None
+    table_ids, table_failures = guard._parse_string_initializer_array(
+        required_table.group("body"),
+        "kAppStateRequiredOwnerFieldIds",
+    )
+    assert table_failures == []
+    assert set(table_ids) == required_ids
+    assert len(table_ids) == len(required_ids)
+    assert re.search(
+        r"AppStateOwnerFieldLookup\(\s*"
+        r"kAppStateRequiredOwnerFieldIds\[index\]\s*\)",
+        source,
+        re.S,
+    )
+
+
 def test_runtime_dispatch_surface_startup_checks_fail_closed() -> None:
     source = Path("src/core/main.c").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- adds startup fail-closed coverage for documented AppState owner fields
- verifies required owner field IDs stay synchronized with `docs/appstate_owner_fields.json`
- extends the AppState contract guard tests for owner-field startup coverage

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'owner_field and startup'`
- `pytest -q tests/test_appstate_contract_guard.py`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
