### PR TITLE
chore(appstate): require shim invariant lookup

### DIFF
--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -9,7 +9,10 @@
       "old_authority_path": "ViewContext.hide_dot_files",
       "read_permission": "Allowed only as a derived compatibility mirror for helpers that have not yet accepted YtreeNovaPanel dotfile visibility.",
       "write_permission": "Write only when synchronizing from the active panel's authoritative dotfile_visibility during transition commit.",
-      "invariant_checks": ["YtreeNovaPanel(active).dotfile_visibility is authoritative", "Inactive panel visibility is never overwritten from the mirror"],
+      "invariant_checks": [
+        "invariant.hidden-entry-visible-navigation",
+        "invariant.shared-state-panel-local-isolation"
+      ],
       "removal_trigger": "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
       "target_transition": "transition.keybinding.navigate-tree",
       "follow_up_task": "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
@@ -21,7 +24,10 @@
       "old_authority_path": "Volume.saved_tree_index",
       "read_permission": "Allowed only as a fallback breadcrumb when a stable path key has already failed to resolve.",
       "write_permission": "Do not write as primary restore authority; future writes must update stable identity keys and generation metadata first.",
-      "invariant_checks": ["Raw index is never used while a stable identity key resolves", "Generation mismatch forces rebind before dereference"],
+      "invariant_checks": [
+        "invariant.viewport-identity-rebind",
+        "invariant.stale-snapshot-fail-closed"
+      ],
       "removal_trigger": "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
       "target_transition": "transition.rebuild-rebind-callback.panel-anchor",
       "follow_up_task": "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
@@ -33,7 +39,10 @@
       "old_authority_path": "ViewContext.focused_window",
       "read_permission": "Allowed for layout routing and footer context selection while AppState focus_shape migration is incomplete.",
       "write_permission": "Write only from transition commit after the active panel focus_shape has been updated.",
-      "invariant_checks": ["Panel focus_shape remains the restore authority", "Session flag must not overwrite inactive panel shape"],
+      "invariant_checks": [
+        "invariant.panel-local-focus-restore",
+        "invariant.inactive-panel-frozen"
+      ],
       "removal_trigger": "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
       "target_transition": "transition.keybinding.navigate-tree",
       "follow_up_task": "Move focus-shape authority from session mirrors into panel-local transition records.",
@@ -45,7 +54,10 @@
       "old_authority_path": "disp_begin_pos + cursor_pos render-derived lookup",
       "read_permission": "Allowed only inside render projection or bounds-correction code after identity restore has run.",
       "write_permission": "Never write authoritative selection from this calculation.",
-      "invariant_checks": ["Render projection is not restore authority", "Temporary row math is discarded after draw"],
+      "invariant_checks": [
+        "invariant.render-projection-read-only",
+        "invariant.viewport-identity-rebind"
+      ],
       "removal_trigger": "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
       "target_transition": "transition.render-reflow.project-state",
       "follow_up_task": "Audit render/reflow call sites for projection-only behavior during runtime migration.",

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -1612,6 +1612,7 @@ def _parse_runtime_shim_registry(
         return [], [f"{runtime_path}: failed to read: {exc}"]
 
     invariant_tables: dict[str, list[str]] = {}
+    failures: list[str] = []
     invariant_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
         r"(kAppStateCompatibilityShimInvariantChecks[0-9]+)\[\]\s*=\s*\{"
@@ -1619,9 +1620,13 @@ def _parse_runtime_shim_registry(
         re.S,
     )
     for invariant_match in invariant_re.finditer(source):
-        invariant_tables[invariant_match.group(1)] = re.findall(
-            r'"([^"]+)"', invariant_match.group("body")
+        table_name = invariant_match.group(1)
+        values, array_failures = _parse_string_initializer_array(
+            invariant_match.group("body"),
+            table_name,
         )
+        invariant_tables[table_name] = values
+        failures.extend(array_failures)
 
     match = re.search(
         r"kAppStateCompatibilityShims\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
@@ -1632,7 +1637,6 @@ def _parse_runtime_shim_registry(
         return [], [f"{runtime_path}: failed to find runtime compatibility shim registry"]
 
     records: list[dict[str, Any]] = []
-    failures: list[str] = []
     row_re = re.compile(
         r"\{\s*\"(?P<id>[^\"]*)\"\s*,\s*\"(?P<owner>[^\"]*)\"\s*,"
         r"\s*\"(?P<old_authority_path>[^\"]*)\"\s*,"
@@ -2454,6 +2458,7 @@ def _validate_runtime_shim_registry(
     runtime_path: Path,
     shim_records: list[Any],
     runtime_transition_ids: set[str],
+    runtime_invariant_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
     expected_shims = {
@@ -2497,6 +2502,14 @@ def _validate_runtime_shim_registry(
         invariant_checks = record.get("invariant_checks")
         if not isinstance(invariant_checks, list) or not invariant_checks:
             failures.append(f"{label}: invariant_checks must be non-empty")
+        else:
+            failures.extend(
+                _validate_invariant_check_refs(
+                    invariant_checks=invariant_checks,
+                    runtime_invariant_ids=runtime_invariant_ids,
+                    label=label,
+                )
+            )
 
         target_transition = record.get("target_transition")
         if (
@@ -2646,6 +2659,29 @@ def _collect_transition_ids_by_string_id(
         ):
             transition_ids[value] = transition_id
     return transition_ids
+
+
+def _validate_invariant_check_refs(
+    *,
+    invariant_checks: Any,
+    runtime_invariant_ids: set[str],
+    label: str,
+) -> list[str]:
+    if not isinstance(invariant_checks, list):
+        return []
+
+    failures: list[str] = []
+    for check_index, invariant_id in enumerate(invariant_checks):
+        if (
+            isinstance(invariant_id, str)
+            and invariant_id.strip()
+            and invariant_id not in runtime_invariant_ids
+        ):
+            failures.append(
+                f"{label}: invariant_checks[{check_index}] does not match "
+                f"runtime invariant registry: {invariant_id}"
+            )
+    return failures
 
 
 def _validate_allowed_direct_writes(
@@ -4174,6 +4210,10 @@ def validate_contract(
         )
     )
 
+    runtime_invariant_ids = {
+        record["invariant_id"] for record in runtime_invariant_records
+    }
+
     if not isinstance(shims_doc, dict):
         failures.append(f"{shims_path}: top-level value must be an object")
         shims = []
@@ -4207,6 +4247,13 @@ def validate_contract(
                 failures.append(
                     f"{label}: target_transition does not match a transition id: {target_transition}"
                 )
+        failures.extend(
+            _validate_invariant_check_refs(
+                invariant_checks=record.get("invariant_checks"),
+                runtime_invariant_ids=runtime_invariant_ids,
+                label=label,
+            )
+        )
     failures.extend(
         _validate_runtime_shim_registry(
             runtime_records=runtime_shim_records,
@@ -4215,6 +4262,7 @@ def validate_contract(
             runtime_transition_ids={
                 record["id"] for record in runtime_transition_records
             },
+            runtime_invariant_ids=runtime_invariant_ids,
         )
     )
 

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2092,23 +2092,23 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    sizeof(kAppStateDispatchSurfaceMigrationNotes9) / sizeof(kAppStateDispatchSurfaceMigrationNotes9[0])},
 };
 static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {
-  "YtreeNovaPanel(active).dotfile_visibility is authoritative",
-  "Inactive panel visibility is never overwritten from the mirror",
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.shared-state-panel-local-isolation",
 };
 
 static const char *const kAppStateCompatibilityShimInvariantChecks1[] = {
-  "Raw index is never used while a stable identity key resolves",
-  "Generation mismatch forces rebind before dereference",
+  "invariant.viewport-identity-rebind",
+  "invariant.stale-snapshot-fail-closed",
 };
 
 static const char *const kAppStateCompatibilityShimInvariantChecks2[] = {
-  "Panel focus_shape remains the restore authority",
-  "Session flag must not overwrite inactive panel shape",
+  "invariant.panel-local-focus-restore",
+  "invariant.inactive-panel-frozen",
 };
 
 static const char *const kAppStateCompatibilityShimInvariantChecks3[] = {
-  "Render projection is not restore authority",
-  "Temporary row math is discarded after draw",
+  "invariant.render-projection-read-only",
+  "invariant.viewport-identity-rebind",
 };
 
 static const char *const kAppStateInvariantProtectedFields0[] = {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -883,6 +883,9 @@ static int AppStateCompatibilityShimsReady(void) {
          invariant_index < metadata->invariant_check_count; invariant_index++) {
       if (!NonEmptyString(metadata->invariant_checks[invariant_index]))
         return 0;
+      if (AppStateInvariantLookup(metadata->invariant_checks[invariant_index]) ==
+          NULL)
+        return 0;
     }
   }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -93,7 +93,7 @@ def _shim(target_transition: str = "transition.keybinding") -> dict[str, object]
         "old_authority_path": "legacy.path",
         "read_permission": "read",
         "write_permission": "write",
-        "invariant_checks": ["invariant"],
+        "invariant_checks": ["invariant.inactive_panel_frozen"],
         "removal_trigger": "trigger",
         "target_transition": target_transition,
         "follow_up_task": "task",
@@ -3796,6 +3796,25 @@ def test_guard_fails_when_shim_targets_unknown_transition(tmp_path: Path) -> Non
     )
 
 
+def test_guard_fails_when_shim_invariant_check_is_not_runtime_registered(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim()
+    shim["invariant_checks"] = ["invariant.not_runtime_registered"]
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "invariant_checks" in failure
+        and "runtime invariant registry" in failure
+        and "invariant.not_runtime_registered" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_shim_metadata_drifts(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     runtime_shims = [_shim()]
@@ -3893,6 +3912,34 @@ def test_guard_fails_when_runtime_shim_invariant_checks_are_missing(
     assert any(
         "runtime_shim[0]" in failure
         and "invariant_checks must be non-empty" in failure
+        for failure in failures
+    )
+
+
+def test_guard_preserves_runtime_shim_invariant_array_parse_failures(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(tmp_path, transitions=transitions)
+    runtime_path = paths[-1]
+    source = runtime_path.read_text(encoding="utf-8")
+    runtime_path.write_text(
+        source.replace(
+            'static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {\n'
+            '  "invariant.inactive_panel_frozen",',
+            "static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {\n"
+            "  NULL,",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateCompatibilityShimInvariantChecks0[0]" in failure
+        and "malformed string literal entry" in failure
+        and "NULL" in failure
         for failure in failures
     )
 
@@ -4939,6 +4986,23 @@ def test_runtime_shim_startup_checks_fail_closed() -> None:
     assert "previous_index < index" in source
     assert "strcmp(previous->id, metadata->id) == 0" in source
     assert "!AppStateCompatibilityShimsReady()" in source
+
+
+def test_runtime_shim_startup_validates_invariant_checks_against_registry() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert re.search(
+        r"for \(invariant_index = 0;\s*"
+        r"invariant_index < metadata->invariant_check_count;\s*"
+        r"invariant_index\+\+\) \{\s*"
+        r"if \(!NonEmptyString\(metadata->invariant_checks\[invariant_index\]\)\)\s*"
+        r"return 0;\s*"
+        r"if \(AppStateInvariantLookup\("
+        r"metadata->invariant_checks\[invariant_index\]\)\s*==\s*NULL\)\s*"
+        r"return 0;",
+        source,
+        re.S,
+    )
 
 
 def test_runtime_shim_startup_requires_documented_shim_ids() -> None:


### PR DESCRIPTION
## Summary
- fail compatibility-shim startup readiness when an invariant check is not registered in the canonical invariant map
- convert shim invariant checks from prose to registered invariant ids in docs and runtime metadata
- extend the contract guard so documented and runtime shim invariant checks must match registered invariants

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'shim and invariant'` — PASS
- `pytest -q tests/test_appstate_contract_guard.py` — PASS
- `python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings
- `git diff --check` — PASS
