### PR TITLE
chore(appstate): require generation startup coverage

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -198,6 +198,20 @@ static const char *const kAppStateRequiredOwnerFieldIds[] = {
   "volume.volume_generation",
 };
 
+static const char *const kAppStateRequiredGenerationDomainIds[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+  "shape.panel.focus",
+  "target.modal-command.session",
+  "state.visibility-filter.panel-volume",
+  "state.topology.volume",
+  "state.file-payload.volume",
+  "lifecycle.volume.registry",
+  "reflow.layout.projection",
+};
+
 static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
   "surface.key-decode-input-dispatch",
   "surface.directory-window-action-dispatch",
@@ -597,14 +611,18 @@ static int AppStateTransitionRegistryReady(void) {
 
 static int AppStateGenerationDomainsReady(void) {
   size_t index;
+  size_t required_generation_domain_id_count =
+      sizeof(kAppStateRequiredGenerationDomainIds) /
+      sizeof(kAppStateRequiredGenerationDomainIds[0]);
 
-  if (AppStateGenerationDomainCount() == 0)
+  if (AppStateGenerationDomainCount() != required_generation_domain_id_count)
     return 0;
 
   for (index = 0; index < AppStateGenerationDomainCount(); index++) {
     const AppStateGenerationDomainMetadata *metadata =
         AppStateGenerationDomainAt(index);
     size_t field_index;
+    size_t previous_index;
     size_t transition_index;
 
     if (metadata == NULL || !NonEmptyString(metadata->domain_id) ||
@@ -627,6 +645,15 @@ static int AppStateGenerationDomainsReady(void) {
     if (AppStateOwnerFieldLookup(metadata->generation_owner_field) == NULL)
       return 0;
 
+    for (previous_index = 0; previous_index < index; previous_index++) {
+      const AppStateGenerationDomainMetadata *previous =
+          AppStateGenerationDomainAt(previous_index);
+
+      if (previous == NULL ||
+          strcmp(previous->domain_id, metadata->domain_id) == 0)
+        return 0;
+    }
+
     for (field_index = 0; field_index < metadata->identity_field_count;
          field_index++) {
       if (AppStateOwnerFieldLookup(metadata->identity_fields[field_index]) ==
@@ -640,6 +667,12 @@ static int AppStateGenerationDomainsReady(void) {
               metadata->advances_on_transition_ids[transition_index]) == NULL)
         return 0;
     }
+  }
+
+  for (index = 0; index < required_generation_domain_id_count; index++) {
+    if (AppStateGenerationDomainLookup(
+            kAppStateRequiredGenerationDomainIds[index]) == NULL)
+      return 0;
   }
 
   if (AppStateGenerationDomainAt(AppStateGenerationDomainCount()) != NULL)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4729,6 +4729,88 @@ def test_runtime_owner_field_startup_requires_documented_field_ids() -> None:
     )
 
 
+def test_runtime_generation_domain_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert (
+        "AppStateGenerationDomainAt(AppStateGenerationDomainCount()) != NULL"
+        in source
+    )
+    assert "AppStateGenerationDomainLookup(NULL) != NULL" in source
+    assert 'AppStateGenerationDomainLookup("") != NULL' in source
+    assert (
+        'AppStateGenerationDomainLookup("generation.__ytnova_unknown__") != NULL'
+        in source
+    )
+    assert (
+        "AppStateGenerationDomainCount() != "
+        "required_generation_domain_id_count"
+        in source
+    )
+    assert "metadata == NULL || !NonEmptyString(metadata->domain_id)" in source
+    assert "!NonEmptyString(metadata->category)" in source
+    assert "!NonEmptyString(metadata->generation_owner_field)" in source
+    assert "!NonEmptyString(metadata->stale_snapshot_policy)" in source
+    assert "!NonEmptyString(metadata->fail_closed_fallback)" in source
+    assert "!NonEmptyString(metadata->restore_boundary)" in source
+    assert "!NonEmptyString(metadata->enforcement_status)" in source
+    assert "NonEmptyStringList(metadata->identity_fields" in source
+    assert "NonEmptyStringList(metadata->advances_on_transition_ids" in source
+    assert "NonEmptyStringList(metadata->migration_notes" in source
+    assert "previous_index < index" in source
+    assert "strcmp(previous->domain_id, metadata->domain_id) == 0" in source
+    assert "AppStateOwnerFieldLookup(metadata->generation_owner_field) == NULL" in source
+    assert "AppStateOwnerFieldLookup(metadata->identity_fields[field_index])" in source
+    assert (
+        "AppStateTransitionLookup(\n"
+        "              metadata->advances_on_transition_ids[transition_index])"
+        in source
+    )
+    assert (
+        "kAppStateRequiredGenerationDomainIds[index]) == NULL"
+        in source
+    )
+    assert "!AppStateGenerationDomainsReady()" in source
+
+
+def test_runtime_generation_domain_startup_requires_documented_domain_ids() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    generation_doc, generation_failures = guard._load_json(
+        guard.DEFAULT_GENERATION_DOMAINS
+    )
+    required_ids = guard._collect_string_ids(
+        generation_doc,
+        collection_key="generation_domains",
+        id_field="domain_id",
+    )
+    required_table = re.search(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"kAppStateRequiredGenerationDomainIds\[\]\s*=\s*"
+        r"\{(?P<body>.*?)\};",
+        source,
+        re.S,
+    )
+
+    assert generation_failures == []
+    assert required_table is not None
+    table_ids, table_failures = guard._parse_string_initializer_array(
+        required_table.group("body"),
+        "kAppStateRequiredGenerationDomainIds",
+    )
+    assert table_failures == []
+    assert table_ids == [
+        domain["domain_id"] for domain in generation_doc["generation_domains"]
+    ]
+    assert set(table_ids) == required_ids
+    assert len(table_ids) == len(required_ids)
+    assert re.search(
+        r"AppStateGenerationDomainLookup\(\s*"
+        r"kAppStateRequiredGenerationDomainIds\[index\]\s*\)",
+        source,
+        re.S,
+    )
+
+
 def test_runtime_dispatch_surface_startup_checks_fail_closed() -> None:
     source = Path("src/core/main.c").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- adds startup fail-closed coverage for documented AppState generation domains
- verifies required generation domain IDs stay synchronized with `docs/appstate_generation_domains.json`
- extends the AppState contract guard tests for generation-domain startup coverage

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'generation_domain and startup'`
- `pytest -q tests/test_appstate_contract_guard.py`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
