### PR TITLE
chore(appstate): require shim invariant alignment

### DIFF
--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -74,7 +74,8 @@
       ],
       "invariant_ids": [
         "invariant.panel-local-focus-restore",
-        "invariant.shared-state-panel-local-isolation"
+        "invariant.shared-state-panel-local-isolation",
+        "invariant.blocked-transition-determinism"
       ],
       "generation_domain_ids": [
         "generation.panel.local-authority",

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2600,6 +2600,7 @@ def _validate_runtime_shim_registry(
     shim_records: list[Any],
     runtime_transition_ids: set[str],
     runtime_invariant_ids: set[str],
+    runtime_invariant_transition_ids: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     expected_shims = {
@@ -2662,6 +2663,16 @@ def _validate_runtime_shim_registry(
                 f"{label}: target_transition does not match runtime transition "
                 f"registry: {target_transition}"
             )
+        failures.extend(
+            _validate_invariant_transition_alignment(
+                invariant_refs=invariant_checks,
+                transition_id=target_transition,
+                invariant_transition_ids=runtime_invariant_transition_ids,
+                label=label,
+                invariant_field="invariant_checks",
+                transition_field="target_transition",
+            )
+        )
 
     missing_ids = sorted(expected_ids - covered_ids)
     if missing_ids:
@@ -3764,6 +3775,47 @@ def _invariant_transition_ids_by_invariant(
     return transition_ids_by_invariant
 
 
+def _invariant_refs_cover_transition(
+    *,
+    invariant_refs: list[str],
+    transition_id: str,
+    invariant_transition_ids: dict[str, set[str]],
+) -> bool:
+    for invariant_id in invariant_refs:
+        if not isinstance(invariant_id, str) or not invariant_id.strip():
+            continue
+        if transition_id in invariant_transition_ids.get(invariant_id, set()):
+            return True
+    return False
+
+
+def _validate_invariant_transition_alignment(
+    *,
+    invariant_refs: Any,
+    transition_id: Any,
+    invariant_transition_ids: dict[str, set[str]],
+    label: str,
+    invariant_field: str,
+    transition_field: str,
+) -> list[str]:
+    if not isinstance(transition_id, str) or not transition_id.strip():
+        return []
+    if not isinstance(invariant_refs, list):
+        return []
+
+    if _invariant_refs_cover_transition(
+        invariant_refs=invariant_refs,
+        transition_id=transition_id,
+        invariant_transition_ids=invariant_transition_ids,
+    ):
+        return []
+
+    return [
+        f"{label}: {invariant_field} must include at least one invariant "
+        f"covering {transition_field} {transition_id}"
+    ]
+
+
 def _validate_step_invariant_transition_alignment(
     *,
     invariant_refs: Any,
@@ -3771,21 +3823,14 @@ def _validate_step_invariant_transition_alignment(
     invariant_transition_ids: dict[str, set[str]],
     label: str,
 ) -> list[str]:
-    if not isinstance(transition_id, str) or not transition_id.strip():
-        return []
-    if not isinstance(invariant_refs, list):
-        return []
-
-    for invariant_id in invariant_refs:
-        if not isinstance(invariant_id, str) or not invariant_id.strip():
-            continue
-        if transition_id in invariant_transition_ids.get(invariant_id, set()):
-            return []
-
-    return [
-        f"{label}: invariant_ids must include at least one invariant "
-        f"covering transition_id {transition_id}"
-    ]
+    return _validate_invariant_transition_alignment(
+        invariant_refs=invariant_refs,
+        transition_id=transition_id,
+        invariant_transition_ids=invariant_transition_ids,
+        label=label,
+        invariant_field="invariant_ids",
+        transition_field="transition_id",
+    )
 
 
 def _validate_step_diff_harness_transition_alignment(
@@ -4622,6 +4667,15 @@ def validate_contract(
             failures.append(f"{shims_path}: shims must be a non-empty list")
             shims = []
 
+    if isinstance(invariants_doc, dict) and isinstance(
+        invariants_doc.get("invariants"), list
+    ):
+        invariant_records = invariants_doc["invariants"]
+    else:
+        invariant_records = []
+    invariant_transition_ids = _invariant_transition_ids_by_invariant(
+        invariant_records
+    )
     shim_ids: set[str] = set()
     for index, record in enumerate(shims):
         label = f"shim[{index}]"
@@ -4653,6 +4707,16 @@ def validate_contract(
                 label=label,
             )
         )
+        failures.extend(
+            _validate_invariant_transition_alignment(
+                invariant_refs=record.get("invariant_checks"),
+                transition_id=target_transition,
+                invariant_transition_ids=invariant_transition_ids,
+                label=label,
+                invariant_field="invariant_checks",
+                transition_field="target_transition",
+            )
+        )
     failures.extend(
         _validate_runtime_shim_registry(
             runtime_records=runtime_shim_records,
@@ -4662,6 +4726,9 @@ def validate_contract(
                 record["id"] for record in runtime_transition_records
             },
             runtime_invariant_ids=runtime_invariant_ids,
+            runtime_invariant_transition_ids=_invariant_transition_ids_by_invariant(
+                runtime_invariant_records
+            ),
         )
     )
 

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2476,6 +2476,7 @@ def _validate_runtime_diff_harness_registry(
     runtime_transition_ids: set[str],
     runtime_owner_fields: set[str],
     runtime_invariant_ids: set[str],
+    runtime_invariant_transition_ids: dict[str, set[str]],
     runtime_generation_domain_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -2492,6 +2493,7 @@ def _validate_runtime_diff_harness_registry(
     for index, record in enumerate(runtime_records):
         label = f"runtime_diff_harness[{index}]"
         runtime_id = record["harness_id"]
+        harness_label = f"{label} {runtime_id}" if runtime_id else label
         if runtime_id in covered_ids:
             failures.append(f"{label}: duplicate runtime diff harness id: {runtime_id}")
         covered_ids.add(runtime_id)
@@ -2569,6 +2571,19 @@ def _validate_runtime_diff_harness_registry(
                         f"{label}: invariant_ids does not match runtime invariant "
                         f"registry: {invariant_id}"
                     )
+
+        if isinstance(transition_refs, list):
+            for transition_id in transition_refs:
+                failures.extend(
+                    _validate_invariant_transition_alignment(
+                        invariant_refs=invariant_refs,
+                        transition_id=transition_id,
+                        invariant_transition_ids=runtime_invariant_transition_ids,
+                        label=harness_label,
+                        invariant_field="invariant_ids",
+                        transition_field="transition_id",
+                    )
+                )
 
         generation_domain_refs = record.get("generation_domain_ids")
         if isinstance(generation_domain_refs, list):
@@ -2919,6 +2934,7 @@ def _validate_appstate_diff_harness(
     transition_ids: dict[str, dict[str, Any]],
     registered_owner_fields: set[str],
     invariant_ids: set[str],
+    invariant_transition_ids: dict[str, set[str]],
     generation_domain_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -2949,7 +2965,9 @@ def _validate_appstate_diff_harness(
             continue
 
         harness_id = record.get("harness_id")
+        harness_label = label
         if isinstance(harness_id, str) and harness_id.strip():
+            harness_label = f"{label} {harness_id}"
             if harness_id in harness_ids:
                 failures.append(f"{label}: duplicate harness_id: {harness_id}")
             harness_ids.add(harness_id)
@@ -2995,6 +3013,19 @@ def _validate_appstate_diff_harness(
                     failures.append(
                         f"{label}: invariant_ids references unknown invariant id: {invariant_id}"
                     )
+
+        if isinstance(transition_refs, list):
+            for transition_id in transition_refs:
+                failures.extend(
+                    _validate_invariant_transition_alignment(
+                        invariant_refs=invariant_refs,
+                        transition_id=transition_id,
+                        invariant_transition_ids=invariant_transition_ids,
+                        label=harness_label,
+                        invariant_field="invariant_ids",
+                        transition_field="transition_id",
+                    )
+                )
 
         generation_domain_refs = record.get("generation_domain_ids")
         if isinstance(generation_domain_refs, list):
@@ -4931,6 +4962,9 @@ def validate_contract(
             transition_ids=transition_ids,
             registered_owner_fields=registered_owner_fields,
             invariant_ids=invariant_ids,
+            invariant_transition_ids=_invariant_transition_ids_by_invariant(
+                invariant_records
+            ),
             generation_domain_ids=generation_domain_ids,
         )
     )
@@ -4954,6 +4988,9 @@ def validate_contract(
             runtime_invariant_ids={
                 record["invariant_id"] for record in runtime_invariant_records
             },
+            runtime_invariant_transition_ids=_invariant_transition_ids_by_invariant(
+                runtime_invariant_records
+            ),
             runtime_generation_domain_ids={
                 record["domain_id"] for record in runtime_generation_domain_records
             },

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -829,6 +829,7 @@ static const char *const kAppStateDiffHarnessOwnerFieldRefs1[] = {
 static const char *const kAppStateDiffHarnessInvariantIds1[] = {
   "invariant.panel-local-focus-restore",
   "invariant.shared-state-panel-local-isolation",
+  "invariant.blocked-transition-determinism",
 };
 
 static const char *const kAppStateDiffHarnessGenerationDomainIds1[] = {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1352,6 +1352,28 @@ static int AppStateDiffHarnessWriteCovered(const char *owner_field,
   return 0;
 }
 
+static int AppStateDiffHarnessInvariantCoversTransition(
+    const AppStateDiffHarnessMetadata *metadata, const char *transition_id) {
+  size_t ref_index;
+
+  if (metadata == NULL || !NonEmptyString(transition_id) ||
+      !NonEmptyStringList(metadata->invariant_ids, metadata->invariant_id_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->invariant_id_count; ref_index++) {
+    const AppStateInvariantMetadata *invariant =
+        AppStateInvariantLookup(metadata->invariant_ids[ref_index]);
+
+    if (invariant == NULL || invariant->transition_ids == NULL)
+      return 0;
+    if (StringListContains(invariant->transition_ids,
+                           invariant->transition_id_count, transition_id))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateDiffHarnessRegistryReady(void) {
   size_t index;
   size_t required_diff_harness_id_count =
@@ -1403,6 +1425,9 @@ static int AppStateDiffHarnessRegistryReady(void) {
          ref_index++) {
       if (AppStateTransitionLookup(metadata->transition_ids[ref_index]) ==
           NULL)
+        return 0;
+      if (!AppStateDiffHarnessInvariantCoversTransition(
+              metadata, metadata->transition_ids[ref_index]))
         return 0;
     }
     for (ref_index = 0; ref_index < metadata->owner_field_ref_count;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -990,6 +990,31 @@ static int AppStateInvariantRegistryReady(void) {
   return 1;
 }
 
+static int AppStateCompatibilityShimInvariantCoversTransition(
+    const AppStateCompatibilityShimMetadata *metadata) {
+  size_t invariant_index;
+
+  if (metadata == NULL || !NonEmptyString(metadata->target_transition) ||
+      !NonEmptyStringList(metadata->invariant_checks,
+                          metadata->invariant_check_count))
+    return 0;
+
+  for (invariant_index = 0; invariant_index < metadata->invariant_check_count;
+       invariant_index++) {
+    const AppStateInvariantMetadata *invariant =
+        AppStateInvariantLookup(metadata->invariant_checks[invariant_index]);
+
+    if (invariant == NULL || invariant->transition_ids == NULL)
+      return 0;
+    if (StringListContains(invariant->transition_ids,
+                           invariant->transition_id_count,
+                           metadata->target_transition))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateCompatibilityShimsReady(void) {
   size_t index;
   size_t required_shim_id_count =
@@ -1037,6 +1062,8 @@ static int AppStateCompatibilityShimsReady(void) {
           NULL)
         return 0;
     }
+    if (!AppStateCompatibilityShimInvariantCoversTransition(metadata))
+      return 0;
   }
 
   for (index = 0; index < required_shim_id_count; index++) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1037,7 +1037,17 @@ def _complete_dispatch_surfaces() -> list[dict[str, object]]:
 
 
 def _complete_invariants() -> list[dict[str, object]]:
-    return [_invariant(category) for category in REQUIRED_INVARIANT_CATEGORIES]
+    return [
+        _invariant(
+            category,
+            transition_ids=(
+                _complete_transition_ids()
+                if category == "blocked_transition_determinism"
+                else None
+            ),
+        )
+        for category in REQUIRED_INVARIANT_CATEGORIES
+    ]
 
 
 def _complete_generation_domains() -> list[dict[str, object]]:
@@ -1059,6 +1069,7 @@ def _complete_diff_harness_checks() -> list[dict[str, object]]:
             if category == "transition_before_after_snapshot"
             else None,
             _complete_transition_ids(),
+            invariant_ids=["invariant.blocked_transition_determinism"],
         )
         for category in REQUIRED_DIFF_HARNESS_CATEGORIES
     ]
@@ -1412,6 +1423,42 @@ def test_guard_fails_when_transition_sequence_invariants_do_not_cover_step(
 
     assert any(
         "transition_sequence[0].step[0]" in failure
+        and "invariant_ids must include at least one invariant covering transition_id transition.keybinding"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_diff_harness_transition_lacks_same_harness_invariant(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    harness = next(
+        record
+        for record in diff_harness_checks
+        if record["harness_id"] == "harness.transition_before_after_snapshot"
+    )
+    harness["transition_ids"] = ["transition.keybinding"]
+    harness["invariant_ids"] = ["invariant.inactive_panel_frozen"]
+    invariants = _complete_invariants()
+    for invariant in invariants:
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen":
+            invariant["transition_ids"] = ["transition.refresh_rebuild"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        invariants=invariants,
+        diff_harness_checks=diff_harness_checks,
+        runtime_invariants=_complete_invariants(),
+        runtime_diff_harness_checks=_complete_diff_harness_checks(),
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "diff_harness_check" in failure
+        and "harness.transition_before_after_snapshot" in failure
         and "invariant_ids must include at least one invariant covering transition_id transition.keybinding"
         in failure
         for failure in failures
@@ -1828,6 +1875,40 @@ def test_guard_fails_when_runtime_transition_sequence_invariants_do_not_cover_st
 
     assert any(
         "runtime_transition_sequence[0].step[0]" in failure
+        and "invariant_ids must include at least one invariant covering transition_id transition.keybinding"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_diff_harness_transition_lacks_same_harness_invariant(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    harness = next(
+        record
+        for record in runtime_diff_harness_checks
+        if record["harness_id"] == "harness.transition_before_after_snapshot"
+    )
+    harness["transition_ids"] = ["transition.keybinding"]
+    harness["invariant_ids"] = ["invariant.inactive_panel_frozen"]
+    runtime_invariants = _complete_invariants()
+    for invariant in runtime_invariants:
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen":
+            invariant["transition_ids"] = ["transition.refresh_rebuild"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=runtime_invariants,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_diff_harness" in failure
+        and "harness.transition_before_after_snapshot" in failure
         and "invariant_ids must include at least one invariant covering transition_id transition.keybinding"
         in failure
         for failure in failures
@@ -5814,6 +5895,7 @@ def test_runtime_shim_startup_requires_documented_shim_ids() -> None:
 def test_runtime_diff_harness_startup_checks_fail_closed() -> None:
     source = Path("src/core/main.c").read_text(encoding="utf-8")
 
+    assert "AppStateDiffHarnessInvariantCoversTransition" in source
     assert "AppStateDiffHarnessAt(AppStateDiffHarnessCount()) != NULL" in source
     assert 'AppStateDiffHarnessLookup("harness.__ytnova_unknown__") != NULL' in source
     assert "AppStateDiffHarnessLookup(NULL) != NULL" in source
@@ -5824,6 +5906,12 @@ def test_runtime_diff_harness_startup_checks_fail_closed() -> None:
     assert "AppStateTransitionLookup(metadata->transition_ids[ref_index])" in source
     assert "AppStateOwnerFieldLookup(metadata->owner_field_refs[ref_index])" in source
     assert "AppStateInvariantLookup(metadata->invariant_ids[ref_index])" in source
+    assert re.search(
+        r"!AppStateDiffHarnessInvariantCoversTransition\(\s*"
+        r"metadata,\s*metadata->transition_ids\[ref_index\]\)",
+        source,
+        re.S,
+    )
     assert (
         "AppStateGenerationDomainLookup(\n"
         "              metadata->generation_domain_ids[ref_index])"

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4357,6 +4357,26 @@ def test_guard_fails_when_shim_invariant_check_is_not_runtime_registered(
     )
 
 
+def test_guard_fails_when_shim_invariant_checks_do_not_cover_target_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(target_transition="transition.render_reflow")
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and (
+            "invariant_checks must include at least one invariant covering "
+            "target_transition transition.render_reflow"
+        )
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_shim_metadata_drifts(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     runtime_shims = [_shim()]
@@ -4433,6 +4453,30 @@ def test_guard_fails_when_runtime_shim_target_transition_drifts(
         "runtime_shim[0]" in failure
         and "runtime target_transition does not match shim" in failure
         and "transition.render_reflow" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_invariant_checks_do_not_cover_target_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim(target_transition="transition.render_reflow")]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and (
+            "invariant_checks must include at least one invariant covering "
+            "target_transition transition.render_reflow"
+        )
+        in failure
         for failure in failures
     )
 
@@ -5714,6 +5758,26 @@ def test_runtime_shim_startup_validates_invariant_checks_against_registry() -> N
         source,
         re.S,
     )
+
+
+def test_runtime_shim_startup_requires_invariant_to_cover_target_transition() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index(
+        "static int AppStateCompatibilityShimInvariantCoversTransition("
+    )
+    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
+    action_start = source.index("static int AppStateActionTransitionsReady(void)")
+    helper_body = source[helper_start:ready_start]
+    ready_body = source[ready_start:action_start]
+
+    assert "metadata->target_transition" in helper_body
+    assert (
+        "AppStateInvariantLookup(metadata->invariant_checks[invariant_index])"
+        in helper_body
+    )
+    assert "invariant->transition_ids" in helper_body
+    assert "invariant->transition_id_count" in helper_body
+    assert "!AppStateCompatibilityShimInvariantCoversTransition(metadata)" in ready_body
 
 
 def test_runtime_shim_startup_requires_documented_shim_ids() -> None:


### PR DESCRIPTION
## Summary
- require compatibility shim invariant checks to cover each shim target transition
- require diff harness transitions to have same-harness invariant coverage
- apply the alignment rules to documented metadata, parsed runtime metadata, and startup readiness

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'shim and invariant'`
- `pytest -q tests/test_appstate_contract_guard.py -k 'diff_harness and invariant'`
- `python3 scripts/check_appstate_contract.py`
- `pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `git diff --check`
