### PR TITLE
chore(appstate): require shim diff harness coverage

### DIFF
--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -26,6 +26,10 @@
         "generation.panel.local-authority",
         "identity.directory.stable-key",
         "state.visibility-filter.panel-volume"
+      ],
+      "diff_harness_refs": [
+        "harness.transition-before-after-snapshot",
+        "harness.generation-mismatch-check"
       ]
     },
     {
@@ -55,6 +59,10 @@
         "identity.directory.stable-key",
         "state.topology.volume",
         "lifecycle.volume.registry"
+      ],
+      "diff_harness_refs": [
+        "harness.transition-before-after-snapshot",
+        "harness.generation-mismatch-check"
       ]
     },
     {
@@ -79,6 +87,9 @@
       "generation_domain_refs": [
         "generation.panel.local-authority",
         "shape.panel.focus"
+      ],
+      "diff_harness_refs": [
+        "harness.declared-write-set-diff"
       ]
     },
     {
@@ -106,6 +117,11 @@
         "identity.directory.stable-key",
         "identity.file.stable-key",
         "reflow.layout.projection"
+      ],
+      "diff_harness_refs": [
+        "harness.render-projection-read-only-diff",
+        "harness.generation-mismatch-check",
+        "harness.blocked-transition-no-unrelated-mutation"
       ]
     }
   ]

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -80,6 +80,8 @@ typedef struct {
   size_t owner_field_ref_count;
   const char *const *generation_domain_refs;
   size_t generation_domain_ref_count;
+  const char *const *diff_harness_refs;
+  size_t diff_harness_ref_count;
   const char *removal_trigger;
   const char *target_transition;
   const char *follow_up_task;

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -64,6 +64,7 @@ REQUIRED_SHIM_FIELDS = {
     "invariant_checks",
     "owner_field_refs",
     "generation_domain_refs",
+    "diff_harness_refs",
     "removal_trigger",
     "target_transition",
     "follow_up_task",
@@ -284,7 +285,11 @@ LIST_FIELDS = {
 }
 
 EVENT_LIST_FIELDS = LIST_FIELDS | {"trigger_paths"}
-SHIM_LIST_FIELDS = LIST_FIELDS | {"owner_field_refs", "generation_domain_refs"}
+SHIM_LIST_FIELDS = LIST_FIELDS | {
+    "owner_field_refs",
+    "generation_domain_refs",
+    "diff_harness_refs",
+}
 VALID_SHIM_WRITE_CAPABILITIES = {
     "write_capable",
     "read_only_projection",
@@ -1623,6 +1628,7 @@ def _parse_runtime_shim_registry(
     invariant_tables: dict[str, list[str]] = {}
     owner_ref_tables: dict[str, list[str]] = {}
     generation_domain_ref_tables: dict[str, list[str]] = {}
+    diff_harness_ref_tables: dict[str, list[str]] = {}
     failures: list[str] = []
     invariant_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
@@ -1669,6 +1675,21 @@ def _parse_runtime_shim_registry(
         generation_domain_ref_tables[table_name] = values
         failures.extend(array_failures)
 
+    diff_harness_ref_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppStateCompatibilityShimDiffHarnessRefs[0-9]+)\[\]\s*=\s*\{"
+        r"(?P<body>.*?)\};",
+        re.S,
+    )
+    for diff_harness_ref_match in diff_harness_ref_re.finditer(source):
+        table_name = diff_harness_ref_match.group(1)
+        values, array_failures = _parse_string_initializer_array(
+            diff_harness_ref_match.group("body"),
+            table_name,
+        )
+        diff_harness_ref_tables[table_name] = values
+        failures.extend(array_failures)
+
     match = re.search(
         r"kAppStateCompatibilityShims\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
         source,
@@ -1693,6 +1714,9 @@ def _parse_runtime_shim_registry(
         r"\s*(?P<generation_refs>kAppStateCompatibilityShimGenerationDomainRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=generation_refs)\)\s*/"
         r"\s*sizeof\((?P=generation_refs)\[0\]\)\s*,"
+        r"\s*(?P<diff_refs>kAppStateCompatibilityShimDiffHarnessRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=diff_refs)\)\s*/"
+        r"\s*sizeof\((?P=diff_refs)\[0\]\)\s*,"
         r"\s*\"(?P<removal_trigger>[^\"]*)\"\s*,"
         r"\s*\"(?P<target_transition>[^\"]*)\"\s*,"
         r"\s*\"(?P<follow_up_task>[^\"]*)\"\s*,"
@@ -1723,6 +1747,13 @@ def _parse_runtime_shim_registry(
                 f"runtime_shim[{index}]: unknown generation-domain-ref table: {generation_ref_table_name}"
             )
             generation_domain_refs = []
+        diff_ref_table_name = row_match.group("diff_refs")
+        diff_harness_refs = diff_harness_ref_tables.get(diff_ref_table_name)
+        if diff_harness_refs is None:
+            failures.append(
+                f"runtime_shim[{index}]: unknown diff-harness-ref table: {diff_ref_table_name}"
+            )
+            diff_harness_refs = []
         records.append(
             {
                 "id": row_match.group("id"),
@@ -1734,6 +1765,7 @@ def _parse_runtime_shim_registry(
                 "invariant_checks": invariant_checks,
                 "owner_field_refs": owner_field_refs,
                 "generation_domain_refs": generation_domain_refs,
+                "diff_harness_refs": diff_harness_refs,
                 "removal_trigger": row_match.group("removal_trigger"),
                 "target_transition": row_match.group("target_transition"),
                 "follow_up_task": row_match.group("follow_up_task"),
@@ -2795,6 +2827,11 @@ def _validate_runtime_shim_registry(
     runtime_invariant_ids: set[str],
     runtime_invariant_transition_ids: dict[str, set[str]],
     runtime_generation_domain_owner_fields: dict[str, str],
+    runtime_diff_harness_ids: set[str],
+    runtime_diff_harness_transition_ids: dict[str, set[str]],
+    runtime_diff_harness_owner_field_refs: dict[str, set[str]],
+    runtime_diff_harness_invariant_ids: dict[str, set[str]],
+    runtime_diff_harness_generation_domain_ids: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     expected_shims = {
@@ -2827,6 +2864,7 @@ def _validate_runtime_shim_registry(
                 "invariant_checks",
                 "owner_field_refs",
                 "generation_domain_refs",
+                "diff_harness_refs",
                 "removal_trigger",
                 "target_transition",
                 "follow_up_task",
@@ -2895,6 +2933,32 @@ def _validate_runtime_shim_registry(
                 generation_domain_owner_fields=runtime_generation_domain_owner_fields,
                 label=label,
                 registry_label="runtime generation domain registry",
+            )
+        )
+        failures.extend(
+            _validate_shim_diff_harness_refs(
+                refs=record.get("diff_harness_refs"),
+                diff_harness_ids=runtime_diff_harness_ids,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_shim_diff_harness_transition_coverage(
+                diff_harness_refs=record.get("diff_harness_refs"),
+                transition_id=target_transition,
+                diff_harness_transition_ids=runtime_diff_harness_transition_ids,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_shim_diff_harness_union_coverage(
+                record=record,
+                diff_harness_owner_field_refs=runtime_diff_harness_owner_field_refs,
+                diff_harness_invariant_ids=runtime_diff_harness_invariant_ids,
+                diff_harness_generation_domain_ids=(
+                    runtime_diff_harness_generation_domain_ids
+                ),
+                label=label,
             )
         )
 
@@ -3080,6 +3144,104 @@ def _validate_shim_generation_domain_refs(
                 failures.append(
                     f"{label}: generation_domain_refs must include a domain "
                     f"whose generation_owner_field is {owner_ref}"
+                )
+
+    return failures
+
+
+def _validate_shim_diff_harness_refs(
+    *,
+    refs: Any,
+    diff_harness_ids: set[str],
+    label: str,
+) -> list[str]:
+    failures = _validate_list_field(
+        value=refs,
+        label=label,
+        field="diff_harness_refs",
+    )
+    if failures:
+        return failures
+
+    seen: set[str] = set()
+    assert isinstance(refs, list)
+    for index, ref in enumerate(refs):
+        assert isinstance(ref, str)
+        if ref in seen:
+            failures.append(f"{label}: duplicate diff_harness_refs[{index}]: {ref}")
+        seen.add(ref)
+        if ref not in diff_harness_ids:
+            failures.append(
+                f"{label}: diff_harness_refs references unknown diff harness id: {ref}"
+            )
+
+    return failures
+
+
+def _validate_shim_diff_harness_transition_coverage(
+    *,
+    diff_harness_refs: Any,
+    transition_id: Any,
+    diff_harness_transition_ids: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    if not isinstance(transition_id, str) or not transition_id.strip():
+        return []
+    if not isinstance(diff_harness_refs, list):
+        return []
+
+    for harness_id in diff_harness_refs:
+        if not isinstance(harness_id, str) or not harness_id.strip():
+            continue
+        if transition_id in diff_harness_transition_ids.get(harness_id, set()):
+            return []
+
+    return [
+        f"{label}: diff_harness_refs must include at least one diff harness "
+        f"covering target_transition {transition_id}"
+    ]
+
+
+def _validate_shim_diff_harness_union_coverage(
+    *,
+    record: dict[str, Any],
+    diff_harness_owner_field_refs: dict[str, set[str]],
+    diff_harness_invariant_ids: dict[str, set[str]],
+    diff_harness_generation_domain_ids: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    diff_harness_refs = record.get("diff_harness_refs")
+    if not isinstance(diff_harness_refs, list):
+        return []
+
+    covered_owner_fields: set[str] = set()
+    covered_invariants: set[str] = set()
+    covered_generation_domains: set[str] = set()
+    for harness_id in diff_harness_refs:
+        if not isinstance(harness_id, str) or not harness_id.strip():
+            continue
+        covered_owner_fields.update(diff_harness_owner_field_refs.get(harness_id, set()))
+        covered_invariants.update(diff_harness_invariant_ids.get(harness_id, set()))
+        covered_generation_domains.update(
+            diff_harness_generation_domain_ids.get(harness_id, set())
+        )
+
+    failures: list[str] = []
+    for field_name, covered_refs in (
+        ("owner_field_refs", covered_owner_fields),
+        ("invariant_checks", covered_invariants),
+        ("generation_domain_refs", covered_generation_domains),
+    ):
+        refs = record.get(field_name)
+        if not isinstance(refs, list):
+            continue
+        for index, ref in enumerate(refs):
+            if not isinstance(ref, str) or not ref.strip():
+                continue
+            if ref not in covered_refs:
+                failures.append(
+                    f"{label}: {field_name}[{index}] lacks referenced "
+                    f"diff_harness_refs coverage: {ref}"
                 )
 
     return failures
@@ -4203,6 +4365,26 @@ def _diff_harness_transition_ids_by_harness(
             if isinstance(transition_id, str) and transition_id.strip()
         }
     return transition_ids_by_harness
+
+
+def _diff_harness_string_refs_by_harness(
+    diff_harness_records: list[Any],
+    field: str,
+) -> dict[str, set[str]]:
+    refs_by_harness: dict[str, set[str]] = {}
+    for record in diff_harness_records:
+        if not isinstance(record, dict):
+            continue
+        harness_id = record.get("harness_id")
+        refs = record.get(field)
+        if not isinstance(harness_id, str) or not harness_id.strip():
+            continue
+        if not isinstance(refs, list):
+            continue
+        refs_by_harness[harness_id] = {
+            ref for ref in refs if isinstance(ref, str) and ref.strip()
+        }
+    return refs_by_harness
 
 
 def _invariant_transition_ids_by_invariant(
@@ -5399,6 +5581,56 @@ def validate_contract(
         )
     )
 
+    if isinstance(diff_harness_doc, dict) and isinstance(
+        diff_harness_doc.get("diff_harness_checks"), list
+    ):
+        diff_harness_records = diff_harness_doc["diff_harness_checks"]
+    else:
+        diff_harness_records = []
+    diff_harness_ids = _collect_string_ids(
+        diff_harness_doc,
+        collection_key="diff_harness_checks",
+        id_field="harness_id",
+    )
+    diff_harness_transition_ids = _diff_harness_transition_ids_by_harness(
+        diff_harness_records
+    )
+    diff_harness_owner_field_refs_by_harness = _diff_harness_string_refs_by_harness(
+        diff_harness_records,
+        "owner_field_refs",
+    )
+    diff_harness_invariant_ids_by_harness = _diff_harness_string_refs_by_harness(
+        diff_harness_records,
+        "invariant_ids",
+    )
+    diff_harness_generation_domain_ids_by_harness = (
+        _diff_harness_string_refs_by_harness(
+            diff_harness_records,
+            "generation_domain_ids",
+        )
+    )
+    runtime_diff_harness_transition_ids = _diff_harness_transition_ids_by_harness(
+        runtime_diff_harness_records
+    )
+    runtime_diff_harness_owner_field_refs_by_harness = (
+        _diff_harness_string_refs_by_harness(
+            runtime_diff_harness_records,
+            "owner_field_refs",
+        )
+    )
+    runtime_diff_harness_invariant_ids_by_harness = (
+        _diff_harness_string_refs_by_harness(
+            runtime_diff_harness_records,
+            "invariant_ids",
+        )
+    )
+    runtime_diff_harness_generation_domain_ids_by_harness = (
+        _diff_harness_string_refs_by_harness(
+            runtime_diff_harness_records,
+            "generation_domain_ids",
+        )
+    )
+
     if not isinstance(shims_doc, dict):
         failures.append(f"{shims_path}: top-level value must be an object")
         shims = []
@@ -5478,6 +5710,32 @@ def validate_contract(
                 registry_label="generation-domain registry",
             )
         )
+        failures.extend(
+            _validate_shim_diff_harness_refs(
+                refs=record.get("diff_harness_refs"),
+                diff_harness_ids=diff_harness_ids,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_shim_diff_harness_transition_coverage(
+                diff_harness_refs=record.get("diff_harness_refs"),
+                transition_id=target_transition,
+                diff_harness_transition_ids=diff_harness_transition_ids,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_shim_diff_harness_union_coverage(
+                record=record,
+                diff_harness_owner_field_refs=diff_harness_owner_field_refs_by_harness,
+                diff_harness_invariant_ids=diff_harness_invariant_ids_by_harness,
+                diff_harness_generation_domain_ids=(
+                    diff_harness_generation_domain_ids_by_harness
+                ),
+                label=label,
+            )
+        )
     failures.extend(
         _validate_runtime_shim_registry(
             runtime_records=runtime_shim_records,
@@ -5494,6 +5752,19 @@ def validate_contract(
                 runtime_invariant_records
             ),
             runtime_generation_domain_owner_fields=runtime_generation_domain_owner_fields,
+            runtime_diff_harness_ids={
+                record["harness_id"] for record in runtime_diff_harness_records
+            },
+            runtime_diff_harness_transition_ids=runtime_diff_harness_transition_ids,
+            runtime_diff_harness_owner_field_refs=(
+                runtime_diff_harness_owner_field_refs_by_harness
+            ),
+            runtime_diff_harness_invariant_ids=(
+                runtime_diff_harness_invariant_ids_by_harness
+            ),
+            runtime_diff_harness_generation_domain_ids=(
+                runtime_diff_harness_generation_domain_ids_by_harness
+            ),
         )
     )
 

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2185,6 +2185,26 @@ static const char *const kAppStateCompatibilityShimGenerationDomainRefs3[] = {
   "reflow.layout.projection",
 };
 
+static const char *const kAppStateCompatibilityShimDiffHarnessRefs0[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.generation-mismatch-check",
+};
+
+static const char *const kAppStateCompatibilityShimDiffHarnessRefs1[] = {
+  "harness.transition-before-after-snapshot",
+  "harness.generation-mismatch-check",
+};
+
+static const char *const kAppStateCompatibilityShimDiffHarnessRefs2[] = {
+  "harness.declared-write-set-diff",
+};
+
+static const char *const kAppStateCompatibilityShimDiffHarnessRefs3[] = {
+  "harness.render-projection-read-only-diff",
+  "harness.generation-mismatch-check",
+  "harness.blocked-transition-no-unrelated-mutation",
+};
+
 static const char *const kAppStateInvariantProtectedFields0[] = {
   "ctx.active",
   "panel.volume_key",
@@ -3878,6 +3898,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    kAppStateCompatibilityShimGenerationDomainRefs0,
    sizeof(kAppStateCompatibilityShimGenerationDomainRefs0) /
        sizeof(kAppStateCompatibilityShimGenerationDomainRefs0[0]),
+   kAppStateCompatibilityShimDiffHarnessRefs0,
+   sizeof(kAppStateCompatibilityShimDiffHarnessRefs0) /
+       sizeof(kAppStateCompatibilityShimDiffHarnessRefs0[0]),
    "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
    "transition.keybinding.navigate-tree",
    "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
@@ -3897,6 +3920,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    kAppStateCompatibilityShimGenerationDomainRefs1,
    sizeof(kAppStateCompatibilityShimGenerationDomainRefs1) /
        sizeof(kAppStateCompatibilityShimGenerationDomainRefs1[0]),
+   kAppStateCompatibilityShimDiffHarnessRefs1,
+   sizeof(kAppStateCompatibilityShimDiffHarnessRefs1) /
+       sizeof(kAppStateCompatibilityShimDiffHarnessRefs1[0]),
    "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
    "transition.rebuild-rebind-callback.panel-anchor",
    "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
@@ -3916,6 +3942,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    kAppStateCompatibilityShimGenerationDomainRefs2,
    sizeof(kAppStateCompatibilityShimGenerationDomainRefs2) /
        sizeof(kAppStateCompatibilityShimGenerationDomainRefs2[0]),
+   kAppStateCompatibilityShimDiffHarnessRefs2,
+   sizeof(kAppStateCompatibilityShimDiffHarnessRefs2) /
+       sizeof(kAppStateCompatibilityShimDiffHarnessRefs2[0]),
    "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
    "transition.keybinding.navigate-tree",
    "Move focus-shape authority from session mirrors into panel-local transition records.",
@@ -3935,6 +3964,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    kAppStateCompatibilityShimGenerationDomainRefs3,
    sizeof(kAppStateCompatibilityShimGenerationDomainRefs3) /
        sizeof(kAppStateCompatibilityShimGenerationDomainRefs3[0]),
+   kAppStateCompatibilityShimDiffHarnessRefs3,
+   sizeof(kAppStateCompatibilityShimDiffHarnessRefs3) /
+       sizeof(kAppStateCompatibilityShimDiffHarnessRefs3[0]),
    "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
    "transition.render-reflow.project-state",
    "Audit render/reflow call sites for projection-only behavior during runtime migration.",

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1193,6 +1193,106 @@ static int AppStateCompatibilityShimGenerationDomainCoversOwnerField(
   return 0;
 }
 
+static int AppStateCompatibilityShimDiffHarnessCoversTransition(
+    const AppStateCompatibilityShimMetadata *metadata) {
+  size_t ref_index;
+
+  if (metadata == NULL || !NonEmptyString(metadata->target_transition) ||
+      !NonEmptyStringList(metadata->diff_harness_refs,
+                          metadata->diff_harness_ref_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->diff_harness_ref_count;
+       ref_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessLookup(metadata->diff_harness_refs[ref_index]);
+
+    if (harness == NULL || harness->transition_ids == NULL)
+      return 0;
+    if (StringListContains(harness->transition_ids,
+                           harness->transition_id_count,
+                           metadata->target_transition))
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateCompatibilityShimDiffHarnessCoversOwnerField(
+    const AppStateCompatibilityShimMetadata *metadata,
+    const char *owner_field) {
+  size_t ref_index;
+
+  if (metadata == NULL || !NonEmptyString(owner_field) ||
+      !NonEmptyStringList(metadata->diff_harness_refs,
+                          metadata->diff_harness_ref_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->diff_harness_ref_count;
+       ref_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessLookup(metadata->diff_harness_refs[ref_index]);
+
+    if (harness == NULL || harness->owner_field_refs == NULL)
+      return 0;
+    if (StringListContains(harness->owner_field_refs,
+                           harness->owner_field_ref_count, owner_field))
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateCompatibilityShimDiffHarnessCoversInvariant(
+    const AppStateCompatibilityShimMetadata *metadata,
+    const char *invariant_id) {
+  size_t ref_index;
+
+  if (metadata == NULL || !NonEmptyString(invariant_id) ||
+      !NonEmptyStringList(metadata->diff_harness_refs,
+                          metadata->diff_harness_ref_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->diff_harness_ref_count;
+       ref_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessLookup(metadata->diff_harness_refs[ref_index]);
+
+    if (harness == NULL || harness->invariant_ids == NULL)
+      return 0;
+    if (StringListContains(harness->invariant_ids,
+                           harness->invariant_id_count, invariant_id))
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateCompatibilityShimDiffHarnessCoversGenerationDomain(
+    const AppStateCompatibilityShimMetadata *metadata,
+    const char *domain_id) {
+  size_t ref_index;
+
+  if (metadata == NULL || !NonEmptyString(domain_id) ||
+      !NonEmptyStringList(metadata->diff_harness_refs,
+                          metadata->diff_harness_ref_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->diff_harness_ref_count;
+       ref_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessLookup(metadata->diff_harness_refs[ref_index]);
+
+    if (harness == NULL || harness->generation_domain_ids == NULL)
+      return 0;
+    if (StringListContains(harness->generation_domain_ids,
+                           harness->generation_domain_id_count, domain_id))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateCompatibilityShimsReady(void) {
   size_t index;
   size_t required_shim_id_count =
@@ -1205,6 +1305,7 @@ static int AppStateCompatibilityShimsReady(void) {
     const AppStateCompatibilityShimMetadata *metadata =
         AppStateCompatibilityShimAt(index);
     size_t invariant_index;
+    size_t diff_index;
     size_t generation_index;
     size_t previous_index;
     size_t ref_index;
@@ -1222,6 +1323,8 @@ static int AppStateCompatibilityShimsReady(void) {
                             metadata->owner_field_ref_count) ||
         !NonEmptyStringList(metadata->generation_domain_refs,
                             metadata->generation_domain_ref_count) ||
+        !NonEmptyStringList(metadata->diff_harness_refs,
+                            metadata->diff_harness_ref_count) ||
         !NonEmptyString(metadata->removal_trigger) ||
         !NonEmptyString(metadata->target_transition) ||
         !NonEmptyString(metadata->follow_up_task) ||
@@ -1248,6 +1351,18 @@ static int AppStateCompatibilityShimsReady(void) {
       if (AppStateInvariantLookup(metadata->invariant_checks[invariant_index]) ==
           NULL)
         return 0;
+      if (!AppStateCompatibilityShimDiffHarnessCoversInvariant(
+              metadata, metadata->invariant_checks[invariant_index]))
+        return 0;
+    }
+    for (diff_index = 0; diff_index < metadata->diff_harness_ref_count;
+         diff_index++) {
+      if (AppStateDiffHarnessLookup(metadata->diff_harness_refs[diff_index]) ==
+          NULL)
+        return 0;
+      if (StringListContains(metadata->diff_harness_refs, diff_index,
+                             metadata->diff_harness_refs[diff_index]))
+        return 0;
     }
     for (generation_index = 0;
          generation_index < metadata->generation_domain_ref_count;
@@ -1257,6 +1372,9 @@ static int AppStateCompatibilityShimsReady(void) {
         return 0;
       if (StringListContains(metadata->generation_domain_refs, generation_index,
                              metadata->generation_domain_refs[generation_index]))
+        return 0;
+      if (!AppStateCompatibilityShimDiffHarnessCoversGenerationDomain(
+              metadata, metadata->generation_domain_refs[generation_index]))
         return 0;
     }
     for (ref_index = 0; ref_index < metadata->owner_field_ref_count;
@@ -1278,8 +1396,13 @@ static int AppStateCompatibilityShimsReady(void) {
           !AppStateCompatibilityShimGenerationDomainCoversOwnerField(
               metadata, metadata->owner_field_refs[ref_index]))
         return 0;
+      if (!AppStateCompatibilityShimDiffHarnessCoversOwnerField(
+              metadata, metadata->owner_field_refs[ref_index]))
+        return 0;
     }
     if (!AppStateCompatibilityShimInvariantCoversTransition(metadata))
+      return 0;
+    if (!AppStateCompatibilityShimDiffHarnessCoversTransition(metadata))
       return 0;
   }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -59,6 +59,7 @@ REQUIRED_LIST_FIELD_CASES = [
     ("shim", "invariant_checks", "shim[0]"),
     ("shim", "owner_field_refs", "shim[0]"),
     ("shim", "generation_domain_refs", "shim[0]"),
+    ("shim", "diff_harness_refs", "shim[0]"),
     ("shim", "migration_notes", "shim[0]"),
 ]
 
@@ -92,6 +93,7 @@ def _shim(
     target_transition: str = "transition.keybinding",
     owner_field_refs: list[str] | None = None,
     generation_domain_refs: list[str] | None = None,
+    diff_harness_refs: list[str] | None = None,
 ) -> dict[str, object]:
     return {
         "id": "shim.test",
@@ -103,6 +105,8 @@ def _shim(
         "invariant_checks": ["invariant.inactive_panel_frozen"],
         "owner_field_refs": owner_field_refs or ["field"],
         "generation_domain_refs": generation_domain_refs or ["domain.panel_generation"],
+        "diff_harness_refs": diff_harness_refs
+        or ["harness.transition_before_after_snapshot"],
         "removal_trigger": "trigger",
         "target_transition": target_transition,
         "follow_up_task": "task",
@@ -687,6 +691,7 @@ def _runtime_source(
     shim_invariants = []
     shim_owner_field_refs = []
     shim_generation_domain_refs = []
+    shim_diff_harness_refs = []
     shim_rows = []
     for index, record in enumerate(shims):
         invariant_checks = record.get("invariant_checks")
@@ -721,6 +726,18 @@ def _runtime_source(
             "static const char *const kAppStateCompatibilityShimGenerationDomainRefs"
             f"{index}[] = {{\n{generation_ref_rows}\n}};\n"
         )
+        diff_harness_refs = record.get("diff_harness_refs")
+        if not isinstance(diff_harness_refs, list):
+            diff_harness_refs = []
+        diff_ref_rows = "\n".join(
+            f'  "{harness_id}",'
+            for harness_id in diff_harness_refs
+            if isinstance(harness_id, str)
+        )
+        shim_diff_harness_refs.append(
+            "static const char *const kAppStateCompatibilityShimDiffHarnessRefs"
+            f"{index}[] = {{\n{diff_ref_rows}\n}};\n"
+        )
         shim_rows.append(
             f'  {{"{record.get("id", "")}", "{record.get("owner", "")}", '
             f'"{record.get("old_authority_path", "")}", '
@@ -736,6 +753,9 @@ def _runtime_source(
             f"kAppStateCompatibilityShimGenerationDomainRefs{index}, "
             f"sizeof(kAppStateCompatibilityShimGenerationDomainRefs{index}) / "
             f"sizeof(kAppStateCompatibilityShimGenerationDomainRefs{index}[0]), "
+            f"kAppStateCompatibilityShimDiffHarnessRefs{index}, "
+            f"sizeof(kAppStateCompatibilityShimDiffHarnessRefs{index}) / "
+            f"sizeof(kAppStateCompatibilityShimDiffHarnessRefs{index}[0]), "
             f'"{record.get("removal_trigger", "")}", '
             f'"{record.get("target_transition", "")}", '
             f'"{record.get("follow_up_task", "")}", '
@@ -1005,6 +1025,7 @@ def _runtime_source(
         + "".join(shim_invariants)
         + "".join(shim_owner_field_refs)
         + "".join(shim_generation_domain_refs)
+        + "".join(shim_diff_harness_refs)
         + "".join(invariant_arrays)
         + "".join(generation_domain_arrays)
         + "".join(diff_harness_arrays)
@@ -1130,7 +1151,10 @@ def _complete_diff_harness_checks() -> list[dict[str, object]]:
             if category == "transition_before_after_snapshot"
             else None,
             _complete_transition_ids(),
-            invariant_ids=["invariant.blocked_transition_determinism"],
+            invariant_ids=[
+                "invariant.blocked_transition_determinism",
+                "invariant.inactive_panel_frozen",
+            ],
             generation_domain_ids=_complete_generation_domain_ids(),
         )
         for category in REQUIRED_DIFF_HARNESS_CATEGORIES
@@ -4811,6 +4835,24 @@ def test_guard_fails_when_required_shim_generation_domain_refs_are_missing(
     )
 
 
+def test_guard_fails_when_required_shim_diff_harness_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim()
+    shim.pop("diff_harness_refs")
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "missing required field" in failure
+        and "diff_harness_refs" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_required_action_field_is_missing(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     actions = _complete_actions()
@@ -5214,6 +5256,108 @@ def test_guard_fails_when_shim_owner_field_ref_is_duplicated(
     )
 
 
+def test_guard_fails_when_shim_diff_harness_ref_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(diff_harness_refs=["harness.unknown"])
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "diff_harness_refs references unknown diff harness id" in failure
+        and "harness.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_shim_diff_harness_ref_is_duplicated(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim(
+        diff_harness_refs=[
+            "harness.transition_before_after_snapshot",
+            "harness.transition_before_after_snapshot",
+        ]
+    )
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "duplicate diff_harness_refs[1]" in failure
+        and "harness.transition_before_after_snapshot" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_shim_diff_harness_lacks_target_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    for harness in diff_harness_checks:
+        harness["transition_ids"] = ["transition.render_reflow"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        diff_harness_checks=diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "diff_harness_refs must include at least one diff harness covering"
+        in failure
+        and "transition.keybinding" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "expected_ref"),
+    (
+        ("owner_field_refs", ["panel.tree_selection_key"], "field"),
+        (
+            "invariant_ids",
+            ["invariant.blocked_transition_determinism"],
+            "invariant.inactive_panel_frozen",
+        ),
+        ("generation_domain_ids", ["domain.volume_generation"], "domain.panel_generation"),
+    ),
+)
+def test_guard_fails_when_shim_diff_harness_union_lacks_declared_coverage(
+    tmp_path: Path,
+    field: str,
+    replacement: list[str],
+    expected_ref: str,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    for harness in diff_harness_checks:
+        if harness["harness_id"] == "harness.transition_before_after_snapshot":
+            harness[field] = replacement
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        diff_harness_checks=diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "lacks referenced diff_harness_refs coverage" in failure
+        and expected_ref in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_write_capable_shim_owner_field_is_outside_write_set(
     tmp_path: Path,
 ) -> None:
@@ -5388,6 +5532,166 @@ def test_guard_fails_when_runtime_shim_generation_domain_refs_drift(
     assert any(
         "runtime_shim[0]" in failure
         and "runtime generation_domain_refs does not match shim" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_diff_harness_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [
+        _shim(
+            diff_harness_refs=[
+                "harness.transition_before_after_snapshot",
+                "harness.declared_write_set_diff",
+            ]
+        )
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "runtime diff_harness_refs does not match shim" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_diff_harness_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim()]
+    runtime_shims[0].pop("diff_harness_refs")
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "diff_harness_refs must be non-empty" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_diff_harness_ref_is_unknown(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim(diff_harness_refs=["harness.unknown"])]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "diff_harness_refs references unknown diff harness id" in failure
+        and "harness.unknown" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_diff_harness_ref_is_duplicated(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [
+        _shim(
+            diff_harness_refs=[
+                "harness.transition_before_after_snapshot",
+                "harness.transition_before_after_snapshot",
+            ]
+        )
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "duplicate diff_harness_refs[1]" in failure
+        and "harness.transition_before_after_snapshot" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_diff_harness_lacks_target_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    for harness in runtime_diff_harness_checks:
+        harness["transition_ids"] = ["transition.render_reflow"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "diff_harness_refs must include at least one diff harness covering"
+        in failure
+        and "transition.keybinding" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "expected_ref"),
+    (
+        ("owner_field_refs", ["panel.tree_selection_key"], "field"),
+        (
+            "invariant_ids",
+            ["invariant.blocked_transition_determinism"],
+            "invariant.inactive_panel_frozen",
+        ),
+        ("generation_domain_ids", ["domain.volume_generation"], "domain.panel_generation"),
+    ),
+)
+def test_guard_fails_when_runtime_shim_diff_harness_union_lacks_declared_coverage(
+    tmp_path: Path,
+    field: str,
+    replacement: list[str],
+    expected_ref: str,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_diff_harness_checks = _complete_diff_harness_checks()
+    for harness in runtime_diff_harness_checks:
+        if harness["harness_id"] == "harness.transition_before_after_snapshot":
+            harness[field] = replacement
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "lacks referenced diff_harness_refs coverage" in failure
+        and expected_ref in failure
         for failure in failures
     )
 
@@ -7138,6 +7442,52 @@ def test_runtime_shim_startup_requires_generation_domain_refs() -> None:
         r"metadata->generation_domain_refs\[generation_index\]\)",
         ready_body,
         re.S,
+    )
+
+
+def test_runtime_shim_startup_requires_diff_harness_refs() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
+    action_start = source.index("static int AppStateActionTransitionsReady(void)")
+    ready_body = source[ready_start:action_start]
+
+    assert "metadata->diff_harness_refs" in ready_body
+    assert "metadata->diff_harness_ref_count" in ready_body
+    assert "AppStateDiffHarnessLookup(metadata->diff_harness_refs[diff_index])" in ready_body
+    assert re.search(
+        r"StringListContains\(metadata->diff_harness_refs,\s*"
+        r"diff_index,\s*metadata->diff_harness_refs\[diff_index\]\)",
+        ready_body,
+        re.S,
+    )
+
+
+def test_runtime_shim_startup_requires_diff_harness_union_coverage() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index(
+        "static int AppStateCompatibilityShimDiffHarnessCoversTransition("
+    )
+    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
+    action_start = source.index("static int AppStateActionTransitionsReady(void)")
+    helper_body = source[helper_start:ready_start]
+    ready_body = source[ready_start:action_start]
+
+    assert "AppStateCompatibilityShimDiffHarnessCoversOwnerField(" in helper_body
+    assert "AppStateCompatibilityShimDiffHarnessCoversInvariant(" in helper_body
+    assert (
+        "AppStateCompatibilityShimDiffHarnessCoversGenerationDomain("
+        in helper_body
+    )
+    assert "harness->transition_ids" in helper_body
+    assert "harness->owner_field_refs" in helper_body
+    assert "harness->invariant_ids" in helper_body
+    assert "harness->generation_domain_ids" in helper_body
+    assert "AppStateCompatibilityShimDiffHarnessCoversTransition(metadata)" in ready_body
+    assert "AppStateCompatibilityShimDiffHarnessCoversOwnerField(" in ready_body
+    assert "AppStateCompatibilityShimDiffHarnessCoversInvariant(" in ready_body
+    assert (
+        "AppStateCompatibilityShimDiffHarnessCoversGenerationDomain("
+        in ready_body
     )
 
 


### PR DESCRIPTION
## Summary
- require compatibility shims to declare AppState diff-harness coverage
- fail closed when shim docs/runtime diff-harness metadata drifts or references unknown checks
- validate referenced harnesses cover each shim target transition, owner fields, invariants, and generation domains

## Validation
- Local AppState shim diff tests: `pytest -q tests/test_appstate_contract_guard.py -k 'shim and diff'` — PASS
- Local AppState shim generation tests: `pytest -q tests/test_appstate_contract_guard.py -k 'shim and generation'` — PASS
- Local AppState shim owner tests: `pytest -q tests/test_appstate_contract_guard.py -k 'shim and owner'` — PASS
- Local AppState guard tests: `pytest -q tests/test_appstate_contract_guard.py` — PASS
- Local contract guard: `python3 scripts/check_appstate_contract.py` — PASS
- Local build: `make clean && make` — PASS with pre-existing warnings
