### PR TITLE
chore(appstate): tighten registry ownership checks

### DIFF
--- a/docs/appstate_owner_fields.json
+++ b/docs/appstate_owner_fields.json
@@ -11,8 +11,8 @@
       "mutation_rule": "May change only during an allowed panel-routing or volume/menu transition commit.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Active panel changes must preserve inactive panel-local records.",
-        "Panel routing must resolve to an existing YtreeNovaPanel carrier before render projection."
+        "invariant.inactive-panel-frozen",
+        "invariant.shared-state-panel-local-isolation"
       ]
     },
     {
@@ -23,8 +23,8 @@
       "mutation_rule": "May change only through command start/completion/cancel transitions.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Command completion must not mutate panel or volume fields outside the declared follow-up transition.",
-        "Command failure or cancellation must preserve authoritative panel and volume state."
+        "invariant.blocked-transition-determinism",
+        "invariant.shared-state-panel-local-isolation"
       ]
     },
     {
@@ -35,8 +35,8 @@
       "mutation_rule": "May change only through transitions that declare user-visible outcome or constraint messaging.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Blocked transitions may write message state only when needed for outcome clarity.",
-        "Message writes must not imply filesystem or panel state success."
+        "invariant.blocked-transition-determinism",
+        "invariant.render-projection-read-only"
       ]
     },
     {
@@ -47,8 +47,8 @@
       "mutation_rule": "May change only when entering, completing, or dismissing a registered modal transition.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Modal dismissal must leave underlying panel and volume authority unchanged unless declared.",
-        "Destructive confirmations must remain explicit and default-safe."
+        "invariant.panel-local-focus-restore",
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -59,8 +59,8 @@
       "mutation_rule": "May be queued only by transitions that declare a deterministic follow-up boundary.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Pending transitions must name a registered transition before later mutation.",
-        "Queueing a transition must not advance panel or volume generations by itself."
+        "invariant.blocked-transition-determinism",
+        "invariant.stale-snapshot-fail-closed"
       ]
     },
     {
@@ -71,8 +71,8 @@
       "mutation_rule": "May change only through volume lifecycle transitions that validate panel bindings.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Releasing a volume must not leave active or inactive panels with stale volume pointers.",
-        "Volume registry changes must rebind affected panels through stable identity or deterministic fallback."
+        "invariant.shared-state-panel-local-isolation",
+        "invariant.viewport-identity-rebind"
       ]
     },
     {
@@ -83,8 +83,8 @@
       "mutation_rule": "May change only during resize/reflow transitions executed in the main loop.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Resize handling must not choose a new authoritative selection from rendered rows.",
-        "Layout changes alone must not advance volume_generation."
+        "invariant.render-projection-read-only",
+        "invariant.viewport-identity-rebind"
       ]
     },
     {
@@ -95,8 +95,8 @@
       "mutation_rule": "May change only when a transition marks or clears declared projection surfaces.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Render invalidation writes must not mutate selection, focus, or identity state.",
-        "Render projection may clear only surfaces produced from settled AppState records."
+        "invariant.render-projection-read-only",
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -107,8 +107,8 @@
       "mutation_rule": "May change only during main-loop layout/reflow or render projection setup.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Ncurses window recreation must happen outside signal handlers.",
-        "Window handles must not become restore authority for panel selection or viewport state."
+        "invariant.render-projection-read-only",
+        "invariant.panel-local-focus-restore"
       ]
     },
     {
@@ -119,8 +119,8 @@
       "mutation_rule": "May change only for the targeted panel through navigation, restore, or rebind transitions.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "File selection identity must be path/name based, not a stale FileEntry pointer.",
-        "Inactive panel file selection must remain frozen across active-only actions."
+        "invariant.viewport-identity-rebind",
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -131,8 +131,8 @@
       "mutation_rule": "May change only for the targeted panel when navigation, bounds correction, or reflow declares it.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "File viewport correction must preserve the stored selection when it remains visible.",
-        "Render paths may compute temporary file projection without overwriting this origin."
+        "invariant.viewport-identity-rebind",
+        "invariant.render-projection-read-only"
       ]
     },
     {
@@ -143,8 +143,8 @@
       "mutation_rule": "May change only during allowed focus, modal restore, split, or file/tree transition commits.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Reactivation must restore the recorded tree/small-file/big-file shape directly.",
-        "Focus shape changes must not import the inactive panel's state."
+        "invariant.panel-local-focus-restore",
+        "invariant.shared-state-panel-local-isolation"
       ]
     },
     {
@@ -155,8 +155,8 @@
       "mutation_rule": "May increment only when panel-local restore authority changes.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Render projection alone must not advance panel_generation.",
-        "Snapshot restore must compare panel_generation before applying saved state."
+        "invariant.render-projection-read-only",
+        "invariant.stale-snapshot-fail-closed"
       ]
     },
     {
@@ -167,8 +167,8 @@
       "mutation_rule": "May change only through snapshot capture, rebind, fallback, or volume-binding transitions.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Restore snapshots must use stable identities plus generation validation.",
-        "Stale snapshots must fail closed through the deterministic fallback order."
+        "invariant.viewport-identity-rebind",
+        "invariant.stale-snapshot-fail-closed"
       ]
     },
     {
@@ -179,8 +179,8 @@
       "mutation_rule": "May change only for the targeted panel during tree navigation or rebind/fallback transitions.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Tree cursor position is interpreted against visible rows, not raw topology indices.",
-        "Inactive panel cursor must remain unchanged unless the transition explicitly targets that panel."
+        "invariant.hidden-entry-visible-navigation",
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -191,8 +191,8 @@
       "mutation_rule": "May change only through tree navigation, restore, or topology rebind transitions for the targeted panel.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Tree selection identity must be stable and path based within the current volume namespace.",
-        "Selection restore must not derive authority from disp_begin_pos plus cursor_pos."
+        "invariant.viewport-identity-rebind",
+        "invariant.stale-snapshot-fail-closed"
       ]
     },
     {
@@ -203,8 +203,8 @@
       "mutation_rule": "May change only when navigation, bounds correction, resize, or rebind declares viewport mutation.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Hidden dotfile visibility must not cause extra viewport shifts when selection remains visible.",
-        "Render-side temporary placement must not overwrite the saved viewport origin."
+        "invariant.hidden-entry-visible-navigation",
+        "invariant.render-projection-read-only"
       ]
     },
     {
@@ -215,8 +215,8 @@
       "mutation_rule": "May change only through volume selection, cycle, release, or restore transitions.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Panel volume binding must point to an existing volume/archive namespace or deterministic fallback.",
-        "A panel must not import the opposite panel's volume-specific snapshot."
+        "invariant.stale-snapshot-fail-closed",
+        "invariant.shared-state-panel-local-isolation"
       ]
     },
     {
@@ -227,8 +227,8 @@
       "mutation_rule": "May change only through logging, rebuild, refresh, release, or completed filesystem mutation transitions.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Shared topology changes must re-anchor each panel by its own stable identity.",
-        "Topology mutation must advance volume_generation before restore consumers observe it."
+        "invariant.shared-state-panel-local-isolation",
+        "invariant.stale-snapshot-fail-closed"
       ]
     },
     {
@@ -239,8 +239,8 @@
       "mutation_rule": "May change only through explicit log, relog, release, collapse, refresh, or rebuild transitions.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Logged state is shared topology and must not store panel-local cursor or tag authority.",
-        "Unlogged placeholders must not degrade a frozen file-view anchor without rebind or payload reload."
+        "invariant.shared-state-panel-local-isolation",
+        "invariant.viewport-identity-rebind"
       ]
     },
     {
@@ -251,8 +251,8 @@
       "mutation_rule": "May change only through payload load, refresh, archive, or completed filesystem mutation transitions.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Payload cache changes must not overwrite panel-local file selection identity.",
-        "Mutation-result commits must distinguish filesystem side effects from AppState metadata updates."
+        "invariant.shared-state-panel-local-isolation",
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -263,8 +263,8 @@
       "mutation_rule": "May increment only when shared topology, payload identity, logged state, or namespace mapping changes.",
       "migration_status": "documented_foundation_only",
       "invariant_checks": [
-        "Render projection alone must not advance volume_generation.",
-        "Generation mismatch must force stable-identity re-resolution before snapshot restore."
+        "invariant.render-projection-read-only",
+        "invariant.stale-snapshot-fail-closed"
       ]
     }
   ]

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -1840,6 +1840,16 @@ def _validate_runtime_action_coverage_registry(
             failures.append(
                 f"{label}: category does not match transition {transition_id}: {category}"
             )
+        owner = record.get("owner")
+        if (
+            isinstance(owner, str)
+            and owner.strip()
+            and transition_record is not None
+            and owner != transition_record.get("owner")
+        ):
+            failures.append(
+                f"{label}: owner does not match transition {transition_id}: {owner}"
+            )
 
         if isinstance(action, str) and action.strip():
             coverage_record = action_coverage_by_action.get(action)
@@ -3339,9 +3349,20 @@ def _validate_runtime_event_coverage_registry(
             failures.append(f"{label}: transition_id missing from runtime transition registry: {transition_id}")
         else:
             if record.get("category") != transition_record.get("category"):
-                failures.append(f"{label}: category does not match transition {transition_id}: {record.get('category')}")
+                failures.append(
+                    f"{label}: category does not match transition "
+                    f"{transition_id}: {record.get('category')}"
+                )
+            if record.get("owner") != transition_record.get("owner"):
+                failures.append(
+                    f"{label}: owner does not match transition "
+                    f"{transition_id}: {record.get('owner')}"
+                )
             if record.get("declared_write_set") != transition_record.get("declared_write_set"):
-                failures.append(f"{label}: declared_write_set does not match transition {transition_id}")
+                failures.append(
+                    f"{label}: declared_write_set does not match "
+                    f"transition {transition_id}"
+                )
 
     missing_ids = sorted(expected_ids - covered_ids)
     if missing_ids:
@@ -3439,6 +3460,16 @@ def _validate_event_coverage(
         ):
             failures.append(
                 f"{label}: category does not match transition {transition_id}: {category}"
+            )
+        owner = record.get("owner")
+        if (
+            isinstance(owner, str)
+            and owner.strip()
+            and transition_record is not None
+            and owner != transition_record.get("owner")
+        ):
+            failures.append(
+                f"{label}: owner does not match transition {transition_id}: {owner}"
             )
 
     missing_event_classes = sorted(REQUIRED_EVENT_CLASSES - covered_event_classes)
@@ -4344,6 +4375,16 @@ def validate_contract(
         ):
             failures.append(
                 f"{label}: category does not match transition {transition_id}: {category}"
+            )
+        owner = record.get("owner")
+        if (
+            isinstance(owner, str)
+            and owner.strip()
+            and transition_record is not None
+            and owner != transition_record.get("owner")
+        ):
+            failures.append(
+                f"{label}: owner does not match transition {transition_id}: {owner}"
             )
 
     missing_actions = sorted(expected_actions - covered_actions)

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -1943,6 +1943,7 @@ def _validate_runtime_owner_field_registry(
     runtime_records: list[dict[str, Any]],
     runtime_path: Path,
     owner_field_records: list[Any],
+    runtime_invariant_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
     expected_owner_fields = {
@@ -1990,6 +1991,13 @@ def _validate_runtime_owner_field_registry(
                         f"{label}: invariant_checks[{check_index}] "
                         "must be a non-empty string"
                     )
+            failures.extend(
+                _validate_invariant_check_refs(
+                    invariant_checks=invariant_checks,
+                    runtime_invariant_ids=runtime_invariant_ids,
+                    label=label,
+                )
+            )
 
     missing_fields = sorted(expected_fields - covered_fields)
     if missing_fields:
@@ -2568,6 +2576,7 @@ def _validate_owner_fields(
     *,
     owner_fields_doc: Any,
     owner_fields_path: Path,
+    runtime_invariant_ids: set[str],
 ) -> tuple[set[str], list[str]]:
     failures: list[str] = []
     registered_fields: set[str] = set()
@@ -2598,6 +2607,13 @@ def _validate_owner_fields(
             if field in registered_fields:
                 failures.append(f"{label}: duplicate field: {field}")
             registered_fields.add(field)
+        failures.extend(
+            _validate_invariant_check_refs(
+                invariant_checks=record.get("invariant_checks"),
+                runtime_invariant_ids=runtime_invariant_ids,
+                label=label,
+            )
+        )
 
     return registered_fields, failures
 
@@ -4104,9 +4120,14 @@ def validate_contract(
     if failures:
         return failures
 
+    runtime_invariant_ids = {
+        record["invariant_id"] for record in runtime_invariant_records
+    }
+
     registered_owner_fields, owner_field_failures = _validate_owner_fields(
         owner_fields_doc=owner_fields_doc,
         owner_fields_path=owner_fields_path,
+        runtime_invariant_ids=runtime_invariant_ids,
     )
     failures.extend(owner_field_failures)
     if isinstance(owner_fields_doc, dict) and isinstance(
@@ -4120,6 +4141,7 @@ def validate_contract(
             runtime_records=runtime_owner_field_records,
             runtime_path=action_runtime_path,
             owner_field_records=owner_field_records,
+            runtime_invariant_ids=runtime_invariant_ids,
         )
     )
 
@@ -4209,10 +4231,6 @@ def validate_contract(
             generation_owner_fields=generation_owner_fields,
         )
     )
-
-    runtime_invariant_ids = {
-        record["invariant_id"] for record in runtime_invariant_records
-    }
 
     if not isinstance(shims_doc, dict):
         failures.append(f"{shims_path}: top-level value must be an object")

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -91,92 +91,92 @@ static const char *const kAppStateTransitionWriteSet9[] = {
 };
 
 static const char *const kAppStateOwnerFieldInvariantChecks0[] = {
-  "Active panel changes must preserve inactive panel-local records.",
-  "Panel routing must resolve to an existing YtreeNovaPanel carrier before render projection.",
+  "invariant.inactive-panel-frozen",
+  "invariant.shared-state-panel-local-isolation",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks1[] = {
-  "Command completion must not mutate panel or volume fields outside the declared follow-up transition.",
-  "Command failure or cancellation must preserve authoritative panel and volume state.",
+  "invariant.blocked-transition-determinism",
+  "invariant.shared-state-panel-local-isolation",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks2[] = {
-  "Blocked transitions may write message state only when needed for outcome clarity.",
-  "Message writes must not imply filesystem or panel state success.",
+  "invariant.blocked-transition-determinism",
+  "invariant.render-projection-read-only",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks3[] = {
-  "Modal dismissal must leave underlying panel and volume authority unchanged unless declared.",
-  "Destructive confirmations must remain explicit and default-safe.",
+  "invariant.panel-local-focus-restore",
+  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks4[] = {
-  "Pending transitions must name a registered transition before later mutation.",
-  "Queueing a transition must not advance panel or volume generations by itself.",
+  "invariant.blocked-transition-determinism",
+  "invariant.stale-snapshot-fail-closed",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks5[] = {
-  "Releasing a volume must not leave active or inactive panels with stale volume pointers.",
-  "Volume registry changes must rebind affected panels through stable identity or deterministic fallback.",
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.viewport-identity-rebind",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks6[] = {
-  "Resize handling must not choose a new authoritative selection from rendered rows.",
-  "Layout changes alone must not advance volume_generation.",
+  "invariant.render-projection-read-only",
+  "invariant.viewport-identity-rebind",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks7[] = {
-  "Render invalidation writes must not mutate selection, focus, or identity state.",
-  "Render projection may clear only surfaces produced from settled AppState records.",
+  "invariant.render-projection-read-only",
+  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks8[] = {
-  "Ncurses window recreation must happen outside signal handlers.",
-  "Window handles must not become restore authority for panel selection or viewport state.",
+  "invariant.render-projection-read-only",
+  "invariant.panel-local-focus-restore",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks9[] = {
-  "File selection identity must be path/name based, not a stale FileEntry pointer.",
-  "Inactive panel file selection must remain frozen across active-only actions.",
+  "invariant.viewport-identity-rebind",
+  "invariant.inactive-panel-frozen",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks10[] = {
-  "File viewport correction must preserve the stored selection when it remains visible.",
-  "Render paths may compute temporary file projection without overwriting this origin.",
+  "invariant.viewport-identity-rebind",
+  "invariant.render-projection-read-only",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks11[] = {
-  "Reactivation must restore the recorded tree/small-file/big-file shape directly.",
-  "Focus shape changes must not import the inactive panel's state.",
+  "invariant.panel-local-focus-restore",
+  "invariant.shared-state-panel-local-isolation",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks12[] = {
-  "Render projection alone must not advance panel_generation.",
-  "Snapshot restore must compare panel_generation before applying saved state.",
+  "invariant.render-projection-read-only",
+  "invariant.stale-snapshot-fail-closed",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks13[] = {
-  "Restore snapshots must use stable identities plus generation validation.",
-  "Stale snapshots must fail closed through the deterministic fallback order.",
+  "invariant.viewport-identity-rebind",
+  "invariant.stale-snapshot-fail-closed",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks14[] = {
-  "Tree cursor position is interpreted against visible rows, not raw topology indices.",
-  "Inactive panel cursor must remain unchanged unless the transition explicitly targets that panel.",
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.inactive-panel-frozen",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks15[] = {
-  "Tree selection identity must be stable and path based within the current volume namespace.",
-  "Selection restore must not derive authority from disp_begin_pos plus cursor_pos.",
+  "invariant.viewport-identity-rebind",
+  "invariant.stale-snapshot-fail-closed",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks16[] = {
-  "Hidden dotfile visibility must not cause extra viewport shifts when selection remains visible.",
-  "Render-side temporary placement must not overwrite the saved viewport origin.",
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.render-projection-read-only",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks17[] = {
-  "Panel volume binding must point to an existing volume/archive namespace or deterministic fallback.",
-  "A panel must not import the opposite panel's volume-specific snapshot.",
+  "invariant.stale-snapshot-fail-closed",
+  "invariant.shared-state-panel-local-isolation",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks18[] = {
-  "Shared topology changes must re-anchor each panel by its own stable identity.",
-  "Topology mutation must advance volume_generation before restore consumers observe it.",
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.stale-snapshot-fail-closed",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks19[] = {
-  "Logged state is shared topology and must not store panel-local cursor or tag authority.",
-  "Unlogged placeholders must not degrade a frozen file-view anchor without rebind or payload reload.",
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.viewport-identity-rebind",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks20[] = {
-  "Payload cache changes must not overwrite panel-local file selection identity.",
-  "Mutation-result commits must distinguish filesystem side effects from AppState metadata updates.",
+  "invariant.shared-state-panel-local-isolation",
+  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateOwnerFieldInvariantChecks21[] = {
-  "Render projection alone must not advance volume_generation.",
-  "Generation mismatch must force stable-identity re-resolution before snapshot restore.",
+  "invariant.render-projection-read-only",
+  "invariant.stale-snapshot-fail-closed",
 };
 
 static const AppStateOwnerFieldMetadata kAppStateOwnerFields[] = {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -512,6 +512,7 @@ static int AppStateOwnerFieldsReady(void) {
 
   for (index = 0; index < AppStateOwnerFieldCount(); index++) {
     const AppStateOwnerFieldMetadata *metadata = AppStateOwnerFieldAt(index);
+    size_t invariant_index;
     size_t previous_index;
 
     if (metadata == NULL || !NonEmptyString(metadata->field) ||
@@ -525,6 +526,13 @@ static int AppStateOwnerFieldsReady(void) {
       return 0;
     if (AppStateOwnerFieldLookup(metadata->field) != metadata)
       return 0;
+
+    for (invariant_index = 0;
+         invariant_index < metadata->invariant_check_count; invariant_index++) {
+      if (AppStateInvariantLookup(metadata->invariant_checks[invariant_index]) ==
+          NULL)
+        return 0;
+    }
 
     for (previous_index = 0; previous_index < index; previous_index++) {
       const AppStateOwnerFieldMetadata *previous =

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1052,6 +1052,8 @@ static int AppStateEventCoverageReady(void) {
       return 0;
     if (strcmp(coverage->category, transition->category) != 0)
       return 0;
+    if (strcmp(coverage->owner, transition->owner) != 0)
+      return 0;
     if (!AppStateEventCoverageWriteSetMatches(coverage, transition))
       return 0;
   }
@@ -1121,6 +1123,8 @@ static int AppStateActionCoverageReady(void) {
     if (transition == NULL)
       return 0;
     if (strcmp(coverage->category, transition->category) != 0)
+      return 0;
+    if (strcmp(coverage->owner, transition->owner) != 0)
       return 0;
     if (!AppStateActionCoverageWriteSetMatches(coverage, transition))
       return 0;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -110,7 +110,7 @@ def _action(
         "action": action,
         "transition_id": transition_id,
         "category": category,
-        "owner": "YtreeNovaPanel(active)",
+        "owner": "owner",
         "declared_write_set": ["panel.tree_selection_key"],
         "boundary_status": "test",
         "migration_notes": ["fixture action coverage"],
@@ -140,7 +140,7 @@ def _event(
         "transition_id": transition_id or f"transition.{resolved_category}",
         "category": resolved_category,
         "source": "fixture source",
-        "owner": "fixture owner",
+        "owner": "owner",
         "declared_write_set": ["field"],
         "boundary_status": "test",
         "trigger_paths": ["fixture trigger"],
@@ -4409,6 +4409,92 @@ def test_guard_fails_when_event_category_does_not_match_transition(tmp_path: Pat
     )
 
 
+def test_guard_fails_when_action_coverage_owner_does_not_match_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0]["owner"] = "different owner"
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure
+        and "owner does not match transition" in failure
+        and "different owner" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_event_coverage_owner_does_not_match_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[0]["owner"] = "different owner"
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure
+        and "owner does not match transition" in failure
+        and "different owner" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_action_coverage_owner_does_not_match_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    runtime_action_coverages = _complete_actions()
+    actions[0]["owner"] = "different owner"
+    runtime_action_coverages[0]["owner"] = "different owner"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        actions=actions,
+        runtime_action_coverages=runtime_action_coverages,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_action_coverage[0]" in failure
+        and "owner does not match transition" in failure
+        and "different owner" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_event_coverage_owner_does_not_match_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    runtime_events = _complete_events()
+    events[0]["owner"] = "different owner"
+    runtime_events[0]["owner"] = "different owner"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        events=events,
+        runtime_events=runtime_events,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_event_coverage[0]" in failure
+        and "owner does not match transition" in failure
+        and "different owner" in failure
+        for failure in failures
+    )
+
+
 def test_guard_catches_enum_drift_from_temporary_header(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     paths = _write_fixture(
@@ -4758,6 +4844,22 @@ def test_runtime_event_coverage_startup_checks_fail_closed() -> None:
     assert "AppStateEventCoverageAt(AppStateEventCoverageCount()) != NULL" in source
     assert 'AppStateEventCoverageLookup("event.__ytnova_unknown__") != NULL' in source
     assert "!AppStateEventCoverageReady()" in source
+
+
+def test_runtime_coverage_startup_validates_owner_alignment() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    event_start = source.index("static int AppStateEventCoverageReady(void)")
+    action_start = source.index("static int AppStateActionCoverageReady(void)")
+    diff_harness_start = source.index(
+        "static int AppStateDiffHarnessRegistryReady(void)"
+    )
+
+    event_body = source[event_start:action_start]
+    action_body = source[action_start:diff_harness_start]
+
+    assert "strcmp(coverage->owner, transition->owner) != 0" in action_body
+    assert "strcmp(coverage->owner, transition->owner) != 0" in event_body
 
 
 def test_runtime_event_coverage_startup_requires_documented_event_ids() -> None:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -311,7 +311,7 @@ def _owner_field(field: str = "field") -> dict[str, object]:
         "runtime_carrier": "YtreeNovaPanel fixture carrier",
         "mutation_rule": "Fixture transitions may mutate only declared fields.",
         "migration_status": "test",
-        "invariant_checks": ["fixture invariant"],
+        "invariant_checks": ["invariant.inactive_panel_frozen"],
     }
 
 
@@ -3329,6 +3329,27 @@ def test_guard_fails_on_malformed_owner_invariant_checks(tmp_path: Path) -> None
     )
 
 
+def test_guard_fails_on_unknown_owner_field_invariant_id(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    owner_fields = _complete_owner_fields()
+    owner_fields[0]["invariant_checks"] = ["invariant.missing"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        owner_fields=owner_fields,
+        runtime_owner_fields=_complete_owner_fields(),
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "owner_field[0]" in failure
+        and "invariant_checks[0] does not match runtime invariant registry"
+        and "invariant.missing" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_owner_field_record_is_malformed(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     owner_fields = _complete_owner_fields()
@@ -3365,6 +3386,28 @@ def test_guard_fails_when_runtime_owner_field_metadata_drifts(
     assert any(
         "runtime_owner_field[0]" in failure
         and "runtime canonical_owner does not match owner field" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_owner_field_invariant_id_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_owner_fields = _complete_owner_fields()
+    runtime_owner_fields[0]["invariant_checks"] = ["invariant.missing"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_owner_fields=runtime_owner_fields,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_owner_field[0]" in failure
+        and "invariant_checks[0] does not match runtime invariant registry"
+        and "invariant.missing" in failure
         for failure in failures
     )
 
@@ -3460,7 +3503,7 @@ def test_guard_fails_when_runtime_owner_field_list_entry_is_malformed(
     runtime_path.write_text(
         source.replace(
             'static const char *const kAppStateOwnerFieldInvariantChecks0[] = {\n'
-            '  "fixture invariant",',
+            '  "invariant.inactive_panel_frozen",',
             "static const char *const kAppStateOwnerFieldInvariantChecks0[] = {\n"
             "  NULL,",
             1,
@@ -4756,6 +4799,21 @@ def test_runtime_owner_field_startup_checks_fail_closed() -> None:
     assert "strcmp(previous->field, metadata->field) == 0" in source
     assert "AppStateOwnerFieldLookup(kAppStateRequiredOwnerFieldIds[index])" in source
     assert "!AppStateOwnerFieldsReady()" in source
+
+
+def test_runtime_owner_field_startup_validates_invariant_checks_against_registry() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert re.search(
+        r"for \(invariant_index = 0;\s*"
+        r"invariant_index < metadata->invariant_check_count;\s*"
+        r"invariant_index\+\+\) \{\s*"
+        r"if \(AppStateInvariantLookup\("
+        r"metadata->invariant_checks\[invariant_index\]\)\s*==\s*NULL\)\s*"
+        r"return 0;",
+        source,
+        re.S,
+    )
 
 
 def test_runtime_owner_field_startup_requires_documented_field_ids() -> None:


### PR DESCRIPTION
## Summary
- Convert owner-field invariant checks to canonical invariant IDs and validate them against the runtime invariant registry.
- Require action/event coverage owners to match their referenced transition owners in guard checks and startup readiness.

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'owner_field and invariant or coverage and owner'` — PASS
- `pytest -q tests/test_appstate_contract_guard.py` — PASS
- `python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings in unchanged runtime files
- `git diff --check` — PASS
