### PR TITLE
chore(appstate): tighten metadata alignment checks

### DIFF
--- a/docs/appstate_dispatch_surfaces.json
+++ b/docs/appstate_dispatch_surfaces.json
@@ -41,13 +41,11 @@
       "transition_id": "transition.keybinding.navigate-tree",
       "boundary_status": "documented_foundation_only",
       "allowed_direct_writes": [
-        "panel.file_selection_key",
-        "panel.file_viewport_origin",
         "panel.focus_shape",
         "panel.panel_generation"
       ],
       "migration_notes": [
-        "Current file-window switch dispatch updates file selection and viewport state under the broad keybinding foundation record until file-specific transitions are split out."
+        "Current file-window dispatch remains under the broad keybinding foundation; only writes shared with the navigate-tree contract stay authorized until file-specific transitions are split out."
       ]
     },
     {

--- a/docs/appstate_transition_sequences.json
+++ b/docs/appstate_transition_sequences.json
@@ -380,6 +380,10 @@
               "expectation": "File identity remains durable across payload or view-shape changes."
             }
           ],
+          "no_unrelated_mutation": {
+            "diff_harness_id": "harness.generation-mismatch-check",
+            "expectation": "Fallback/stale-snapshot/generation-mismatch handling may mutate only the declared transition fields and must leave unrelated owner fields unchanged."
+          },
           "precondition": "stale_snapshot",
           "deterministic_fallback": {
             "outcome": "Fail closed to the nearest valid durable identity or preserve the prior valid selection without using stale rows.",
@@ -460,6 +464,10 @@
               "expectation": "File payload generation advances only for declared payload rebuilds."
             }
           ],
+          "no_unrelated_mutation": {
+            "diff_harness_id": "harness.generation-mismatch-check",
+            "expectation": "Fallback/stale-snapshot/generation-mismatch handling may mutate only the declared transition fields and must leave unrelated owner fields unchanged."
+          },
           "precondition": "generation_mismatch",
           "deterministic_fallback": {
             "outcome": "Reject stale mutation result, request a registered refresh/rebind, and keep unrelated panel state unchanged.",

--- a/docs/appstate_transition_sequences.json
+++ b/docs/appstate_transition_sequences.json
@@ -585,6 +585,7 @@
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.shared-state-panel-local-isolation",
+            "invariant.hidden-entry-visible-navigation",
             "invariant.render-projection-read-only"
           ],
           "diff_harness_ids": [

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -3762,6 +3762,15 @@ def _requires_deterministic_fallback(record: dict[str, Any]) -> bool:
     )
 
 
+def _requires_no_unrelated_mutation(record: dict[str, Any]) -> bool:
+    precondition = record.get("precondition")
+    expected_result = record.get("expected_result")
+    return (
+        precondition in {"generation_mismatch", "stale_snapshot"}
+        or expected_result in {"blocked", "fallback", "invalid"}
+    )
+
+
 def _validate_deterministic_fallback(
     *,
     record: dict[str, Any],
@@ -3785,11 +3794,17 @@ def _validate_no_unrelated_mutation(
     record: dict[str, Any],
     label: str,
     diff_harness_ids: set[str],
+    step_diff_harness_refs: Any,
+    transition_id: Any,
+    diff_harness_transition_ids: dict[str, set[str]],
+    required: bool,
 ) -> list[str]:
     expectation = record.get("no_unrelated_mutation")
     if not isinstance(expectation, dict):
+        if not required:
+            return []
         return [
-            f"{label}: blocked/invalid steps require no_unrelated_mutation expectations"
+            f"{label}: blocked/invalid/fallback steps require no_unrelated_mutation expectations"
         ]
 
     failures = _validate_required_fields(
@@ -3803,6 +3818,23 @@ def _validate_no_unrelated_mutation(
         failures.append(
             f"{label}.no_unrelated_mutation: diff_harness_id references unknown diff harness id: {harness_id}"
         )
+    if isinstance(harness_id, str) and harness_id.strip():
+        if not isinstance(step_diff_harness_refs, list) or harness_id not in {
+            value
+            for value in step_diff_harness_refs
+            if isinstance(value, str) and value.strip()
+        }:
+            failures.append(
+                f"{label}.no_unrelated_mutation: diff_harness_id must be listed in step diff_harness_ids: {harness_id}"
+            )
+        if (
+            isinstance(transition_id, str)
+            and transition_id.strip()
+            and transition_id not in diff_harness_transition_ids.get(harness_id, set())
+        ):
+            failures.append(
+                f"{label}.no_unrelated_mutation: diff_harness_id must cover transition_id {transition_id}: {harness_id}"
+            )
     return failures
 
 
@@ -3958,12 +3990,17 @@ def _validate_appstate_transition_sequences(
                     _validate_deterministic_fallback(record=step, label=label)
                 )
 
-            if expected_result in {"blocked", "invalid"}:
+            no_unrelated_required = _requires_no_unrelated_mutation(step)
+            if no_unrelated_required or step.get("no_unrelated_mutation") is not None:
                 failures.extend(
                     _validate_no_unrelated_mutation(
                         record=step,
                         label=label,
                         diff_harness_ids=diff_harness_ids,
+                        step_diff_harness_refs=step.get("diff_harness_ids"),
+                        transition_id=transition_id,
+                        diff_harness_transition_ids=diff_harness_transition_ids,
+                        required=no_unrelated_required,
                     )
                 )
 
@@ -4218,12 +4255,17 @@ def _validate_runtime_transition_sequence_registry(
                     f"{step_label}: deterministic_fallback must be an object"
                 )
 
-            if expected_result in {"blocked", "invalid"}:
+            no_unrelated_required = _requires_no_unrelated_mutation(step)
+            if no_unrelated_required or step.get("no_unrelated_mutation") is not None:
                 failures.extend(
                     _validate_no_unrelated_mutation(
                         record=step,
                         label=step_label,
                         diff_harness_ids=runtime_diff_harness_ids,
+                        step_diff_harness_refs=step.get("diff_harness_ids"),
+                        transition_id=transition_id,
+                        diff_harness_transition_ids=runtime_diff_harness_transition_ids,
+                        required=no_unrelated_required,
                     )
                 )
             no_unrelated = step.get("no_unrelated_mutation")

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -3690,6 +3690,51 @@ def _diff_harness_transition_ids_by_harness(
     return transition_ids_by_harness
 
 
+def _invariant_transition_ids_by_invariant(
+    invariant_records: list[Any],
+) -> dict[str, set[str]]:
+    transition_ids_by_invariant: dict[str, set[str]] = {}
+    for record in invariant_records:
+        if not isinstance(record, dict):
+            continue
+        invariant_id = record.get("invariant_id")
+        transition_ids = record.get("transition_ids")
+        if not isinstance(invariant_id, str) or not invariant_id.strip():
+            continue
+        if not isinstance(transition_ids, list):
+            continue
+        transition_ids_by_invariant[invariant_id] = {
+            transition_id
+            for transition_id in transition_ids
+            if isinstance(transition_id, str) and transition_id.strip()
+        }
+    return transition_ids_by_invariant
+
+
+def _validate_step_invariant_transition_alignment(
+    *,
+    invariant_refs: Any,
+    transition_id: Any,
+    invariant_transition_ids: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    if not isinstance(transition_id, str) or not transition_id.strip():
+        return []
+    if not isinstance(invariant_refs, list):
+        return []
+
+    for invariant_id in invariant_refs:
+        if not isinstance(invariant_id, str) or not invariant_id.strip():
+            continue
+        if transition_id in invariant_transition_ids.get(invariant_id, set()):
+            return []
+
+    return [
+        f"{label}: invariant_ids must include at least one invariant "
+        f"covering transition_id {transition_id}"
+    ]
+
+
 def _validate_step_diff_harness_transition_alignment(
     *,
     diff_harness_refs: Any,
@@ -3848,6 +3893,7 @@ def _validate_appstate_transition_sequences(
     event_ids: set[str],
     event_transition_ids: dict[str, str],
     invariant_ids: set[str],
+    invariant_transition_ids: dict[str, set[str]],
     diff_harness_ids: set[str],
     diff_harness_transition_ids: dict[str, set[str]],
     generation_domain_ids: set[str],
@@ -3962,6 +4008,14 @@ def _validate_appstate_transition_sequences(
                 )
             )
             failures.extend(
+                _validate_step_invariant_transition_alignment(
+                    invariant_refs=step.get("invariant_ids"),
+                    transition_id=transition_id,
+                    invariant_transition_ids=invariant_transition_ids,
+                    label=label,
+                )
+            )
+            failures.extend(
                 _validate_step_diff_harness_transition_alignment(
                     diff_harness_refs=step.get("diff_harness_ids"),
                     transition_id=transition_id,
@@ -4068,6 +4122,7 @@ def _validate_runtime_transition_sequence_registry(
     event_ids: set[str],
     event_transition_ids: dict[str, str],
     runtime_invariant_ids: set[str],
+    runtime_invariant_transition_ids: dict[str, set[str]],
     runtime_diff_harness_ids: set[str],
     runtime_diff_harness_transition_ids: dict[str, set[str]],
     runtime_generation_domain_ids: set[str],
@@ -4212,6 +4267,14 @@ def _validate_runtime_transition_sequence_registry(
                         reference_label=reference_label,
                     )
                 )
+            failures.extend(
+                _validate_step_invariant_transition_alignment(
+                    invariant_refs=step.get("invariant_ids"),
+                    transition_id=transition_id,
+                    invariant_transition_ids=runtime_invariant_transition_ids,
+                    label=step_label,
+                )
+            )
             failures.extend(
                 _validate_step_diff_harness_transition_alignment(
                     diff_harness_refs=step.get("diff_harness_ids"),
@@ -4817,6 +4880,9 @@ def validate_contract(
             event_ids=event_ids,
             event_transition_ids=event_transition_ids,
             invariant_ids=invariant_ids,
+            invariant_transition_ids=_invariant_transition_ids_by_invariant(
+                invariant_records
+            ),
             diff_harness_ids=diff_harness_ids,
             diff_harness_transition_ids=_diff_harness_transition_ids_by_harness(
                 diff_harness_records
@@ -4845,6 +4911,9 @@ def validate_contract(
             runtime_invariant_ids={
                 record["invariant_id"] for record in runtime_invariant_records
             },
+            runtime_invariant_transition_ids=_invariant_transition_ids_by_invariant(
+                runtime_invariant_records
+            ),
             runtime_diff_harness_ids={
                 record["harness_id"] for record in runtime_diff_harness_records
             },

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2139,6 +2139,7 @@ def _validate_runtime_dispatch_surface_registry(
     runtime_records: list[dict[str, Any]],
     runtime_path: Path,
     dispatch_surface_records: list[Any],
+    runtime_transition_records: dict[str, dict[str, Any]],
     runtime_transition_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -2207,6 +2208,13 @@ def _validate_runtime_dispatch_surface_registry(
                 f"{label}: transition_id does not match runtime transition "
                 f"registry: {transition_id}"
             )
+        failures.extend(
+            _validate_allowed_direct_writes_within_transition(
+                record=record,
+                transition_records=runtime_transition_records,
+                label=label,
+            )
+        )
 
     missing_ids = sorted(expected_ids - covered_ids)
     if missing_ids:
@@ -2855,6 +2863,44 @@ def _validate_allowed_direct_writes(
     return failures
 
 
+def _validate_allowed_direct_writes_within_transition(
+    *,
+    record: dict[str, Any],
+    transition_records: dict[str, dict[str, Any]],
+    label: str,
+) -> list[str]:
+    writes = record.get("allowed_direct_writes")
+    transition_id = record.get("transition_id")
+    if not isinstance(writes, list):
+        return []
+    if not isinstance(transition_id, str) or not transition_id.strip():
+        return []
+
+    transition_record = transition_records.get(transition_id)
+    if transition_record is None:
+        return []
+
+    declared_write_set = transition_record.get("declared_write_set")
+    if not isinstance(declared_write_set, list):
+        return []
+
+    declared_fields = {
+        field
+        for field in declared_write_set
+        if isinstance(field, str) and field.strip()
+    }
+    failures: list[str] = []
+    for index, field in enumerate(writes):
+        if not isinstance(field, str) or not field.strip():
+            continue
+        if field not in declared_fields:
+            failures.append(
+                f"{label}: allowed_direct_writes[{index}] outside transition "
+                f"declared_write_set for {transition_id}: {field}"
+            )
+    return failures
+
+
 def _validate_appstate_diff_harness(
     *,
     diff_harness_doc: Any,
@@ -3095,6 +3141,13 @@ def _validate_dispatch_surfaces(
                 failures.append(
                     f"{label}: transition_id does not match a transition id: {transition_id}"
                 )
+            failures.extend(
+                _validate_allowed_direct_writes_within_transition(
+                    record=record,
+                    transition_records=transition_ids,
+                    label=label,
+                )
+            )
 
         source_path = record.get("source_path")
         entry_symbol_or_path = record.get("entry_symbol_or_path")
@@ -4751,6 +4804,9 @@ def validate_contract(
             runtime_records=runtime_dispatch_surface_records,
             runtime_path=action_runtime_path,
             dispatch_surface_records=dispatch_surface_records,
+            runtime_transition_records={
+                record["id"]: record for record in runtime_transition_records
+            },
             runtime_transition_ids={record["id"] for record in runtime_transition_records},
         )
     )

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -1593,6 +1593,7 @@ static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTr
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds8_1[] = {
   "invariant.shared-state-panel-local-isolation",
+  "invariant.hidden-entry-visible-navigation",
   "invariant.render-projection-read-only",
 };
 

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -1405,6 +1405,8 @@ static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTr
   {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
 };
 
+static const AppStateTransitionSequenceNoUnrelatedMutationMetadata kAppStateTransitionSequenceStepNoUnrelatedMutation5_1 = {"harness.generation-mismatch-check", "Fallback/stale-snapshot/generation-mismatch handling may mutate only the declared transition fields and must leave unrelated owner fields unchanged."};
+
 static const AppStateTransitionSequenceDeterministicFallbackMetadata kAppStateTransitionSequenceStepDeterministicFallback5_1 = {"Fail closed to the nearest valid durable identity or preserve the prior valid selection without using stale rows.", "Only the registered fallback/no-op result may run; unrelated owner fields remain unchanged."};
 
 static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps5[] = {
@@ -1435,7 +1437,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    sizeof(kAppStateTransitionSequenceStepDiffHarnessIds5_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds5_1[0]),
    kAppStateTransitionSequenceStepGenerationExpectations5_1,
    sizeof(kAppStateTransitionSequenceStepGenerationExpectations5_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations5_1[0]),
-   NULL,
+   &kAppStateTransitionSequenceStepNoUnrelatedMutation5_1,
    "stale_snapshot",
    &kAppStateTransitionSequenceStepDeterministicFallback5_1},
 };
@@ -1473,6 +1475,8 @@ static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTr
   {"state.file-payload.volume", "File payload generation advances only for declared payload rebuilds."},
 };
 
+static const AppStateTransitionSequenceNoUnrelatedMutationMetadata kAppStateTransitionSequenceStepNoUnrelatedMutation6_1 = {"harness.generation-mismatch-check", "Fallback/stale-snapshot/generation-mismatch handling may mutate only the declared transition fields and must leave unrelated owner fields unchanged."};
+
 static const AppStateTransitionSequenceDeterministicFallbackMetadata kAppStateTransitionSequenceStepDeterministicFallback6_1 = {"Reject stale mutation result, request a registered refresh/rebind, and keep unrelated panel state unchanged.", "Only the registered fallback/no-op result may run; unrelated owner fields remain unchanged."};
 
 static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps6[] = {
@@ -1503,7 +1507,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    sizeof(kAppStateTransitionSequenceStepDiffHarnessIds6_1) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds6_1[0]),
    kAppStateTransitionSequenceStepGenerationExpectations6_1,
    sizeof(kAppStateTransitionSequenceStepGenerationExpectations6_1) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations6_1[0]),
-   NULL,
+   &kAppStateTransitionSequenceStepNoUnrelatedMutation6_1,
    "generation_mismatch",
    &kAppStateTransitionSequenceStepDeterministicFallback6_1},
 };

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -1929,14 +1929,12 @@ static const char *const kAppStateDispatchSurfaceMigrationNotes1[] = {
 };
 
 static const char *const kAppStateDispatchSurfaceAllowedDirectWrites2[] = {
-  "panel.file_selection_key",
-  "panel.file_viewport_origin",
   "panel.focus_shape",
   "panel.panel_generation",
 };
 
 static const char *const kAppStateDispatchSurfaceMigrationNotes2[] = {
-  "Current file-window switch dispatch updates file selection and viewport state under the broad keybinding foundation record until file-specific transitions are split out.",
+  "Current file-window dispatch remains under the broad keybinding foundation; only writes shared with the navigate-tree contract stay authorized until file-specific transitions are split out.",
 };
 
 static const char *const kAppStateDispatchSurfaceMigrationNotes3[] = {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -345,6 +345,29 @@ static int AppStateTransitionSequenceStepDiffHarnessCoversTransition(
   return 0;
 }
 
+static int AppStateTransitionSequenceStepInvariantCoversTransition(
+    const AppStateTransitionSequenceStepMetadata *step) {
+  size_t ref_index;
+
+  if (step == NULL || !NonEmptyString(step->transition_id) ||
+      !NonEmptyStringList(step->invariant_ids, step->invariant_id_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < step->invariant_id_count; ref_index++) {
+    const AppStateInvariantMetadata *invariant =
+        AppStateInvariantLookup(step->invariant_ids[ref_index]);
+
+    if (invariant == NULL || invariant->transition_ids == NULL)
+      return 0;
+    if (StringListContains(invariant->transition_ids,
+                           invariant->transition_id_count,
+                           step->transition_id))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateTransitionSequenceStepRequiresNoUnrelatedMutation(
     const AppStateTransitionSequenceStepMetadata *step) {
   if (step == NULL || !NonEmptyString(step->expected_result))
@@ -430,6 +453,8 @@ static int AppStateTransitionSequenceStepReady(
                            step->invariant_ids[ref_index]))
       return 0;
   }
+  if (!AppStateTransitionSequenceStepInvariantCoversTransition(step))
+    return 0;
   for (ref_index = 0; ref_index < step->diff_harness_id_count; ref_index++) {
     if (AppStateDiffHarnessLookup(step->diff_harness_ids[ref_index]) == NULL)
       return 0;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -823,7 +823,12 @@ static int AppStateGenerationDomainsReady(void) {
 
 static int AppStateDispatchSurfaceWritesReady(
     const AppStateDispatchSurfaceMetadata *metadata) {
+  const AppStateTransitionMetadata *transition =
+      AppStateTransitionLookup(metadata->transition_id);
   size_t write_index;
+
+  if (transition == NULL)
+    return 0;
 
   if (metadata->allowed_direct_write_count == 0)
     return metadata->allowed_direct_writes == NULL;
@@ -838,6 +843,9 @@ static int AppStateDispatchSurfaceWritesReady(
     if (!NonEmptyString(field))
       return 0;
     if (AppStateOwnerFieldLookup(field) == NULL)
+      return 0;
+    if (!StringListContains(transition->declared_write_set,
+                            transition->declared_write_set_count, field))
       return 0;
   }
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -345,6 +345,43 @@ static int AppStateTransitionSequenceStepDiffHarnessCoversTransition(
   return 0;
 }
 
+static int AppStateTransitionSequenceStepRequiresNoUnrelatedMutation(
+    const AppStateTransitionSequenceStepMetadata *step) {
+  if (step == NULL || !NonEmptyString(step->expected_result))
+    return 0;
+  return strcmp(step->expected_result, "blocked") == 0 ||
+         strcmp(step->expected_result, "fallback") == 0 ||
+         strcmp(step->expected_result, "invalid") == 0 ||
+         step->precondition != NULL;
+}
+
+static int AppStateTransitionSequenceStepNoUnrelatedMutationReady(
+    const AppStateTransitionSequenceStepMetadata *step) {
+  const AppStateDiffHarnessMetadata *harness;
+
+  if (step == NULL)
+    return 1;
+  if (!AppStateTransitionSequenceStepRequiresNoUnrelatedMutation(step) &&
+      step->no_unrelated_mutation == NULL)
+    return 1;
+  if (step->no_unrelated_mutation == NULL)
+    return 0;
+  if (!NonEmptyString(step->no_unrelated_mutation->diff_harness_id) ||
+      !NonEmptyString(step->no_unrelated_mutation->expectation))
+    return 0;
+  if (!StringListContains(step->diff_harness_ids, step->diff_harness_id_count,
+                          step->no_unrelated_mutation->diff_harness_id))
+    return 0;
+
+  harness = AppStateDiffHarnessLookup(step->no_unrelated_mutation->diff_harness_id);
+  if (harness == NULL || harness->transition_ids == NULL ||
+      !StringListContains(harness->transition_ids, harness->transition_id_count,
+                          step->transition_id))
+    return 0;
+
+  return 1;
+}
+
 static int AppStateTransitionSequenceStepReady(
     const AppStateTransitionSequenceMetadata *sequence,
     const AppStateTransitionSequenceStepMetadata *step, size_t step_index,
@@ -420,11 +457,8 @@ static int AppStateTransitionSequenceStepReady(
     }
   }
 
-  if (strcmp(step->expected_result, "blocked") == 0 ||
-      strcmp(step->expected_result, "invalid") == 0) {
-    if (step->no_unrelated_mutation == NULL)
-      return 0;
-  }
+  if (!AppStateTransitionSequenceStepNoUnrelatedMutationReady(step))
+    return 0;
   if (step->no_unrelated_mutation != NULL) {
     if (!NonEmptyString(step->no_unrelated_mutation->diff_harness_id) ||
         !NonEmptyString(step->no_unrelated_mutation->expectation) ||

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1395,6 +1395,29 @@ def test_guard_fails_on_unknown_transition_sequence_step_references(
     )
 
 
+def test_guard_fails_when_transition_sequence_invariants_do_not_cover_step(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    unrelated_transition_id = next(
+        record["id"] for record in transitions if record["id"] != "transition.keybinding"
+    )
+    invariants = _complete_invariants()
+    for invariant in invariants:
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen":
+            invariant["transition_ids"] = [unrelated_transition_id]
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "invariant_ids must include at least one invariant covering transition_id transition.keybinding"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_transition_sequence_diff_harness_misses_step_transition(
     tmp_path: Path,
 ) -> None:
@@ -1784,6 +1807,33 @@ def test_guard_fails_on_runtime_transition_sequence_invalid_links(
     )
 
 
+def test_guard_fails_when_runtime_transition_sequence_invariants_do_not_cover_step(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    unrelated_transition_id = next(
+        record["id"] for record in transitions if record["id"] != "transition.keybinding"
+    )
+    runtime_invariants = _complete_invariants()
+    for invariant in runtime_invariants:
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen":
+            invariant["transition_ids"] = [unrelated_transition_id]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0].step[0]" in failure
+        and "invariant_ids must include at least one invariant covering transition_id transition.keybinding"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_transition_sequence_diff_harness_misses_step_transition(
     tmp_path: Path,
 ) -> None:
@@ -2007,6 +2057,9 @@ def test_runtime_transition_sequence_startup_checks_fail_closed() -> None:
     assert "!AppStateTransitionSequenceStepReady(sequence, step, step_index," in source
     assert "AppStateTransitionLookup(step->transition_id) == NULL" in source
     assert "AppStateInvariantLookup(step->invariant_ids[ref_index]) == NULL" in source
+    assert "AppStateTransitionSequenceStepInvariantCoversTransition(step)" in source
+    assert "invariant->transition_ids" in source
+    assert "invariant->transition_id_count" in source
     assert (
         "AppStateDiffHarnessLookup(step->diff_harness_ids[ref_index]) == NULL"
         in source

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1506,6 +1506,102 @@ def test_guard_fails_when_blocked_transition_sequence_lacks_no_mutation_expectat
     )
 
 
+@pytest.mark.parametrize("precondition", ("stale_snapshot", "generation_mismatch"))
+def test_guard_fallback_steps_require_no_unrelated_mutation_expectation(
+    tmp_path: Path, precondition: str
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    step = transition_sequences[0]["steps"][0]
+    step["precondition"] = precondition
+    step["expected_result"] = "fallback"
+    step["deterministic_fallback"] = {
+        "outcome": "restore stable identity",
+        "allowed_mutation_scope": "declared transition fields only",
+    }
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "require no_unrelated_mutation" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fallback_no_unrelated_diff_harness_must_be_listed_on_step(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    step = transition_sequences[0]["steps"][0]
+    step["precondition"] = "stale_snapshot"
+    step["expected_result"] = "fallback"
+    step["deterministic_fallback"] = {
+        "outcome": "restore stable identity",
+        "allowed_mutation_scope": "declared transition fields only",
+    }
+    step["no_unrelated_mutation"] = {
+        "diff_harness_id": "harness.blocked-transition-no-unrelated-mutation",
+        "expectation": "no unrelated owner fields change",
+    }
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0].no_unrelated_mutation" in failure
+        and "diff_harness_id must be listed in step diff_harness_ids" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fallback_no_unrelated_diff_harness_must_cover_step_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    for harness in diff_harness_checks:
+        if harness["harness_id"] == "harness.blocked-transition-no-unrelated-mutation":
+            harness["transition_ids"] = ["transition.refresh_rebuild"]
+    transition_sequences = _complete_transition_sequences()
+    step = transition_sequences[0]["steps"][0]
+    step["precondition"] = "generation_mismatch"
+    step["expected_result"] = "fallback"
+    step["diff_harness_ids"] = [
+        "harness.transition_before_after_snapshot",
+        "harness.blocked-transition-no-unrelated-mutation",
+    ]
+    step["deterministic_fallback"] = {
+        "outcome": "restore stable identity",
+        "allowed_mutation_scope": "declared transition fields only",
+    }
+    step["no_unrelated_mutation"] = {
+        "diff_harness_id": "harness.blocked-transition-no-unrelated-mutation",
+        "expectation": "no unrelated owner fields change",
+    }
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        diff_harness_checks=diff_harness_checks,
+        transition_sequences=transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0].no_unrelated_mutation" in failure
+        and "diff_harness_id must cover transition_id transition.keybinding"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_transition_sequence_is_missing(
     tmp_path: Path,
 ) -> None:
@@ -1715,6 +1811,114 @@ def test_guard_fails_when_runtime_transition_sequence_diff_harness_misses_step_t
     )
 
 
+def test_guard_runtime_fallback_steps_require_no_unrelated_mutation_expectation(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences = copy.deepcopy(transition_sequences)
+    for sequences in (transition_sequences, runtime_transition_sequences):
+        step = sequences[0]["steps"][0]
+        step["precondition"] = "stale_snapshot"
+        step["expected_result"] = "fallback"
+        step["deterministic_fallback"] = {
+            "outcome": "restore stable identity",
+            "allowed_mutation_scope": "declared transition fields only",
+        }
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        transition_sequences=transition_sequences,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0].step[0]" in failure
+        and "require no_unrelated_mutation" in failure
+        for failure in failures
+    )
+
+
+def test_guard_runtime_fallback_no_unrelated_diff_harness_must_be_listed_on_step(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences = copy.deepcopy(transition_sequences)
+    for sequences in (transition_sequences, runtime_transition_sequences):
+        step = sequences[0]["steps"][0]
+        step["precondition"] = "generation_mismatch"
+        step["expected_result"] = "fallback"
+        step["deterministic_fallback"] = {
+            "outcome": "restore stable identity",
+            "allowed_mutation_scope": "declared transition fields only",
+        }
+        step["no_unrelated_mutation"] = {
+            "diff_harness_id": "harness.blocked-transition-no-unrelated-mutation",
+            "expectation": "no unrelated owner fields change",
+        }
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        transition_sequences=transition_sequences,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0].step[0].no_unrelated_mutation" in failure
+        and "diff_harness_id must be listed in step diff_harness_ids" in failure
+        for failure in failures
+    )
+
+
+def test_guard_runtime_fallback_no_unrelated_diff_harness_must_cover_step_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    for harness in runtime_diff_harness_checks:
+        if harness["harness_id"] == "harness.blocked-transition-no-unrelated-mutation":
+            harness["transition_ids"] = ["transition.refresh_rebuild"]
+    transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences = copy.deepcopy(transition_sequences)
+    for sequences in (transition_sequences, runtime_transition_sequences):
+        step = sequences[0]["steps"][0]
+        step["precondition"] = "stale_snapshot"
+        step["expected_result"] = "fallback"
+        step["diff_harness_ids"] = [
+            "harness.transition_before_after_snapshot",
+            "harness.blocked-transition-no-unrelated-mutation",
+        ]
+        step["deterministic_fallback"] = {
+            "outcome": "restore stable identity",
+            "allowed_mutation_scope": "declared transition fields only",
+        }
+        step["no_unrelated_mutation"] = {
+            "diff_harness_id": "harness.blocked-transition-no-unrelated-mutation",
+            "expectation": "no unrelated owner fields change",
+        }
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        transition_sequences=transition_sequences,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0].step[0].no_unrelated_mutation" in failure
+        and "diff_harness_id must cover transition_id transition.keybinding"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_transition_sequence_fallback_drifts(
     tmp_path: Path,
 ) -> None:
@@ -1811,6 +2015,27 @@ def test_runtime_transition_sequence_startup_checks_fail_closed() -> None:
     assert "!AppStateTransitionSequenceStepDiffHarnessCoversTransition(step)" in source
     assert "AppStateGenerationDomainLookup(expectation->domain_id) == NULL" in source
     assert "!AppStateTransitionSequencesReady()" in source
+
+
+def test_runtime_transition_sequence_startup_validates_fallback_no_unrelated_shape() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateTransitionSequenceStepNoUnrelatedMutationReady" in source
+    assert 'strcmp(step->expected_result, "fallback") == 0' in source
+    assert "step->precondition != NULL" in source
+    assert (
+        "StringListContains(step->diff_harness_ids, step->diff_harness_id_count,"
+        in source
+    )
+    assert (
+        "step->no_unrelated_mutation->diff_harness_id)"
+        in source
+    )
+    assert (
+        "StringListContains(harness->transition_ids, harness->transition_id_count,"
+        in source
+    )
+    assert "step->transition_id)" in source
 
 
 def test_runtime_transition_sequence_startup_requires_documented_scenario_ids() -> None:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -3592,6 +3592,27 @@ def test_guard_fails_when_dispatch_surface_allowed_write_is_unregistered(
     )
 
 
+def test_guard_fails_when_dispatch_surface_allowed_write_exceeds_transition_contract(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["allowed_direct_writes"] = ["panel.tree_selection_key"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "allowed_direct_writes[0]" in failure
+        and "outside transition declared_write_set" in failure
+        and "panel.tree_selection_key" in failure
+        for failure in failures
+    )
+
+
 def test_guard_accepts_empty_dispatch_surface_allowed_writes(
     tmp_path: Path,
 ) -> None:
@@ -3713,6 +3734,30 @@ def test_guard_fails_when_runtime_dispatch_surface_list_entry_is_malformed(
     assert any(
         "kAppStateDispatchSurfaceMigrationNotes0" in failure
         and "malformed string literal entry" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_allowed_write_exceeds_transition_contract(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["allowed_direct_writes"] = ["panel.tree_selection_key"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        dispatch_surfaces=dispatch_surfaces,
+        runtime_dispatch_surfaces=copy.deepcopy(dispatch_surfaces),
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_dispatch_surface[0]" in failure
+        and "allowed_direct_writes[0]" in failure
+        and "outside transition declared_write_set" in failure
+        and "panel.tree_selection_key" in failure
         for failure in failures
     )
 
@@ -5525,6 +5570,25 @@ def test_runtime_dispatch_surface_startup_validates_allowed_write_owner_fields()
         r"if \(!NonEmptyString\(field\)\)\s*return 0;\s*"
         r"if \(AppStateOwnerFieldLookup\(field\) == NULL\)\s*return 0;",
         source,
+        re.S,
+    )
+
+
+def test_runtime_dispatch_surface_startup_validates_allowed_write_contract() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index("static int AppStateDispatchSurfaceWritesReady(")
+    dispatch_start = source.index("static int AppStateDispatchSurfacesReady(void)")
+    helper_body = source[helper_start:dispatch_start]
+
+    assert (
+        "const AppStateTransitionMetadata *transition =\n"
+        "      AppStateTransitionLookup(metadata->transition_id);"
+    ) in helper_body
+    assert "transition == NULL" in helper_body
+    assert re.search(
+        r"StringListContains\(transition->declared_write_set,\s*"
+        r"transition->declared_write_set_count, field\)",
+        helper_body,
         re.S,
     )
 


### PR DESCRIPTION
## Summary
- Require fallback/stale-snapshot/generation-mismatch sequence steps to declare no-unrelated-mutation expectations.
- Require those expectations to use a same-step diff harness that covers the step transition.
- Require transition-sequence steps to reference at least one invariant covering the same transition.
- Require dispatch-surface allowed writes to stay within the referenced transition write set.
- Add fail-closed runtime startup checks and focused contract regressions for these metadata invariants.

## Validation
- Local focused AppState guard checks passed.
- Local AppState contract guard passed.
- Local build passed with existing warnings in unchanged files.