### PR TITLE
chore(appstate): require generation harness coverage

### DIFF
--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -38,7 +38,11 @@
         "generation.panel.local-authority",
         "generation.volume.shared-authority",
         "identity.directory.stable-key",
-        "identity.file.stable-key"
+        "identity.file.stable-key",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume",
+        "state.topology.volume",
+        "lifecycle.volume.registry"
       ],
       "expected_behavior": "A later dynamic harness snapshots every referenced AppState region before guard evaluation and after the transition result, then compares only authoritative state owned by the registered transition boundary.",
       "failure_mode": "Any unclassified region change, stale snapshot reuse, or missing before/after phase is reported as a transition contract violation.",
@@ -80,7 +84,8 @@
       "generation_domain_ids": [
         "generation.panel.local-authority",
         "shape.panel.focus",
-        "target.modal-command.session"
+        "target.modal-command.session",
+        "lifecycle.volume.registry"
       ],
       "expected_behavior": "The after snapshot may differ from the before snapshot only in owner fields named by the transition's declared_write_set or by an explicitly registered follow-up transition.",
       "failure_mode": "A changed owner field outside the registered write set is rejected as an undeclared AppState mutation.",
@@ -160,7 +165,8 @@
         "identity.directory.stable-key",
         "identity.file.stable-key",
         "state.topology.volume",
-        "state.file-payload.volume"
+        "state.file-payload.volume",
+        "reflow.layout.projection"
       ],
       "expected_behavior": "Saved panel or volume snapshots whose generation markers mismatch current authority must be rejected or rebound through stable identity fallback before any restore commit.",
       "failure_mode": "Reusing stale row, pointer, or payload identity after a generation mismatch is rejected as a fail-closed violation.",

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2063,6 +2063,65 @@ def _validate_diff_harness_write_coverage(
     return failures
 
 
+def _diff_harness_generation_coverage_by_domain(
+    diff_harness_records: list[Any],
+) -> dict[str, set[str]]:
+    coverage: dict[str, set[str]] = {}
+    for record in diff_harness_records:
+        if not isinstance(record, dict):
+            continue
+        domain_refs = record.get("generation_domain_ids")
+        transition_refs = record.get("transition_ids")
+        if not isinstance(domain_refs, list) or not isinstance(
+            transition_refs, list
+        ):
+            continue
+        for domain_id in domain_refs:
+            if not isinstance(domain_id, str) or not domain_id.strip():
+                continue
+            domain_coverage = coverage.setdefault(domain_id, set())
+            for transition_id in transition_refs:
+                if isinstance(transition_id, str) and transition_id.strip():
+                    domain_coverage.add(transition_id)
+    return coverage
+
+
+def _validate_generation_diff_harness_coverage(
+    *,
+    generation_domain_records: list[Any],
+    diff_harness_records: list[Any],
+    label_prefix: str,
+) -> list[str]:
+    failures: list[str] = []
+    coverage_by_domain = _diff_harness_generation_coverage_by_domain(
+        diff_harness_records
+    )
+
+    for index, record in enumerate(generation_domain_records):
+        if not isinstance(record, dict):
+            continue
+        domain_id = record.get("domain_id")
+        transition_refs = record.get("advances_on_transition_ids")
+        if not isinstance(domain_id, str) or not domain_id.strip():
+            continue
+        if not isinstance(transition_refs, list):
+            continue
+
+        covered_transitions = coverage_by_domain.get(domain_id, set())
+        for transition_id in transition_refs:
+            if not isinstance(transition_id, str) or not transition_id.strip():
+                continue
+            if transition_id not in covered_transitions:
+                failures.append(
+                    f"{label_prefix}[{index}] {domain_id}: "
+                    "advances_on_transition_ids lacks same-domain/same-transition "
+                    "diff harness coverage for transition "
+                    f"{transition_id}"
+                )
+
+    return failures
+
+
 def _validate_runtime_owner_field_registry(
     *,
     runtime_records: list[dict[str, Any]],
@@ -4975,6 +5034,13 @@ def validate_contract(
     else:
         diff_harness_records = []
     failures.extend(
+        _validate_generation_diff_harness_coverage(
+            generation_domain_records=generation_domain_records,
+            diff_harness_records=diff_harness_records,
+            label_prefix="generation_domain",
+        )
+    )
+    failures.extend(
         _validate_runtime_diff_harness_registry(
             runtime_records=runtime_diff_harness_records,
             runtime_path=action_runtime_path,
@@ -4994,6 +5060,13 @@ def validate_contract(
             runtime_generation_domain_ids={
                 record["domain_id"] for record in runtime_generation_domain_records
             },
+        )
+    )
+    failures.extend(
+        _validate_generation_diff_harness_coverage(
+            generation_domain_records=runtime_generation_domain_records,
+            diff_harness_records=runtime_diff_harness_records,
+            label_prefix="runtime_generation_domain",
         )
     )
     failures.extend(

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -787,6 +787,10 @@ static const char *const kAppStateDiffHarnessGenerationDomainIds0[] = {
   "generation.volume.shared-authority",
   "identity.directory.stable-key",
   "identity.file.stable-key",
+  "shape.panel.focus",
+  "state.visibility-filter.panel-volume",
+  "state.topology.volume",
+  "lifecycle.volume.registry",
 };
 
 static const char *const kAppStateDiffHarnessMigrationNotes0[] = {
@@ -836,6 +840,7 @@ static const char *const kAppStateDiffHarnessGenerationDomainIds1[] = {
   "generation.panel.local-authority",
   "shape.panel.focus",
   "target.modal-command.session",
+  "lifecycle.volume.registry",
 };
 
 static const char *const kAppStateDiffHarnessMigrationNotes1[] = {
@@ -930,6 +935,7 @@ static const char *const kAppStateDiffHarnessGenerationDomainIds3[] = {
   "identity.file.stable-key",
   "state.topology.volume",
   "state.file-payload.volume",
+  "reflow.layout.projection",
 };
 
 static const char *const kAppStateDiffHarnessMigrationNotes3[] = {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1352,6 +1352,50 @@ static int AppStateDiffHarnessWriteCovered(const char *owner_field,
   return 0;
 }
 
+static int AppStateGenerationAdvanceHasDiffHarnessCoverage(
+    const char *domain_id, const char *transition_id) {
+  size_t harness_index;
+
+  if (!NonEmptyString(domain_id) || !NonEmptyString(transition_id))
+    return 0;
+
+  for (harness_index = 0; harness_index < AppStateDiffHarnessCount();
+       harness_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessAt(harness_index);
+    size_t ref_index;
+    int domain_seen = 0;
+    int transition_seen = 0;
+
+    if (harness == NULL || harness->generation_domain_ids == NULL ||
+        harness->transition_ids == NULL)
+      return 0;
+
+    for (ref_index = 0; ref_index < harness->generation_domain_id_count;
+         ref_index++) {
+      const char *harness_domain_id = harness->generation_domain_ids[ref_index];
+
+      if (!NonEmptyString(harness_domain_id))
+        return 0;
+      if (strcmp(harness_domain_id, domain_id) == 0)
+        domain_seen = 1;
+    }
+    for (ref_index = 0; ref_index < harness->transition_id_count;
+         ref_index++) {
+      const char *harness_transition_id = harness->transition_ids[ref_index];
+
+      if (!NonEmptyString(harness_transition_id))
+        return 0;
+      if (strcmp(harness_transition_id, transition_id) == 0)
+        transition_seen = 1;
+    }
+    if (domain_seen && transition_seen)
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateDiffHarnessInvariantCoversTransition(
     const AppStateDiffHarnessMetadata *metadata, const char *transition_id) {
   size_t ref_index;
@@ -1375,6 +1419,7 @@ static int AppStateDiffHarnessInvariantCoversTransition(
 }
 
 static int AppStateDiffHarnessRegistryReady(void) {
+  size_t generation_index;
   size_t index;
   size_t required_diff_harness_id_count =
       sizeof(kAppStateRequiredDiffHarnessIds) /
@@ -1453,6 +1498,25 @@ static int AppStateDiffHarnessRegistryReady(void) {
     if (AppStateDiffHarnessLookup(kAppStateRequiredDiffHarnessIds[index]) ==
         NULL)
       return 0;
+  }
+
+  for (generation_index = 0; generation_index < AppStateGenerationDomainCount();
+       generation_index++) {
+    const AppStateGenerationDomainMetadata *domain =
+        AppStateGenerationDomainAt(generation_index);
+    size_t transition_index;
+
+    if (domain == NULL || !NonEmptyString(domain->domain_id) ||
+        domain->advances_on_transition_ids == NULL)
+      return 0;
+    for (transition_index = 0;
+         transition_index < domain->advances_on_transition_id_count;
+         transition_index++) {
+      if (!AppStateGenerationAdvanceHasDiffHarnessCoverage(
+              domain->domain_id,
+              domain->advances_on_transition_ids[transition_index]))
+        return 0;
+    }
   }
 
   for (index = 0; index < AppStateTransitionCount(); index++) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1061,6 +1061,10 @@ def _complete_generation_domains() -> list[dict[str, object]]:
     ]
 
 
+def _complete_generation_domain_ids() -> list[str]:
+    return [str(record["domain_id"]) for record in _complete_generation_domains()]
+
+
 def _complete_diff_harness_checks() -> list[dict[str, object]]:
     return [
         _diff_harness(
@@ -1070,6 +1074,7 @@ def _complete_diff_harness_checks() -> list[dict[str, object]]:
             else None,
             _complete_transition_ids(),
             invariant_ids=["invariant.blocked_transition_determinism"],
+            generation_domain_ids=_complete_generation_domain_ids(),
         )
         for category in REQUIRED_DIFF_HARNESS_CATEGORIES
     ]
@@ -2405,6 +2410,38 @@ def test_guard_fails_when_diff_harness_references_unknown_generation_domain(
     )
 
 
+def test_guard_fails_when_generation_domain_lacks_diff_harness_transition_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    generation_domains = _complete_generation_domains()
+    missing_domain_id = str(generation_domains[0]["domain_id"])
+    missing_transition_id = str(generation_domains[0]["advances_on_transition_ids"][0])
+    diff_harness_checks = _complete_diff_harness_checks()
+    for harness in diff_harness_checks:
+        harness["generation_domain_ids"] = [
+            domain_id
+            for domain_id in _complete_generation_domain_ids()
+            if domain_id != missing_domain_id
+        ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        generation_domains=generation_domains,
+        diff_harness_checks=diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "generation_domain[0]" in failure
+        and missing_domain_id in failure
+        and "same-domain/same-transition diff harness coverage" in failure
+        and missing_transition_id in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_diff_harness_write_coverage_is_missing(
     tmp_path: Path,
 ) -> None:
@@ -2633,6 +2670,40 @@ def test_guard_fails_when_runtime_diff_harness_write_coverage_is_missing(
         and "lacks diff harness coverage" in failure
         and missing_transition_id in failure
         and "field" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_lacks_diff_harness_transition_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()
+    missing_domain_id = str(runtime_generation_domains[0]["domain_id"])
+    missing_transition_id = str(
+        runtime_generation_domains[0]["advances_on_transition_ids"][0]
+    )
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    for harness in runtime_diff_harness_checks:
+        harness["generation_domain_ids"] = [
+            domain_id
+            for domain_id in _complete_generation_domain_ids()
+            if domain_id != missing_domain_id
+        ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and missing_domain_id in failure
+        and "same-domain/same-transition diff harness coverage" in failure
+        and missing_transition_id in failure
         for failure in failures
     )
 
@@ -5931,6 +6002,33 @@ def test_runtime_diff_harness_write_coverage_startup_checks_fail_closed() -> Non
         r"if \(!AppStateDiffHarnessWriteCovered\(field, transition->id\)\)\s*"
         r"return 0;",
         source,
+        re.S,
+    )
+
+
+def test_runtime_generation_harness_startup_checks_fail_closed() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index(
+        "static int AppStateGenerationAdvanceHasDiffHarnessCoverage("
+    )
+    invariant_start = source.index(
+        "static int AppStateDiffHarnessInvariantCoversTransition("
+    )
+    ready_start = source.index("static int AppStateDiffHarnessRegistryReady(void)")
+    signal_start = source.index("static void SigIntHandler(int sig)")
+    helper_body = source[helper_start:invariant_start]
+    ready_body = source[ready_start:signal_start]
+
+    assert "harness->generation_domain_ids" in helper_body
+    assert "harness->transition_ids" in helper_body
+    assert "domain_seen && transition_seen" in helper_body
+    assert "AppStateGenerationDomainCount()" in ready_body
+    assert "domain->advances_on_transition_ids" in ready_body
+    assert re.search(
+        r"!AppStateGenerationAdvanceHasDiffHarnessCoverage\(\s*"
+        r"domain->domain_id,\s*"
+        r"domain->advances_on_transition_ids\[transition_index\]\)",
+        ready_body,
         re.S,
     )
 


### PR DESCRIPTION
## Summary
- require generation-domain advances to have same-domain and same-transition diff-harness coverage
- mirror the metadata coverage corrections in runtime AppState registry metadata
- add docs/runtime/startup guard regressions for generation harness coverage

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'generation and harness'`
- `python3 scripts/check_appstate_contract.py`
- `pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `git diff --check`
