### PR TITLE
chore(appstate): require owner invariant alignment

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2128,6 +2128,7 @@ def _validate_runtime_owner_field_registry(
     runtime_path: Path,
     owner_field_records: list[Any],
     runtime_invariant_ids: set[str],
+    runtime_invariant_protected_fields: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     expected_owner_fields = {
@@ -2179,6 +2180,14 @@ def _validate_runtime_owner_field_registry(
                 _validate_invariant_check_refs(
                     invariant_checks=invariant_checks,
                     runtime_invariant_ids=runtime_invariant_ids,
+                    label=label,
+                )
+            )
+            failures.extend(
+                _validate_owner_field_invariant_alignment(
+                    invariant_checks=invariant_checks,
+                    owner_field=runtime_field,
+                    invariant_protected_fields=runtime_invariant_protected_fields,
                     label=label,
                 )
             )
@@ -2795,6 +2804,7 @@ def _validate_owner_fields(
     owner_fields_doc: Any,
     owner_fields_path: Path,
     runtime_invariant_ids: set[str],
+    invariant_protected_fields: dict[str, set[str]],
 ) -> tuple[set[str], list[str]]:
     failures: list[str] = []
     registered_fields: set[str] = set()
@@ -2829,6 +2839,14 @@ def _validate_owner_fields(
             _validate_invariant_check_refs(
                 invariant_checks=record.get("invariant_checks"),
                 runtime_invariant_ids=runtime_invariant_ids,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_owner_field_invariant_alignment(
+                invariant_checks=record.get("invariant_checks"),
+                owner_field=field,
+                invariant_protected_fields=invariant_protected_fields,
                 label=label,
             )
         )
@@ -3865,6 +3883,51 @@ def _invariant_transition_ids_by_invariant(
     return transition_ids_by_invariant
 
 
+def _invariant_protected_fields_by_invariant(
+    invariant_records: list[Any],
+) -> dict[str, set[str]]:
+    protected_fields_by_invariant: dict[str, set[str]] = {}
+    for record in invariant_records:
+        if not isinstance(record, dict):
+            continue
+        invariant_id = record.get("invariant_id")
+        protected_fields = record.get("protected_fields")
+        if not isinstance(invariant_id, str) or not invariant_id.strip():
+            continue
+        if not isinstance(protected_fields, list):
+            continue
+        protected_fields_by_invariant[invariant_id] = {
+            field
+            for field in protected_fields
+            if isinstance(field, str) and field.strip()
+        }
+    return protected_fields_by_invariant
+
+
+def _validate_owner_field_invariant_alignment(
+    *,
+    invariant_checks: Any,
+    owner_field: Any,
+    invariant_protected_fields: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    if not isinstance(owner_field, str) or not owner_field.strip():
+        return []
+    if not isinstance(invariant_checks, list):
+        return []
+
+    for invariant_id in invariant_checks:
+        if not isinstance(invariant_id, str) or not invariant_id.strip():
+            continue
+        if owner_field in invariant_protected_fields.get(invariant_id, set()):
+            return []
+
+    return [
+        f"{label}: invariant_checks must include at least one invariant "
+        f"protecting owner field {owner_field}"
+    ]
+
+
 def _invariant_refs_cover_transition(
     *,
     invariant_refs: list[str],
@@ -4625,11 +4688,24 @@ def validate_contract(
     runtime_invariant_ids = {
         record["invariant_id"] for record in runtime_invariant_records
     }
+    runtime_invariant_protected_fields = _invariant_protected_fields_by_invariant(
+        runtime_invariant_records
+    )
+    if isinstance(invariants_doc, dict) and isinstance(
+        invariants_doc.get("invariants"), list
+    ):
+        invariant_records = invariants_doc["invariants"]
+    else:
+        invariant_records = []
+    invariant_protected_fields = _invariant_protected_fields_by_invariant(
+        invariant_records
+    )
 
     registered_owner_fields, owner_field_failures = _validate_owner_fields(
         owner_fields_doc=owner_fields_doc,
         owner_fields_path=owner_fields_path,
         runtime_invariant_ids=runtime_invariant_ids,
+        invariant_protected_fields=invariant_protected_fields,
     )
     failures.extend(owner_field_failures)
     if isinstance(owner_fields_doc, dict) and isinstance(
@@ -4644,6 +4720,7 @@ def validate_contract(
             runtime_path=action_runtime_path,
             owner_field_records=owner_field_records,
             runtime_invariant_ids=runtime_invariant_ids,
+            runtime_invariant_protected_fields=runtime_invariant_protected_fields,
         )
     )
 
@@ -4757,12 +4834,6 @@ def validate_contract(
             failures.append(f"{shims_path}: shims must be a non-empty list")
             shims = []
 
-    if isinstance(invariants_doc, dict) and isinstance(
-        invariants_doc.get("invariants"), list
-    ):
-        invariant_records = invariants_doc["invariants"]
-    else:
-        invariant_records = []
     invariant_transition_ids = _invariant_transition_ids_by_invariant(
         invariant_records
     )

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -585,6 +585,24 @@ static int AppStateInvariantDispatchSurfacesReady(
   return 0;
 }
 
+static int AppStateInvariantProtectsField(const char *invariant_id,
+                                          const char *field) {
+  const AppStateInvariantMetadata *metadata;
+
+  if (!NonEmptyString(invariant_id) || !NonEmptyString(field))
+    return 0;
+
+  metadata = AppStateInvariantLookup(invariant_id);
+  if (metadata == NULL)
+    return 0;
+  if (!NonEmptyStringList(metadata->protected_fields,
+                          metadata->protected_field_count))
+    return 0;
+
+  return StringListContains(metadata->protected_fields,
+                            metadata->protected_field_count, field);
+}
+
 static int AppStateOwnerFieldsReady(void) {
   size_t index;
   size_t required_owner_field_id_count =
@@ -596,6 +614,7 @@ static int AppStateOwnerFieldsReady(void) {
 
   for (index = 0; index < AppStateOwnerFieldCount(); index++) {
     const AppStateOwnerFieldMetadata *metadata = AppStateOwnerFieldAt(index);
+    int field_protected = 0;
     size_t invariant_index;
     size_t previous_index;
 
@@ -616,7 +635,12 @@ static int AppStateOwnerFieldsReady(void) {
       if (AppStateInvariantLookup(metadata->invariant_checks[invariant_index]) ==
           NULL)
         return 0;
+      if (AppStateInvariantProtectsField(
+              metadata->invariant_checks[invariant_index], metadata->field))
+        field_protected = 1;
     }
+    if (!field_protected)
+      return 0;
 
     for (previous_index = 0; previous_index < index; previous_index++) {
       const AppStateOwnerFieldMetadata *previous =

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4020,6 +4020,34 @@ def test_guard_fails_when_owner_field_record_is_malformed(tmp_path: Path) -> Non
     )
 
 
+def test_guard_fails_when_owner_field_invariant_does_not_protect_field(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    owner_fields = _complete_owner_fields()
+    invariants = _complete_invariants()
+    for invariant in invariants:
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen":
+            invariant["protected_fields"] = ["panel.tree_selection_key"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        owner_fields=owner_fields,
+        invariants=invariants,
+        runtime_owner_fields=_complete_owner_fields(),
+        runtime_invariants=_complete_invariants(),
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "owner_field[0]" in failure
+        and "invariant_checks must include at least one invariant"
+        and "owner field field" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_owner_field_metadata_drifts(
     tmp_path: Path,
 ) -> None:
@@ -4059,6 +4087,30 @@ def test_guard_fails_when_runtime_owner_field_invariant_id_is_unknown(
         "runtime_owner_field[0]" in failure
         and "invariant_checks[0] does not match runtime invariant registry"
         and "invariant.missing" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_owner_field_invariant_does_not_protect_field(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_invariants = _complete_invariants()
+    for invariant in runtime_invariants:
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen":
+            invariant["protected_fields"] = ["panel.tree_selection_key"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_owner_field[0]" in failure
+        and "invariant_checks must include at least one invariant"
+        and "owner field field" in failure
         for failure in failures
     )
 
@@ -5602,6 +5654,16 @@ def test_runtime_owner_field_startup_validates_invariant_checks_against_registry
     source = Path("src/core/main.c").read_text(encoding="utf-8")
 
     assert re.search(
+        r"static int AppStateInvariantProtectsField\(.*?"
+        r"metadata = AppStateInvariantLookup\(invariant_id\);\s*"
+        r"if \(metadata == NULL\)\s*return 0;\s*"
+        r"if \(!NonEmptyStringList\(metadata->protected_fields,\s*"
+        r"metadata->protected_field_count\)\)\s*return 0;\s*"
+        r"return StringListContains\(metadata->protected_fields,",
+        source,
+        re.S,
+    )
+    assert re.search(
         r"for \(invariant_index = 0;\s*"
         r"invariant_index < metadata->invariant_check_count;\s*"
         r"invariant_index\+\+\) \{\s*"
@@ -5611,6 +5673,8 @@ def test_runtime_owner_field_startup_validates_invariant_checks_against_registry
         source,
         re.S,
     )
+    assert "field_protected = 1" in source
+    assert re.search(r"if \(!field_protected\)\s*return 0;", source, re.S)
 
 
 def test_runtime_owner_field_startup_requires_documented_field_ids() -> None:


### PR DESCRIPTION
## Summary
- require owner-field invariant checks to protect the owner field they are assigned to
- apply the alignment rule to documented metadata, parsed runtime metadata, and startup readiness
- add docs/runtime/startup guard regressions for owner invariant coverage

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'owner and invariant'`
- `python3 scripts/check_appstate_contract.py`
- `pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `git diff --check`
