### PR TITLE
chore(appstate): require transition startup coverage

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -160,6 +160,19 @@ static const char *const kAppStateRequiredEventIds[] = {
   "event.render-reflow",
 };
 
+static const char *const kAppStateRequiredTransitionIds[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.menu-action.volume-select",
+  "transition.modal-action.dismiss",
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.terminal-signal-resize",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.command-completion.user-command",
+  "transition.rebuild-rebind-callback.panel-anchor",
+  "transition.render-reflow.project-state",
+};
+
 static const char *const kAppStateRequiredOwnerFieldIds[] = {
   "ctx.active",
   "ctx.command_state",
@@ -527,12 +540,16 @@ static int AppStateOwnerFieldsReady(void) {
 
 static int AppStateTransitionRegistryReady(void) {
   size_t index;
+  size_t required_transition_id_count =
+      sizeof(kAppStateRequiredTransitionIds) /
+      sizeof(kAppStateRequiredTransitionIds[0]);
 
-  if (AppStateTransitionCount() == 0)
+  if (AppStateTransitionCount() != required_transition_id_count)
     return 0;
 
   for (index = 0; index < AppStateTransitionCount(); index++) {
     const AppStateTransitionMetadata *metadata = AppStateTransitionAt(index);
+    size_t previous_index;
     size_t write_index;
 
     if (metadata == NULL || !NonEmptyString(metadata->id) ||
@@ -544,6 +561,14 @@ static int AppStateTransitionRegistryReady(void) {
     if (AppStateTransitionLookup(metadata->id) != metadata)
       return 0;
 
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateTransitionMetadata *previous =
+          AppStateTransitionAt(previous_index);
+
+      if (previous == NULL || strcmp(previous->id, metadata->id) == 0)
+        return 0;
+    }
+
     for (write_index = 0; write_index < metadata->declared_write_set_count;
          write_index++) {
       const char *field = metadata->declared_write_set[write_index];
@@ -553,6 +578,17 @@ static int AppStateTransitionRegistryReady(void) {
     }
   }
 
+  for (index = 0; index < required_transition_id_count; index++) {
+    if (AppStateTransitionLookup(kAppStateRequiredTransitionIds[index]) == NULL)
+      return 0;
+  }
+
+  if (AppStateTransitionAt(AppStateTransitionCount()) != NULL)
+    return 0;
+  if (AppStateTransitionLookup(NULL) != NULL)
+    return 0;
+  if (AppStateTransitionLookup("") != NULL)
+    return 0;
   if (AppStateTransitionLookup("transition.__ytnova_unknown__") != NULL)
     return 0;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1785,6 +1785,59 @@ def test_runtime_transition_sequence_startup_requires_documented_scenario_ids() 
     )
 
 
+def test_runtime_transition_registry_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateTransitionAt(AppStateTransitionCount()) != NULL" in source
+    assert "AppStateTransitionLookup(NULL) != NULL" in source
+    assert 'AppStateTransitionLookup("") != NULL' in source
+    assert 'AppStateTransitionLookup("transition.__ytnova_unknown__") != NULL' in source
+    assert "AppStateTransitionCount() != required_transition_id_count" in source
+    assert "metadata == NULL || !NonEmptyString(metadata->id)" in source
+    assert "metadata->declared_write_set == NULL" in source
+    assert "metadata->declared_write_set_count == 0" in source
+    assert "previous_index < index" in source
+    assert "strcmp(previous->id, metadata->id) == 0" in source
+    assert "if (!NonEmptyString(field))" in source
+    assert "AppStateTransitionLookup(kAppStateRequiredTransitionIds[index])" in source
+    assert "!AppStateTransitionRegistryReady()" in source
+
+
+def test_runtime_transition_registry_startup_requires_documented_transition_ids() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    transition_doc, transition_failures = guard._load_json(guard.DEFAULT_TRANSITIONS)
+    required_ids = guard._collect_string_ids(
+        transition_doc,
+        collection_key="transitions",
+        id_field="id",
+    )
+    required_table = re.search(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"kAppStateRequiredTransitionIds\[\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+
+    assert transition_failures == []
+    assert required_table is not None
+    table_ids, table_failures = guard._parse_string_initializer_array(
+        required_table.group("body"),
+        "kAppStateRequiredTransitionIds",
+    )
+    assert table_failures == []
+    assert table_ids == [
+        transition["id"] for transition in transition_doc["transitions"]
+    ]
+    assert set(table_ids) == required_ids
+    assert len(table_ids) == len(required_ids)
+    assert re.search(
+        r"AppStateTransitionLookup\(\s*"
+        r"kAppStateRequiredTransitionIds\[index\]\s*\)",
+        source,
+        re.S,
+    )
+
+
 def test_guard_fails_when_required_diff_harness_field_is_missing(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- adds startup fail-closed coverage for documented AppState transitions
- verifies required transition IDs stay synchronized with `docs/appstate_transition_matrix.json`
- extends the AppState contract guard tests for transition-registry startup coverage

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'transition_registry and startup'`
- `pytest -q tests/test_appstate_contract_guard.py`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
