### PR TITLE
chore(appstate): require dispatch write owners

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -691,11 +691,25 @@ static int AppStateGenerationDomainsReady(void) {
 
 static int AppStateDispatchSurfaceWritesReady(
     const AppStateDispatchSurfaceMetadata *metadata) {
+  size_t write_index;
+
   if (metadata->allowed_direct_write_count == 0)
     return metadata->allowed_direct_writes == NULL;
 
-  return NonEmptyStringList(metadata->allowed_direct_writes,
-                            metadata->allowed_direct_write_count);
+  if (metadata->allowed_direct_writes == NULL)
+    return 0;
+
+  for (write_index = 0; write_index < metadata->allowed_direct_write_count;
+       write_index++) {
+    const char *field = metadata->allowed_direct_writes[write_index];
+
+    if (!NonEmptyString(field))
+      return 0;
+    if (AppStateOwnerFieldLookup(field) == NULL)
+      return 0;
+  }
+
+  return 1;
 }
 
 static int AppStateDispatchSurfacesReady(void) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4836,6 +4836,21 @@ def test_runtime_dispatch_surface_startup_checks_fail_closed() -> None:
     assert "!AppStateDispatchSurfacesReady()" in source
 
 
+def test_runtime_dispatch_surface_startup_validates_allowed_write_owner_fields() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert re.search(
+        r"if \(metadata->allowed_direct_writes == NULL\)\s*return 0;\s*"
+        r"for \(write_index = 0; write_index < "
+        r"metadata->allowed_direct_write_count;\s*write_index\+\+\) \{\s*"
+        r"const char \*field = metadata->allowed_direct_writes\[write_index\];\s*"
+        r"if \(!NonEmptyString\(field\)\)\s*return 0;\s*"
+        r"if \(AppStateOwnerFieldLookup\(field\) == NULL\)\s*return 0;",
+        source,
+        re.S,
+    )
+
+
 def test_runtime_dispatch_surface_startup_requires_documented_surface_ids() -> None:
     source = Path("src/core/main.c").read_text(encoding="utf-8")
     dispatch_doc, dispatch_failures = guard._load_json(guard.DEFAULT_DISPATCH_SURFACES)


### PR DESCRIPTION
## Summary
- fail dispatch-surface startup readiness when an allowed direct-write field is not registered in the canonical owner-field map
- preserve fail-closed handling for empty, null, and zero-count direct-write declarations
- add focused contract coverage for the dispatch direct-write owner startup guard

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'dispatch and startup'` — PASS
- `pytest -q tests/test_appstate_contract_guard.py` — PASS
- `python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings
- `git diff --check` — PASS
