### PR TITLE
chore(appstate): require invariant field owners

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -779,6 +779,7 @@ static int AppStateInvariantRegistryReady(void) {
 
   for (index = 0; index < AppStateInvariantCount(); index++) {
     const AppStateInvariantMetadata *metadata = AppStateInvariantAt(index);
+    size_t protected_field_index;
     size_t transition_index;
     size_t previous_index;
 
@@ -805,6 +806,15 @@ static int AppStateInvariantRegistryReady(void) {
 
       if (previous == NULL ||
           strcmp(previous->invariant_id, metadata->invariant_id) == 0)
+        return 0;
+    }
+
+    for (protected_field_index = 0;
+         protected_field_index < metadata->protected_field_count;
+         protected_field_index++) {
+      const char *field = metadata->protected_fields[protected_field_index];
+
+      if (AppStateOwnerFieldLookup(field) == NULL)
         return 0;
     }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4940,6 +4940,22 @@ def test_runtime_invariant_startup_checks_fail_closed() -> None:
     assert "!AppStateInvariantRegistryReady()" in source
 
 
+def test_runtime_invariant_startup_validates_protected_fields_against_owner_registry() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "NonEmptyStringList(metadata->protected_fields" in source
+    assert re.search(
+        r"for \(protected_field_index = 0;\s*"
+        r"protected_field_index < metadata->protected_field_count;\s*"
+        r"protected_field_index\+\+\) \{\s*"
+        r"const char \*field = "
+        r"metadata->protected_fields\[protected_field_index\];\s*"
+        r"if \(AppStateOwnerFieldLookup\(field\) == NULL\)\s*return 0;",
+        source,
+        re.S,
+    )
+
+
 def test_runtime_invariant_startup_requires_documented_invariant_ids() -> None:
     source = Path("src/core/main.c").read_text(encoding="utf-8")
     invariant_doc, invariant_failures = guard._load_json(guard.DEFAULT_INVARIANTS)


### PR DESCRIPTION
## Summary
- Add startup validation that every AppState invariant protected field resolves through the canonical owner-field registry.
- Add focused contract-guard coverage for the protected-field owner lookup requirement.

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'invariant and startup'` — PASS
- `pytest -q tests/test_appstate_contract_guard.py` — PASS
- `python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings in unchanged runtime files
- `git diff --check` — PASS
