### PR TITLE
chore(appstate): align diff harness invariants

### DIFF
--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -79,7 +79,8 @@
       "invariant_ids": [
         "invariant.panel-local-focus-restore",
         "invariant.shared-state-panel-local-isolation",
-        "invariant.blocked-transition-determinism"
+        "invariant.blocked-transition-determinism",
+        "invariant.inactive-panel-frozen"
       ],
       "generation_domain_ids": [
         "generation.panel.local-authority",
@@ -157,7 +158,9 @@
       "invariant_ids": [
         "invariant.stale-snapshot-fail-closed",
         "invariant.viewport-identity-rebind",
-        "invariant.hidden-entry-visible-navigation"
+        "invariant.hidden-entry-visible-navigation",
+        "invariant.render-projection-read-only",
+        "invariant.shared-state-panel-local-isolation"
       ],
       "generation_domain_ids": [
         "generation.panel.local-authority",

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2574,6 +2574,7 @@ def _validate_runtime_diff_harness_registry(
     runtime_owner_fields: set[str],
     runtime_invariant_ids: set[str],
     runtime_invariant_transition_ids: dict[str, set[str]],
+    runtime_invariant_protected_fields: dict[str, set[str]],
     runtime_generation_domain_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -2681,6 +2682,18 @@ def _validate_runtime_diff_harness_registry(
                         transition_field="transition_id",
                     )
                 )
+
+        if isinstance(owner_field_refs, list):
+            failures.extend(
+                _validate_diff_harness_owner_field_invariant_alignment(
+                    owner_field_refs=owner_field_refs,
+                    invariant_refs=invariant_refs,
+                    invariant_protected_fields=runtime_invariant_protected_fields,
+                    valid_owner_fields=runtime_owner_fields,
+                    valid_invariant_ids=runtime_invariant_ids,
+                    label=harness_label,
+                )
+            )
 
         generation_domain_refs = record.get("generation_domain_ids")
         if isinstance(generation_domain_refs, list):
@@ -3041,6 +3054,7 @@ def _validate_appstate_diff_harness(
     registered_owner_fields: set[str],
     invariant_ids: set[str],
     invariant_transition_ids: dict[str, set[str]],
+    invariant_protected_fields: dict[str, set[str]],
     generation_domain_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -3132,6 +3146,18 @@ def _validate_appstate_diff_harness(
                         transition_field="transition_id",
                     )
                 )
+
+        if isinstance(owner_field_refs, list):
+            failures.extend(
+                _validate_diff_harness_owner_field_invariant_alignment(
+                    owner_field_refs=owner_field_refs,
+                    invariant_refs=invariant_refs,
+                    invariant_protected_fields=invariant_protected_fields,
+                    valid_owner_fields=registered_owner_fields,
+                    valid_invariant_ids=invariant_ids,
+                    label=harness_label,
+                )
+            )
 
         generation_domain_refs = record.get("generation_domain_ids")
         if isinstance(generation_domain_refs, list):
@@ -4127,6 +4153,42 @@ def _validate_owner_field_invariant_alignment(
         f"{label}: invariant_checks must include at least one invariant "
         f"protecting owner field {owner_field}"
     ]
+
+
+def _validate_diff_harness_owner_field_invariant_alignment(
+    *,
+    owner_field_refs: Any,
+    invariant_refs: Any,
+    invariant_protected_fields: dict[str, set[str]],
+    valid_owner_fields: set[str],
+    valid_invariant_ids: set[str],
+    label: str,
+) -> list[str]:
+    if not isinstance(owner_field_refs, list):
+        return []
+    if not isinstance(invariant_refs, list):
+        return []
+
+    protected_fields: set[str] = set()
+    for invariant_id in invariant_refs:
+        if not isinstance(invariant_id, str) or not invariant_id.strip():
+            continue
+        if invariant_id not in valid_invariant_ids:
+            continue
+        protected_fields.update(invariant_protected_fields.get(invariant_id, set()))
+
+    failures: list[str] = []
+    for field in owner_field_refs:
+        if not isinstance(field, str) or not field.strip():
+            continue
+        if field not in valid_owner_fields:
+            continue
+        if field not in protected_fields:
+            failures.append(
+                f"{label}: invariant_ids must include at least one invariant "
+                f"protecting owner_field_refs field {field}"
+            )
+    return failures
 
 
 def _invariant_refs_cover_transition(
@@ -5340,6 +5402,9 @@ def validate_contract(
             invariant_transition_ids=_invariant_transition_ids_by_invariant(
                 invariant_records
             ),
+            invariant_protected_fields=_invariant_protected_fields_by_invariant(
+                invariant_records
+            ),
             generation_domain_ids=generation_domain_ids,
         )
     )
@@ -5365,6 +5430,9 @@ def validate_contract(
                 record["invariant_id"] for record in runtime_invariant_records
             },
             runtime_invariant_transition_ids=_invariant_transition_ids_by_invariant(
+                runtime_invariant_records
+            ),
+            runtime_invariant_protected_fields=_invariant_protected_fields_by_invariant(
                 runtime_invariant_records
             ),
             runtime_generation_domain_ids={

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -834,6 +834,7 @@ static const char *const kAppStateDiffHarnessInvariantIds1[] = {
   "invariant.panel-local-focus-restore",
   "invariant.shared-state-panel-local-isolation",
   "invariant.blocked-transition-determinism",
+  "invariant.inactive-panel-frozen",
 };
 
 static const char *const kAppStateDiffHarnessGenerationDomainIds1[] = {
@@ -926,6 +927,8 @@ static const char *const kAppStateDiffHarnessInvariantIds3[] = {
   "invariant.stale-snapshot-fail-closed",
   "invariant.viewport-identity-rebind",
   "invariant.hidden-entry-visible-navigation",
+  "invariant.render-projection-read-only",
+  "invariant.shared-state-panel-local-isolation",
 };
 
 static const char *const kAppStateDiffHarnessGenerationDomainIds3[] = {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1536,6 +1536,24 @@ static int AppStateDiffHarnessInvariantCoversTransition(
   return 0;
 }
 
+static int AppStateDiffHarnessInvariantProtectsOwnerField(
+    const AppStateDiffHarnessMetadata *metadata, const char *owner_field) {
+  size_t ref_index;
+
+  if (metadata == NULL || !NonEmptyString(owner_field) ||
+      !NonEmptyStringList(metadata->invariant_ids,
+                          metadata->invariant_id_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->invariant_id_count; ref_index++) {
+    if (AppStateInvariantProtectsField(metadata->invariant_ids[ref_index],
+                                       owner_field))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateDiffHarnessRegistryReady(void) {
   size_t generation_index;
   size_t index;
@@ -1602,6 +1620,12 @@ static int AppStateDiffHarnessRegistryReady(void) {
     for (ref_index = 0; ref_index < metadata->invariant_id_count;
          ref_index++) {
       if (AppStateInvariantLookup(metadata->invariant_ids[ref_index]) == NULL)
+        return 0;
+    }
+    for (ref_index = 0; ref_index < metadata->owner_field_ref_count;
+         ref_index++) {
+      if (!AppStateDiffHarnessInvariantProtectsOwnerField(
+              metadata, metadata->owner_field_refs[ref_index]))
         return 0;
     }
     for (ref_index = 0; ref_index < metadata->generation_domain_id_count;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1533,6 +1533,44 @@ def test_guard_fails_when_diff_harness_transition_lacks_same_harness_invariant(
     )
 
 
+def test_guard_fails_when_diff_harness_owner_field_lacks_same_harness_invariant(
+    tmp_path: Path,
+) -> None:
+    diff_harness_checks = _complete_diff_harness_checks()
+    harness = next(
+        record
+        for record in diff_harness_checks
+        if record["harness_id"] == "harness.transition_before_after_snapshot"
+    )
+    harness["owner_field_refs"] = ["panel.tree_selection_key"]
+    harness["invariant_ids"] = ["invariant.inactive_panel_frozen"]
+    invariants = _complete_invariants()
+    for invariant in invariants:
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen":
+            invariant["protected_fields"] = ["field"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=_complete_transitions(),
+        invariants=invariants,
+        diff_harness_checks=diff_harness_checks,
+        runtime_invariants=_complete_invariants(),
+        runtime_diff_harness_checks=_complete_diff_harness_checks(),
+    )
+
+    failures = _validate(paths)
+
+    expected = (
+        "invariant_ids must include at least one invariant protecting "
+        "owner_field_refs field panel.tree_selection_key"
+    )
+    assert any(
+        "diff_harness_check" in failure
+        and "harness.transition_before_after_snapshot" in failure
+        and expected in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_transition_sequence_diff_harness_misses_step_transition(
     tmp_path: Path,
 ) -> None:
@@ -1979,6 +2017,42 @@ def test_guard_fails_when_runtime_diff_harness_transition_lacks_same_harness_inv
         and "harness.transition_before_after_snapshot" in failure
         and "invariant_ids must include at least one invariant covering transition_id transition.keybinding"
         in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_diff_harness_owner_field_lacks_same_harness_invariant(
+    tmp_path: Path,
+) -> None:
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    harness = next(
+        record
+        for record in runtime_diff_harness_checks
+        if record["harness_id"] == "harness.transition_before_after_snapshot"
+    )
+    harness["owner_field_refs"] = ["panel.tree_selection_key"]
+    harness["invariant_ids"] = ["invariant.inactive_panel_frozen"]
+    runtime_invariants = _complete_invariants()
+    for invariant in runtime_invariants:
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen":
+            invariant["protected_fields"] = ["field"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=_complete_transitions(),
+        runtime_invariants=runtime_invariants,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    expected = (
+        "invariant_ids must include at least one invariant protecting "
+        "owner_field_refs field panel.tree_selection_key"
+    )
+    assert any(
+        "runtime_diff_harness" in failure
+        and "harness.transition_before_after_snapshot" in failure
+        and expected in failure
         for failure in failures
     )
 
@@ -6437,6 +6511,54 @@ def test_runtime_diff_harness_startup_checks_fail_closed() -> None:
         in source
     )
     assert "!AppStateDiffHarnessRegistryReady()" in source
+
+
+def test_runtime_diff_harness_startup_requires_owner_field_invariant() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index(
+        "static int AppStateDiffHarnessInvariantProtectsOwnerField("
+    )
+    ready_start = source.index("static int AppStateDiffHarnessRegistryReady(void)")
+    signal_start = source.index("static void SigIntHandler(int sig)")
+    helper_body = source[helper_start:ready_start]
+    ready_body = source[ready_start:signal_start]
+
+    assert re.search(
+        r"if \(metadata == NULL \|\| !NonEmptyString\(owner_field\) \|\|\s*"
+        r"!NonEmptyStringList\(metadata->invariant_ids,\s*"
+        r"metadata->invariant_id_count\)\)\s*"
+        r"return 0;\s*"
+        r"for \(ref_index = 0; "
+        r"ref_index < metadata->invariant_id_count; ref_index\+\+\) \{\s*"
+        r"if \(AppStateInvariantProtectsField\("
+        r"metadata->invariant_ids\[ref_index\],\s*owner_field\)\)\s*"
+        r"return 1;",
+        helper_body,
+        re.S,
+    )
+    assert re.search(
+        r"!NonEmptyStringList\(metadata->owner_field_refs,\s*"
+        r"metadata->owner_field_ref_count\).*?"
+        r"!NonEmptyStringList\(metadata->invariant_ids,\s*"
+        r"metadata->invariant_id_count\).*?"
+        r"for \(ref_index = 0; ref_index < metadata->owner_field_ref_count;\s*"
+        r"ref_index\+\+\) \{\s*"
+        r"if \(AppStateOwnerFieldLookup\("
+        r"metadata->owner_field_refs\[ref_index\]\) ==\s*NULL\)\s*"
+        r"return 0;\s*\}\s*"
+        r"for \(ref_index = 0; ref_index < metadata->invariant_id_count;\s*"
+        r"ref_index\+\+\) \{\s*"
+        r"if \(AppStateInvariantLookup\("
+        r"metadata->invariant_ids\[ref_index\]\) == NULL\)\s*"
+        r"return 0;\s*\}\s*"
+        r"for \(ref_index = 0; ref_index < metadata->owner_field_ref_count;\s*"
+        r"ref_index\+\+\) \{\s*"
+        r"if \(!AppStateDiffHarnessInvariantProtectsOwnerField\(\s*"
+        r"metadata,\s*metadata->owner_field_refs\[ref_index\]\)\)\s*"
+        r"return 0;",
+        ready_body,
+        re.S,
+    )
 
 
 def test_runtime_diff_harness_write_coverage_startup_checks_fail_closed() -> None:


### PR DESCRIPTION
## Summary
- require diff-harness owner-field references to be protected by invariants listed on the same harness
- align existing diff-harness metadata and runtime registry invariant lists with observed owner fields
- add guard and startup regressions for same-harness invariant coverage

## Validation
- Local AppState guard tests: `pytest -q tests/test_appstate_contract_guard.py` — PASS
- Local contract guard: `python3 scripts/check_appstate_contract.py` — PASS
- Local build: `make clean && make` — PASS with pre-existing warnings
