### PR TITLE
chore(appstate): require invariant write coverage

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2209,6 +2209,7 @@ def _validate_runtime_dispatch_surface_registry(
     dispatch_surface_records: list[Any],
     runtime_transition_records: dict[str, dict[str, Any]],
     runtime_transition_ids: set[str],
+    runtime_invariant_protected_fields_by_surface: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     expected_surfaces = {
@@ -2280,6 +2281,13 @@ def _validate_runtime_dispatch_surface_registry(
             _validate_allowed_direct_writes_within_transition(
                 record=record,
                 transition_records=runtime_transition_records,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_allowed_direct_writes_have_invariant_coverage(
+                record=record,
+                protected_fields_by_surface=runtime_invariant_protected_fields_by_surface,
                 label=label,
             )
         )
@@ -3203,6 +3211,7 @@ def _validate_dispatch_surfaces(
     dispatch_surfaces_path: Path,
     transition_ids: dict[str, dict[str, Any]],
     registered_owner_fields: set[str],
+    invariant_protected_fields_by_surface: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     if not isinstance(dispatch_surfaces_doc, dict):
@@ -3264,6 +3273,13 @@ def _validate_dispatch_surfaces(
                 _validate_allowed_direct_writes_within_transition(
                     record=record,
                     transition_records=transition_ids,
+                    label=label,
+                )
+            )
+            failures.extend(
+                _validate_allowed_direct_writes_have_invariant_coverage(
+                    record=record,
+                    protected_fields_by_surface=invariant_protected_fields_by_surface,
                     label=label,
                 )
             )
@@ -3902,6 +3918,61 @@ def _invariant_protected_fields_by_invariant(
             if isinstance(field, str) and field.strip()
         }
     return protected_fields_by_invariant
+
+
+def _invariant_protected_fields_by_dispatch_surface(
+    invariant_records: list[Any],
+) -> dict[str, set[str]]:
+    protected_fields_by_surface: dict[str, set[str]] = {}
+    for record in invariant_records:
+        if not isinstance(record, dict):
+            continue
+        surface_refs = record.get("dispatch_surface_ids")
+        protected_fields = record.get("protected_fields")
+        if not isinstance(surface_refs, list) or not isinstance(
+            protected_fields, list
+        ):
+            continue
+        valid_fields = {
+            field
+            for field in protected_fields
+            if isinstance(field, str) and field.strip()
+        }
+        if not valid_fields:
+            continue
+        for surface_id in surface_refs:
+            if not isinstance(surface_id, str) or not surface_id.strip():
+                continue
+            protected_fields_by_surface.setdefault(surface_id, set()).update(
+                valid_fields
+            )
+    return protected_fields_by_surface
+
+
+def _validate_allowed_direct_writes_have_invariant_coverage(
+    *,
+    record: dict[str, Any],
+    protected_fields_by_surface: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    surface_id = record.get("surface_id")
+    writes = record.get("allowed_direct_writes")
+    if not isinstance(surface_id, str) or not surface_id.strip():
+        return []
+    if not isinstance(writes, list):
+        return []
+
+    protected_fields = protected_fields_by_surface.get(surface_id, set())
+    failures: list[str] = []
+    for index, field in enumerate(writes):
+        if not isinstance(field, str) or not field.strip():
+            continue
+        if field not in protected_fields:
+            failures.append(
+                f"{label}: {surface_id} allowed_direct_writes[{index}] "
+                f"lacks same-surface invariant coverage for owner field: {field}"
+            )
+    return failures
 
 
 def _validate_owner_field_invariant_alignment(
@@ -4691,6 +4762,11 @@ def validate_contract(
     runtime_invariant_protected_fields = _invariant_protected_fields_by_invariant(
         runtime_invariant_records
     )
+    runtime_invariant_protected_fields_by_surface = (
+        _invariant_protected_fields_by_dispatch_surface(
+            runtime_invariant_records
+        )
+    )
     if isinstance(invariants_doc, dict) and isinstance(
         invariants_doc.get("invariants"), list
     ):
@@ -4699,6 +4775,9 @@ def validate_contract(
         invariant_records = []
     invariant_protected_fields = _invariant_protected_fields_by_invariant(
         invariant_records
+    )
+    invariant_protected_fields_by_surface = (
+        _invariant_protected_fields_by_dispatch_surface(invariant_records)
     )
 
     registered_owner_fields, owner_field_failures = _validate_owner_fields(
@@ -5019,6 +5098,7 @@ def validate_contract(
             dispatch_surfaces_path=dispatch_surfaces_path,
             transition_ids=transition_ids,
             registered_owner_fields=registered_owner_fields,
+            invariant_protected_fields_by_surface=invariant_protected_fields_by_surface,
         )
     )
     if isinstance(dispatch_surfaces_doc, dict) and isinstance(
@@ -5036,6 +5116,9 @@ def validate_contract(
                 record["id"]: record for record in runtime_transition_records
             },
             runtime_transition_ids={record["id"] for record in runtime_transition_records},
+            runtime_invariant_protected_fields_by_surface=(
+                runtime_invariant_protected_fields_by_surface
+            ),
         )
     )
     dispatch_surface_ids = _collect_string_ids(

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -1905,6 +1905,7 @@ def _validate_runtime_transition_registry(
     runtime_path: Path,
     transition_ids: dict[str, dict[str, Any]],
     registered_owner_fields: set[str],
+    runtime_invariant_protected_fields_by_transition: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     expected_ids = set(transition_ids)
@@ -1934,6 +1935,15 @@ def _validate_runtime_transition_registry(
             _validate_registered_write_set(
                 record=record,
                 registered_fields=registered_owner_fields,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_transition_write_set_has_invariant_coverage(
+                record=record,
+                protected_fields_by_transition=(
+                    runtime_invariant_protected_fields_by_transition
+                ),
                 label=label,
             )
         )
@@ -3949,6 +3959,35 @@ def _invariant_protected_fields_by_dispatch_surface(
     return protected_fields_by_surface
 
 
+def _invariant_protected_fields_by_transition(
+    invariant_records: list[Any],
+) -> dict[str, set[str]]:
+    protected_fields_by_transition: dict[str, set[str]] = {}
+    for record in invariant_records:
+        if not isinstance(record, dict):
+            continue
+        transition_refs = record.get("transition_ids")
+        protected_fields = record.get("protected_fields")
+        if not isinstance(transition_refs, list) or not isinstance(
+            protected_fields, list
+        ):
+            continue
+        valid_fields = {
+            field
+            for field in protected_fields
+            if isinstance(field, str) and field.strip()
+        }
+        if not valid_fields:
+            continue
+        for transition_id in transition_refs:
+            if not isinstance(transition_id, str) or not transition_id.strip():
+                continue
+            protected_fields_by_transition.setdefault(transition_id, set()).update(
+                valid_fields
+            )
+    return protected_fields_by_transition
+
+
 def _validate_allowed_direct_writes_have_invariant_coverage(
     *,
     record: dict[str, Any],
@@ -3971,6 +4010,33 @@ def _validate_allowed_direct_writes_have_invariant_coverage(
             failures.append(
                 f"{label}: {surface_id} allowed_direct_writes[{index}] "
                 f"lacks same-surface invariant coverage for owner field: {field}"
+            )
+    return failures
+
+
+def _validate_transition_write_set_has_invariant_coverage(
+    *,
+    record: dict[str, Any],
+    protected_fields_by_transition: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    transition_id = record.get("id")
+    write_set = record.get("declared_write_set")
+    if not isinstance(transition_id, str) or not transition_id.strip():
+        return []
+    if not isinstance(write_set, list):
+        return []
+
+    protected_fields = protected_fields_by_transition.get(transition_id, set())
+    failures: list[str] = []
+    for index, field in enumerate(write_set):
+        if not isinstance(field, str) or not field.strip():
+            continue
+        if field not in protected_fields:
+            failures.append(
+                f"{label}: declared_write_set[{index}] lacks same-transition "
+                f"invariant coverage for transition {transition_id} "
+                f"owner field: {field}"
             )
     return failures
 
@@ -4767,6 +4833,9 @@ def validate_contract(
             runtime_invariant_records
         )
     )
+    runtime_invariant_protected_fields_by_transition = (
+        _invariant_protected_fields_by_transition(runtime_invariant_records)
+    )
     if isinstance(invariants_doc, dict) and isinstance(
         invariants_doc.get("invariants"), list
     ):
@@ -4778,6 +4847,9 @@ def validate_contract(
     )
     invariant_protected_fields_by_surface = (
         _invariant_protected_fields_by_dispatch_surface(invariant_records)
+    )
+    invariant_protected_fields_by_transition = (
+        _invariant_protected_fields_by_transition(invariant_records)
     )
 
     registered_owner_fields, owner_field_failures = _validate_owner_fields(
@@ -4833,6 +4905,13 @@ def validate_contract(
                 label=label,
             )
         )
+        failures.extend(
+            _validate_transition_write_set_has_invariant_coverage(
+                record=record,
+                protected_fields_by_transition=invariant_protected_fields_by_transition,
+                label=label,
+            )
+        )
         transition_id = record.get("id")
         if isinstance(transition_id, str) and transition_id.strip():
             if transition_id in transition_ids:
@@ -4854,6 +4933,9 @@ def validate_contract(
             runtime_path=action_runtime_path,
             transition_ids=transition_ids,
             registered_owner_fields=registered_owner_fields,
+            runtime_invariant_protected_fields_by_transition=(
+                runtime_invariant_protected_fields_by_transition
+            ),
         )
     )
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -845,6 +845,35 @@ static int AppStateGenerationDomainsReady(void) {
   return 1;
 }
 
+static int AppStateDispatchSurfaceWriteHasInvariantCoverage(
+    const char *surface_id, const char *field) {
+  size_t invariant_index;
+
+  if (!NonEmptyString(surface_id) || !NonEmptyString(field))
+    return 0;
+
+  for (invariant_index = 0; invariant_index < AppStateInvariantCount();
+       invariant_index++) {
+    const AppStateInvariantMetadata *invariant =
+        AppStateInvariantAt(invariant_index);
+
+    if (invariant == NULL)
+      continue;
+    if (!NonEmptyStringList(invariant->dispatch_surface_ids,
+                            invariant->dispatch_surface_id_count) ||
+        !NonEmptyStringList(invariant->protected_fields,
+                            invariant->protected_field_count))
+      continue;
+    if (StringListContains(invariant->dispatch_surface_ids,
+                           invariant->dispatch_surface_id_count, surface_id) &&
+        StringListContains(invariant->protected_fields,
+                           invariant->protected_field_count, field))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateDispatchSurfaceWritesReady(
     const AppStateDispatchSurfaceMetadata *metadata) {
   const AppStateTransitionMetadata *transition =
@@ -870,6 +899,9 @@ static int AppStateDispatchSurfaceWritesReady(
       return 0;
     if (!StringListContains(transition->declared_write_set,
                             transition->declared_write_set_count, field))
+      return 0;
+    if (!AppStateDispatchSurfaceWriteHasInvariantCoverage(metadata->surface_id,
+                                                          field))
       return 0;
   }
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -706,6 +706,35 @@ static int AppStateGenerationWriteCovered(const char *owner_field,
   return !generation_owner_seen;
 }
 
+static int AppStateTransitionWriteHasInvariantCoverage(
+    const char *transition_id, const char *field) {
+  size_t invariant_index;
+
+  if (!NonEmptyString(transition_id) || !NonEmptyString(field))
+    return 0;
+
+  for (invariant_index = 0; invariant_index < AppStateInvariantCount();
+       invariant_index++) {
+    const AppStateInvariantMetadata *invariant =
+        AppStateInvariantAt(invariant_index);
+
+    if (invariant == NULL)
+      continue;
+    if (!NonEmptyStringList(invariant->transition_ids,
+                            invariant->transition_id_count) ||
+        !NonEmptyStringList(invariant->protected_fields,
+                            invariant->protected_field_count))
+      continue;
+    if (StringListContains(invariant->transition_ids,
+                           invariant->transition_id_count, transition_id) &&
+        StringListContains(invariant->protected_fields,
+                           invariant->protected_field_count, field))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateTransitionRegistryReady(void) {
   size_t index;
   size_t required_transition_id_count =
@@ -746,6 +775,8 @@ static int AppStateTransitionRegistryReady(void) {
       if (AppStateOwnerFieldLookup(field) == NULL)
         return 0;
       if (!AppStateGenerationWriteCovered(field, metadata->id))
+        return 0;
+      if (!AppStateTransitionWriteHasInvariantCoverage(metadata->id, field))
         return 0;
     }
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1122,6 +1122,27 @@ def _split_dispatch_surface_invariant_coverage(
     invariants[1]["protected_fields"] = ["field"]
 
 
+def _split_transition_invariant_coverage(
+    invariants: list[dict[str, object]],
+    transition_id: str,
+    fallback_transition_id: str,
+    field: str = "field",
+) -> None:
+    alternate_field = "panel.tree_selection_key" if field == "field" else "field"
+    for invariant in invariants:
+        transition_refs = invariant.get("transition_ids")
+        if not isinstance(transition_refs, list):
+            invariant["transition_ids"] = [fallback_transition_id]
+            continue
+        remaining_refs = [ref for ref in transition_refs if ref != transition_id]
+        invariant["transition_ids"] = remaining_refs or [fallback_transition_id]
+
+    invariants[0]["transition_ids"] = [transition_id]
+    invariants[0]["protected_fields"] = [alternate_field]
+    invariants[1]["transition_ids"] = [fallback_transition_id]
+    invariants[1]["protected_fields"] = [field]
+
+
 def _complete_owner_fields() -> list[dict[str, object]]:
     return [_owner_field("field"), _owner_field("panel.tree_selection_key")]
 
@@ -2282,6 +2303,32 @@ def test_runtime_transition_registry_startup_validates_write_set_owner_fields() 
         r"if \(AppStateOwnerFieldLookup\(field\) == NULL\)\s*return 0;",
         source,
         re.S,
+    )
+
+
+def test_runtime_transition_registry_startup_requires_invariant_write_coverage() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index("static int AppStateTransitionWriteHasInvariantCoverage(")
+    transition_start = source.index("static int AppStateTransitionRegistryReady(void)")
+    generation_start = source.index("static int AppStateGenerationDomainsReady(void)")
+    helper_body = source[helper_start:transition_start]
+    transition_body = source[transition_start:generation_start]
+
+    assert "AppStateInvariantAt(invariant_index)" in helper_body
+    assert re.search(
+        r"StringListContains\(invariant->transition_ids,\s*"
+        r"invariant->transition_id_count, transition_id\)",
+        helper_body,
+        re.S,
+    )
+    assert re.search(
+        r"StringListContains\(invariant->protected_fields,\s*"
+        r"invariant->protected_field_count, field\)",
+        helper_body,
+        re.S,
+    )
+    assert "!AppStateTransitionWriteHasInvariantCoverage(metadata->id, field)" in (
+        transition_body
     )
 
 
@@ -3870,6 +3917,41 @@ def test_guard_fails_when_dispatch_surface_allowed_write_splits_invariant_covera
     )
 
 
+def test_guard_fails_when_transition_write_splits_invariant_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    target_index = next(
+        index
+        for index, record in enumerate(transitions)
+        if record["id"] != "transition.keybinding"
+    )
+    transition_id = str(transitions[target_index]["id"])
+    fallback_transition_id = next(
+        str(record["id"]) for record in transitions if record["id"] != transition_id
+    )
+    invariants = _complete_invariants()
+    _split_transition_invariant_coverage(
+        invariants, transition_id, fallback_transition_id
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        invariants=invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        f"transition[{target_index}]" in failure
+        and "declared_write_set[0]" in failure
+        and transition_id in failure
+        and "field" in failure
+        and "lacks same-transition invariant coverage" in failure
+        for failure in failures
+    )
+
+
 def test_guard_accepts_empty_dispatch_surface_allowed_writes(
     tmp_path: Path,
 ) -> None:
@@ -4078,6 +4160,51 @@ def test_guard_fails_when_runtime_dispatch_surface_allowed_write_splits_invarian
         and "allowed_direct_writes[0]" in failure
         and "field" in failure
         and "lacks same-surface invariant coverage" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_write_splits_invariant_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transitions = [dict(record) for record in transitions]
+    target_index = next(
+        index
+        for index, record in enumerate(runtime_transitions)
+        if record["id"] != "transition.keybinding"
+    )
+    transition_id = str(runtime_transitions[target_index]["id"])
+    fallback_transition_id = next(
+        str(record["id"])
+        for record in runtime_transitions
+        if record["id"] != transition_id
+    )
+    runtime_transitions[target_index]["declared_write_set"] = [
+        "panel.tree_selection_key"
+    ]
+    runtime_invariants = _complete_invariants()
+    _split_transition_invariant_coverage(
+        runtime_invariants,
+        transition_id,
+        fallback_transition_id,
+        field="panel.tree_selection_key",
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=runtime_transitions,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        f"runtime_transition[{target_index}]" in failure
+        and "declared_write_set[0]" in failure
+        and transition_id in failure
+        and "panel.tree_selection_key" in failure
+        and "lacks same-transition invariant coverage" in failure
         for failure in failures
     )
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1036,7 +1036,21 @@ def _complete_dispatch_surfaces() -> list[dict[str, object]]:
     ]
 
 
+def _complete_invariant_dispatch_surface_ids() -> dict[str, list[str]]:
+    categories = REQUIRED_INVARIANT_CATEGORIES
+    surface_ids = [str(record["surface_id"]) for record in _complete_dispatch_surfaces()]
+    return {
+        category: [
+            surface_id
+            for surface_index, surface_id in enumerate(surface_ids)
+            if surface_index % len(categories) == category_index
+        ]
+        for category_index, category in enumerate(categories)
+    }
+
+
 def _complete_invariants() -> list[dict[str, object]]:
+    dispatch_surface_ids_by_category = _complete_invariant_dispatch_surface_ids()
     return [
         _invariant(
             category,
@@ -1045,6 +1059,7 @@ def _complete_invariants() -> list[dict[str, object]]:
                 if category == "blocked_transition_determinism"
                 else None
             ),
+            dispatch_surface_ids=dispatch_surface_ids_by_category[category],
         )
         for category in REQUIRED_INVARIANT_CATEGORIES
     ]
@@ -1078,6 +1093,33 @@ def _complete_diff_harness_checks() -> list[dict[str, object]]:
         )
         for category in REQUIRED_DIFF_HARNESS_CATEGORIES
     ]
+
+
+def _remove_dispatch_surface_id(
+    invariant: dict[str, object],
+    surface_id: str,
+    fallback_surface_id: str,
+) -> None:
+    refs = invariant.get("dispatch_surface_ids")
+    if not isinstance(refs, list):
+        invariant["dispatch_surface_ids"] = [fallback_surface_id]
+        return
+    remaining_refs = [ref for ref in refs if ref != surface_id]
+    invariant["dispatch_surface_ids"] = remaining_refs or [fallback_surface_id]
+
+
+def _split_dispatch_surface_invariant_coverage(
+    invariants: list[dict[str, object]],
+    surface_id: str,
+    fallback_surface_id: str,
+) -> None:
+    for invariant in invariants:
+        _remove_dispatch_surface_id(invariant, surface_id, fallback_surface_id)
+
+    invariants[0]["dispatch_surface_ids"] = [surface_id]
+    invariants[0]["protected_fields"] = ["panel.tree_selection_key"]
+    invariants[1]["dispatch_surface_ids"] = [fallback_surface_id]
+    invariants[1]["protected_fields"] = ["field"]
 
 
 def _complete_owner_fields() -> list[dict[str, object]]:
@@ -3502,6 +3544,10 @@ def test_guard_accepts_empty_invariant_dispatch_surfaces_with_cross_cutting_note
 ) -> None:
     transitions = _complete_transitions()
     invariants = _complete_invariants()
+    moved_surface_ids = list(invariants[0]["dispatch_surface_ids"])
+    invariants[1]["dispatch_surface_ids"] = list(
+        dict.fromkeys(invariants[1]["dispatch_surface_ids"] + moved_surface_ids)
+    )
     invariants[0]["dispatch_surface_ids"] = []
     invariants[0]["migration_notes"] = ["cross-cutting fixture invariant"]
     paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
@@ -3765,6 +3811,65 @@ def test_guard_fails_when_dispatch_surface_allowed_write_exceeds_transition_cont
     )
 
 
+def test_guard_fails_when_dispatch_surface_allowed_write_lacks_invariant_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    surface_id = str(dispatch_surfaces[0]["surface_id"])
+    fallback_surface_id = str(dispatch_surfaces[1]["surface_id"])
+    invariants = _complete_invariants()
+    for invariant in invariants:
+        _remove_dispatch_surface_id(invariant, surface_id, fallback_surface_id)
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        dispatch_surfaces=dispatch_surfaces,
+        invariants=invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and surface_id in failure
+        and "allowed_direct_writes[0]" in failure
+        and "field" in failure
+        and "lacks same-surface invariant coverage" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_allowed_write_splits_invariant_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    surface_id = str(dispatch_surfaces[0]["surface_id"])
+    fallback_surface_id = str(dispatch_surfaces[1]["surface_id"])
+    invariants = _complete_invariants()
+    _split_dispatch_surface_invariant_coverage(
+        invariants, surface_id, fallback_surface_id
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        dispatch_surfaces=dispatch_surfaces,
+        invariants=invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and surface_id in failure
+        and "allowed_direct_writes[0]" in failure
+        and "field" in failure
+        and "lacks same-surface invariant coverage" in failure
+        for failure in failures
+    )
+
+
 def test_guard_accepts_empty_dispatch_surface_allowed_writes(
     tmp_path: Path,
 ) -> None:
@@ -3910,6 +4015,69 @@ def test_guard_fails_when_runtime_dispatch_surface_allowed_write_exceeds_transit
         and "allowed_direct_writes[0]" in failure
         and "outside transition declared_write_set" in failure
         and "panel.tree_selection_key" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_allowed_write_lacks_invariant_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    runtime_dispatch_surfaces = copy.deepcopy(dispatch_surfaces)
+    surface_id = str(runtime_dispatch_surfaces[0]["surface_id"])
+    fallback_surface_id = str(runtime_dispatch_surfaces[1]["surface_id"])
+    runtime_invariants = _complete_invariants()
+    for invariant in runtime_invariants:
+        _remove_dispatch_surface_id(invariant, surface_id, fallback_surface_id)
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        dispatch_surfaces=dispatch_surfaces,
+        runtime_dispatch_surfaces=runtime_dispatch_surfaces,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_dispatch_surface[0]" in failure
+        and surface_id in failure
+        and "allowed_direct_writes[0]" in failure
+        and "field" in failure
+        and "lacks same-surface invariant coverage" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_allowed_write_splits_invariant_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    runtime_dispatch_surfaces = copy.deepcopy(dispatch_surfaces)
+    surface_id = str(runtime_dispatch_surfaces[0]["surface_id"])
+    fallback_surface_id = str(runtime_dispatch_surfaces[1]["surface_id"])
+    runtime_invariants = _complete_invariants()
+    _split_dispatch_surface_invariant_coverage(
+        runtime_invariants, surface_id, fallback_surface_id
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        dispatch_surfaces=dispatch_surfaces,
+        runtime_dispatch_surfaces=runtime_dispatch_surfaces,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_dispatch_surface[0]" in failure
+        and surface_id in failure
+        and "allowed_direct_writes[0]" in failure
+        and "field" in failure
+        and "lacks same-surface invariant coverage" in failure
         for failure in failures
     )
 
@@ -5849,6 +6017,28 @@ def test_runtime_dispatch_surface_startup_validates_allowed_write_contract() -> 
         r"StringListContains\(transition->declared_write_set,\s*"
         r"transition->declared_write_set_count, field\)",
         helper_body,
+        re.S,
+    )
+
+
+def test_runtime_dispatch_surface_startup_requires_invariant_coverage() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index("static int AppStateDispatchSurfaceWritesReady(")
+    dispatch_start = source.index("static int AppStateDispatchSurfacesReady(void)")
+    helper_body = source[helper_start:dispatch_start]
+
+    assert "AppStateDispatchSurfaceWriteHasInvariantCoverage(" in helper_body
+    assert "AppStateInvariantAt(invariant_index)" in source
+    assert re.search(
+        r"StringListContains\(invariant->dispatch_surface_ids,\s*"
+        r"invariant->dispatch_surface_id_count, surface_id\)",
+        source,
+        re.S,
+    )
+    assert re.search(
+        r"StringListContains\(invariant->protected_fields,\s*"
+        r"invariant->protected_field_count, field\)",
+        source,
         re.S,
     )
 


### PR DESCRIPTION
## Summary
- require dispatch-surface direct-write permissions to be protected by a same-surface AppState invariant
- require transition declared-write-set entries to be protected by a same-transition AppState invariant
- add runtime startup fail-closed coverage for invariant/write-field mismatches
- add guard regressions for missing coverage and split-invariant coverage cases

## Validation
- Local AppState guard tests: `pytest -q tests/test_appstate_contract_guard.py` — PASS
- Local contract guard: `python3 scripts/check_appstate_contract.py` — PASS
- Local build: `make clean && make` — PASS with pre-existing warnings
