### PR TITLE
chore(appstate): tighten write coverage checks

### DIFF
--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -19,10 +19,14 @@
         "ctx.active",
         "ctx.volumes_head",
         "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
         "panel.file_selection_key",
+        "panel.file_viewport_origin",
         "panel.restore_snapshot",
         "panel.panel_generation",
         "volume.dir_tree",
+        "volume.logged_state",
         "volume.volume_generation"
       ],
       "invariant_ids": [
@@ -55,14 +59,17 @@
         "transition.command-completion.user-command"
       ],
       "owner_field_refs": [
+        "ctx.active",
         "ctx.command_state",
         "ctx.message_state",
         "ctx.modal_state",
         "ctx.pending_transition",
+        "panel.volume_key",
         "panel.tree_selection_key",
         "panel.tree_cursor_pos",
         "panel.tree_viewport_origin",
         "panel.focus_shape",
+        "panel.restore_snapshot",
         "panel.panel_generation"
       ],
       "invariant_ids": [
@@ -128,9 +135,14 @@
         "transition.terminal-signal-resize"
       ],
       "owner_field_refs": [
+        "ctx.layout",
+        "ctx.window_handles",
         "panel.restore_snapshot",
         "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
         "panel.file_selection_key",
+        "panel.file_viewport_origin",
         "panel.panel_generation",
         "volume.dir_tree",
         "volume.payload_cache",

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -3669,6 +3669,51 @@ def _validate_step_reference_list(
     return failures
 
 
+def _diff_harness_transition_ids_by_harness(
+    diff_harness_records: list[Any],
+) -> dict[str, set[str]]:
+    transition_ids_by_harness: dict[str, set[str]] = {}
+    for record in diff_harness_records:
+        if not isinstance(record, dict):
+            continue
+        harness_id = record.get("harness_id")
+        transition_ids = record.get("transition_ids")
+        if not isinstance(harness_id, str) or not harness_id.strip():
+            continue
+        if not isinstance(transition_ids, list):
+            continue
+        transition_ids_by_harness[harness_id] = {
+            transition_id
+            for transition_id in transition_ids
+            if isinstance(transition_id, str) and transition_id.strip()
+        }
+    return transition_ids_by_harness
+
+
+def _validate_step_diff_harness_transition_alignment(
+    *,
+    diff_harness_refs: Any,
+    transition_id: Any,
+    diff_harness_transition_ids: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    if not isinstance(transition_id, str) or not transition_id.strip():
+        return []
+    if not isinstance(diff_harness_refs, list):
+        return []
+
+    for harness_id in diff_harness_refs:
+        if not isinstance(harness_id, str) or not harness_id.strip():
+            continue
+        if transition_id in diff_harness_transition_ids.get(harness_id, set()):
+            return []
+
+    return [
+        f"{label}: diff_harness_ids must include at least one diff harness "
+        f"covering transition_id {transition_id}"
+    ]
+
+
 def _validate_generation_expectations(
     *,
     value: Any,
@@ -3772,6 +3817,7 @@ def _validate_appstate_transition_sequences(
     event_transition_ids: dict[str, str],
     invariant_ids: set[str],
     diff_harness_ids: set[str],
+    diff_harness_transition_ids: dict[str, set[str]],
     generation_domain_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -3884,6 +3930,14 @@ def _validate_appstate_transition_sequences(
                 )
             )
             failures.extend(
+                _validate_step_diff_harness_transition_alignment(
+                    diff_harness_refs=step.get("diff_harness_ids"),
+                    transition_id=transition_id,
+                    diff_harness_transition_ids=diff_harness_transition_ids,
+                    label=label,
+                )
+            )
+            failures.extend(
                 _validate_generation_expectations(
                     value=step.get("generation_domain_expectations"),
                     label=label,
@@ -3978,6 +4032,7 @@ def _validate_runtime_transition_sequence_registry(
     event_transition_ids: dict[str, str],
     runtime_invariant_ids: set[str],
     runtime_diff_harness_ids: set[str],
+    runtime_diff_harness_transition_ids: dict[str, set[str]],
     runtime_generation_domain_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -4120,6 +4175,14 @@ def _validate_runtime_transition_sequence_registry(
                         reference_label=reference_label,
                     )
                 )
+            failures.extend(
+                _validate_step_diff_harness_transition_alignment(
+                    diff_harness_refs=step.get("diff_harness_ids"),
+                    transition_id=transition_id,
+                    diff_harness_transition_ids=runtime_diff_harness_transition_ids,
+                    label=step_label,
+                )
+            )
 
             failures.extend(
                 _validate_generation_expectations(
@@ -4713,6 +4776,9 @@ def validate_contract(
             event_transition_ids=event_transition_ids,
             invariant_ids=invariant_ids,
             diff_harness_ids=diff_harness_ids,
+            diff_harness_transition_ids=_diff_harness_transition_ids_by_harness(
+                diff_harness_records
+            ),
             generation_domain_ids=generation_domain_ids,
         )
     )
@@ -4740,6 +4806,9 @@ def validate_contract(
             runtime_diff_harness_ids={
                 record["harness_id"] for record in runtime_diff_harness_records
             },
+            runtime_diff_harness_transition_ids=_diff_harness_transition_ids_by_harness(
+                runtime_diff_harness_records
+            ),
             runtime_generation_domain_ids={
                 record["domain_id"] for record in runtime_generation_domain_records
             },

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -1948,6 +1948,63 @@ def _validate_runtime_transition_registry(
     return failures
 
 
+def _generation_write_coverage_by_owner_field(
+    generation_domain_records: list[Any],
+) -> dict[str, set[str]]:
+    coverage: dict[str, set[str]] = {}
+    for record in generation_domain_records:
+        if not isinstance(record, dict):
+            continue
+        owner_field = record.get("generation_owner_field")
+        transition_refs = record.get("advances_on_transition_ids")
+        if not isinstance(owner_field, str) or not owner_field.strip():
+            continue
+        if not isinstance(transition_refs, list):
+            continue
+        owner_coverage = coverage.setdefault(owner_field, set())
+        for transition_id in transition_refs:
+            if isinstance(transition_id, str) and transition_id.strip():
+                owner_coverage.add(transition_id)
+    return coverage
+
+
+def _validate_generation_write_coverage(
+    *,
+    transitions: list[Any],
+    generation_domain_records: list[Any],
+    label_prefix: str,
+) -> list[str]:
+    failures: list[str] = []
+    coverage_by_owner = _generation_write_coverage_by_owner_field(
+        generation_domain_records
+    )
+
+    for index, record in enumerate(transitions):
+        if not isinstance(record, dict):
+            continue
+        transition_id = record.get("id")
+        write_set = record.get("declared_write_set")
+        if not isinstance(transition_id, str) or not transition_id.strip():
+            continue
+        if not isinstance(write_set, list):
+            continue
+
+        for write_index, field in enumerate(write_set):
+            if not isinstance(field, str) or not field.strip():
+                continue
+            covered_transitions = coverage_by_owner.get(field)
+            if covered_transitions is None:
+                continue
+            if transition_id not in covered_transitions:
+                failures.append(
+                    f"{label_prefix}[{index}]: declared_write_set[{write_index}] "
+                    "writes generation owner field without generation domain "
+                    f"coverage for transition {transition_id}: {field}"
+                )
+
+    return failures
+
+
 def _validate_runtime_owner_field_registry(
     *,
     runtime_records: list[dict[str, Any]],
@@ -4260,6 +4317,20 @@ def validate_contract(
         _validate_transition_generation_effects(
             transitions=transitions,
             generation_owner_fields=generation_owner_fields,
+        )
+    )
+    failures.extend(
+        _validate_generation_write_coverage(
+            transitions=transitions,
+            generation_domain_records=generation_domain_records,
+            label_prefix="transition",
+        )
+    )
+    failures.extend(
+        _validate_generation_write_coverage(
+            transitions=runtime_transition_records,
+            generation_domain_records=runtime_generation_domain_records,
+            label_prefix="runtime_transition",
         )
     )
 

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2005,6 +2005,64 @@ def _validate_generation_write_coverage(
     return failures
 
 
+def _diff_harness_write_coverage_by_transition(
+    diff_harness_records: list[Any],
+) -> dict[str, set[str]]:
+    coverage: dict[str, set[str]] = {}
+    for record in diff_harness_records:
+        if not isinstance(record, dict):
+            continue
+        transition_refs = record.get("transition_ids")
+        owner_field_refs = record.get("owner_field_refs")
+        if not isinstance(transition_refs, list) or not isinstance(
+            owner_field_refs, list
+        ):
+            continue
+        for transition_id in transition_refs:
+            if not isinstance(transition_id, str) or not transition_id.strip():
+                continue
+            transition_coverage = coverage.setdefault(transition_id, set())
+            for owner_field in owner_field_refs:
+                if isinstance(owner_field, str) and owner_field.strip():
+                    transition_coverage.add(owner_field)
+    return coverage
+
+
+def _validate_diff_harness_write_coverage(
+    *,
+    transitions: list[Any],
+    diff_harness_records: list[Any],
+    label_prefix: str,
+) -> list[str]:
+    failures: list[str] = []
+    coverage_by_transition = _diff_harness_write_coverage_by_transition(
+        diff_harness_records
+    )
+
+    for index, record in enumerate(transitions):
+        if not isinstance(record, dict):
+            continue
+        transition_id = record.get("id")
+        write_set = record.get("declared_write_set")
+        if not isinstance(transition_id, str) or not transition_id.strip():
+            continue
+        if not isinstance(write_set, list):
+            continue
+
+        covered_fields = coverage_by_transition.get(transition_id, set())
+        for write_index, field in enumerate(write_set):
+            if not isinstance(field, str) or not field.strip():
+                continue
+            if field not in covered_fields:
+                failures.append(
+                    f"{label_prefix}[{index}]: declared_write_set[{write_index}] "
+                    "lacks diff harness coverage for transition "
+                    f"{transition_id}: {field}"
+                )
+
+    return failures
+
+
 def _validate_runtime_owner_field_registry(
     *,
     runtime_records: list[dict[str, Any]],
@@ -4608,6 +4666,20 @@ def validate_contract(
             runtime_generation_domain_ids={
                 record["domain_id"] for record in runtime_generation_domain_records
             },
+        )
+    )
+    failures.extend(
+        _validate_diff_harness_write_coverage(
+            transitions=transitions,
+            diff_harness_records=diff_harness_records,
+            label_prefix="transition",
+        )
+    )
+    failures.extend(
+        _validate_diff_harness_write_coverage(
+            transitions=runtime_transition_records,
+            diff_harness_records=runtime_diff_harness_records,
+            label_prefix="runtime_transition",
         )
     )
     action_ids = _collect_string_ids(

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -765,10 +765,14 @@ static const char *const kAppStateDiffHarnessOwnerFieldRefs0[] = {
   "ctx.active",
   "ctx.volumes_head",
   "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
   "panel.file_selection_key",
+  "panel.file_viewport_origin",
   "panel.restore_snapshot",
   "panel.panel_generation",
   "volume.dir_tree",
+  "volume.logged_state",
   "volume.volume_generation",
 };
 
@@ -808,14 +812,17 @@ static const char *const kAppStateDiffHarnessTransitionIds1[] = {
 };
 
 static const char *const kAppStateDiffHarnessOwnerFieldRefs1[] = {
+  "ctx.active",
   "ctx.command_state",
   "ctx.message_state",
   "ctx.modal_state",
   "ctx.pending_transition",
+  "panel.volume_key",
   "panel.tree_selection_key",
   "panel.tree_cursor_pos",
   "panel.tree_viewport_origin",
   "panel.focus_shape",
+  "panel.restore_snapshot",
   "panel.panel_generation",
 };
 
@@ -895,9 +902,14 @@ static const char *const kAppStateDiffHarnessTransitionIds3[] = {
 };
 
 static const char *const kAppStateDiffHarnessOwnerFieldRefs3[] = {
+  "ctx.layout",
+  "ctx.window_handles",
   "panel.restore_snapshot",
   "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
   "panel.file_selection_key",
+  "panel.file_viewport_origin",
   "panel.panel_generation",
   "volume.dir_tree",
   "volume.payload_cache",

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -323,6 +323,28 @@ static int AppStateFallbackPreconditionValid(const char *precondition) {
          strcmp(precondition, "stale_snapshot") == 0;
 }
 
+static int AppStateTransitionSequenceStepDiffHarnessCoversTransition(
+    const AppStateTransitionSequenceStepMetadata *step) {
+  size_t ref_index;
+
+  if (step == NULL || !NonEmptyString(step->transition_id) ||
+      !NonEmptyStringList(step->diff_harness_ids, step->diff_harness_id_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < step->diff_harness_id_count; ref_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessLookup(step->diff_harness_ids[ref_index]);
+
+    if (harness == NULL || harness->transition_ids == NULL)
+      return 0;
+    if (StringListContains(harness->transition_ids, harness->transition_id_count,
+                           step->transition_id))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateTransitionSequenceStepReady(
     const AppStateTransitionSequenceMetadata *sequence,
     const AppStateTransitionSequenceStepMetadata *step, size_t step_index,
@@ -378,6 +400,9 @@ static int AppStateTransitionSequenceStepReady(
                            step->diff_harness_ids[ref_index]))
       return 0;
   }
+  if (!AppStateTransitionSequenceStepDiffHarnessCoversTransition(step))
+    return 0;
+
   for (ref_index = 0; ref_index < step->generation_domain_expectation_count;
        ref_index++) {
     const AppStateTransitionSequenceGenerationExpectationMetadata *expectation =

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1189,6 +1189,50 @@ static int AppStateActionCoverageReady(void) {
   return 1;
 }
 
+static int AppStateDiffHarnessWriteCovered(const char *owner_field,
+                                           const char *transition_id) {
+  size_t harness_index;
+
+  if (!NonEmptyString(owner_field) || !NonEmptyString(transition_id))
+    return 0;
+
+  for (harness_index = 0; harness_index < AppStateDiffHarnessCount();
+       harness_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessAt(harness_index);
+    size_t ref_index;
+    int transition_seen = 0;
+    int owner_field_seen = 0;
+
+    if (harness == NULL || harness->transition_ids == NULL ||
+        harness->owner_field_refs == NULL)
+      return 0;
+
+    for (ref_index = 0; ref_index < harness->transition_id_count;
+         ref_index++) {
+      const char *harness_transition_id = harness->transition_ids[ref_index];
+
+      if (!NonEmptyString(harness_transition_id))
+        return 0;
+      if (strcmp(harness_transition_id, transition_id) == 0)
+        transition_seen = 1;
+    }
+    for (ref_index = 0; ref_index < harness->owner_field_ref_count;
+         ref_index++) {
+      const char *harness_owner_field = harness->owner_field_refs[ref_index];
+
+      if (!NonEmptyString(harness_owner_field))
+        return 0;
+      if (strcmp(harness_owner_field, owner_field) == 0)
+        owner_field_seen = 1;
+    }
+    if (transition_seen && owner_field_seen)
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateDiffHarnessRegistryReady(void) {
   size_t index;
   size_t required_diff_harness_id_count =
@@ -1265,6 +1309,22 @@ static int AppStateDiffHarnessRegistryReady(void) {
     if (AppStateDiffHarnessLookup(kAppStateRequiredDiffHarnessIds[index]) ==
         NULL)
       return 0;
+  }
+
+  for (index = 0; index < AppStateTransitionCount(); index++) {
+    const AppStateTransitionMetadata *transition = AppStateTransitionAt(index);
+    size_t write_index;
+
+    if (transition == NULL || !NonEmptyString(transition->id) ||
+        transition->declared_write_set == NULL)
+      return 0;
+    for (write_index = 0; write_index < transition->declared_write_set_count;
+         write_index++) {
+      const char *field = transition->declared_write_set[write_index];
+
+      if (!AppStateDiffHarnessWriteCovered(field, transition->id))
+        return 0;
+    }
   }
 
   if (AppStateDiffHarnessAt(AppStateDiffHarnessCount()) != NULL)

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -560,6 +560,44 @@ static int AppStateOwnerFieldsReady(void) {
   return 1;
 }
 
+static int AppStateGenerationWriteCovered(const char *owner_field,
+                                          const char *transition_id) {
+  size_t domain_index;
+  int generation_owner_seen = 0;
+
+  if (!NonEmptyString(owner_field) || !NonEmptyString(transition_id))
+    return 0;
+
+  for (domain_index = 0; domain_index < AppStateGenerationDomainCount();
+       domain_index++) {
+    const AppStateGenerationDomainMetadata *domain =
+        AppStateGenerationDomainAt(domain_index);
+    size_t transition_index;
+
+    if (domain == NULL || !NonEmptyString(domain->generation_owner_field))
+      return 0;
+    if (strcmp(domain->generation_owner_field, owner_field) != 0)
+      continue;
+
+    generation_owner_seen = 1;
+    if (domain->advances_on_transition_ids == NULL)
+      return 0;
+    for (transition_index = 0;
+         transition_index < domain->advances_on_transition_id_count;
+         transition_index++) {
+      const char *domain_transition_id =
+          domain->advances_on_transition_ids[transition_index];
+
+      if (!NonEmptyString(domain_transition_id))
+        return 0;
+      if (strcmp(domain_transition_id, transition_id) == 0)
+        return 1;
+    }
+  }
+
+  return !generation_owner_seen;
+}
+
 static int AppStateTransitionRegistryReady(void) {
   size_t index;
   size_t required_transition_id_count =
@@ -598,6 +636,8 @@ static int AppStateTransitionRegistryReady(void) {
       if (!NonEmptyString(field))
         return 0;
       if (AppStateOwnerFieldLookup(field) == NULL)
+        return 0;
+      if (!AppStateGenerationWriteCovered(field, metadata->id))
         return 0;
     }
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1058,6 +1058,7 @@ def _complete_diff_harness_checks() -> list[dict[str, object]]:
             "harness.transition_before_after_snapshot"
             if category == "transition_before_after_snapshot"
             else None,
+            _complete_transition_ids(),
         )
         for category in REQUIRED_DIFF_HARNESS_CATEGORIES
     ]
@@ -1989,6 +1990,33 @@ def test_guard_fails_when_diff_harness_references_unknown_generation_domain(
     )
 
 
+def test_guard_fails_when_diff_harness_write_coverage_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    missing_transition_id = str(transitions[0]["id"])
+    diff_harness_checks = _complete_diff_harness_checks()
+    for harness in diff_harness_checks:
+        harness["transition_ids"] = [
+            transition_id
+            for transition_id in _complete_transition_ids()
+            if transition_id != missing_transition_id
+        ]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition[0]" in failure
+        and "lacks diff harness coverage" in failure
+        and missing_transition_id in failure
+        and "field" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_diff_harness_is_missing(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     runtime_diff_harness_checks = _complete_diff_harness_checks()[1:]
@@ -2161,6 +2189,35 @@ def test_guard_fails_on_runtime_diff_harness_invalid_linkage(
         "runtime_diff_harness[0]" in failure
         and expected in failure
         and value[0] in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_diff_harness_write_coverage_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    missing_transition_id = str(transitions[0]["id"])
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    for harness in runtime_diff_harness_checks:
+        harness["transition_ids"] = [
+            transition_id
+            for transition_id in _complete_transition_ids()
+            if transition_id != missing_transition_id
+        ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition[0]" in failure
+        and "lacks diff harness coverage" in failure
+        and missing_transition_id in failure
+        and "field" in failure
         for failure in failures
     )
 
@@ -5311,6 +5368,21 @@ def test_runtime_diff_harness_startup_checks_fail_closed() -> None:
         in source
     )
     assert "!AppStateDiffHarnessRegistryReady()" in source
+
+
+def test_runtime_diff_harness_write_coverage_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateDiffHarnessWriteCovered" in source
+    assert re.search(
+        r"for \(write_index = 0; write_index < "
+        r"transition->declared_write_set_count;\s*write_index\+\+\) \{\s*"
+        r"const char \*field = transition->declared_write_set\[write_index\];\s*"
+        r"if \(!AppStateDiffHarnessWriteCovered\(field, transition->id\)\)\s*"
+        r"return 0;",
+        source,
+        re.S,
+    )
 
 
 def test_runtime_diff_harness_startup_requires_documented_harness_ids() -> None:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1017,6 +1017,10 @@ def _complete_transitions() -> list[dict[str, object]]:
     ]
 
 
+def _complete_transition_ids() -> list[str]:
+    return [str(record["id"]) for record in _complete_transitions()]
+
+
 def _complete_actions() -> list[dict[str, object]]:
     return [_action(action) for action in FIXTURE_ACTIONS]
 
@@ -1041,6 +1045,7 @@ def _complete_generation_domains() -> list[dict[str, object]]:
         _generation_domain(
             category,
             "domain.panel_generation" if category == "panel_generation" else None,
+            _complete_transition_ids(),
         )
         for category in REQUIRED_GENERATION_DOMAIN_CATEGORIES
     ]
@@ -2422,6 +2427,34 @@ def test_guard_fails_when_generation_domain_transition_is_unknown(
     )
 
 
+def test_guard_fails_when_generation_write_lacks_domain_transition_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_id = str(transitions[0]["id"])
+    generation_domains = _complete_generation_domains()
+    for domain in generation_domains:
+        domain["advances_on_transition_ids"] = [
+            candidate
+            for candidate in _complete_transition_ids()
+            if candidate != transition_id
+        ]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition[0]" in failure
+        and "writes generation owner field without generation domain coverage"
+        in failure
+        and transition_id in failure
+        and "field" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_generation_domain_advances_is_not_a_list(
     tmp_path: Path,
 ) -> None:
@@ -2663,6 +2696,36 @@ def test_guard_fails_when_runtime_generation_domain_transition_link_is_invalid(
         and "advances_on_transition_ids does not match runtime transition registry"
         in failure
         and "transition.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_write_lacks_domain_transition_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_id = str(transitions[0]["id"])
+    runtime_generation_domains = _complete_generation_domains()
+    for domain in runtime_generation_domains:
+        domain["advances_on_transition_ids"] = [
+            candidate
+            for candidate in _complete_transition_ids()
+            if candidate != transition_id
+        ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition[0]" in failure
+        and "writes generation owner field without generation domain coverage"
+        in failure
+        and transition_id in failure
+        and "field" in failure
         for failure in failures
     )
 
@@ -4992,6 +5055,23 @@ def test_runtime_generation_domain_startup_checks_fail_closed() -> None:
         in source
     )
     assert "!AppStateGenerationDomainsReady()" in source
+
+
+def test_runtime_generation_write_startup_validates_runtime_metadata() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    helper_start = source.index("static int AppStateGenerationWriteCovered(")
+    transition_start = source.index("static int AppStateTransitionRegistryReady(void)")
+    generation_start = source.index("static int AppStateGenerationDomainsReady(void)")
+    helper_body = source[helper_start:transition_start]
+    transition_body = source[transition_start:generation_start]
+
+    assert "AppStateGenerationDomainCount()" in helper_body
+    assert "AppStateGenerationDomainAt(domain_index)" in helper_body
+    assert "domain->generation_owner_field" in helper_body
+    assert "domain->advances_on_transition_ids" in helper_body
+    assert "strcmp(domain_transition_id, transition_id) == 0" in helper_body
+    assert "!AppStateGenerationWriteCovered(field, metadata->id)" in transition_body
 
 
 def test_runtime_generation_domain_startup_requires_documented_domain_ids() -> None:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1395,6 +1395,33 @@ def test_guard_fails_on_unknown_transition_sequence_step_references(
     )
 
 
+def test_guard_fails_when_transition_sequence_diff_harness_misses_step_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    diff_harness_checks[0]["transition_ids"] = ["transition.refresh_rebuild"]
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"][0]["diff_harness_ids"] = [
+        diff_harness_checks[0]["harness_id"]
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        diff_harness_checks=diff_harness_checks,
+        transition_sequences=transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "diff_harness_ids must include at least one diff harness" in failure
+        and "transition.keybinding" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_transition_sequence_action_mismatches_transition(
     tmp_path: Path,
 ) -> None:
@@ -1661,6 +1688,33 @@ def test_guard_fails_on_runtime_transition_sequence_invalid_links(
     )
 
 
+def test_guard_fails_when_runtime_transition_sequence_diff_harness_misses_step_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    runtime_diff_harness_checks[0]["transition_ids"] = ["transition.refresh_rebuild"]
+    runtime_transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences[0]["steps"][0]["diff_harness_ids"] = [
+        runtime_diff_harness_checks[0]["harness_id"]
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0].step[0]" in failure
+        and "diff_harness_ids must include at least one diff harness" in failure
+        and "transition.keybinding" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_transition_sequence_fallback_drifts(
     tmp_path: Path,
 ) -> None:
@@ -1753,6 +1807,8 @@ def test_runtime_transition_sequence_startup_checks_fail_closed() -> None:
         "AppStateDiffHarnessLookup(step->diff_harness_ids[ref_index]) == NULL"
         in source
     )
+    assert "AppStateTransitionSequenceStepDiffHarnessCoversTransition" in source
+    assert "!AppStateTransitionSequenceStepDiffHarnessCoversTransition(step)" in source
     assert "AppStateGenerationDomainLookup(expectation->domain_id) == NULL" in source
     assert "!AppStateTransitionSequencesReady()" in source
 


### PR DESCRIPTION
## Summary
- Require AppState generation-owner writes to be covered by matching generation-domain metadata.
- Require transition write-set fields to be covered by same-transition diff-harness metadata.
- Require transition-sequence steps to reference at least one diff harness covering the same transition.
- Add fail-closed runtime startup checks and focused contract regressions for these metadata invariants.

## Validation
- Local focused AppState guard checks passed.
- Local AppState contract guard passed.
- Local build passed with existing warnings in unchanged files.