### PR TITLE
chore(appstate): require transition write owners

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -589,6 +589,8 @@ static int AppStateTransitionRegistryReady(void) {
 
       if (!NonEmptyString(field))
         return 0;
+      if (AppStateOwnerFieldLookup(field) == NULL)
+        return 0;
     }
   }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1803,6 +1803,20 @@ def test_runtime_transition_registry_startup_checks_fail_closed() -> None:
     assert "!AppStateTransitionRegistryReady()" in source
 
 
+def test_runtime_transition_registry_startup_validates_write_set_owner_fields() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert re.search(
+        r"for \(write_index = 0; write_index < "
+        r"metadata->declared_write_set_count;\s*write_index\+\+\) \{\s*"
+        r"const char \*field = metadata->declared_write_set\[write_index\];\s*"
+        r"if \(!NonEmptyString\(field\)\)\s*return 0;\s*"
+        r"if \(AppStateOwnerFieldLookup\(field\) == NULL\)\s*return 0;",
+        source,
+        re.S,
+    )
+
+
 def test_runtime_transition_registry_startup_requires_documented_transition_ids() -> None:
     source = Path("src/core/main.c").read_text(encoding="utf-8")
     transition_doc, transition_failures = guard._load_json(guard.DEFAULT_TRANSITIONS)


### PR DESCRIPTION
## Summary
- fail AppState transition startup readiness when a declared write-set field is not registered in the canonical owner-field map
- keep the existing fail-closed check for empty write-set fields
- add focused contract coverage for the transition write-owner startup guard

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'transition and startup'` — PASS
- `pytest -q tests/test_appstate_contract_guard.py` — PASS
- `python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings
- `git diff --check` — PASS
