### PR TITLE
chore(appstate): require shim contract coverage

### DIFF
--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -9,6 +9,7 @@
       "old_authority_path": "ViewContext.hide_dot_files",
       "read_permission": "Allowed only as a derived compatibility mirror for helpers that have not yet accepted YtreeNovaPanel dotfile visibility.",
       "write_permission": "Write only when synchronizing from the active panel's authoritative dotfile_visibility during transition commit.",
+      "write_capability": "write_capable",
       "invariant_checks": [
         "invariant.hidden-entry-visible-navigation",
         "invariant.shared-state-panel-local-isolation"
@@ -16,7 +17,11 @@
       "removal_trigger": "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
       "target_transition": "transition.keybinding.navigate-tree",
       "follow_up_task": "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
-      "qa_enforcement": "check_appstate_contract.py requires this shim to declare permissions, invariants, target transition, and removal trigger."
+      "qa_enforcement": "check_appstate_contract.py requires this shim to declare permissions, invariants, target transition, and removal trigger.",
+      "owner_field_refs": [
+        "panel.tree_viewport_origin",
+        "panel.panel_generation"
+      ]
     },
     {
       "id": "shim.volume-saved-tree-index",
@@ -24,6 +29,7 @@
       "old_authority_path": "Volume.saved_tree_index",
       "read_permission": "Allowed only as a fallback breadcrumb when a stable path key has already failed to resolve.",
       "write_permission": "Do not write as primary restore authority; future writes must update stable identity keys and generation metadata first.",
+      "write_capability": "write_capable",
       "invariant_checks": [
         "invariant.viewport-identity-rebind",
         "invariant.stale-snapshot-fail-closed"
@@ -31,7 +37,13 @@
       "removal_trigger": "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
       "target_transition": "transition.rebuild-rebind-callback.panel-anchor",
       "follow_up_task": "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
-      "qa_enforcement": "check_appstate_contract.py keeps this debt visible until runtime migration removes the shim."
+      "qa_enforcement": "check_appstate_contract.py keeps this debt visible until runtime migration removes the shim.",
+      "owner_field_refs": [
+        "panel.tree_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.panel_generation"
+      ]
     },
     {
       "id": "shim.focused-window-session-flag",
@@ -39,6 +51,7 @@
       "old_authority_path": "ViewContext.focused_window",
       "read_permission": "Allowed for layout routing and footer context selection while AppState focus_shape migration is incomplete.",
       "write_permission": "Write only from transition commit after the active panel focus_shape has been updated.",
+      "write_capability": "write_capable",
       "invariant_checks": [
         "invariant.panel-local-focus-restore",
         "invariant.inactive-panel-frozen"
@@ -46,7 +59,11 @@
       "removal_trigger": "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
       "target_transition": "transition.keybinding.navigate-tree",
       "follow_up_task": "Move focus-shape authority from session mirrors into panel-local transition records.",
-      "qa_enforcement": "check_appstate_contract.py validates shim coverage and links it to an existing transition id."
+      "qa_enforcement": "check_appstate_contract.py validates shim coverage and links it to an existing transition id.",
+      "owner_field_refs": [
+        "panel.focus_shape",
+        "panel.panel_generation"
+      ]
     },
     {
       "id": "shim-render-derived-row-position",
@@ -54,6 +71,7 @@
       "old_authority_path": "disp_begin_pos + cursor_pos render-derived lookup",
       "read_permission": "Allowed only inside render projection or bounds-correction code after identity restore has run.",
       "write_permission": "Never write authoritative selection from this calculation.",
+      "write_capability": "read_only_projection",
       "invariant_checks": [
         "invariant.render-projection-read-only",
         "invariant.viewport-identity-rebind"
@@ -61,7 +79,12 @@
       "removal_trigger": "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
       "target_transition": "transition.render-reflow.project-state",
       "follow_up_task": "Audit render/reflow call sites for projection-only behavior during runtime migration.",
-      "qa_enforcement": "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage."
+      "qa_enforcement": "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage.",
+      "owner_field_refs": [
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin"
+      ]
     }
   ]
 }

--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -12,7 +12,7 @@
       "write_capability": "write_capable",
       "invariant_checks": [
         "invariant.hidden-entry-visible-navigation",
-        "invariant.shared-state-panel-local-isolation"
+        "invariant.inactive-panel-frozen"
       ],
       "removal_trigger": "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
       "target_transition": "transition.keybinding.navigate-tree",
@@ -21,6 +21,11 @@
       "owner_field_refs": [
         "panel.tree_viewport_origin",
         "panel.panel_generation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "identity.directory.stable-key",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -43,6 +48,13 @@
         "panel.tree_cursor_pos",
         "panel.tree_viewport_origin",
         "panel.panel_generation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "state.topology.volume",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -63,6 +75,10 @@
       "owner_field_refs": [
         "panel.focus_shape",
         "panel.panel_generation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus"
       ]
     },
     {
@@ -74,7 +90,7 @@
       "write_capability": "read_only_projection",
       "invariant_checks": [
         "invariant.render-projection-read-only",
-        "invariant.viewport-identity-rebind"
+        "invariant.blocked-transition-determinism"
       ],
       "removal_trigger": "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
       "target_transition": "transition.render-reflow.project-state",
@@ -84,6 +100,12 @@
         "panel.tree_cursor_pos",
         "panel.tree_viewport_origin",
         "panel.file_viewport_origin"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "reflow.layout.projection"
       ]
     }
   ]

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -73,8 +73,11 @@ typedef struct {
   const char *old_authority_path;
   const char *read_permission;
   const char *write_permission;
+  const char *write_capability;
   const char *const *invariant_checks;
   size_t invariant_check_count;
+  const char *const *owner_field_refs;
+  size_t owner_field_ref_count;
   const char *removal_trigger;
   const char *target_transition;
   const char *follow_up_task;

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -78,6 +78,8 @@ typedef struct {
   size_t invariant_check_count;
   const char *const *owner_field_refs;
   size_t owner_field_ref_count;
+  const char *const *generation_domain_refs;
+  size_t generation_domain_ref_count;
   const char *removal_trigger;
   const char *target_transition;
   const char *follow_up_task;

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -63,6 +63,7 @@ REQUIRED_SHIM_FIELDS = {
     "write_capability",
     "invariant_checks",
     "owner_field_refs",
+    "generation_domain_refs",
     "removal_trigger",
     "target_transition",
     "follow_up_task",
@@ -283,7 +284,7 @@ LIST_FIELDS = {
 }
 
 EVENT_LIST_FIELDS = LIST_FIELDS | {"trigger_paths"}
-SHIM_LIST_FIELDS = LIST_FIELDS | {"owner_field_refs"}
+SHIM_LIST_FIELDS = LIST_FIELDS | {"owner_field_refs", "generation_domain_refs"}
 VALID_SHIM_WRITE_CAPABILITIES = {
     "write_capable",
     "read_only_projection",
@@ -1621,6 +1622,7 @@ def _parse_runtime_shim_registry(
 
     invariant_tables: dict[str, list[str]] = {}
     owner_ref_tables: dict[str, list[str]] = {}
+    generation_domain_ref_tables: dict[str, list[str]] = {}
     failures: list[str] = []
     invariant_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
@@ -1652,6 +1654,21 @@ def _parse_runtime_shim_registry(
         owner_ref_tables[table_name] = values
         failures.extend(array_failures)
 
+    generation_domain_ref_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppStateCompatibilityShimGenerationDomainRefs[0-9]+)\[\]\s*=\s*\{"
+        r"(?P<body>.*?)\};",
+        re.S,
+    )
+    for generation_domain_ref_match in generation_domain_ref_re.finditer(source):
+        table_name = generation_domain_ref_match.group(1)
+        values, array_failures = _parse_string_initializer_array(
+            generation_domain_ref_match.group("body"),
+            table_name,
+        )
+        generation_domain_ref_tables[table_name] = values
+        failures.extend(array_failures)
+
     match = re.search(
         r"kAppStateCompatibilityShims\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
         source,
@@ -1673,6 +1690,9 @@ def _parse_runtime_shim_registry(
         r"\s*(?P<owner_refs>kAppStateCompatibilityShimOwnerFieldRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=owner_refs)\)\s*/"
         r"\s*sizeof\((?P=owner_refs)\[0\]\)\s*,"
+        r"\s*(?P<generation_refs>kAppStateCompatibilityShimGenerationDomainRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=generation_refs)\)\s*/"
+        r"\s*sizeof\((?P=generation_refs)\[0\]\)\s*,"
         r"\s*\"(?P<removal_trigger>[^\"]*)\"\s*,"
         r"\s*\"(?P<target_transition>[^\"]*)\"\s*,"
         r"\s*\"(?P<follow_up_task>[^\"]*)\"\s*,"
@@ -1694,6 +1714,15 @@ def _parse_runtime_shim_registry(
                 f"runtime_shim[{index}]: unknown owner-field-ref table: {owner_ref_table_name}"
             )
             owner_field_refs = []
+        generation_ref_table_name = row_match.group("generation_refs")
+        generation_domain_refs = generation_domain_ref_tables.get(
+            generation_ref_table_name
+        )
+        if generation_domain_refs is None:
+            failures.append(
+                f"runtime_shim[{index}]: unknown generation-domain-ref table: {generation_ref_table_name}"
+            )
+            generation_domain_refs = []
         records.append(
             {
                 "id": row_match.group("id"),
@@ -1704,6 +1733,7 @@ def _parse_runtime_shim_registry(
                 "write_capability": row_match.group("write_capability"),
                 "invariant_checks": invariant_checks,
                 "owner_field_refs": owner_field_refs,
+                "generation_domain_refs": generation_domain_refs,
                 "removal_trigger": row_match.group("removal_trigger"),
                 "target_transition": row_match.group("target_transition"),
                 "follow_up_task": row_match.group("follow_up_task"),
@@ -2764,6 +2794,7 @@ def _validate_runtime_shim_registry(
     runtime_owner_fields: set[str],
     runtime_invariant_ids: set[str],
     runtime_invariant_transition_ids: dict[str, set[str]],
+    runtime_generation_domain_owner_fields: dict[str, str],
 ) -> list[str]:
     failures: list[str] = []
     expected_shims = {
@@ -2795,6 +2826,7 @@ def _validate_runtime_shim_registry(
                 "write_capability",
                 "invariant_checks",
                 "owner_field_refs",
+                "generation_domain_refs",
                 "removal_trigger",
                 "target_transition",
                 "follow_up_task",
@@ -2847,6 +2879,22 @@ def _validate_runtime_shim_registry(
                 label=label,
                 invariant_field="invariant_checks",
                 transition_field="target_transition",
+            )
+        )
+        failures.extend(
+            _validate_each_shim_invariant_covers_transition(
+                invariant_refs=invariant_checks,
+                transition_id=target_transition,
+                invariant_transition_ids=runtime_invariant_transition_ids,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_shim_generation_domain_refs(
+                record=record,
+                generation_domain_owner_fields=runtime_generation_domain_owner_fields,
+                label=label,
+                registry_label="runtime generation domain registry",
             )
         )
 
@@ -2979,6 +3027,84 @@ def _validate_shim_owner_field_refs(
             failures.append(
                 f"{label}: owner_field_refs must be declared by "
                 f"target_transition write set {target_transition}: {owner_ref}"
+            )
+
+    return failures
+
+
+def _validate_shim_generation_domain_refs(
+    *,
+    record: dict[str, Any],
+    generation_domain_owner_fields: dict[str, str],
+    label: str,
+    registry_label: str,
+) -> list[str]:
+    failures = _validate_list_field(
+        value=record.get("generation_domain_refs"),
+        label=label,
+        field="generation_domain_refs",
+    )
+    if failures:
+        return failures
+
+    generation_domain_refs = record.get("generation_domain_refs")
+    owner_field_refs = record.get("owner_field_refs")
+    assert isinstance(generation_domain_refs, list)
+    seen: set[str] = set()
+    covered_generation_owner_fields: set[str] = set()
+    for index, ref in enumerate(generation_domain_refs):
+        assert isinstance(ref, str)
+        if ref in seen:
+            failures.append(f"{label}: duplicate generation_domain_refs[{index}]: {ref}")
+        seen.add(ref)
+        generation_owner_field = generation_domain_owner_fields.get(ref)
+        if generation_owner_field is None:
+            failures.append(
+                f"{label}: generation_domain_refs does not match {registry_label}: {ref}"
+            )
+        else:
+            covered_generation_owner_fields.add(generation_owner_field)
+
+    if (
+        _shim_write_capable(record.get("write_capability"))
+        and isinstance(owner_field_refs, list)
+        and not failures
+    ):
+        known_generation_owner_fields = set(generation_domain_owner_fields.values())
+        for owner_ref in owner_field_refs:
+            if (
+                isinstance(owner_ref, str)
+                and owner_ref in known_generation_owner_fields
+                and owner_ref not in covered_generation_owner_fields
+            ):
+                failures.append(
+                    f"{label}: generation_domain_refs must include a domain "
+                    f"whose generation_owner_field is {owner_ref}"
+                )
+
+    return failures
+
+
+def _validate_each_shim_invariant_covers_transition(
+    *,
+    invariant_refs: Any,
+    transition_id: Any,
+    invariant_transition_ids: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    if not isinstance(transition_id, str) or not transition_id.strip():
+        return []
+    if not isinstance(invariant_refs, list):
+        return []
+
+    failures: list[str] = []
+    for index, invariant_ref in enumerate(invariant_refs):
+        if not isinstance(invariant_ref, str) or not invariant_ref.strip():
+            continue
+        if transition_id not in invariant_transition_ids.get(invariant_ref, set()):
+            failures.append(
+                f"{label}: invariant_checks[{index}] must cover "
+                f"target_transition {transition_id}: {invariant_ref}"
             )
 
     return failures
@@ -5221,6 +5347,24 @@ def validate_contract(
         generation_domain_records = generation_domains_doc["generation_domains"]
     else:
         generation_domain_records = []
+    generation_domain_owner_fields = {
+        record["domain_id"]: record["generation_owner_field"]
+        for record in generation_domain_records
+        if isinstance(record, dict)
+        and isinstance(record.get("domain_id"), str)
+        and record["domain_id"].strip()
+        and isinstance(record.get("generation_owner_field"), str)
+        and record["generation_owner_field"].strip()
+    }
+    runtime_generation_domain_owner_fields = {
+        record["domain_id"]: record["generation_owner_field"]
+        for record in runtime_generation_domain_records
+        if isinstance(record, dict)
+        and isinstance(record.get("domain_id"), str)
+        and record["domain_id"].strip()
+        and isinstance(record.get("generation_owner_field"), str)
+        and record["generation_owner_field"].strip()
+    }
     failures.extend(
         _validate_runtime_generation_domain_registry(
             runtime_records=runtime_generation_domain_records,
@@ -5310,12 +5454,28 @@ def validate_contract(
             )
         )
         failures.extend(
+            _validate_each_shim_invariant_covers_transition(
+                invariant_refs=record.get("invariant_checks"),
+                transition_id=target_transition,
+                invariant_transition_ids=invariant_transition_ids,
+                label=label,
+            )
+        )
+        failures.extend(
             _validate_shim_owner_field_refs(
                 record=record,
                 registered_fields=registered_owner_fields,
                 transition_ids=transition_ids,
                 label=label,
                 registry_label="owner-field registry",
+            )
+        )
+        failures.extend(
+            _validate_shim_generation_domain_refs(
+                record=record,
+                generation_domain_owner_fields=generation_domain_owner_fields,
+                label=label,
+                registry_label="generation-domain registry",
             )
         )
     failures.extend(
@@ -5333,6 +5493,7 @@ def validate_contract(
             runtime_invariant_transition_ids=_invariant_transition_ids_by_invariant(
                 runtime_invariant_records
             ),
+            runtime_generation_domain_owner_fields=runtime_generation_domain_owner_fields,
         )
     )
 

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -60,7 +60,9 @@ REQUIRED_SHIM_FIELDS = {
     "old_authority_path",
     "read_permission",
     "write_permission",
+    "write_capability",
     "invariant_checks",
+    "owner_field_refs",
     "removal_trigger",
     "target_transition",
     "follow_up_task",
@@ -281,6 +283,12 @@ LIST_FIELDS = {
 }
 
 EVENT_LIST_FIELDS = LIST_FIELDS | {"trigger_paths"}
+SHIM_LIST_FIELDS = LIST_FIELDS | {"owner_field_refs"}
+VALID_SHIM_WRITE_CAPABILITIES = {
+    "write_capable",
+    "read_only_projection",
+    "no_write",
+}
 DISPATCH_LIST_FIELDS = {"migration_notes"}
 INVARIANT_LIST_FIELDS = {
     "protected_fields",
@@ -1612,6 +1620,7 @@ def _parse_runtime_shim_registry(
         return [], [f"{runtime_path}: failed to read: {exc}"]
 
     invariant_tables: dict[str, list[str]] = {}
+    owner_ref_tables: dict[str, list[str]] = {}
     failures: list[str] = []
     invariant_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
@@ -1628,6 +1637,21 @@ def _parse_runtime_shim_registry(
         invariant_tables[table_name] = values
         failures.extend(array_failures)
 
+    owner_ref_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppStateCompatibilityShimOwnerFieldRefs[0-9]+)\[\]\s*=\s*\{"
+        r"(?P<body>.*?)\};",
+        re.S,
+    )
+    for owner_ref_match in owner_ref_re.finditer(source):
+        table_name = owner_ref_match.group(1)
+        values, array_failures = _parse_string_initializer_array(
+            owner_ref_match.group("body"),
+            table_name,
+        )
+        owner_ref_tables[table_name] = values
+        failures.extend(array_failures)
+
     match = re.search(
         r"kAppStateCompatibilityShims\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
         source,
@@ -1642,9 +1666,13 @@ def _parse_runtime_shim_registry(
         r"\s*\"(?P<old_authority_path>[^\"]*)\"\s*,"
         r"\s*\"(?P<read_permission>[^\"]*)\"\s*,"
         r"\s*\"(?P<write_permission>[^\"]*)\"\s*,"
+        r"\s*\"(?P<write_capability>[^\"]*)\"\s*,"
         r"\s*(?P<invariants>kAppStateCompatibilityShimInvariantChecks[0-9]+)\s*,"
         r"\s*sizeof\((?P=invariants)\)\s*/"
         r"\s*sizeof\((?P=invariants)\[0\]\)\s*,"
+        r"\s*(?P<owner_refs>kAppStateCompatibilityShimOwnerFieldRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=owner_refs)\)\s*/"
+        r"\s*sizeof\((?P=owner_refs)\[0\]\)\s*,"
         r"\s*\"(?P<removal_trigger>[^\"]*)\"\s*,"
         r"\s*\"(?P<target_transition>[^\"]*)\"\s*,"
         r"\s*\"(?P<follow_up_task>[^\"]*)\"\s*,"
@@ -1659,6 +1687,13 @@ def _parse_runtime_shim_registry(
                 f"runtime_shim[{index}]: unknown invariant-check table: {invariant_table_name}"
             )
             invariant_checks = []
+        owner_ref_table_name = row_match.group("owner_refs")
+        owner_field_refs = owner_ref_tables.get(owner_ref_table_name)
+        if owner_field_refs is None:
+            failures.append(
+                f"runtime_shim[{index}]: unknown owner-field-ref table: {owner_ref_table_name}"
+            )
+            owner_field_refs = []
         records.append(
             {
                 "id": row_match.group("id"),
@@ -1666,7 +1701,9 @@ def _parse_runtime_shim_registry(
                 "old_authority_path": row_match.group("old_authority_path"),
                 "read_permission": row_match.group("read_permission"),
                 "write_permission": row_match.group("write_permission"),
+                "write_capability": row_match.group("write_capability"),
                 "invariant_checks": invariant_checks,
+                "owner_field_refs": owner_field_refs,
                 "removal_trigger": row_match.group("removal_trigger"),
                 "target_transition": row_match.group("target_transition"),
                 "follow_up_task": row_match.group("follow_up_task"),
@@ -2723,7 +2760,8 @@ def _validate_runtime_shim_registry(
     runtime_records: list[dict[str, Any]],
     runtime_path: Path,
     shim_records: list[Any],
-    runtime_transition_ids: set[str],
+    runtime_transition_ids: dict[str, dict[str, Any]],
+    runtime_owner_fields: set[str],
     runtime_invariant_ids: set[str],
     runtime_invariant_transition_ids: dict[str, set[str]],
 ) -> list[str]:
@@ -2754,7 +2792,9 @@ def _validate_runtime_shim_registry(
                 "old_authority_path",
                 "read_permission",
                 "write_permission",
+                "write_capability",
                 "invariant_checks",
+                "owner_field_refs",
                 "removal_trigger",
                 "target_transition",
                 "follow_up_task",
@@ -2765,6 +2805,8 @@ def _validate_runtime_shim_registry(
                         f"{label}: runtime {field} does not match shim "
                         f"{runtime_id}: {record.get(field)}"
                     )
+
+        failures.extend(_validate_shim_write_capability(record, label))
 
         invariant_checks = record.get("invariant_checks")
         if not isinstance(invariant_checks, list) or not invariant_checks:
@@ -2788,6 +2830,15 @@ def _validate_runtime_shim_registry(
                 f"{label}: target_transition does not match runtime transition "
                 f"registry: {target_transition}"
             )
+        failures.extend(
+            _validate_shim_owner_field_refs(
+                record=record,
+                registered_fields=runtime_owner_fields,
+                transition_ids=runtime_transition_ids,
+                label=label,
+                registry_label="runtime owner field registry",
+            )
+        )
         failures.extend(
             _validate_invariant_transition_alignment(
                 invariant_refs=invariant_checks,
@@ -2837,6 +2888,98 @@ def _validate_required_string_list(
     unknown_values = sorted(declared - required_values)
     if unknown_values:
         failures.append(f"{label}: unknown value(s): {', '.join(unknown_values)}")
+
+    return failures
+
+
+def _validate_shim_write_capability(record: dict[str, Any], label: str) -> list[str]:
+    value = record.get("write_capability")
+    if isinstance(value, str) and value in VALID_SHIM_WRITE_CAPABILITIES:
+        return []
+
+    allowed = ", ".join(sorted(VALID_SHIM_WRITE_CAPABILITIES))
+    return [f"{label}: write_capability must be one of {allowed}: {value}"]
+
+
+def _shim_write_capable(write_capability: Any) -> bool:
+    return write_capability == "write_capable"
+
+
+def _validate_owner_field_ref_list(
+    *,
+    refs: Any,
+    registered_fields: set[str],
+    label: str,
+    registry_label: str,
+) -> list[str]:
+    failures = _validate_list_field(
+        value=refs,
+        label=label,
+        field="owner_field_refs",
+    )
+    if failures:
+        return failures
+
+    seen: set[str] = set()
+    assert isinstance(refs, list)
+    for index, ref in enumerate(refs):
+        assert isinstance(ref, str)
+        if ref in seen:
+            failures.append(f"{label}: duplicate owner_field_refs[{index}]: {ref}")
+        seen.add(ref)
+        if ref not in registered_fields:
+            failures.append(
+                f"{label}: owner_field_refs does not match {registry_label}: {ref}"
+            )
+
+    return failures
+
+
+def _validate_shim_owner_field_refs(
+    *,
+    record: dict[str, Any],
+    registered_fields: set[str],
+    transition_ids: dict[str, dict[str, Any]],
+    label: str,
+    registry_label: str,
+) -> list[str]:
+    failures = _validate_owner_field_ref_list(
+        refs=record.get("owner_field_refs"),
+        registered_fields=registered_fields,
+        label=label,
+        registry_label=registry_label,
+    )
+    if failures:
+        return failures
+
+    if not _shim_write_capable(record.get("write_capability")):
+        return failures
+
+    target_transition = record.get("target_transition")
+    transition = (
+        transition_ids.get(target_transition)
+        if isinstance(target_transition, str)
+        else None
+    )
+    if transition is None:
+        return failures
+
+    declared_write_set = transition.get("declared_write_set")
+    if not isinstance(declared_write_set, list):
+        return failures
+    declared_writes = {
+        field
+        for field in declared_write_set
+        if isinstance(field, str) and field.strip()
+    }
+    owner_refs = record.get("owner_field_refs")
+    assert isinstance(owner_refs, list)
+    for owner_ref in owner_refs:
+        if owner_ref not in declared_writes:
+            failures.append(
+                f"{label}: owner_field_refs must be declared by "
+                f"target_transition write set {target_transition}: {owner_ref}"
+            )
 
     return failures
 
@@ -5131,7 +5274,7 @@ def validate_contract(
             _validate_required_fields(
                 record=record,
                 required_fields=REQUIRED_SHIM_FIELDS,
-                list_fields=LIST_FIELDS,
+                list_fields=SHIM_LIST_FIELDS,
                 label=label,
             )
         )
@@ -5148,6 +5291,7 @@ def validate_contract(
                 failures.append(
                     f"{label}: target_transition does not match a transition id: {target_transition}"
                 )
+        failures.extend(_validate_shim_write_capability(record, label))
         failures.extend(
             _validate_invariant_check_refs(
                 invariant_checks=record.get("invariant_checks"),
@@ -5165,13 +5309,25 @@ def validate_contract(
                 transition_field="target_transition",
             )
         )
+        failures.extend(
+            _validate_shim_owner_field_refs(
+                record=record,
+                registered_fields=registered_owner_fields,
+                transition_ids=transition_ids,
+                label=label,
+                registry_label="owner-field registry",
+            )
+        )
     failures.extend(
         _validate_runtime_shim_registry(
             runtime_records=runtime_shim_records,
             runtime_path=action_runtime_path,
             shim_records=shims,
             runtime_transition_ids={
-                record["id"] for record in runtime_transition_records
+                record["id"]: record for record in runtime_transition_records
+            },
+            runtime_owner_fields={
+                record["field"] for record in runtime_owner_field_records
             },
             runtime_invariant_ids=runtime_invariant_ids,
             runtime_invariant_transition_ids=_invariant_transition_ids_by_invariant(

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2136,6 +2136,29 @@ static const char *const kAppStateCompatibilityShimInvariantChecks3[] = {
   "invariant.viewport-identity-rebind",
 };
 
+static const char *const kAppStateCompatibilityShimOwnerFieldRefs0[] = {
+  "panel.tree_viewport_origin",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateCompatibilityShimOwnerFieldRefs1[] = {
+  "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateCompatibilityShimOwnerFieldRefs2[] = {
+  "panel.focus_shape",
+  "panel.panel_generation",
+};
+
+static const char *const kAppStateCompatibilityShimOwnerFieldRefs3[] = {
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+};
+
 static const char *const kAppStateInvariantProtectedFields0[] = {
   "ctx.active",
   "panel.volume_key",
@@ -3819,9 +3842,13 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    "ViewContext.hide_dot_files",
    "Allowed only as a derived compatibility mirror for helpers that have not yet accepted YtreeNovaPanel dotfile visibility.",
    "Write only when synchronizing from the active panel's authoritative dotfile_visibility during transition commit.",
+   "write_capable",
    kAppStateCompatibilityShimInvariantChecks0,
    sizeof(kAppStateCompatibilityShimInvariantChecks0) /
        sizeof(kAppStateCompatibilityShimInvariantChecks0[0]),
+   kAppStateCompatibilityShimOwnerFieldRefs0,
+   sizeof(kAppStateCompatibilityShimOwnerFieldRefs0) /
+       sizeof(kAppStateCompatibilityShimOwnerFieldRefs0[0]),
    "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
    "transition.keybinding.navigate-tree",
    "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
@@ -3831,9 +3858,13 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    "Volume.saved_tree_index",
    "Allowed only as a fallback breadcrumb when a stable path key has already failed to resolve.",
    "Do not write as primary restore authority; future writes must update stable identity keys and generation metadata first.",
+   "write_capable",
    kAppStateCompatibilityShimInvariantChecks1,
    sizeof(kAppStateCompatibilityShimInvariantChecks1) /
        sizeof(kAppStateCompatibilityShimInvariantChecks1[0]),
+   kAppStateCompatibilityShimOwnerFieldRefs1,
+   sizeof(kAppStateCompatibilityShimOwnerFieldRefs1) /
+       sizeof(kAppStateCompatibilityShimOwnerFieldRefs1[0]),
    "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
    "transition.rebuild-rebind-callback.panel-anchor",
    "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
@@ -3843,9 +3874,13 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    "ViewContext.focused_window",
    "Allowed for layout routing and footer context selection while AppState focus_shape migration is incomplete.",
    "Write only from transition commit after the active panel focus_shape has been updated.",
+   "write_capable",
    kAppStateCompatibilityShimInvariantChecks2,
    sizeof(kAppStateCompatibilityShimInvariantChecks2) /
        sizeof(kAppStateCompatibilityShimInvariantChecks2[0]),
+   kAppStateCompatibilityShimOwnerFieldRefs2,
+   sizeof(kAppStateCompatibilityShimOwnerFieldRefs2) /
+       sizeof(kAppStateCompatibilityShimOwnerFieldRefs2[0]),
    "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
    "transition.keybinding.navigate-tree",
    "Move focus-shape authority from session mirrors into panel-local transition records.",
@@ -3855,9 +3890,13 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    "disp_begin_pos + cursor_pos render-derived lookup",
    "Allowed only inside render projection or bounds-correction code after identity restore has run.",
    "Never write authoritative selection from this calculation.",
+   "read_only_projection",
    kAppStateCompatibilityShimInvariantChecks3,
    sizeof(kAppStateCompatibilityShimInvariantChecks3) /
        sizeof(kAppStateCompatibilityShimInvariantChecks3[0]),
+   kAppStateCompatibilityShimOwnerFieldRefs3,
+   sizeof(kAppStateCompatibilityShimOwnerFieldRefs3) /
+       sizeof(kAppStateCompatibilityShimOwnerFieldRefs3[0]),
    "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
    "transition.render-reflow.project-state",
    "Audit render/reflow call sites for projection-only behavior during runtime migration.",

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2118,7 +2118,7 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
 };
 static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {
   "invariant.hidden-entry-visible-navigation",
-  "invariant.shared-state-panel-local-isolation",
+  "invariant.inactive-panel-frozen",
 };
 
 static const char *const kAppStateCompatibilityShimInvariantChecks1[] = {
@@ -2133,7 +2133,7 @@ static const char *const kAppStateCompatibilityShimInvariantChecks2[] = {
 
 static const char *const kAppStateCompatibilityShimInvariantChecks3[] = {
   "invariant.render-projection-read-only",
-  "invariant.viewport-identity-rebind",
+  "invariant.blocked-transition-determinism",
 };
 
 static const char *const kAppStateCompatibilityShimOwnerFieldRefs0[] = {
@@ -2157,6 +2157,32 @@ static const char *const kAppStateCompatibilityShimOwnerFieldRefs3[] = {
   "panel.tree_cursor_pos",
   "panel.tree_viewport_origin",
   "panel.file_viewport_origin",
+};
+
+static const char *const kAppStateCompatibilityShimGenerationDomainRefs0[] = {
+  "generation.panel.local-authority",
+  "identity.directory.stable-key",
+  "state.visibility-filter.panel-volume",
+};
+
+static const char *const kAppStateCompatibilityShimGenerationDomainRefs1[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "state.topology.volume",
+  "lifecycle.volume.registry",
+};
+
+static const char *const kAppStateCompatibilityShimGenerationDomainRefs2[] = {
+  "generation.panel.local-authority",
+  "shape.panel.focus",
+};
+
+static const char *const kAppStateCompatibilityShimGenerationDomainRefs3[] = {
+  "generation.panel.local-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+  "reflow.layout.projection",
 };
 
 static const char *const kAppStateInvariantProtectedFields0[] = {
@@ -3849,6 +3875,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    kAppStateCompatibilityShimOwnerFieldRefs0,
    sizeof(kAppStateCompatibilityShimOwnerFieldRefs0) /
        sizeof(kAppStateCompatibilityShimOwnerFieldRefs0[0]),
+   kAppStateCompatibilityShimGenerationDomainRefs0,
+   sizeof(kAppStateCompatibilityShimGenerationDomainRefs0) /
+       sizeof(kAppStateCompatibilityShimGenerationDomainRefs0[0]),
    "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
    "transition.keybinding.navigate-tree",
    "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
@@ -3865,6 +3894,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    kAppStateCompatibilityShimOwnerFieldRefs1,
    sizeof(kAppStateCompatibilityShimOwnerFieldRefs1) /
        sizeof(kAppStateCompatibilityShimOwnerFieldRefs1[0]),
+   kAppStateCompatibilityShimGenerationDomainRefs1,
+   sizeof(kAppStateCompatibilityShimGenerationDomainRefs1) /
+       sizeof(kAppStateCompatibilityShimGenerationDomainRefs1[0]),
    "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
    "transition.rebuild-rebind-callback.panel-anchor",
    "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
@@ -3881,6 +3913,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    kAppStateCompatibilityShimOwnerFieldRefs2,
    sizeof(kAppStateCompatibilityShimOwnerFieldRefs2) /
        sizeof(kAppStateCompatibilityShimOwnerFieldRefs2[0]),
+   kAppStateCompatibilityShimGenerationDomainRefs2,
+   sizeof(kAppStateCompatibilityShimGenerationDomainRefs2) /
+       sizeof(kAppStateCompatibilityShimGenerationDomainRefs2[0]),
    "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
    "transition.keybinding.navigate-tree",
    "Move focus-shape authority from session mirrors into panel-local transition records.",
@@ -3897,6 +3932,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    kAppStateCompatibilityShimOwnerFieldRefs3,
    sizeof(kAppStateCompatibilityShimOwnerFieldRefs3) /
        sizeof(kAppStateCompatibilityShimOwnerFieldRefs3[0]),
+   kAppStateCompatibilityShimGenerationDomainRefs3,
+   sizeof(kAppStateCompatibilityShimGenerationDomainRefs3) /
+       sizeof(kAppStateCompatibilityShimGenerationDomainRefs3[0]),
    "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
    "transition.render-reflow.project-state",
    "Audit render/reflow call sites for projection-only behavior during runtime migration.",

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1140,9 +1140,53 @@ static int AppStateCompatibilityShimInvariantCoversTransition(
 
     if (invariant == NULL || invariant->transition_ids == NULL)
       return 0;
-    if (StringListContains(invariant->transition_ids,
-                           invariant->transition_id_count,
-                           metadata->target_transition))
+    if (!StringListContains(invariant->transition_ids,
+                            invariant->transition_id_count,
+                            metadata->target_transition))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int AppStateGenerationOwnerFieldRegistered(const char *owner_field) {
+  size_t domain_index;
+
+  if (!NonEmptyString(owner_field))
+    return 0;
+
+  for (domain_index = 0; domain_index < AppStateGenerationDomainCount();
+       domain_index++) {
+    const AppStateGenerationDomainMetadata *domain =
+        AppStateGenerationDomainAt(domain_index);
+
+    if (domain == NULL || !NonEmptyString(domain->generation_owner_field))
+      return 0;
+    if (strcmp(domain->generation_owner_field, owner_field) == 0)
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateCompatibilityShimGenerationDomainCoversOwnerField(
+    const AppStateCompatibilityShimMetadata *metadata,
+    const char *owner_field) {
+  size_t ref_index;
+
+  if (metadata == NULL || !NonEmptyString(owner_field) ||
+      metadata->generation_domain_refs == NULL)
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->generation_domain_ref_count;
+       ref_index++) {
+    const AppStateGenerationDomainMetadata *domain =
+        AppStateGenerationDomainLookup(
+            metadata->generation_domain_refs[ref_index]);
+
+    if (domain == NULL || !NonEmptyString(domain->generation_owner_field))
+      return 0;
+    if (strcmp(domain->generation_owner_field, owner_field) == 0)
       return 1;
   }
 
@@ -1161,6 +1205,7 @@ static int AppStateCompatibilityShimsReady(void) {
     const AppStateCompatibilityShimMetadata *metadata =
         AppStateCompatibilityShimAt(index);
     size_t invariant_index;
+    size_t generation_index;
     size_t previous_index;
     size_t ref_index;
     const AppStateTransitionMetadata *transition;
@@ -1175,6 +1220,8 @@ static int AppStateCompatibilityShimsReady(void) {
         metadata->invariant_check_count == 0 ||
         !NonEmptyStringList(metadata->owner_field_refs,
                             metadata->owner_field_ref_count) ||
+        !NonEmptyStringList(metadata->generation_domain_refs,
+                            metadata->generation_domain_ref_count) ||
         !NonEmptyString(metadata->removal_trigger) ||
         !NonEmptyString(metadata->target_transition) ||
         !NonEmptyString(metadata->follow_up_task) ||
@@ -1202,6 +1249,16 @@ static int AppStateCompatibilityShimsReady(void) {
           NULL)
         return 0;
     }
+    for (generation_index = 0;
+         generation_index < metadata->generation_domain_ref_count;
+         generation_index++) {
+      if (AppStateGenerationDomainLookup(
+              metadata->generation_domain_refs[generation_index]) == NULL)
+        return 0;
+      if (StringListContains(metadata->generation_domain_refs, generation_index,
+                             metadata->generation_domain_refs[generation_index]))
+        return 0;
+    }
     for (ref_index = 0; ref_index < metadata->owner_field_ref_count;
          ref_index++) {
       if (AppStateOwnerFieldLookup(metadata->owner_field_refs[ref_index]) ==
@@ -1214,6 +1271,12 @@ static int AppStateCompatibilityShimsReady(void) {
           !StringListContains(transition->declared_write_set,
                               transition->declared_write_set_count,
                               metadata->owner_field_refs[ref_index]))
+        return 0;
+      if (AppStateCompatibilityShimWriteCapable(metadata) &&
+          AppStateGenerationOwnerFieldRegistered(
+              metadata->owner_field_refs[ref_index]) &&
+          !AppStateCompatibilityShimGenerationDomainCoversOwnerField(
+              metadata, metadata->owner_field_refs[ref_index]))
         return 0;
     }
     if (!AppStateCompatibilityShimInvariantCoversTransition(metadata))

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1108,6 +1108,22 @@ static int AppStateInvariantRegistryReady(void) {
   return 1;
 }
 
+static int AppStateCompatibilityShimWriteCapable(
+    const AppStateCompatibilityShimMetadata *metadata) {
+  return metadata != NULL && metadata->write_capability != NULL &&
+         strcmp(metadata->write_capability, "write_capable") == 0;
+}
+
+static int AppStateCompatibilityShimWriteCapabilityKnown(
+    const AppStateCompatibilityShimMetadata *metadata) {
+  if (metadata == NULL || !NonEmptyString(metadata->write_capability))
+    return 0;
+
+  return strcmp(metadata->write_capability, "write_capable") == 0 ||
+         strcmp(metadata->write_capability, "read_only_projection") == 0 ||
+         strcmp(metadata->write_capability, "no_write") == 0;
+}
+
 static int AppStateCompatibilityShimInvariantCoversTransition(
     const AppStateCompatibilityShimMetadata *metadata) {
   size_t invariant_index;
@@ -1146,14 +1162,19 @@ static int AppStateCompatibilityShimsReady(void) {
         AppStateCompatibilityShimAt(index);
     size_t invariant_index;
     size_t previous_index;
+    size_t ref_index;
+    const AppStateTransitionMetadata *transition;
 
     if (metadata == NULL || !NonEmptyString(metadata->id) ||
         !NonEmptyString(metadata->owner) ||
         !NonEmptyString(metadata->old_authority_path) ||
         !NonEmptyString(metadata->read_permission) ||
         !NonEmptyString(metadata->write_permission) ||
+        !AppStateCompatibilityShimWriteCapabilityKnown(metadata) ||
         metadata->invariant_checks == NULL ||
         metadata->invariant_check_count == 0 ||
+        !NonEmptyStringList(metadata->owner_field_refs,
+                            metadata->owner_field_ref_count) ||
         !NonEmptyString(metadata->removal_trigger) ||
         !NonEmptyString(metadata->target_transition) ||
         !NonEmptyString(metadata->follow_up_task) ||
@@ -1163,6 +1184,7 @@ static int AppStateCompatibilityShimsReady(void) {
       return 0;
     if (AppStateTransitionLookup(metadata->target_transition) == NULL)
       return 0;
+    transition = AppStateTransitionLookup(metadata->target_transition);
 
     for (previous_index = 0; previous_index < index; previous_index++) {
       const AppStateCompatibilityShimMetadata *previous =
@@ -1178,6 +1200,20 @@ static int AppStateCompatibilityShimsReady(void) {
         return 0;
       if (AppStateInvariantLookup(metadata->invariant_checks[invariant_index]) ==
           NULL)
+        return 0;
+    }
+    for (ref_index = 0; ref_index < metadata->owner_field_ref_count;
+         ref_index++) {
+      if (AppStateOwnerFieldLookup(metadata->owner_field_refs[ref_index]) ==
+          NULL)
+        return 0;
+      if (StringListContains(metadata->owner_field_refs, ref_index,
+                             metadata->owner_field_refs[ref_index]))
+        return 0;
+      if (AppStateCompatibilityShimWriteCapable(metadata) &&
+          !StringListContains(transition->declared_write_set,
+                              transition->declared_write_set_count,
+                              metadata->owner_field_refs[ref_index]))
         return 0;
     }
     if (!AppStateCompatibilityShimInvariantCoversTransition(metadata))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -57,6 +57,7 @@ REQUIRED_LIST_FIELD_CASES = [
         "transition_sequence[0].step[0]",
     ),
     ("shim", "invariant_checks", "shim[0]"),
+    ("shim", "owner_field_refs", "shim[0]"),
     ("shim", "migration_notes", "shim[0]"),
 ]
 
@@ -86,14 +87,19 @@ def _transition(category: str, transition_id: str | None = None) -> dict[str, ob
     }
 
 
-def _shim(target_transition: str = "transition.keybinding") -> dict[str, object]:
+def _shim(
+    target_transition: str = "transition.keybinding",
+    owner_field_refs: list[str] | None = None,
+) -> dict[str, object]:
     return {
         "id": "shim.test",
         "owner": "owner",
         "old_authority_path": "legacy.path",
         "read_permission": "read",
         "write_permission": "write",
+        "write_capability": "write_capable",
         "invariant_checks": ["invariant.inactive_panel_frozen"],
+        "owner_field_refs": owner_field_refs or ["field"],
         "removal_trigger": "trigger",
         "target_transition": target_transition,
         "follow_up_task": "task",
@@ -676,6 +682,7 @@ def _runtime_source(
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
     shim_invariants = []
+    shim_owner_field_refs = []
     shim_rows = []
     for index, record in enumerate(shims):
         invariant_checks = record.get("invariant_checks")
@@ -688,14 +695,28 @@ def _runtime_source(
             "static const char *const kAppStateCompatibilityShimInvariantChecks"
             f"{index}[] = {{\n{invariant_rows}\n}};\n"
         )
+        owner_field_refs = record.get("owner_field_refs")
+        if not isinstance(owner_field_refs, list):
+            owner_field_refs = []
+        owner_ref_rows = "\n".join(
+            f'  "{field}",' for field in owner_field_refs if isinstance(field, str)
+        )
+        shim_owner_field_refs.append(
+            "static const char *const kAppStateCompatibilityShimOwnerFieldRefs"
+            f"{index}[] = {{\n{owner_ref_rows}\n}};\n"
+        )
         shim_rows.append(
             f'  {{"{record.get("id", "")}", "{record.get("owner", "")}", '
             f'"{record.get("old_authority_path", "")}", '
             f'"{record.get("read_permission", "")}", '
             f'"{record.get("write_permission", "")}", '
+            f'"{record.get("write_capability", "")}", '
             f"kAppStateCompatibilityShimInvariantChecks{index}, "
             f"sizeof(kAppStateCompatibilityShimInvariantChecks{index}) / "
             f"sizeof(kAppStateCompatibilityShimInvariantChecks{index}[0]), "
+            f"kAppStateCompatibilityShimOwnerFieldRefs{index}, "
+            f"sizeof(kAppStateCompatibilityShimOwnerFieldRefs{index}) / "
+            f"sizeof(kAppStateCompatibilityShimOwnerFieldRefs{index}[0]), "
             f'"{record.get("removal_trigger", "")}", '
             f'"{record.get("target_transition", "")}", '
             f'"{record.get("follow_up_task", "")}", '
@@ -963,6 +984,7 @@ def _runtime_source(
         + "".join(owner_field_arrays)
         + "".join(dispatch_surface_arrays)
         + "".join(shim_invariants)
+        + "".join(shim_owner_field_refs)
         + "".join(invariant_arrays)
         + "".join(generation_domain_arrays)
         + "".join(diff_harness_arrays)
@@ -4733,6 +4755,24 @@ def test_guard_fails_when_required_shim_field_is_missing(tmp_path: Path) -> None
     )
 
 
+def test_guard_fails_when_required_shim_owner_field_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim()
+    shim.pop("owner_field_refs")
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "missing required field" in failure
+        and "owner_field_refs" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_required_action_field_is_missing(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     actions = _complete_actions()
@@ -5005,6 +5045,155 @@ def test_guard_fails_when_shim_invariant_checks_do_not_cover_target_transition(
     )
 
 
+def test_guard_fails_when_shim_owner_field_ref_is_unknown(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(owner_field_refs=["field.unknown"])
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "owner_field_refs does not match owner-field registry" in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_shim_owner_field_ref_is_duplicated(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(owner_field_refs=["field", "field"])
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "duplicate owner_field_refs[1]" in failure
+        and "field" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_write_capable_shim_owner_field_is_outside_write_set(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(owner_field_refs=["panel.tree_selection_key"])
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "owner_field_refs must be declared by target_transition write set"
+        in failure
+        and "panel.tree_selection_key" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    "write_permission",
+    (
+        "Do not write stale mirror directly; write only from transition commit after canonical state changes.",
+        "No write should happen before transition commit; write the compatibility mirror after canonical state changes.",
+        "Never write before canonical state changes; write during the transition commit.",
+        "Read-only before commit; write the compatibility mirror after canonical state changes.",
+    ),
+)
+def test_guard_treats_explicit_write_capability_as_authoritative_over_prose(
+    tmp_path: Path, write_permission: str
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(owner_field_refs=["panel.tree_selection_key"])
+    shim["write_permission"] = write_permission
+    shim["write_capability"] = "write_capable"
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "owner_field_refs must be declared by target_transition write set"
+        in failure
+        and "panel.tree_selection_key" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_shim_write_capability_is_missing(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    shim = _shim()
+    shim.pop("write_capability")
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "write_capability" in failure
+        and "missing required field" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_shim_write_capability_is_unknown(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    shim = _shim()
+    shim["write_capability"] = "sometimes"
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "write_capability must be one of" in failure
+        and "sometimes" in failure
+        for failure in failures
+    )
+
+
+def test_guard_allows_no_write_shim_owner_field_outside_write_set(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(owner_field_refs=["panel.tree_selection_key"])
+    shim["write_permission"] = "Never write authoritative selection from this projection."
+    shim["write_capability"] = "no_write"
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert not any(
+        "shim[0]" in failure
+        and "owner_field_refs must be declared by target_transition write set"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_allows_read_only_projection_shim_owner_field_outside_write_set(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(owner_field_refs=["panel.tree_selection_key"])
+    shim["write_permission"] = "Read-only projection for render calculations."
+    shim["write_capability"] = "read_only_projection"
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert not any(
+        "shim[0]" in failure
+        and "owner_field_refs must be declared by target_transition write set"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_shim_metadata_drifts(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     runtime_shims = [_shim()]
@@ -5020,6 +5209,146 @@ def test_guard_fails_when_runtime_shim_metadata_drifts(tmp_path: Path) -> None:
     assert any(
         "runtime_shim[0]" in failure
         and "runtime owner does not match shim" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_owner_field_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim(owner_field_refs=["panel.tree_selection_key"])]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "runtime owner_field_refs does not match shim" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_owner_field_ref_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim(owner_field_refs=["field.unknown"])]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "owner_field_refs does not match runtime owner field registry"
+        in failure
+        and "field.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_write_capability_is_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim()]
+    runtime_shims[0]["write_capability"] = ""
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "write_capability must be one of" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_write_capability_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim()]
+    runtime_shims[0]["write_capability"] = "sometimes"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "write_capability must be one of" in failure
+        and "sometimes" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    "write_permission",
+    (
+        "Do not write stale mirror directly; write only from transition commit after canonical state changes.",
+        "No write should happen before transition commit; write the compatibility mirror after canonical state changes.",
+        "Never write before canonical state changes; write during the transition commit.",
+        "Read-only before commit; write the compatibility mirror after canonical state changes.",
+    ),
+)
+def test_guard_runtime_treats_explicit_write_capability_as_authoritative_over_prose(
+    tmp_path: Path, write_permission: str
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim(owner_field_refs=["panel.tree_selection_key"])]
+    runtime_shims[0]["write_permission"] = write_permission
+    runtime_shims[0]["write_capability"] = "write_capable"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "owner_field_refs must be declared by target_transition write set"
+        in failure
+        and "panel.tree_selection_key" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_write_capable_shim_owner_field_is_outside_write_set(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim(owner_field_refs=["panel.tree_selection_key"])]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "owner_field_refs must be declared by target_transition write set"
+        in failure
+        and "panel.tree_selection_key" in failure
         for failure in failures
     )
 
@@ -6452,6 +6781,52 @@ def test_runtime_shim_startup_requires_invariant_to_cover_target_transition() ->
     assert "invariant->transition_ids" in helper_body
     assert "invariant->transition_id_count" in helper_body
     assert "!AppStateCompatibilityShimInvariantCoversTransition(metadata)" in ready_body
+
+
+def test_runtime_shim_startup_requires_owner_field_refs() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
+    action_start = source.index("static int AppStateActionTransitionsReady(void)")
+    ready_body = source[ready_start:action_start]
+
+    assert "metadata->owner_field_refs" in ready_body
+    assert "metadata->owner_field_ref_count" in ready_body
+    assert "AppStateOwnerFieldLookup(metadata->owner_field_refs[ref_index])" in ready_body
+    assert re.search(
+        r"StringListContains\(metadata->owner_field_refs,\s*"
+        r"ref_index,\s*metadata->owner_field_refs\[ref_index\]\)",
+        ready_body,
+        re.S,
+    )
+
+
+def test_runtime_shim_startup_requires_write_refs_to_match_target_write_set() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index("static int AppStateCompatibilityShimWriteCapable(")
+    invariant_start = source.index(
+        "static int AppStateCompatibilityShimInvariantCoversTransition("
+    )
+    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
+    action_start = source.index("static int AppStateActionTransitionsReady(void)")
+    helper_body = source[helper_start:invariant_start]
+    ready_body = source[ready_start:action_start]
+
+    assert "metadata->write_capability" in helper_body
+    assert 'strcmp(metadata->write_capability, "write_capable") == 0' in helper_body
+    assert "strstr" not in helper_body
+    assert "write_permission" not in helper_body
+    assert "AppStateCompatibilityShimWriteCapabilityKnown(metadata)" in ready_body
+    assert '"read_only_projection"' in helper_body
+    assert '"no_write"' in helper_body
+    assert "const AppStateTransitionMetadata *transition" in ready_body
+    assert re.search(
+        r"AppStateCompatibilityShimWriteCapable\(metadata\).*?"
+        r"!StringListContains\(transition->declared_write_set,\s*"
+        r"transition->declared_write_set_count,\s*"
+        r"metadata->owner_field_refs\[ref_index\]\)",
+        ready_body,
+        re.S,
+    )
 
 
 def test_runtime_shim_startup_requires_documented_shim_ids() -> None:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -58,6 +58,7 @@ REQUIRED_LIST_FIELD_CASES = [
     ),
     ("shim", "invariant_checks", "shim[0]"),
     ("shim", "owner_field_refs", "shim[0]"),
+    ("shim", "generation_domain_refs", "shim[0]"),
     ("shim", "migration_notes", "shim[0]"),
 ]
 
@@ -90,6 +91,7 @@ def _transition(category: str, transition_id: str | None = None) -> dict[str, ob
 def _shim(
     target_transition: str = "transition.keybinding",
     owner_field_refs: list[str] | None = None,
+    generation_domain_refs: list[str] | None = None,
 ) -> dict[str, object]:
     return {
         "id": "shim.test",
@@ -100,6 +102,7 @@ def _shim(
         "write_capability": "write_capable",
         "invariant_checks": ["invariant.inactive_panel_frozen"],
         "owner_field_refs": owner_field_refs or ["field"],
+        "generation_domain_refs": generation_domain_refs or ["domain.panel_generation"],
         "removal_trigger": "trigger",
         "target_transition": target_transition,
         "follow_up_task": "task",
@@ -683,6 +686,7 @@ def _runtime_source(
         )
     shim_invariants = []
     shim_owner_field_refs = []
+    shim_generation_domain_refs = []
     shim_rows = []
     for index, record in enumerate(shims):
         invariant_checks = record.get("invariant_checks")
@@ -705,6 +709,18 @@ def _runtime_source(
             "static const char *const kAppStateCompatibilityShimOwnerFieldRefs"
             f"{index}[] = {{\n{owner_ref_rows}\n}};\n"
         )
+        generation_domain_refs = record.get("generation_domain_refs")
+        if not isinstance(generation_domain_refs, list):
+            generation_domain_refs = []
+        generation_ref_rows = "\n".join(
+            f'  "{domain_id}",'
+            for domain_id in generation_domain_refs
+            if isinstance(domain_id, str)
+        )
+        shim_generation_domain_refs.append(
+            "static const char *const kAppStateCompatibilityShimGenerationDomainRefs"
+            f"{index}[] = {{\n{generation_ref_rows}\n}};\n"
+        )
         shim_rows.append(
             f'  {{"{record.get("id", "")}", "{record.get("owner", "")}", '
             f'"{record.get("old_authority_path", "")}", '
@@ -717,6 +733,9 @@ def _runtime_source(
             f"kAppStateCompatibilityShimOwnerFieldRefs{index}, "
             f"sizeof(kAppStateCompatibilityShimOwnerFieldRefs{index}) / "
             f"sizeof(kAppStateCompatibilityShimOwnerFieldRefs{index}[0]), "
+            f"kAppStateCompatibilityShimGenerationDomainRefs{index}, "
+            f"sizeof(kAppStateCompatibilityShimGenerationDomainRefs{index}) / "
+            f"sizeof(kAppStateCompatibilityShimGenerationDomainRefs{index}[0]), "
             f'"{record.get("removal_trigger", "")}", '
             f'"{record.get("target_transition", "")}", '
             f'"{record.get("follow_up_task", "")}", '
@@ -985,6 +1004,7 @@ def _runtime_source(
         + "".join(dispatch_surface_arrays)
         + "".join(shim_invariants)
         + "".join(shim_owner_field_refs)
+        + "".join(shim_generation_domain_refs)
         + "".join(invariant_arrays)
         + "".join(generation_domain_arrays)
         + "".join(diff_harness_arrays)
@@ -4773,6 +4793,24 @@ def test_guard_fails_when_required_shim_owner_field_refs_are_missing(
     )
 
 
+def test_guard_fails_when_required_shim_generation_domain_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim()
+    shim.pop("generation_domain_refs")
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "missing required field" in failure
+        and "generation_domain_refs" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_required_action_field_is_missing(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     actions = _complete_actions()
@@ -5045,6 +5083,105 @@ def test_guard_fails_when_shim_invariant_checks_do_not_cover_target_transition(
     )
 
 
+def test_guard_fails_when_each_shim_invariant_check_lacks_generation_target_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim()
+    shim["invariant_checks"] = [
+        "invariant.inactive_panel_frozen",
+        "invariant.render_projection_read_only",
+    ]
+    invariants = _complete_invariants()
+    for invariant in invariants:
+        if invariant["invariant_id"] == "invariant.render_projection_read_only":
+            invariant["transition_ids"] = ["transition.render_reflow"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        shims=[shim],
+        invariants=invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "invariant_checks[1] must cover target_transition transition.keybinding"
+        in failure
+        and "invariant.render_projection_read_only" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_shim_generation_domain_ref_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(generation_domain_refs=["domain.unknown"])
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "generation_domain_refs does not match generation-domain registry"
+        in failure
+        and "domain.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_shim_generation_domain_ref_is_duplicated(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(
+        generation_domain_refs=["domain.panel_generation", "domain.panel_generation"]
+    )
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "duplicate generation_domain_refs[1]" in failure
+        and "domain.panel_generation" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_shim_generation_owner_ref_lacks_matching_domain(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transitions[0]["declared_write_set"] = ["field", "panel.panel_generation"]
+    owner_fields = _complete_owner_fields() + [_owner_field("panel.panel_generation")]
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["generation_owner_field"] = "panel.panel_generation"
+    generation_domains[0]["identity_fields"] = ["panel.panel_generation"]
+    shim = _shim(
+        owner_field_refs=["panel.panel_generation"],
+        generation_domain_refs=["domain.volume_generation"],
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        owner_fields=owner_fields,
+        generation_domains=generation_domains,
+        shims=[shim],
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "generation_domain_refs must include a domain whose "
+        "generation_owner_field is panel.panel_generation" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_shim_owner_field_ref_is_unknown(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     shim = _shim(owner_field_refs=["field.unknown"])
@@ -5229,6 +5366,132 @@ def test_guard_fails_when_runtime_shim_owner_field_refs_drift(
     assert any(
         "runtime_shim[0]" in failure
         and "runtime owner_field_refs does not match shim" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_generation_domain_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [
+        _shim(generation_domain_refs=["domain.panel_generation", "domain.volume_generation"])
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "runtime generation_domain_refs does not match shim" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_generation_domain_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim()]
+    runtime_shims[0].pop("generation_domain_refs")
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "generation_domain_refs must be non-empty" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_generation_domain_ref_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim(generation_domain_refs=["domain.unknown"])]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "generation_domain_refs does not match runtime generation domain registry"
+        in failure
+        and "domain.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_generation_domain_ref_is_duplicated(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [
+        _shim(
+            generation_domain_refs=[
+                "domain.panel_generation",
+                "domain.panel_generation",
+            ]
+        )
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "duplicate generation_domain_refs[1]" in failure
+        and "domain.panel_generation" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_generation_owner_ref_lacks_matching_domain(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transitions[0]["declared_write_set"] = ["field", "panel.panel_generation"]
+    owner_fields = _complete_owner_fields() + [_owner_field("panel.panel_generation")]
+    generation_domains = _complete_generation_domains()
+    generation_domains[0]["generation_owner_field"] = "panel.panel_generation"
+    generation_domains[0]["identity_fields"] = ["panel.panel_generation"]
+    runtime_shims = [
+        _shim(
+            owner_field_refs=["panel.panel_generation"],
+            generation_domain_refs=["domain.volume_generation"],
+        )
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        owner_fields=owner_fields,
+        generation_domains=generation_domains,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "generation_domain_refs must include a domain whose "
+        "generation_owner_field is panel.panel_generation" in failure
         for failure in failures
     )
 
@@ -5438,6 +5701,37 @@ def test_guard_fails_when_runtime_shim_invariant_checks_do_not_cover_target_tran
     )
 
 
+def test_guard_fails_when_each_runtime_shim_invariant_check_lacks_generation_target_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim()]
+    runtime_shims[0]["invariant_checks"] = [
+        "invariant.inactive_panel_frozen",
+        "invariant.render_projection_read_only",
+    ]
+    invariants = _complete_invariants()
+    for invariant in invariants:
+        if invariant["invariant_id"] == "invariant.render_projection_read_only":
+            invariant["transition_ids"] = ["transition.render_reflow"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+        invariants=invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "invariant_checks[1] must cover target_transition transition.keybinding"
+        in failure
+        and "invariant.render_projection_read_only" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_shim_invariant_checks_are_missing(
     tmp_path: Path,
 ) -> None:
@@ -5481,6 +5775,34 @@ def test_guard_preserves_runtime_shim_invariant_array_parse_failures(
 
     assert any(
         "kAppStateCompatibilityShimInvariantChecks0[0]" in failure
+        and "malformed string literal entry" in failure
+        and "NULL" in failure
+        for failure in failures
+    )
+
+
+def test_guard_preserves_runtime_shim_generation_domain_array_parse_failures(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    paths = _write_fixture(tmp_path, transitions=transitions)
+    runtime_path = paths[-1]
+    source = runtime_path.read_text(encoding="utf-8")
+    runtime_path.write_text(
+        source.replace(
+            'static const char *const kAppStateCompatibilityShimGenerationDomainRefs0[] = {\n'
+            '  "domain.panel_generation",',
+            "static const char *const kAppStateCompatibilityShimGenerationDomainRefs0[] = {\n"
+            "  NULL,",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateCompatibilityShimGenerationDomainRefs0[0]" in failure
         and "malformed string literal entry" in failure
         and "NULL" in failure
         for failure in failures
@@ -6780,6 +7102,7 @@ def test_runtime_shim_startup_requires_invariant_to_cover_target_transition() ->
     )
     assert "invariant->transition_ids" in helper_body
     assert "invariant->transition_id_count" in helper_body
+    assert "!StringListContains(invariant->transition_ids" in helper_body
     assert "!AppStateCompatibilityShimInvariantCoversTransition(metadata)" in ready_body
 
 
@@ -6798,6 +7121,43 @@ def test_runtime_shim_startup_requires_owner_field_refs() -> None:
         ready_body,
         re.S,
     )
+
+
+def test_runtime_shim_startup_requires_generation_domain_refs() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
+    action_start = source.index("static int AppStateActionTransitionsReady(void)")
+    ready_body = source[ready_start:action_start]
+
+    assert "metadata->generation_domain_refs" in ready_body
+    assert "metadata->generation_domain_ref_count" in ready_body
+    assert "AppStateGenerationDomainLookup(" in ready_body
+    assert re.search(
+        r"StringListContains\(metadata->generation_domain_refs,\s*"
+        r"generation_index,\s*"
+        r"metadata->generation_domain_refs\[generation_index\]\)",
+        ready_body,
+        re.S,
+    )
+
+
+def test_runtime_shim_startup_requires_generation_owner_refs_to_match_domains() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    owner_helper_start = source.index(
+        "static int AppStateGenerationOwnerFieldRegistered("
+    )
+    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
+    action_start = source.index("static int AppStateActionTransitionsReady(void)")
+    helper_body = source[owner_helper_start:ready_start]
+    ready_body = source[ready_start:action_start]
+
+    assert "AppStateGenerationDomainAt(domain_index)" in helper_body
+    assert "domain->generation_owner_field" in helper_body
+    assert "AppStateCompatibilityShimGenerationDomainCoversOwnerField(" in helper_body
+    assert "AppStateGenerationDomainLookup(" in helper_body
+    assert "metadata->generation_domain_refs[ref_index]" in helper_body
+    assert "AppStateGenerationOwnerFieldRegistered(" in ready_body
+    assert "AppStateCompatibilityShimGenerationDomainCoversOwnerField(" in ready_body
 
 
 def test_runtime_shim_startup_requires_write_refs_to_match_target_write_set() -> None:


### PR DESCRIPTION
## Summary
- require compatibility shims to declare AppState owner-field references and generation-domain coverage
- add explicit shim write-capability metadata so write-set enforcement is structured, not inferred from prose
- fail closed when docs/runtime shim metadata drifts or write-capable shims exceed target transition and generation contracts

## Validation
- Local AppState shim capability tests: `pytest -q tests/test_appstate_contract_guard.py -k 'write_capability or explicit_write_capability'` — PASS
- Local AppState shim owner tests: `pytest -q tests/test_appstate_contract_guard.py -k 'shim and owner'` — PASS
- Local AppState shim generation tests: `pytest -q tests/test_appstate_contract_guard.py -k 'shim and generation'` — PASS
- Local AppState guard tests: `pytest -q tests/test_appstate_contract_guard.py` — PASS
- Local contract guard: `python3 scripts/check_appstate_contract.py` — PASS
- Local build: `make clean && make` — PASS with pre-existing warnings