### PR TITLE
chore(appstate): require invariant diff coverage

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2319,6 +2319,7 @@ def _validate_runtime_invariant_registry(
     invariant_records: list[Any],
     runtime_transition_ids: set[str],
     dispatch_surface_ids: set[str],
+    runtime_diff_harness_owner_field_refs: set[str],
 ) -> list[str]:
     failures: list[str] = []
     expected_invariants = {
@@ -2367,6 +2368,16 @@ def _validate_runtime_invariant_registry(
             values = record.get(field)
             if not isinstance(values, list) or not values:
                 failures.append(f"{label}: {field} must be non-empty")
+
+        failures.extend(
+            _validate_invariant_diff_harness_owner_field_coverage(
+                protected_fields=record.get("protected_fields"),
+                invariant_id=runtime_id,
+                diff_harness_owner_field_refs=runtime_diff_harness_owner_field_refs,
+                label=label,
+                coverage_label="runtime diff harness",
+            )
+        )
 
         runtime_surface_refs = record.get("dispatch_surface_ids")
         if not isinstance(runtime_surface_refs, list):
@@ -3335,6 +3346,7 @@ def _validate_invariants(
     transition_ids: dict[str, dict[str, Any]],
     registered_owner_fields: set[str],
     dispatch_surface_ids: set[str],
+    diff_harness_owner_field_refs: set[str],
 ) -> list[str]:
     failures: list[str] = []
     if not isinstance(invariants_doc, dict):
@@ -3398,6 +3410,16 @@ def _validate_invariants(
                     failures.append(
                         f"{label}: protected_fields references unregistered owner field: {field}"
                     )
+        failures.extend(
+            _validate_invariant_diff_harness_owner_field_coverage(
+                protected_fields=protected_fields,
+                invariant_id=invariant_id,
+                diff_harness_owner_field_refs=diff_harness_owner_field_refs,
+                label=label,
+                coverage_label="diff harness",
+                registered_owner_fields=registered_owner_fields,
+            )
+        )
 
         transition_refs = record.get("transition_ids")
         if isinstance(transition_refs, list):
@@ -3928,6 +3950,48 @@ def _invariant_protected_fields_by_invariant(
             if isinstance(field, str) and field.strip()
         }
     return protected_fields_by_invariant
+
+
+def _diff_harness_owner_field_refs(diff_harness_records: list[Any]) -> set[str]:
+    owner_field_refs: set[str] = set()
+    for record in diff_harness_records:
+        if not isinstance(record, dict):
+            continue
+        refs = record.get("owner_field_refs")
+        if not isinstance(refs, list):
+            continue
+        owner_field_refs.update(
+            field for field in refs if isinstance(field, str) and field.strip()
+        )
+    return owner_field_refs
+
+
+def _validate_invariant_diff_harness_owner_field_coverage(
+    *,
+    protected_fields: Any,
+    invariant_id: Any,
+    diff_harness_owner_field_refs: set[str],
+    label: str,
+    coverage_label: str,
+    registered_owner_fields: set[str] | None = None,
+) -> list[str]:
+    if not isinstance(invariant_id, str) or not invariant_id.strip():
+        return []
+    if not isinstance(protected_fields, list):
+        return []
+
+    failures: list[str] = []
+    for field in protected_fields:
+        if not isinstance(field, str) or not field.strip():
+            continue
+        if registered_owner_fields is not None and field not in registered_owner_fields:
+            continue
+        if field not in diff_harness_owner_field_refs:
+            failures.append(
+                f"{label}: invariant {invariant_id} protected field lacks "
+                f"{coverage_label} owner_field_refs coverage: {field}"
+            )
+    return failures
 
 
 def _invariant_protected_fields_by_dispatch_surface(
@@ -5211,6 +5275,18 @@ def validate_contract(
     runtime_dispatch_surface_ids = {
         record["surface_id"] for record in runtime_dispatch_surface_records
     }
+    if isinstance(diff_harness_doc, dict) and isinstance(
+        diff_harness_doc.get("diff_harness_checks"), list
+    ):
+        diff_harness_records = diff_harness_doc["diff_harness_checks"]
+    else:
+        diff_harness_records = []
+    diff_harness_owner_field_refs = _diff_harness_owner_field_refs(
+        diff_harness_records
+    )
+    runtime_diff_harness_owner_field_refs = _diff_harness_owner_field_refs(
+        runtime_diff_harness_records
+    )
     failures.extend(
         _validate_invariants(
             invariants_doc=invariants_doc,
@@ -5218,6 +5294,7 @@ def validate_contract(
             transition_ids=transition_ids,
             registered_owner_fields=registered_owner_fields,
             dispatch_surface_ids=dispatch_surface_ids,
+            diff_harness_owner_field_refs=diff_harness_owner_field_refs,
         )
     )
     if isinstance(invariants_doc, dict) and isinstance(
@@ -5233,6 +5310,9 @@ def validate_contract(
             invariant_records=invariant_records,
             runtime_transition_ids={record["id"] for record in runtime_transition_records},
             dispatch_surface_ids=runtime_dispatch_surface_ids,
+            runtime_diff_harness_owner_field_refs=(
+                runtime_diff_harness_owner_field_refs
+            ),
         )
     )
     invariant_ids = _collect_string_ids(
@@ -5263,12 +5343,6 @@ def validate_contract(
             generation_domain_ids=generation_domain_ids,
         )
     )
-    if isinstance(diff_harness_doc, dict) and isinstance(
-        diff_harness_doc.get("diff_harness_checks"), list
-    ):
-        diff_harness_records = diff_harness_doc["diff_harness_checks"]
-    else:
-        diff_harness_records = []
     failures.extend(
         _validate_generation_diff_harness_coverage(
             generation_domain_records=generation_domain_records,

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -603,6 +603,35 @@ static int AppStateInvariantProtectsField(const char *invariant_id,
                             metadata->protected_field_count, field);
 }
 
+static int AppStateDiffHarnessOwnerFieldCovered(const char *owner_field) {
+  size_t harness_index;
+
+  if (!NonEmptyString(owner_field))
+    return 0;
+
+  for (harness_index = 0; harness_index < AppStateDiffHarnessCount();
+       harness_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessAt(harness_index);
+    size_t ref_index;
+
+    if (harness == NULL || harness->owner_field_refs == NULL)
+      return 0;
+
+    for (ref_index = 0; ref_index < harness->owner_field_ref_count;
+         ref_index++) {
+      const char *harness_owner_field = harness->owner_field_refs[ref_index];
+
+      if (!NonEmptyString(harness_owner_field))
+        return 0;
+      if (strcmp(harness_owner_field, owner_field) == 0)
+        return 1;
+    }
+  }
+
+  return 0;
+}
+
 static int AppStateOwnerFieldsReady(void) {
   size_t index;
   size_t required_owner_field_id_count =
@@ -1042,6 +1071,8 @@ static int AppStateInvariantRegistryReady(void) {
       const char *field = metadata->protected_fields[protected_field_index];
 
       if (AppStateOwnerFieldLookup(field) == NULL)
+        return 0;
+      if (!AppStateDiffHarnessOwnerFieldCovered(field))
         return 0;
     }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -235,7 +235,7 @@ def _diff_harness(
         "snapshot_phases": ["before", "after"],
         "snapshot_regions": ["panel-local state"],
         "transition_ids": transition_ids or ["transition.keybinding"],
-        "owner_field_refs": owner_field_refs or ["field"],
+        "owner_field_refs": owner_field_refs or ["field", "panel.tree_selection_key"],
         "invariant_ids": invariant_ids or ["invariant.inactive_panel_frozen"],
         "generation_domain_ids": generation_domain_ids or ["domain.panel_generation"],
         "expected_behavior": "fixture expected behavior",
@@ -2459,6 +2459,28 @@ def test_guard_fails_when_diff_harness_references_unknown_owner_field(
     )
 
 
+def test_guard_fails_when_invariant_protected_field_lacks_diff_harness_owner_ref(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    for harness in diff_harness_checks:
+        harness["owner_field_refs"] = ["field"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, diff_harness_checks=diff_harness_checks
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "invariant[" in failure
+        and "protected field lacks diff harness owner_field_refs coverage" in failure
+        and "invariant." in failure
+        and "panel.tree_selection_key" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_diff_harness_references_unknown_invariant(
     tmp_path: Path,
 ) -> None:
@@ -2759,6 +2781,39 @@ def test_guard_fails_when_runtime_diff_harness_write_coverage_is_missing(
         and "lacks diff harness coverage" in failure
         and missing_transition_id in failure
         and "field" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_field_lacks_diff_harness_owner_ref(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_invariants = copy.deepcopy(_complete_invariants())
+    missing_owner_field_ref = "panel.tree_selection_key"
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    for harness in runtime_diff_harness_checks:
+        owner_field_refs = harness["owner_field_refs"]
+        assert isinstance(owner_field_refs, list)
+        harness["owner_field_refs"] = [
+            owner_field_ref
+            for owner_field_ref in owner_field_refs
+            if owner_field_ref != missing_owner_field_ref
+        ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=runtime_invariants,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_invariant[0]" in failure
+        and "protected field lacks runtime diff harness owner_field_refs coverage" in failure
+        and str(runtime_invariants[0]["invariant_id"]) in failure
+        and missing_owner_field_ref in failure
         for failure in failures
     )
 
@@ -6223,6 +6278,18 @@ def test_runtime_invariant_startup_validates_protected_fields_against_owner_regi
         r"const char \*field = "
         r"metadata->protected_fields\[protected_field_index\];\s*"
         r"if \(AppStateOwnerFieldLookup\(field\) == NULL\)\s*return 0;",
+        source,
+        re.S,
+    )
+
+
+def test_runtime_invariant_startup_requires_diff_harness_owner_field_coverage() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+
+    assert "AppStateDiffHarnessOwnerFieldCovered" in source
+    assert re.search(
+        r"if \(AppStateOwnerFieldLookup\(field\) == NULL\)\s*return 0;\s*"
+        r"if \(!AppStateDiffHarnessOwnerFieldCovered\(field\)\)\s*return 0;",
         source,
         re.S,
     )


### PR DESCRIPTION
## Summary
- require invariant protected fields to have diff-harness owner-field coverage
- add runtime startup fail-closed coverage for invariant/diff-harness mismatches
- add guard regressions for docs and runtime missing owner-field coverage

## Validation
- Local AppState guard tests: `pytest -q tests/test_appstate_contract_guard.py` — PASS
- Local contract guard: `python3 scripts/check_appstate_contract.py` — PASS
- Local build: `make clean && make` — PASS with pre-existing warnings
