### PR TITLE
chore(appstate): require dispatch sequence coverage

### DIFF
--- a/docs/appstate_dispatch_surfaces.json
+++ b/docs/appstate_dispatch_surfaces.json
@@ -13,6 +13,9 @@
       "allowed_direct_writes": [],
       "migration_notes": [
         "Current input polling and key normalization feed controller dispatch; AppState mutation remains in downstream handlers until runtime transition objects are introduced."
+      ],
+      "transition_sequence_refs": [
+        "sequence.split-toggle-f8"
       ]
     },
     {
@@ -31,6 +34,9 @@
       ],
       "migration_notes": [
         "Current directory-window switch dispatch owns tree navigation and focus updates; later migration should route each action through canonical transition boundaries."
+      ],
+      "transition_sequence_refs": [
+        "sequence.split-toggle-f8"
       ]
     },
     {
@@ -46,6 +52,9 @@
       ],
       "migration_notes": [
         "Current file-window dispatch remains under the broad keybinding foundation; only writes shared with the navigate-tree contract stay authorized until file-specific transitions are split out."
+      ],
+      "transition_sequence_refs": [
+        "sequence.file-small-big-transitions"
       ]
     },
     {
@@ -58,6 +67,9 @@
       "allowed_direct_writes": [],
       "migration_notes": [
         "Current menu and modal choice completion returns a selected key to callers; AppState modal writes remain with the caller until modal transition boundaries are introduced."
+      ],
+      "transition_sequence_refs": [
+        "sequence.esc-modal-dismissal"
       ]
     },
     {
@@ -76,6 +88,9 @@
       ],
       "migration_notes": [
         "Current resize dispatch converts KEY_RESIZE and resize_request state into controller refresh handling; signal-safe work must remain outside asynchronous handlers."
+      ],
+      "transition_sequence_refs": [
+        "sequence.terminal-resize-reflow"
       ]
     },
     {
@@ -94,6 +109,9 @@
       ],
       "migration_notes": [
         "Current safe refresh saves state, rescans, restores, and rebinds panel anchors; migration must preserve that ordering at the transition boundary."
+      ],
+      "transition_sequence_refs": [
+        "sequence.refresh-rebuild"
       ]
     },
     {
@@ -113,6 +131,9 @@
       ],
       "migration_notes": [
         "Current filesystem command handlers refresh and rebind after successful mutations; only completed mutation results should commit AppState metadata."
+      ],
+      "transition_sequence_refs": [
+        "sequence.filesystem-mutation-result"
       ]
     },
     {
@@ -131,6 +152,9 @@
       ],
       "migration_notes": [
         "Current loaded-volume selection and cycling update panel bindings directly; migration must preserve inactive panel restore records."
+      ],
+      "transition_sequence_refs": [
+        "sequence.volume-cycling-release"
       ]
     },
     {
@@ -143,6 +167,9 @@
       "allowed_direct_writes": [],
       "migration_notes": [
         "Current watcher processing reports settled filesystem activity to input dispatch; topology mutation remains mapped to the broad refresh/rebuild transition."
+      ],
+      "transition_sequence_refs": [
+        "sequence.refresh-rebuild"
       ]
     },
     {
@@ -155,6 +182,9 @@
       "allowed_direct_writes": [],
       "migration_notes": [
         "Current render refresh projects settled state to ncurses windows; projection must not become selection, viewport, or topology authority."
+      ],
+      "transition_sequence_refs": [
+        "sequence.render-reflow-projection"
       ]
     }
   ]

--- a/docs/appstate_transition_sequences.json
+++ b/docs/appstate_transition_sequences.json
@@ -820,6 +820,86 @@
           ]
         }
       ]
+    },
+    {
+      "scenario_id": "sequence.terminal-resize-reflow",
+      "category": "terminal_resize",
+      "flow": "terminal_resize_reflow",
+      "description": "Handle terminal resize events with layout, window-handle, viewport, and generation coverage.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "terminal-resize-event",
+          "transition_id": "transition.terminal-signal-resize",
+          "stimulus": {
+            "event_id": "event.terminal-resize-signal"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.render-projection-read-only",
+            "invariant.viewport-identity-rebind"
+          ],
+          "diff_harness_ids": [
+            "harness.generation-mismatch-check"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "reflow.layout.projection",
+              "expectation": "Layout reflow generation changes only through the resize transition."
+            },
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Panel generation validates before viewport rebind after resize."
+            },
+            {
+              "domain_id": "identity.directory.stable-key",
+              "expectation": "Directory identity remains durable while viewport geometry is rebound."
+            },
+            {
+              "domain_id": "identity.file.stable-key",
+              "expectation": "File identity remains durable while viewport geometry is rebound."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "scenario_id": "sequence.render-reflow-projection",
+      "category": "render_reflow",
+      "flow": "render_reflow_projection",
+      "description": "Project settled AppState to render output without mutating authoritative owner fields.",
+      "steps": [
+        {
+          "ordinal": 1,
+          "step_id": "render-reflow-event",
+          "transition_id": "transition.render-reflow.project-state",
+          "stimulus": {
+            "event_id": "event.render-reflow"
+          },
+          "expected_result": "allowed",
+          "invariant_ids": [
+            "invariant.render-projection-read-only",
+            "invariant.blocked-transition-determinism"
+          ],
+          "diff_harness_ids": [
+            "harness.render-projection-read-only-diff"
+          ],
+          "generation_domain_expectations": [
+            {
+              "domain_id": "reflow.layout.projection",
+              "expectation": "Render projection consumes layout reflow state without claiming owner authority."
+            },
+            {
+              "domain_id": "generation.panel.local-authority",
+              "expectation": "Panel generation remains an input to projection, not a render-owned mutation."
+            },
+            {
+              "domain_id": "generation.volume.shared-authority",
+              "expectation": "Volume generation remains an input to projection, not a render-owned mutation."
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -63,6 +63,8 @@ typedef struct {
   const char *boundary_status;
   const char *const *allowed_direct_writes;
   size_t allowed_direct_write_count;
+  const char *const *transition_sequence_refs;
+  size_t transition_sequence_ref_count;
   const char *const *migration_notes;
   size_t migration_note_count;
 } AppStateDispatchSurfaceMetadata;

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -147,7 +147,9 @@ REQUIRED_SEQUENCE_CATEGORIES = {
     "modal_command",
     "panel_navigation",
     "refresh_rebuild",
+    "render_reflow",
     "search_jump",
+    "terminal_resize",
     "visibility_filter",
     "volume_lifecycle",
 }
@@ -159,11 +161,13 @@ REQUIRED_SEQUENCE_FLOWS = {
     "file_small_big_transitions",
     "filesystem_mutation_result",
     "refresh_rebuild",
+    "render_reflow_projection",
     "search_jump",
     "showall_global_tagged_only",
     "split_close_reopen",
     "split_toggle_f8",
     "tab_panel_switch",
+    "terminal_resize_reflow",
     "volume_cycling_release",
 }
 
@@ -173,6 +177,7 @@ REQUIRED_DISPATCH_SURFACE_FIELDS = {
     "source_path",
     "entry_symbol_or_path",
     "transition_id",
+    "transition_sequence_refs",
     "boundary_status",
     "allowed_direct_writes",
     "migration_notes",
@@ -295,7 +300,7 @@ VALID_SHIM_WRITE_CAPABILITIES = {
     "read_only_projection",
     "no_write",
 }
-DISPATCH_LIST_FIELDS = {"migration_notes"}
+DISPATCH_LIST_FIELDS = {"migration_notes", "transition_sequence_refs"}
 INVARIANT_LIST_FIELDS = {
     "protected_fields",
     "transition_ids",
@@ -947,6 +952,7 @@ def _parse_runtime_dispatch_surface_registry(
 
     array_fields = {
         "AllowedDirectWrites": "allowed_direct_writes",
+        "TransitionSequenceRefs": "transition_sequence_refs",
         "MigrationNotes": "migration_notes",
     }
     arrays: dict[str, list[str]] = {}
@@ -988,6 +994,10 @@ def _parse_runtime_dispatch_surface_registry(
         r"\s*(?:(?P<allowed_direct_write_zero>0)|"
         r"sizeof\((?P=allowed_direct_writes)\)\s*/"
         r"\s*sizeof\((?P=allowed_direct_writes)\[0\]\))\s*,"
+        r"\s*(?P<transition_sequence_refs>"
+        r"kAppStateDispatchSurfaceTransitionSequenceRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=transition_sequence_refs)\)\s*/"
+        r"\s*sizeof\((?P=transition_sequence_refs)\[0\]\)\s*,"
         r"\s*(?P<migration_notes>kAppStateDispatchSurfaceMigrationNotes[0-9]+)\s*,"
         r"\s*sizeof\((?P=migration_notes)\)\s*/"
         r"\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
@@ -1014,7 +1024,11 @@ def _parse_runtime_dispatch_surface_registry(
             "transition_id": row_match.group("transition_id"),
             "boundary_status": row_match.group("boundary_status"),
         }
-        for field in ("allowed_direct_writes", "migration_notes"):
+        for field in (
+            "allowed_direct_writes",
+            "transition_sequence_refs",
+            "migration_notes",
+        ):
             table_name = row_match.group(field)
             if table_name == "NULL":
                 values = []
@@ -2319,6 +2333,9 @@ def _validate_runtime_dispatch_surface_registry(
     runtime_transition_records: dict[str, dict[str, Any]],
     runtime_transition_ids: set[str],
     runtime_invariant_protected_fields_by_surface: dict[str, set[str]],
+    runtime_transition_sequence_records: list[Any],
+    runtime_diff_harness_owner_field_refs: dict[str, set[str]],
+    runtime_invariant_protected_fields: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     expected_surfaces = {
@@ -2351,6 +2368,7 @@ def _validate_runtime_dispatch_surface_registry(
                 "transition_id",
                 "boundary_status",
                 "allowed_direct_writes",
+                "transition_sequence_refs",
                 "migration_notes",
             ):
                 if record.get(field) != surface_record.get(field):
@@ -2375,6 +2393,16 @@ def _validate_runtime_dispatch_surface_registry(
             failures.append(f"{label}: migration_notes must be non-empty")
         elif any(not isinstance(note, str) or not note.strip() for note in notes):
             failures.append(f"{label}: migration_notes must contain non-empty strings")
+
+        failures.extend(
+            _validate_dispatch_surface_transition_sequence_coverage(
+                record=record,
+                transition_sequence_records=runtime_transition_sequence_records,
+                diff_harness_owner_field_refs=runtime_diff_harness_owner_field_refs,
+                invariant_protected_fields=runtime_invariant_protected_fields,
+                label=label,
+            )
+        )
 
         transition_id = record.get("transition_id")
         if (
@@ -3477,6 +3505,104 @@ def _validate_allowed_direct_writes_within_transition(
     return failures
 
 
+def _validate_dispatch_surface_transition_sequence_coverage(
+    *,
+    record: dict[str, Any],
+    transition_sequence_records: list[Any],
+    diff_harness_owner_field_refs: dict[str, set[str]],
+    invariant_protected_fields: dict[str, set[str]],
+    label: str,
+) -> list[str]:
+    refs = record.get("transition_sequence_refs")
+    transition_id = record.get("transition_id")
+    writes = record.get("allowed_direct_writes")
+    if not isinstance(refs, list):
+        return [f"{label}: transition_sequence_refs must be a non-empty list"]
+
+    sequences: dict[str, dict[str, Any]] = {
+        sequence["scenario_id"]: sequence
+        for sequence in transition_sequence_records
+        if isinstance(sequence, dict)
+        and isinstance(sequence.get("scenario_id"), str)
+        and sequence["scenario_id"].strip()
+    }
+    failures: list[str] = []
+    seen: set[str] = set()
+    matching_steps: list[dict[str, Any]] = []
+
+    for index, sequence_ref in enumerate(refs):
+        if not isinstance(sequence_ref, str) or not sequence_ref.strip():
+            failures.append(
+                f"{label}: transition_sequence_refs[{index}] must be a non-empty string"
+            )
+            continue
+        if sequence_ref in seen:
+            failures.append(
+                f"{label}: duplicate transition_sequence_refs[{index}]: {sequence_ref}"
+            )
+        seen.add(sequence_ref)
+        sequence = sequences.get(sequence_ref)
+        if sequence is None:
+            failures.append(
+                f"{label}: transition_sequence_refs references unknown transition "
+                f"sequence: {sequence_ref}"
+            )
+            continue
+        steps = sequence.get("steps")
+        if not isinstance(steps, list):
+            continue
+        if not isinstance(transition_id, str) or not transition_id.strip():
+            continue
+        matching_steps.extend(
+            step
+            for step in steps
+            if isinstance(step, dict) and step.get("transition_id") == transition_id
+        )
+
+    if isinstance(transition_id, str) and transition_id.strip() and not matching_steps:
+        failures.append(
+            f"{label}: transition_sequence_refs must include at least one step "
+            f"covering transition_id {transition_id}"
+        )
+
+    if not isinstance(writes, list):
+        return failures
+
+    diff_covered_fields: set[str] = set()
+    invariant_covered_fields: set[str] = set()
+    for step in matching_steps:
+        diff_harness_ids = step.get("diff_harness_ids")
+        if isinstance(diff_harness_ids, list):
+            for harness_id in diff_harness_ids:
+                if isinstance(harness_id, str) and harness_id.strip():
+                    diff_covered_fields.update(
+                        diff_harness_owner_field_refs.get(harness_id, set())
+                    )
+        invariant_ids = step.get("invariant_ids")
+        if isinstance(invariant_ids, list):
+            for invariant_id in invariant_ids:
+                if isinstance(invariant_id, str) and invariant_id.strip():
+                    invariant_covered_fields.update(
+                        invariant_protected_fields.get(invariant_id, set())
+                    )
+
+    for write_index, field in enumerate(writes):
+        if not isinstance(field, str) or not field.strip():
+            continue
+        if field not in diff_covered_fields:
+            failures.append(
+                f"{label}: allowed_direct_writes[{write_index}] lacks "
+                f"transition-sequence diff harness coverage for owner field: {field}"
+            )
+        if field not in invariant_covered_fields:
+            failures.append(
+                f"{label}: allowed_direct_writes[{write_index}] lacks "
+                f"transition-sequence invariant coverage for owner field: {field}"
+            )
+
+    return failures
+
+
 def _validate_appstate_diff_harness(
     *,
     diff_harness_doc: Any,
@@ -3690,6 +3816,9 @@ def _validate_dispatch_surfaces(
     transition_ids: dict[str, dict[str, Any]],
     registered_owner_fields: set[str],
     invariant_protected_fields_by_surface: dict[str, set[str]],
+    transition_sequence_records: list[Any],
+    diff_harness_owner_field_refs: dict[str, set[str]],
+    invariant_protected_fields: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     if not isinstance(dispatch_surfaces_doc, dict):
@@ -3761,6 +3890,15 @@ def _validate_dispatch_surfaces(
                     label=label,
                 )
             )
+        failures.extend(
+            _validate_dispatch_surface_transition_sequence_coverage(
+                record=record,
+                transition_sequence_records=transition_sequence_records,
+                diff_harness_owner_field_refs=diff_harness_owner_field_refs,
+                invariant_protected_fields=invariant_protected_fields,
+                label=label,
+            )
+        )
 
         source_path = record.get("source_path")
         entry_symbol_or_path = record.get("entry_symbol_or_path")
@@ -5895,6 +6033,14 @@ def validate_contract(
             transition_ids=transition_ids,
             registered_owner_fields=registered_owner_fields,
             invariant_protected_fields_by_surface=invariant_protected_fields_by_surface,
+            transition_sequence_records=(
+                transition_sequences_doc["scenarios"]
+                if isinstance(transition_sequences_doc, dict)
+                and isinstance(transition_sequences_doc.get("scenarios"), list)
+                else []
+            ),
+            diff_harness_owner_field_refs=diff_harness_owner_field_refs_by_harness,
+            invariant_protected_fields=invariant_protected_fields,
         )
     )
     if isinstance(dispatch_surfaces_doc, dict) and isinstance(
@@ -5915,6 +6061,11 @@ def validate_contract(
             runtime_invariant_protected_fields_by_surface=(
                 runtime_invariant_protected_fields_by_surface
             ),
+            runtime_transition_sequence_records=runtime_transition_sequence_records,
+            runtime_diff_harness_owner_field_refs=(
+                runtime_diff_harness_owner_field_refs_by_harness
+            ),
+            runtime_invariant_protected_fields=runtime_invariant_protected_fields,
         )
     )
     dispatch_surface_ids = _collect_string_ids(

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -1848,6 +1848,73 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    NULL},
 };
 
+static const char *const kAppStateTransitionSequenceStepInvariantIds12_0[] = {
+  "invariant.render-projection-read-only",
+  "invariant.viewport-identity-rebind",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds12_0[] = {
+  "harness.generation-mismatch-check",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations12_0[] = {
+  {"reflow.layout.projection", "Layout reflow generation changes only through the resize transition."},
+  {"generation.panel.local-authority", "Panel generation validates before viewport rebind after resize."},
+  {"identity.directory.stable-key", "Directory identity remains durable while viewport geometry is rebound."},
+  {"identity.file.stable-key", "File identity remains durable while viewport geometry is rebound."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps12[] = {
+  {1,
+   "terminal-resize-event",
+   "transition.terminal-signal-resize",
+   NULL,
+   "event.terminal-resize-signal",
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds12_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds12_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds12_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds12_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds12_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds12_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations12_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations12_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations12_0[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
+static const char *const kAppStateTransitionSequenceStepInvariantIds13_0[] = {
+  "invariant.render-projection-read-only",
+  "invariant.blocked-transition-determinism",
+};
+
+static const char *const kAppStateTransitionSequenceStepDiffHarnessIds13_0[] = {
+  "harness.render-projection-read-only-diff",
+};
+
+static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations13_0[] = {
+  {"reflow.layout.projection", "Render projection consumes layout reflow state without claiming owner authority."},
+  {"generation.panel.local-authority", "Panel generation remains an input to projection, not a render-owned mutation."},
+  {"generation.volume.shared-authority", "Volume generation remains an input to projection, not a render-owned mutation."},
+};
+
+static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceSteps13[] = {
+  {1,
+   "render-reflow-event",
+   "transition.render-reflow.project-state",
+   NULL,
+   "event.render-reflow",
+   "allowed",
+   kAppStateTransitionSequenceStepInvariantIds13_0,
+   sizeof(kAppStateTransitionSequenceStepInvariantIds13_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds13_0[0]),
+   kAppStateTransitionSequenceStepDiffHarnessIds13_0,
+   sizeof(kAppStateTransitionSequenceStepDiffHarnessIds13_0) / sizeof(kAppStateTransitionSequenceStepDiffHarnessIds13_0[0]),
+   kAppStateTransitionSequenceStepGenerationExpectations13_0,
+   sizeof(kAppStateTransitionSequenceStepGenerationExpectations13_0) / sizeof(kAppStateTransitionSequenceStepGenerationExpectations13_0[0]),
+   NULL,
+   NULL,
+   NULL},
+};
+
 static const AppStateTransitionSequenceMetadata kAppStateTransitionSequences[] = {
   {"sequence.split-toggle-f8",
    "layout_split",
@@ -1921,9 +1988,25 @@ static const AppStateTransitionSequenceMetadata kAppStateTransitionSequences[] =
    "Close and reopen split layout and prove panel snapshots survive layout projection changes.",
    kAppStateTransitionSequenceSteps11,
    sizeof(kAppStateTransitionSequenceSteps11) / sizeof(kAppStateTransitionSequenceSteps11[0])},
+  {"sequence.terminal-resize-reflow",
+   "terminal_resize",
+   "terminal_resize_reflow",
+   "Handle terminal resize events with layout, window-handle, viewport, and generation coverage.",
+   kAppStateTransitionSequenceSteps12,
+   sizeof(kAppStateTransitionSequenceSteps12) / sizeof(kAppStateTransitionSequenceSteps12[0])},
+  {"sequence.render-reflow-projection",
+   "render_reflow",
+   "render_reflow_projection",
+   "Project settled AppState to render output without mutating authoritative owner fields.",
+   kAppStateTransitionSequenceSteps13,
+   sizeof(kAppStateTransitionSequenceSteps13) / sizeof(kAppStateTransitionSequenceSteps13[0])},
 };
 static const char *const kAppStateDispatchSurfaceMigrationNotes0[] = {
   "Current input polling and key normalization feed controller dispatch; AppState mutation remains in downstream handlers until runtime transition objects are introduced.",
+};
+
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs0[] = {
+  "sequence.split-toggle-f8",
 };
 
 static const char *const kAppStateDispatchSurfaceAllowedDirectWrites1[] = {
@@ -1932,6 +2015,10 @@ static const char *const kAppStateDispatchSurfaceAllowedDirectWrites1[] = {
   "panel.tree_viewport_origin",
   "panel.focus_shape",
   "panel.panel_generation",
+};
+
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs1[] = {
+  "sequence.split-toggle-f8",
 };
 
 static const char *const kAppStateDispatchSurfaceMigrationNotes1[] = {
@@ -1943,8 +2030,16 @@ static const char *const kAppStateDispatchSurfaceAllowedDirectWrites2[] = {
   "panel.panel_generation",
 };
 
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs2[] = {
+  "sequence.file-small-big-transitions",
+};
+
 static const char *const kAppStateDispatchSurfaceMigrationNotes2[] = {
   "Current file-window dispatch remains under the broad keybinding foundation; only writes shared with the navigate-tree contract stay authorized until file-specific transitions are split out.",
+};
+
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs3[] = {
+  "sequence.esc-modal-dismissal",
 };
 
 static const char *const kAppStateDispatchSurfaceMigrationNotes3[] = {
@@ -1959,6 +2054,10 @@ static const char *const kAppStateDispatchSurfaceAllowedDirectWrites4[] = {
   "panel.panel_generation",
 };
 
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs4[] = {
+  "sequence.terminal-resize-reflow",
+};
+
 static const char *const kAppStateDispatchSurfaceMigrationNotes4[] = {
   "Current resize dispatch converts KEY_RESIZE and resize_request state into controller refresh handling; signal-safe work must remain outside asynchronous handlers.",
 };
@@ -1969,6 +2068,10 @@ static const char *const kAppStateDispatchSurfaceAllowedDirectWrites5[] = {
   "volume.volume_generation",
   "panel.restore_snapshot",
   "panel.panel_generation",
+};
+
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs5[] = {
+  "sequence.refresh-rebuild",
 };
 
 static const char *const kAppStateDispatchSurfaceMigrationNotes5[] = {
@@ -1984,6 +2087,10 @@ static const char *const kAppStateDispatchSurfaceAllowedDirectWrites6[] = {
   "ctx.message_state",
 };
 
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs6[] = {
+  "sequence.filesystem-mutation-result",
+};
+
 static const char *const kAppStateDispatchSurfaceMigrationNotes6[] = {
   "Current filesystem command handlers refresh and rebind after successful mutations; only completed mutation results should commit AppState metadata.",
 };
@@ -1996,12 +2103,24 @@ static const char *const kAppStateDispatchSurfaceAllowedDirectWrites7[] = {
   "volume.volume_generation",
 };
 
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs7[] = {
+  "sequence.volume-cycling-release",
+};
+
 static const char *const kAppStateDispatchSurfaceMigrationNotes7[] = {
   "Current loaded-volume selection and cycling update panel bindings directly; migration must preserve inactive panel restore records.",
 };
 
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs8[] = {
+  "sequence.refresh-rebuild",
+};
+
 static const char *const kAppStateDispatchSurfaceMigrationNotes8[] = {
   "Current watcher processing reports settled filesystem activity to input dispatch; topology mutation remains mapped to the broad refresh/rebuild transition.",
+};
+
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs9[] = {
+  "sequence.render-reflow-projection",
 };
 
 static const char *const kAppStateDispatchSurfaceMigrationNotes9[] = {
@@ -2017,6 +2136,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    "documented_foundation_only",
    NULL,
    0,
+   kAppStateDispatchSurfaceTransitionSequenceRefs0,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs0) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs0[0]),
    kAppStateDispatchSurfaceMigrationNotes0,
    sizeof(kAppStateDispatchSurfaceMigrationNotes0) / sizeof(kAppStateDispatchSurfaceMigrationNotes0[0])},
   {"surface.directory-window-action-dispatch",
@@ -2028,6 +2150,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceAllowedDirectWrites1,
    sizeof(kAppStateDispatchSurfaceAllowedDirectWrites1) /
        sizeof(kAppStateDispatchSurfaceAllowedDirectWrites1[0]),
+   kAppStateDispatchSurfaceTransitionSequenceRefs1,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs1) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs1[0]),
    kAppStateDispatchSurfaceMigrationNotes1,
    sizeof(kAppStateDispatchSurfaceMigrationNotes1) / sizeof(kAppStateDispatchSurfaceMigrationNotes1[0])},
   {"surface.file-window-action-dispatch",
@@ -2039,6 +2164,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceAllowedDirectWrites2,
    sizeof(kAppStateDispatchSurfaceAllowedDirectWrites2) /
        sizeof(kAppStateDispatchSurfaceAllowedDirectWrites2[0]),
+   kAppStateDispatchSurfaceTransitionSequenceRefs2,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs2) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs2[0]),
    kAppStateDispatchSurfaceMigrationNotes2,
    sizeof(kAppStateDispatchSurfaceMigrationNotes2) / sizeof(kAppStateDispatchSurfaceMigrationNotes2[0])},
   {"surface.menu-modal-completion",
@@ -2049,6 +2177,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    "documented_foundation_only",
    NULL,
    0,
+   kAppStateDispatchSurfaceTransitionSequenceRefs3,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs3) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs3[0]),
    kAppStateDispatchSurfaceMigrationNotes3,
    sizeof(kAppStateDispatchSurfaceMigrationNotes3) / sizeof(kAppStateDispatchSurfaceMigrationNotes3[0])},
   {"surface.resize-signal-handling",
@@ -2060,6 +2191,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceAllowedDirectWrites4,
    sizeof(kAppStateDispatchSurfaceAllowedDirectWrites4) /
        sizeof(kAppStateDispatchSurfaceAllowedDirectWrites4[0]),
+   kAppStateDispatchSurfaceTransitionSequenceRefs4,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs4) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs4[0]),
    kAppStateDispatchSurfaceMigrationNotes4,
    sizeof(kAppStateDispatchSurfaceMigrationNotes4) / sizeof(kAppStateDispatchSurfaceMigrationNotes4[0])},
   {"surface.refresh-rebuild-rebind",
@@ -2071,6 +2205,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceAllowedDirectWrites5,
    sizeof(kAppStateDispatchSurfaceAllowedDirectWrites5) /
        sizeof(kAppStateDispatchSurfaceAllowedDirectWrites5[0]),
+   kAppStateDispatchSurfaceTransitionSequenceRefs5,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs5) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs5[0]),
    kAppStateDispatchSurfaceMigrationNotes5,
    sizeof(kAppStateDispatchSurfaceMigrationNotes5) / sizeof(kAppStateDispatchSurfaceMigrationNotes5[0])},
   {"surface.filesystem-mutation-result",
@@ -2082,6 +2219,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceAllowedDirectWrites6,
    sizeof(kAppStateDispatchSurfaceAllowedDirectWrites6) /
        sizeof(kAppStateDispatchSurfaceAllowedDirectWrites6[0]),
+   kAppStateDispatchSurfaceTransitionSequenceRefs6,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs6) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs6[0]),
    kAppStateDispatchSurfaceMigrationNotes6,
    sizeof(kAppStateDispatchSurfaceMigrationNotes6) / sizeof(kAppStateDispatchSurfaceMigrationNotes6[0])},
   {"surface.volume-operation",
@@ -2093,6 +2233,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceAllowedDirectWrites7,
    sizeof(kAppStateDispatchSurfaceAllowedDirectWrites7) /
        sizeof(kAppStateDispatchSurfaceAllowedDirectWrites7[0]),
+   kAppStateDispatchSurfaceTransitionSequenceRefs7,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs7) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs7[0]),
    kAppStateDispatchSurfaceMigrationNotes7,
    sizeof(kAppStateDispatchSurfaceMigrationNotes7) / sizeof(kAppStateDispatchSurfaceMigrationNotes7[0])},
   {"surface.watcher-live-refresh",
@@ -2103,6 +2246,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    "documented_foundation_only",
    NULL,
    0,
+   kAppStateDispatchSurfaceTransitionSequenceRefs8,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs8) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs8[0]),
    kAppStateDispatchSurfaceMigrationNotes8,
    sizeof(kAppStateDispatchSurfaceMigrationNotes8) / sizeof(kAppStateDispatchSurfaceMigrationNotes8[0])},
   {"surface.render-reflow-projection",
@@ -2113,6 +2259,9 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    "documented_foundation_only",
    NULL,
    0,
+   kAppStateDispatchSurfaceTransitionSequenceRefs9,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs9) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs9[0]),
    kAppStateDispatchSurfaceMigrationNotes9,
    sizeof(kAppStateDispatchSurfaceMigrationNotes9) / sizeof(kAppStateDispatchSurfaceMigrationNotes9[0])},
 };

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -264,6 +264,8 @@ static const char *const kAppStateRequiredTransitionSequenceScenarioIds[] = {
   "sequence.file-small-big-transitions",
   "sequence.volume-cycling-release",
   "sequence.split-close-reopen",
+  "sequence.terminal-resize-reflow",
+  "sequence.render-reflow-projection",
 };
 
 static int StringListContains(const char *const *values, size_t count,
@@ -934,6 +936,129 @@ static int AppStateDispatchSurfaceWriteHasInvariantCoverage(
   return 0;
 }
 
+static int AppStateTransitionSequenceStepDiffHarnessCoversField(
+    const AppStateTransitionSequenceStepMetadata *step, const char *field) {
+  size_t harness_index;
+
+  if (step == NULL || !NonEmptyString(field) ||
+      !NonEmptyStringList(step->diff_harness_ids, step->diff_harness_id_count))
+    return 0;
+
+  for (harness_index = 0; harness_index < step->diff_harness_id_count;
+       harness_index++) {
+    const AppStateDiffHarnessMetadata *harness =
+        AppStateDiffHarnessLookup(step->diff_harness_ids[harness_index]);
+
+    if (harness == NULL ||
+        !NonEmptyStringList(harness->owner_field_refs,
+                            harness->owner_field_ref_count))
+      return 0;
+    if (StringListContains(harness->owner_field_refs,
+                           harness->owner_field_ref_count, field))
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateTransitionSequenceStepInvariantCoversField(
+    const AppStateTransitionSequenceStepMetadata *step, const char *field) {
+  size_t invariant_index;
+
+  if (step == NULL || !NonEmptyString(field) ||
+      !NonEmptyStringList(step->invariant_ids, step->invariant_id_count))
+    return 0;
+
+  for (invariant_index = 0; invariant_index < step->invariant_id_count;
+       invariant_index++) {
+    const AppStateInvariantMetadata *invariant =
+        AppStateInvariantLookup(step->invariant_ids[invariant_index]);
+
+    if (invariant == NULL ||
+        !NonEmptyStringList(invariant->protected_fields,
+                            invariant->protected_field_count))
+      return 0;
+    if (StringListContains(invariant->protected_fields,
+                           invariant->protected_field_count, field))
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateDispatchSurfaceSequenceRefsReady(
+    const AppStateDispatchSurfaceMetadata *metadata) {
+  size_t ref_index;
+  int transition_step_found = 0;
+
+  if (metadata == NULL ||
+      !NonEmptyStringList(metadata->transition_sequence_refs,
+                          metadata->transition_sequence_ref_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->transition_sequence_ref_count;
+       ref_index++) {
+    const AppStateTransitionSequenceMetadata *sequence =
+        AppStateTransitionSequenceLookup(metadata->transition_sequence_refs[ref_index]);
+    size_t previous_index;
+    size_t step_index;
+
+    if (sequence == NULL)
+      return 0;
+    for (previous_index = 0; previous_index < ref_index; previous_index++) {
+      if (strcmp(metadata->transition_sequence_refs[previous_index],
+                 metadata->transition_sequence_refs[ref_index]) == 0)
+        return 0;
+    }
+    for (step_index = 0; step_index < sequence->step_count; step_index++) {
+      const AppStateTransitionSequenceStepMetadata *step =
+          &sequence->steps[step_index];
+
+      if (!NonEmptyString(step->transition_id))
+        return 0;
+      if (strcmp(step->transition_id, metadata->transition_id) == 0)
+        transition_step_found = 1;
+    }
+  }
+
+  return transition_step_found;
+}
+
+static int AppStateDispatchSurfaceSequenceRefsCoverField(
+    const AppStateDispatchSurfaceMetadata *metadata, const char *field) {
+  size_t ref_index;
+  int diff_covered = 0;
+  int invariant_covered = 0;
+
+  if (metadata == NULL || !NonEmptyString(field))
+    return 0;
+
+  for (ref_index = 0; ref_index < metadata->transition_sequence_ref_count;
+       ref_index++) {
+    const AppStateTransitionSequenceMetadata *sequence =
+        AppStateTransitionSequenceLookup(metadata->transition_sequence_refs[ref_index]);
+    size_t step_index;
+
+    if (sequence == NULL)
+      return 0;
+    for (step_index = 0; step_index < sequence->step_count; step_index++) {
+      const AppStateTransitionSequenceStepMetadata *step =
+          &sequence->steps[step_index];
+
+      if (!NonEmptyString(step->transition_id))
+        return 0;
+      if (strcmp(step->transition_id, metadata->transition_id) != 0)
+        continue;
+      if (AppStateTransitionSequenceStepDiffHarnessCoversField(step, field))
+        diff_covered = 1;
+      if (AppStateTransitionSequenceStepInvariantCoversField(step, field))
+        invariant_covered = 1;
+    }
+  }
+
+  return diff_covered && invariant_covered;
+}
+
 static int AppStateDispatchSurfaceWritesReady(
     const AppStateDispatchSurfaceMetadata *metadata) {
   const AppStateTransitionMetadata *transition =
@@ -963,6 +1088,8 @@ static int AppStateDispatchSurfaceWritesReady(
     if (!AppStateDispatchSurfaceWriteHasInvariantCoverage(metadata->surface_id,
                                                           field))
       return 0;
+    if (!AppStateDispatchSurfaceSequenceRefsCoverField(metadata, field))
+      return 0;
   }
 
   return 1;
@@ -988,6 +1115,7 @@ static int AppStateDispatchSurfacesReady(void) {
         !NonEmptyString(metadata->entry_symbol_or_path) ||
         !NonEmptyString(metadata->transition_id) ||
         !NonEmptyString(metadata->boundary_status) ||
+        !AppStateDispatchSurfaceSequenceRefsReady(metadata) ||
         !AppStateDispatchSurfaceWritesReady(metadata) ||
         !NonEmptyStringList(metadata->migration_notes,
                             metadata->migration_note_count))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -39,6 +39,7 @@ REQUIRED_LIST_FIELD_CASES = [
     ("invariant", "protected_fields", "invariant[0]"),
     ("invariant", "transition_ids", "invariant[0]"),
     ("invariant", "migration_notes", "invariant[0]"),
+    ("dispatch_surface", "transition_sequence_refs", "dispatch_surface[0]"),
     ("diff_harness", "snapshot_phases", "diff_harness_check[0]"),
     ("diff_harness", "snapshot_regions", "diff_harness_check[0]"),
     ("diff_harness", "transition_ids", "diff_harness_check[0]"),
@@ -178,6 +179,18 @@ def _dispatch_surface(
         "watcher_live_refresh": "transition.refresh_rebuild",
         "render_reflow_projection": "transition.render_reflow",
     }
+    sequence_by_surface_category = {
+        "key_decode_input_dispatch": "sequence.split_toggle_f8",
+        "directory_window_action_dispatch": "sequence.split_toggle_f8",
+        "file_window_action_dispatch": "sequence.file_small_big_transitions",
+        "menu_modal_completion": "sequence.esc_modal_dismissal",
+        "resize_signal_handling": "sequence.terminal_resize_reflow",
+        "refresh_rebuild_rebind": "sequence.refresh_rebuild",
+        "filesystem_mutation_result": "sequence.filesystem_mutation_result",
+        "volume_operation": "sequence.volume_cycling_release",
+        "watcher_live_refresh": "sequence.refresh_rebuild",
+        "render_reflow_projection": "sequence.render_reflow_projection",
+    }
     return {
         "surface_id": surface_id or f"surface.{category}",
         "category": category,
@@ -186,6 +199,7 @@ def _dispatch_surface(
         "transition_id": transition_id or transition_by_surface_category[category],
         "boundary_status": "test",
         "allowed_direct_writes": ["field"],
+        "transition_sequence_refs": [sequence_by_surface_category[category]],
         "migration_notes": ["fixture coverage"],
     }
 
@@ -278,14 +292,16 @@ def _sequence_step(
     *,
     ordinal: int = 1,
     transition_id: str = "transition.keybinding",
-    action_id: str = "ACTION_NONE",
+    action_id: str | None = "ACTION_NONE",
     event_id: str | None = None,
     invariant_ids: list[str] | None = None,
     diff_harness_ids: list[str] | None = None,
     generation_domain_id: str = "domain.panel_generation",
     expected_result: str = "allowed",
 ) -> dict[str, object]:
-    stimulus: dict[str, object] = {"action_id": action_id}
+    stimulus: dict[str, object] = {}
+    if action_id is not None:
+        stimulus["action_id"] = action_id
     if event_id is not None:
         stimulus["event_id"] = event_id
     return {
@@ -307,10 +323,60 @@ def _sequence_step(
 
 
 def _complete_transition_sequences() -> list[dict[str, object]]:
+    category_by_flow = {
+        "esc_modal_dismissal": "modal_command",
+        "filesystem_mutation_result": "filesystem_mutation",
+        "refresh_rebuild": "refresh_rebuild",
+        "render_reflow_projection": "render_reflow",
+        "terminal_resize_reflow": "terminal_resize",
+        "volume_cycling_release": "volume_lifecycle",
+    }
+    step_by_flow = {
+        "esc_modal_dismissal": _sequence_step(
+            transition_id="transition.modal_action",
+            action_id=None,
+            event_id="event.modal_completion",
+            invariant_ids=["invariant.blocked_transition_determinism"],
+        ),
+        "filesystem_mutation_result": _sequence_step(
+            transition_id="transition.filesystem_mutation_result",
+            action_id=None,
+            event_id="event.filesystem_mutation_result",
+            invariant_ids=["invariant.blocked_transition_determinism"],
+        ),
+        "refresh_rebuild": _sequence_step(
+            transition_id="transition.refresh_rebuild",
+            action_id=None,
+            event_id="event.refresh_rebuild",
+            invariant_ids=["invariant.blocked_transition_determinism"],
+        ),
+        "render_reflow_projection": _sequence_step(
+            transition_id="transition.render_reflow",
+            action_id=None,
+            event_id="event.render_reflow",
+            invariant_ids=["invariant.blocked_transition_determinism"],
+        ),
+        "terminal_resize_reflow": _sequence_step(
+            transition_id="transition.terminal_signal_or_resize",
+            action_id=None,
+            event_id="event.terminal_resize_signal",
+            invariant_ids=["invariant.blocked_transition_determinism"],
+        ),
+        "volume_cycling_release": _sequence_step(
+            transition_id="transition.volume_operation",
+            action_id=None,
+            event_id="event.volume_lifecycle",
+            invariant_ids=["invariant.blocked_transition_determinism"],
+        ),
+    }
     return [
         _transition_sequence(
             flow,
-            category="layout_split" if flow.startswith("split_") else "panel_navigation",
+            category=category_by_flow.get(
+                flow,
+                "layout_split" if flow.startswith("split_") else "panel_navigation",
+            ),
+            steps=[copy.deepcopy(step_by_flow.get(flow, _sequence_step()))],
         )
         for flow in REQUIRED_SEQUENCE_FLOWS
     ]
@@ -667,6 +733,17 @@ def _runtime_source(
         else:
             writes_table = "NULL"
             writes_count = "0"
+        transition_sequence_refs = record.get("transition_sequence_refs")
+        if not isinstance(transition_sequence_refs, list):
+            transition_sequence_refs = []
+        sequence_ref_rows = "\n".join(
+            f'  "{ref}",' for ref in transition_sequence_refs if isinstance(ref, str)
+        )
+        sequence_refs_table = f"kAppStateDispatchSurfaceTransitionSequenceRefs{index}"
+        dispatch_surface_arrays.append(
+            f"static const char *const {sequence_refs_table}[] = "
+            f"{{\n{sequence_ref_rows}\n}};\n"
+        )
         migration_notes = record.get("migration_notes")
         if not isinstance(migration_notes, list):
             migration_notes = []
@@ -686,6 +763,8 @@ def _runtime_source(
             f'"{record.get("transition_id", "")}", '
             f'"{record.get("boundary_status", "")}", '
             f"{writes_table}, {writes_count}, "
+            f"{sequence_refs_table}, sizeof({sequence_refs_table}) / "
+            f"sizeof({sequence_refs_table}[0]), "
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
     shim_invariants = []
@@ -4112,6 +4191,126 @@ def test_guard_fails_when_dispatch_surface_allowed_write_splits_invariant_covera
     )
 
 
+def test_guard_fails_when_dispatch_surface_sequence_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0].pop("transition_sequence_refs")
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "missing required field" in failure
+        and "transition_sequence_refs" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("refs", "expected"),
+    [
+        (["sequence.missing"], "references unknown transition sequence"),
+        (["sequence.split_toggle_f8", "sequence.split_toggle_f8"], "duplicate transition_sequence_refs"),
+        ([123], "transition_sequence_refs[0] must be a non-empty string"),
+    ],
+)
+def test_guard_fails_on_malformed_dispatch_surface_sequence_refs(
+    tmp_path: Path, refs: list[object], expected: str
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["transition_sequence_refs"] = refs
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure and expected in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_sequence_misses_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    dispatch_surfaces[0]["transition_sequence_refs"] = ["sequence.refresh_rebuild"]
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, dispatch_surfaces=dispatch_surfaces
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "must include at least one step covering transition_id transition.keybinding"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_sequence_lacks_diff_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    transition_harness = next(
+        harness
+        for harness in diff_harness_checks
+        if harness["harness_id"] == "harness.transition_before_after_snapshot"
+    )
+    transition_harness["owner_field_refs"] = ["panel.tree_selection_key"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        diff_harness_checks=diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "lacks transition-sequence diff harness coverage" in failure
+        and "field" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_dispatch_surface_sequence_lacks_invariant_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    inactive_invariant = next(
+        invariant
+        for invariant in invariants
+        if invariant["invariant_id"] == "invariant.inactive_panel_frozen"
+    )
+    inactive_invariant["protected_fields"] = ["panel.tree_selection_key"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        invariants=invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "lacks transition-sequence invariant coverage" in failure
+        and "field" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_transition_write_splits_invariant_coverage(
     tmp_path: Path,
 ) -> None:
@@ -4179,6 +4378,30 @@ def test_guard_fails_when_runtime_dispatch_surface_metadata_drifts(
     assert any(
         "runtime_dispatch_surface[0]" in failure
         and "runtime category does not match dispatch surface" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_dispatch_surface_sequence_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_dispatch_surfaces = _complete_dispatch_surfaces()
+    runtime_dispatch_surfaces[0]["transition_sequence_refs"] = [
+        "sequence.tab_panel_switch"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_dispatch_surfaces=runtime_dispatch_surfaces,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_dispatch_surface[0]" in failure
+        and "runtime transition_sequence_refs does not match dispatch surface"
+        in failure
         for failure in failures
     )
 
@@ -7195,6 +7418,13 @@ def test_runtime_dispatch_surface_startup_checks_fail_closed() -> None:
     assert "AppStateDispatchSurfaceCount() != required_surface_id_count" in source
     assert "previous_index < index" in source
     assert "strcmp(previous->surface_id, metadata->surface_id) == 0" in source
+    assert "AppStateDispatchSurfaceSequenceRefsReady(metadata)" in source
+    assert "metadata->transition_sequence_ref_count" in source
+    assert "AppStateTransitionSequenceLookup(metadata->transition_sequence_refs[ref_index])" in source
+    assert (
+        "strcmp(metadata->transition_sequence_refs[previous_index],\n"
+        "                 metadata->transition_sequence_refs[ref_index]) == 0"
+    ) in source
     assert "!AppStateDispatchSurfacesReady()" in source
 
 
@@ -7243,6 +7473,29 @@ def test_runtime_dispatch_surface_startup_requires_invariant_coverage() -> None:
     assert re.search(
         r"StringListContains\(invariant->dispatch_surface_ids,\s*"
         r"invariant->dispatch_surface_id_count, surface_id\)",
+        source,
+        re.S,
+    )
+    assert re.search(
+        r"StringListContains\(invariant->protected_fields,\s*"
+        r"invariant->protected_field_count, field\)",
+        source,
+        re.S,
+    )
+
+
+def test_runtime_dispatch_surface_startup_requires_sequence_field_coverage() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index("static int AppStateDispatchSurfaceWritesReady(")
+    dispatch_start = source.index("static int AppStateDispatchSurfacesReady(void)")
+    helper_body = source[helper_start:dispatch_start]
+
+    assert "AppStateDispatchSurfaceSequenceRefsCoverField(metadata, field)" in helper_body
+    assert "AppStateTransitionSequenceStepDiffHarnessCoversField(" in source
+    assert "AppStateTransitionSequenceStepInvariantCoversField(" in source
+    assert re.search(
+        r"StringListContains\(harness->owner_field_refs,\s*"
+        r"harness->owner_field_ref_count, field\)",
         source,
         re.S,
     )


### PR DESCRIPTION
## Summary
- require dispatch surfaces to declare transition-sequence coverage
- add terminal resize and render reflow scenarios for dispatch-boundary coverage
- fail closed when dispatch sequence refs drift or lack transition, diff, and invariant coverage

## Validation
- Local dispatch sequence tests: `pytest -q tests/test_appstate_contract_guard.py -k 'dispatch and sequence'` — PASS
- Local dispatch/sequence tests: `pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or transition_sequence'` — PASS
- Local AppState guard tests: `pytest -q tests/test_appstate_contract_guard.py` — PASS
- Local contract guard: `python3 scripts/check_appstate_contract.py` — PASS
- Local build: `make clean && make` — PASS with pre-existing warnings
