### PR TITLE
chore(appstate): require coverage dispatch refs

### DIFF
--- a/docs/appstate_action_coverage.json
+++ b/docs/appstate_action_coverage.json
@@ -28,6 +28,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -55,6 +60,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -82,6 +92,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -109,6 +124,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -136,6 +156,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -163,6 +188,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -190,6 +220,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -217,6 +252,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -244,6 +284,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -271,6 +316,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -298,6 +348,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -325,6 +380,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -352,6 +412,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -379,6 +444,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -406,6 +476,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -425,6 +500,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.esc-modal-dismissal"
+      ],
+      "dispatch_surface_refs": [
+        "surface.menu-modal-completion"
       ]
     },
     {
@@ -445,6 +523,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.refresh-rebuild"
+      ],
+      "dispatch_surface_refs": [
+        "surface.refresh-rebuild-rebind"
       ]
     },
     {
@@ -464,6 +545,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.search-jump"
+      ],
+      "dispatch_surface_refs": [
+        "surface.command-completion-dispatch"
       ]
     },
     {
@@ -483,6 +567,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.search-jump"
+      ],
+      "dispatch_surface_refs": [
+        "surface.command-completion-dispatch"
       ]
     },
     {
@@ -510,6 +597,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -537,6 +629,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -564,6 +661,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -591,6 +693,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -618,6 +725,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -645,6 +757,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -672,6 +789,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -699,6 +821,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -719,6 +846,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.refresh-rebuild"
+      ],
+      "dispatch_surface_refs": [
+        "surface.refresh-rebuild-rebind"
       ]
     },
     {
@@ -739,6 +869,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.terminal-resize-reflow"
+      ],
+      "dispatch_surface_refs": [
+        "surface.resize-signal-handling"
       ]
     },
     {
@@ -758,6 +891,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.volume-menu-select"
+      ],
+      "dispatch_surface_refs": [
+        "surface.volume-menu-selection"
       ]
     },
     {
@@ -778,6 +914,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.volume-cycling-release"
+      ],
+      "dispatch_surface_refs": [
+        "surface.volume-operation"
       ]
     },
     {
@@ -798,6 +937,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.volume-cycling-release"
+      ],
+      "dispatch_surface_refs": [
+        "surface.volume-operation"
       ]
     },
     {
@@ -819,6 +961,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -840,6 +985,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -861,6 +1009,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -882,6 +1033,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -903,6 +1057,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -924,6 +1081,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -945,6 +1105,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -966,6 +1129,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -987,6 +1153,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1008,6 +1177,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1029,6 +1201,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1050,6 +1225,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1071,6 +1249,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1092,6 +1273,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1113,6 +1297,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1134,6 +1321,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1153,6 +1343,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.search-jump"
+      ],
+      "dispatch_surface_refs": [
+        "surface.command-completion-dispatch"
       ]
     },
     {
@@ -1180,6 +1373,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1207,6 +1405,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1228,6 +1431,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1249,6 +1455,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1270,6 +1479,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1291,6 +1503,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1312,6 +1527,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1333,6 +1551,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1354,6 +1575,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1375,6 +1599,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1396,6 +1623,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1417,6 +1647,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1438,6 +1671,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1459,6 +1695,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1480,6 +1719,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -1499,6 +1741,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.search-jump"
+      ],
+      "dispatch_surface_refs": [
+        "surface.command-completion-dispatch"
       ]
     },
     {
@@ -1526,6 +1771,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1553,6 +1803,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1580,6 +1835,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1607,6 +1867,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1634,6 +1899,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1661,6 +1931,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1688,6 +1963,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1715,6 +1995,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1742,6 +2027,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1769,6 +2059,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1796,6 +2091,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1823,6 +2123,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1850,6 +2155,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1877,6 +2187,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1904,6 +2219,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1931,6 +2251,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1958,6 +2283,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -1985,6 +2315,11 @@
         "sequence.split-close-reopen",
         "sequence.split-toggle-f8",
         "sequence.tab-panel-switch"
+      ],
+      "dispatch_surface_refs": [
+        "surface.key-decode-input-dispatch",
+        "surface.directory-window-action-dispatch",
+        "surface.file-window-action-dispatch"
       ]
     },
     {
@@ -2004,6 +2339,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.search-jump"
+      ],
+      "dispatch_surface_refs": [
+        "surface.command-completion-dispatch"
       ]
     },
     {
@@ -2023,6 +2361,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.search-jump"
+      ],
+      "dispatch_surface_refs": [
+        "surface.command-completion-dispatch"
       ]
     }
   ]

--- a/docs/appstate_dispatch_surfaces.json
+++ b/docs/appstate_dispatch_surfaces.json
@@ -186,6 +186,63 @@
       "transition_sequence_refs": [
         "sequence.render-reflow-projection"
       ]
+    },
+    {
+      "surface_id": "surface.command-completion-dispatch",
+      "category": "command_completion_dispatch",
+      "source_path": "src/ui/ctrl_file_ops.c",
+      "entry_symbol_or_path": "handle_file_window_command_action",
+      "transition_id": "transition.command-completion.user-command",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [],
+      "migration_notes": [
+        "Current command handlers settle completion state after external or user-command execution returns; runtime migration should lift that completion boundary without broadening write authority here."
+      ],
+      "transition_sequence_refs": [
+        "sequence.search-jump"
+      ]
+    },
+    {
+      "surface_id": "surface.volume-menu-selection",
+      "category": "volume_menu_selection",
+      "source_path": "src/ui/volume_menu.c",
+      "entry_symbol_or_path": "SelectLoadedVolume",
+      "transition_id": "transition.menu-action.volume-select",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [
+        "ctx.active",
+        "panel.volume_key",
+        "panel.restore_snapshot",
+        "panel.panel_generation"
+      ],
+      "migration_notes": [
+        "Current loaded-volume menu selection remains the existing selection boundary for active-panel volume binding until dedicated runtime transition objects replace menu-coupled control flow."
+      ],
+      "transition_sequence_refs": [
+        "sequence.volume-menu-select"
+      ]
+    },
+    {
+      "surface_id": "surface.panel-anchor-rebind",
+      "category": "rebuild_rebind_callback",
+      "source_path": "src/ui/panel_anchor.c",
+      "entry_symbol_or_path": "RestorePanelViewportSnapshot",
+      "transition_id": "transition.rebuild-rebind-callback.panel-anchor",
+      "boundary_status": "documented_foundation_only",
+      "allowed_direct_writes": [
+        "panel.tree_selection_key",
+        "panel.file_selection_key",
+        "panel.tree_cursor_pos",
+        "panel.tree_viewport_origin",
+        "panel.file_viewport_origin",
+        "panel.panel_generation"
+      ],
+      "migration_notes": [
+        "Current panel-anchor restore helpers remain the canonical callback surface for post-rebuild re-resolution; migration should keep fallback ordering anchored here."
+      ],
+      "transition_sequence_refs": [
+        "sequence.refresh-rebuild"
+      ]
     }
   ]
 }

--- a/docs/appstate_event_coverage.json
+++ b/docs/appstate_event_coverage.json
@@ -38,6 +38,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.terminal-resize-reflow"
+      ],
+      "dispatch_surface_refs": [
+        "surface.resize-signal-handling"
       ]
     },
     {
@@ -64,6 +67,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.refresh-rebuild"
+      ],
+      "dispatch_surface_refs": [
+        "surface.refresh-rebuild-rebind"
       ]
     },
     {
@@ -92,6 +98,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.refresh-rebuild"
+      ],
+      "dispatch_surface_refs": [
+        "surface.panel-anchor-rebind"
       ]
     },
     {
@@ -120,6 +129,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.filesystem-mutation-result"
+      ],
+      "dispatch_surface_refs": [
+        "surface.filesystem-mutation-result"
       ]
     },
     {
@@ -147,6 +159,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.refresh-rebuild"
+      ],
+      "dispatch_surface_refs": [
+        "surface.watcher-live-refresh"
       ]
     },
     {
@@ -173,6 +188,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.search-jump"
+      ],
+      "dispatch_surface_refs": [
+        "surface.command-completion-dispatch"
       ]
     },
     {
@@ -199,6 +217,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.esc-modal-dismissal"
+      ],
+      "dispatch_surface_refs": [
+        "surface.menu-modal-completion"
       ]
     },
     {
@@ -226,6 +247,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.volume-cycling-release"
+      ],
+      "dispatch_surface_refs": [
+        "surface.volume-operation"
       ]
     },
     {
@@ -250,6 +274,9 @@
       ],
       "transition_sequence_refs": [
         "sequence.render-reflow-projection"
+      ],
+      "dispatch_surface_refs": [
+        "surface.render-reflow-projection"
       ]
     }
   ]

--- a/docs/appstate_invariants.json
+++ b/docs/appstate_invariants.json
@@ -30,6 +30,7 @@
       "dispatch_surface_ids": [
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch",
+        "surface.volume-menu-selection",
         "surface.menu-modal-completion",
         "surface.refresh-rebuild-rebind",
         "surface.volume-operation",
@@ -95,6 +96,7 @@
       "dispatch_surface_ids": [
         "surface.directory-window-action-dispatch",
         "surface.refresh-rebuild-rebind",
+        "surface.panel-anchor-rebind",
         "surface.watcher-live-refresh"
       ],
       "failure_mode": "Fail if visible navigation lands on a hidden entry or resurrects a concealed identity after visibility/topology changes.",
@@ -161,6 +163,7 @@
         "surface.refresh-rebuild-rebind",
         "surface.resize-signal-handling",
         "surface.filesystem-mutation-result",
+        "surface.panel-anchor-rebind",
         "surface.watcher-live-refresh"
       ],
       "failure_mode": "Fail if rebuild, mutation, or resize restores viewport from raw rows when the stable identity is still visible or before deterministic fallback order is exhausted.",
@@ -195,6 +198,7 @@
         "transition.filesystem-mutation-result.mkdir-copy-delete"
       ],
       "dispatch_surface_ids": [
+        "surface.volume-menu-selection",
         "surface.volume-operation",
         "surface.refresh-rebuild-rebind",
         "surface.filesystem-mutation-result",
@@ -231,6 +235,7 @@
         "surface.refresh-rebuild-rebind",
         "surface.volume-operation",
         "surface.filesystem-mutation-result",
+        "surface.panel-anchor-rebind",
         "surface.watcher-live-refresh"
       ],
       "failure_mode": "Fail if a generation mismatch reuses stale DirEntry/FileEntry pointers, stale flat-list rows, or stale snapshot payloads instead of exact rebind or deterministic fallback.",

--- a/docs/appstate_transition_sequences.json
+++ b/docs/appstate_transition_sequences.json
@@ -360,6 +360,7 @@
           "expected_result": "fallback",
           "invariant_ids": [
             "invariant.stale-snapshot-fail-closed",
+            "invariant.hidden-entry-visible-navigation",
             "invariant.viewport-identity-rebind"
           ],
           "diff_harness_ids": [

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -27,6 +27,8 @@ typedef struct {
   size_t declared_write_set_count;
   const char *const *transition_sequence_refs;
   size_t transition_sequence_ref_count;
+  const char *const *dispatch_surface_refs;
+  size_t dispatch_surface_ref_count;
   const char *boundary_status;
   const char *const *migration_notes;
   size_t migration_note_count;
@@ -46,6 +48,8 @@ typedef struct {
   size_t trigger_path_count;
   const char *const *transition_sequence_refs;
   size_t transition_sequence_ref_count;
+  const char *const *dispatch_surface_refs;
+  size_t dispatch_surface_ref_count;
   const char *const *migration_notes;
   size_t migration_note_count;
 } AppStateEventCoverageMetadata;

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -78,6 +78,7 @@ REQUIRED_ACTION_FIELDS = {
     "owner",
     "declared_write_set",
     "transition_sequence_refs",
+    "dispatch_surface_refs",
     "boundary_status",
     "migration_notes",
 }
@@ -105,6 +106,9 @@ REQUIRED_DISPATCH_SURFACE_CATEGORIES = {
     "volume_operation",
     "watcher_live_refresh",
     "render_reflow_projection",
+    "command_completion_dispatch",
+    "volume_menu_selection",
+    "rebuild_rebind_callback",
 }
 
 REQUIRED_INVARIANT_CATEGORIES = {
@@ -195,6 +199,7 @@ REQUIRED_EVENT_FIELDS = {
     "owner",
     "declared_write_set",
     "transition_sequence_refs",
+    "dispatch_surface_refs",
     "boundary_status",
     "trigger_paths",
     "migration_notes",
@@ -293,8 +298,12 @@ LIST_FIELDS = {
     "migration_notes",
 }
 
-ACTION_LIST_FIELDS = LIST_FIELDS | {"transition_sequence_refs"}
-EVENT_LIST_FIELDS = LIST_FIELDS | {"trigger_paths", "transition_sequence_refs"}
+ACTION_LIST_FIELDS = LIST_FIELDS | {"transition_sequence_refs", "dispatch_surface_refs"}
+EVENT_LIST_FIELDS = LIST_FIELDS | {
+    "trigger_paths",
+    "transition_sequence_refs",
+    "dispatch_surface_refs",
+}
 SHIM_LIST_FIELDS = LIST_FIELDS | {
     "owner_field_refs",
     "generation_domain_refs",
@@ -616,7 +625,7 @@ def _parse_runtime_action_coverage_registry(
     arrays: dict[str, list[str]] = {}
     array_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateActionCoverage(?:TransitionSequenceRefs|MigrationNotes)[0-9]+)"
+        r"(kAppStateActionCoverage(?:TransitionSequenceRefs|DispatchSurfaceRefs|MigrationNotes)[0-9]+)"
         r"\[\]\s*=\s*\{(?P<body>.*?)\};",
         re.S,
     )
@@ -649,6 +658,9 @@ def _parse_runtime_action_coverage_registry(
         r"\s*(?P<transition_sequence_refs>kAppStateActionCoverageTransitionSequenceRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=transition_sequence_refs)\)\s*/"
         r"\s*sizeof\((?P=transition_sequence_refs)\[0\]\)\s*,"
+        r"\s*(?P<dispatch_surface_refs>kAppStateActionCoverageDispatchSurfaceRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=dispatch_surface_refs)\)\s*/"
+        r"\s*sizeof\((?P=dispatch_surface_refs)\[0\]\)\s*,"
         r"\s*\"(?P<boundary_status>[^\"]*)\"\s*,"
         r"\s*(?P<migration_notes>kAppStateActionCoverageMigrationNotes[0-9]+)\s*,"
         r"\s*sizeof\((?P=migration_notes)\)\s*/"
@@ -684,6 +696,14 @@ def _parse_runtime_action_coverage_registry(
                 f"table: {sequence_refs_name}"
             )
             sequence_refs = []
+        dispatch_surface_refs_name = row_match.group("dispatch_surface_refs")
+        dispatch_surface_refs = arrays.get(dispatch_surface_refs_name)
+        if dispatch_surface_refs is None:
+            failures.append(
+                f"runtime_action_coverage[{index}]: unknown dispatch-surface-refs "
+                f"table: {dispatch_surface_refs_name}"
+            )
+            dispatch_surface_refs = []
         notes_name = row_match.group("migration_notes")
         notes = arrays.get(notes_name)
         if notes is None:
@@ -701,6 +721,7 @@ def _parse_runtime_action_coverage_registry(
                 "owner": row_match.group("owner"),
                 "declared_write_set": declared_write_set,
                 "transition_sequence_refs": sequence_refs,
+                "dispatch_surface_refs": dispatch_surface_refs,
                 "boundary_status": row_match.group("boundary_status"),
                 "migration_notes": notes,
             }
@@ -725,7 +746,7 @@ def _parse_runtime_event_coverage_registry(
     arrays: dict[str, list[str]] = {}
     array_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppState(?:TransitionWriteSet|EventCoverageTriggerPaths|EventCoverageTransitionSequenceRefs|EventCoverageMigrationNotes)[0-9]+)"
+        r"(kAppState(?:TransitionWriteSet|EventCoverageTriggerPaths|EventCoverageTransitionSequenceRefs|EventCoverageDispatchSurfaceRefs|EventCoverageMigrationNotes)[0-9]+)"
         r"\[\]\s*=\s*\{(?P<body>.*?)\};",
         re.S,
     )
@@ -761,6 +782,8 @@ def _parse_runtime_event_coverage_registry(
         r"\s*sizeof\((?P=trigger_paths)\)\s*/\s*sizeof\((?P=trigger_paths)\[0\]\)\s*,"
         r"\s*(?P<transition_sequence_refs>kAppStateEventCoverageTransitionSequenceRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=transition_sequence_refs)\)\s*/\s*sizeof\((?P=transition_sequence_refs)\[0\]\)\s*,"
+        r"\s*(?P<dispatch_surface_refs>kAppStateEventCoverageDispatchSurfaceRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=dispatch_surface_refs)\)\s*/\s*sizeof\((?P=dispatch_surface_refs)\[0\]\)\s*,"
         r"\s*(?P<migration_notes>kAppStateEventCoverageMigrationNotes[0-9]+)\s*,"
         r"\s*sizeof\((?P=migration_notes)\)\s*/\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
         re.S,
@@ -800,6 +823,13 @@ def _parse_runtime_event_coverage_registry(
                 f"{row_match.group('transition_sequence_refs')}"
             )
             transition_sequence_refs = []
+        dispatch_surface_refs = arrays.get(row_match.group("dispatch_surface_refs"))
+        if dispatch_surface_refs is None:
+            failures.append(
+                f"runtime_event_coverage[{index}]: unknown dispatch-surface-refs table: "
+                f"{row_match.group('dispatch_surface_refs')}"
+            )
+            dispatch_surface_refs = []
         if migration_notes is None:
             failures.append(
                 f"runtime_event_coverage[{index}]: unknown migration-notes table: "
@@ -818,6 +848,7 @@ def _parse_runtime_event_coverage_registry(
                 "boundary_status": row_match.group("boundary_status"),
                 "trigger_paths": trigger_paths,
                 "transition_sequence_refs": transition_sequence_refs,
+                "dispatch_surface_refs": dispatch_surface_refs,
                 "migration_notes": migration_notes,
             }
         )
@@ -1906,6 +1937,7 @@ def _validate_runtime_action_coverage_registry(
     runtime_transition_ids: set[str],
     runtime_transition_sequence_records: list[Any],
     runtime_action_transitions: list[dict[str, str]],
+    runtime_dispatch_surface_records: list[Any],
     registered_owner_fields: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -1964,6 +1996,13 @@ def _validate_runtime_action_coverage_registry(
                 label=label,
             )[0]
         )
+        failures.extend(
+            _validate_dispatch_surface_refs(
+                record=record,
+                dispatch_surface_records=runtime_dispatch_surface_records,
+                label=label,
+            )
+        )
 
         transition_id = record.get("transition_id")
         transition_record = None
@@ -2013,6 +2052,7 @@ def _validate_runtime_action_coverage_registry(
                     "owner",
                     "declared_write_set",
                     "transition_sequence_refs",
+                    "dispatch_surface_refs",
                     "boundary_status",
                     "migration_notes",
                 ):
@@ -3621,6 +3661,65 @@ def _validate_transition_sequence_refs(
     return failures, matching_steps
 
 
+def _dispatch_surfaces_by_id(
+    dispatch_surface_records: list[Any],
+) -> dict[str, dict[str, Any]]:
+    return {
+        surface["surface_id"]: surface
+        for surface in dispatch_surface_records
+        if isinstance(surface, dict)
+        and isinstance(surface.get("surface_id"), str)
+        and surface["surface_id"].strip()
+    }
+
+
+def _validate_dispatch_surface_refs(
+    *,
+    record: dict[str, Any],
+    dispatch_surface_records: list[Any],
+    label: str,
+) -> list[str]:
+    refs = record.get("dispatch_surface_refs")
+    transition_id = record.get("transition_id")
+    failures = _validate_list_field(
+        value=refs,
+        label=label,
+        field="dispatch_surface_refs",
+    )
+    if failures:
+        return failures
+
+    assert isinstance(refs, list)
+    surfaces = _dispatch_surfaces_by_id(dispatch_surface_records)
+    seen: set[str] = set()
+    for index, surface_id in enumerate(refs):
+        if not isinstance(surface_id, str) or not surface_id.strip():
+            failures.append(
+                f"{label}: dispatch_surface_refs[{index}] must be a non-empty string"
+            )
+            continue
+        if surface_id in seen:
+            failures.append(f"{label}: duplicate dispatch_surface_refs[{index}]: {surface_id}")
+        seen.add(surface_id)
+        surface = surfaces.get(surface_id)
+        if surface is None:
+            failures.append(
+                f"{label}: dispatch_surface_refs references unknown dispatch surface: {surface_id}"
+            )
+            continue
+        if (
+            isinstance(transition_id, str)
+            and transition_id.strip()
+            and surface.get("transition_id") != transition_id
+        ):
+            failures.append(
+                f"{label}: dispatch_surface_refs[{index}] transition_id does not match "
+                f"{transition_id}: {surface_id}"
+            )
+
+    return failures
+
+
 def _validate_dispatch_surface_transition_sequence_coverage(
     *,
     record: dict[str, Any],
@@ -4300,6 +4399,7 @@ def _validate_runtime_event_coverage_registry(
     event_coverage_doc: Any,
     transition_ids: dict[str, dict[str, Any]],
     runtime_transition_sequence_records: list[Any],
+    runtime_dispatch_surface_records: list[Any],
     runtime_transition_ids: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -4329,6 +4429,13 @@ def _validate_runtime_event_coverage_registry(
                 transition_sequence_records=runtime_transition_sequence_records,
                 label=label,
             )[0]
+        )
+        failures.extend(
+            _validate_dispatch_surface_refs(
+                record=record,
+                dispatch_surface_records=runtime_dispatch_surface_records,
+                label=label,
+            )
         )
         event_id = record.get("event_id")
         if isinstance(event_id, str) and event_id.strip():
@@ -4393,6 +4500,7 @@ def _validate_event_coverage(
     event_coverage_path: Path,
     transition_ids: dict[str, dict[str, Any]],
     transition_sequence_records: list[Any],
+    dispatch_surface_records: list[Any],
     registered_owner_fields: set[str],
 ) -> list[str]:
     failures: list[str] = []
@@ -4442,6 +4550,13 @@ def _validate_event_coverage(
                 transition_sequence_records=transition_sequence_records,
                 label=label,
             )[0]
+        )
+        failures.extend(
+            _validate_dispatch_surface_refs(
+                record=record,
+                dispatch_surface_records=dispatch_surface_records,
+                label=label,
+            )
         )
 
         event_id = record.get("event_id")
@@ -6000,6 +6115,12 @@ def validate_contract(
         if not isinstance(action_records, list) or not action_records:
             failures.append(f"{action_coverage_path}: actions must be a non-empty list")
             action_records = []
+    if isinstance(dispatch_surfaces_doc, dict) and isinstance(
+        dispatch_surfaces_doc.get("dispatch_surfaces"), list
+    ):
+        dispatch_surface_records = dispatch_surfaces_doc["dispatch_surfaces"]
+    else:
+        dispatch_surface_records = []
 
     expected_actions = set(enum_actions)
     covered_actions: set[str] = set()
@@ -6034,6 +6155,13 @@ def validate_contract(
                 ),
                 label=label,
             )[0]
+        )
+        failures.extend(
+            _validate_dispatch_surface_refs(
+                record=record,
+                dispatch_surface_records=dispatch_surface_records,
+                label=label,
+            )
         )
 
         action = record.get("action")
@@ -6110,6 +6238,7 @@ def validate_contract(
             },
             runtime_transition_sequence_records=runtime_transition_sequence_records,
             runtime_action_transitions=runtime_action_records,
+            runtime_dispatch_surface_records=runtime_dispatch_surface_records,
             registered_owner_fields=registered_owner_fields,
         )
     )
@@ -6125,6 +6254,7 @@ def validate_contract(
                 and isinstance(transition_sequences_doc.get("scenarios"), list)
                 else []
             ),
+            dispatch_surface_records=dispatch_surface_records,
             registered_owner_fields=registered_owner_fields,
         )
     )
@@ -6135,6 +6265,7 @@ def validate_contract(
             event_coverage_doc=event_coverage_doc,
             transition_ids=transition_ids,
             runtime_transition_sequence_records=runtime_transition_sequence_records,
+            runtime_dispatch_surface_records=runtime_dispatch_surface_records,
             runtime_transition_ids={record["id"] for record in runtime_transition_records},
         )
     )
@@ -6155,12 +6286,6 @@ def validate_contract(
             invariant_protected_fields=invariant_protected_fields,
         )
     )
-    if isinstance(dispatch_surfaces_doc, dict) and isinstance(
-        dispatch_surfaces_doc.get("dispatch_surfaces"), list
-    ):
-        dispatch_surface_records = dispatch_surfaces_doc["dispatch_surfaces"]
-    else:
-        dispatch_surface_records = []
     failures.extend(
         _validate_runtime_dispatch_surface_registry(
             runtime_records=runtime_dispatch_surface_records,

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -1401,6 +1401,7 @@ static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTr
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds5_1[] = {
   "invariant.stale-snapshot-fail-closed",
+  "invariant.hidden-entry-visible-navigation",
   "invariant.viewport-identity-rebind",
 };
 
@@ -2169,6 +2170,39 @@ static const char *const kAppStateDispatchSurfaceMigrationNotes9[] = {
   "Current render refresh projects settled state to ncurses windows; projection must not become selection, viewport, or topology authority.",
 };
 
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs10[] = {
+  "sequence.search-jump",
+};
+static const char *const kAppStateDispatchSurfaceMigrationNotes10[] = {
+  "Current command handlers settle completion state after external or user-command execution returns; runtime migration should lift that completion boundary without broadening write authority here.",
+};
+static const char *const kAppStateDispatchSurfaceAllowedDirectWrites11[] = {
+  "ctx.active",
+  "panel.volume_key",
+  "panel.restore_snapshot",
+  "panel.panel_generation",
+};
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs11[] = {
+  "sequence.volume-menu-select",
+};
+static const char *const kAppStateDispatchSurfaceMigrationNotes11[] = {
+  "Current loaded-volume menu selection remains the existing selection boundary for active-panel volume binding until dedicated runtime transition objects replace menu-coupled control flow.",
+};
+static const char *const kAppStateDispatchSurfaceAllowedDirectWrites12[] = {
+  "panel.tree_selection_key",
+  "panel.file_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+  "panel.panel_generation",
+};
+static const char *const kAppStateDispatchSurfaceTransitionSequenceRefs12[] = {
+  "sequence.refresh-rebuild",
+};
+static const char *const kAppStateDispatchSurfaceMigrationNotes12[] = {
+  "Current panel-anchor restore helpers remain the canonical callback surface for post-rebuild re-resolution; migration should keep fallback ordering anchored here.",
+};
+
 static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
   {"surface.key-decode-input-dispatch",
    "key_decode_input_dispatch",
@@ -2306,6 +2340,47 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
        sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs9[0]),
    kAppStateDispatchSurfaceMigrationNotes9,
    sizeof(kAppStateDispatchSurfaceMigrationNotes9) / sizeof(kAppStateDispatchSurfaceMigrationNotes9[0])},
+  {"surface.command-completion-dispatch",
+   "command_completion_dispatch",
+   "src/ui/ctrl_file_ops.c",
+   "handle_file_window_command_action",
+   "transition.command-completion.user-command",
+   "documented_foundation_only",
+   NULL,
+   0,
+   kAppStateDispatchSurfaceTransitionSequenceRefs10,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs10) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs10[0]),
+   kAppStateDispatchSurfaceMigrationNotes10,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes10) / sizeof(kAppStateDispatchSurfaceMigrationNotes10[0])},
+  {"surface.volume-menu-selection",
+   "volume_menu_selection",
+   "src/ui/volume_menu.c",
+   "SelectLoadedVolume",
+   "transition.menu-action.volume-select",
+   "documented_foundation_only",
+   kAppStateDispatchSurfaceAllowedDirectWrites11,
+   sizeof(kAppStateDispatchSurfaceAllowedDirectWrites11) /
+       sizeof(kAppStateDispatchSurfaceAllowedDirectWrites11[0]),
+   kAppStateDispatchSurfaceTransitionSequenceRefs11,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs11) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs11[0]),
+   kAppStateDispatchSurfaceMigrationNotes11,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes11) / sizeof(kAppStateDispatchSurfaceMigrationNotes11[0])},
+  {"surface.panel-anchor-rebind",
+   "rebuild_rebind_callback",
+   "src/ui/panel_anchor.c",
+   "RestorePanelViewportSnapshot",
+   "transition.rebuild-rebind-callback.panel-anchor",
+   "documented_foundation_only",
+   kAppStateDispatchSurfaceAllowedDirectWrites12,
+   sizeof(kAppStateDispatchSurfaceAllowedDirectWrites12) /
+       sizeof(kAppStateDispatchSurfaceAllowedDirectWrites12[0]),
+   kAppStateDispatchSurfaceTransitionSequenceRefs12,
+   sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs12) /
+       sizeof(kAppStateDispatchSurfaceTransitionSequenceRefs12[0]),
+   kAppStateDispatchSurfaceMigrationNotes12,
+   sizeof(kAppStateDispatchSurfaceMigrationNotes12) / sizeof(kAppStateDispatchSurfaceMigrationNotes12[0])},
 };
 static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {
   "invariant.hidden-entry-visible-navigation",
@@ -2421,6 +2496,7 @@ static const char *const kAppStateInvariantTransitionIds0[] = {
 static const char *const kAppStateInvariantDispatchSurfaceIds0[] = {
   "surface.directory-window-action-dispatch",
   "surface.file-window-action-dispatch",
+  "surface.volume-menu-selection",
   "surface.menu-modal-completion",
   "surface.refresh-rebuild-rebind",
   "surface.volume-operation",
@@ -2478,6 +2554,7 @@ static const char *const kAppStateInvariantTransitionIds2[] = {
 static const char *const kAppStateInvariantDispatchSurfaceIds2[] = {
   "surface.directory-window-action-dispatch",
   "surface.refresh-rebuild-rebind",
+  "surface.panel-anchor-rebind",
   "surface.watcher-live-refresh",
 };
 
@@ -2536,6 +2613,7 @@ static const char *const kAppStateInvariantDispatchSurfaceIds4[] = {
   "surface.refresh-rebuild-rebind",
   "surface.resize-signal-handling",
   "surface.filesystem-mutation-result",
+  "surface.panel-anchor-rebind",
   "surface.watcher-live-refresh",
 };
 
@@ -2566,6 +2644,7 @@ static const char *const kAppStateInvariantTransitionIds5[] = {
 };
 
 static const char *const kAppStateInvariantDispatchSurfaceIds5[] = {
+  "surface.volume-menu-selection",
   "surface.volume-operation",
   "surface.refresh-rebuild-rebind",
   "surface.filesystem-mutation-result",
@@ -2598,6 +2677,7 @@ static const char *const kAppStateInvariantDispatchSurfaceIds6[] = {
   "surface.refresh-rebuild-rebind",
   "surface.volume-operation",
   "surface.filesystem-mutation-result",
+  "surface.panel-anchor-rebind",
   "surface.watcher-live-refresh",
 };
 
@@ -3011,6 +3091,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs0[] = {
 static const char *const kAppStateEventCoverageMigrationNotes0[] = {
   "Signal handlers may only set flags; resize commits through the main-loop transition boundary.",
 };
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs0[] = {
+  "surface.resize-signal-handling",
+};
 static const char *const kAppStateEventCoverageTriggerPaths1[] = {
   "Manual refresh command",
   "Explicit relog of the current path",
@@ -3020,6 +3103,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs1[] = {
 };
 static const char *const kAppStateEventCoverageMigrationNotes1[] = {
   "Rebuild must settle topology, advance generation, then rebind panels by stable identity.",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs1[] = {
+  "surface.refresh-rebuild-rebind",
 };
 static const char *const kAppStateEventCoverageTriggerPaths2[] = {
   "Post-refresh restore",
@@ -3032,6 +3118,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs2[] = {
 static const char *const kAppStateEventCoverageMigrationNotes2[] = {
   "Callback coverage points to the existing rebuild/rebind transition rather than inventing a separate runtime event.",
 };
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs2[] = {
+  "surface.panel-anchor-rebind",
+};
 static const char *const kAppStateEventCoverageTriggerPaths3[] = {
   "Create directory result",
   "Copy or move result",
@@ -3042,6 +3131,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs3[] = {
 };
 static const char *const kAppStateEventCoverageMigrationNotes3[] = {
   "Command side effects remain outside AppState commit; only completed results may update AppState metadata.",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs3[] = {
+  "surface.filesystem-mutation-result",
 };
 static const char *const kAppStateEventCoverageTriggerPaths4[] = {
   "Watcher notification",
@@ -3054,6 +3146,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs4[] = {
 static const char *const kAppStateEventCoverageMigrationNotes4[] = {
   "Watcher/live-refresh intentionally maps to the broad refresh_rebuild transition until a dedicated watcher runtime boundary exists.",
 };
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs4[] = {
+  "surface.watcher-live-refresh",
+};
 static const char *const kAppStateEventCoverageTriggerPaths5[] = {
   "External command completion",
   "User command menu completion",
@@ -3064,6 +3159,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs5[] = {
 };
 static const char *const kAppStateEventCoverageMigrationNotes5[] = {
   "Command completion may schedule refresh only when the command contract declares filesystem impact.",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs5[] = {
+  "surface.command-completion-dispatch",
 };
 static const char *const kAppStateEventCoverageTriggerPaths6[] = {
   "Modal Enter completion",
@@ -3076,6 +3174,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs6[] = {
 static const char *const kAppStateEventCoverageMigrationNotes6[] = {
   "Modal completion maps to the modal_action dismiss record while destructive confirmations remain governed by their own command transitions.",
 };
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs6[] = {
+  "surface.menu-modal-completion",
+};
 static const char *const kAppStateEventCoverageTriggerPaths7[] = {
   "Cycle loaded volume",
   "Release volume",
@@ -3087,6 +3188,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs7[] = {
 static const char *const kAppStateEventCoverageMigrationNotes7[] = {
   "Lifecycle coverage keeps inactive panels from inheriting stale volume pointers during migration.",
 };
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs7[] = {
+  "surface.volume-operation",
+};
 static const char *const kAppStateEventCoverageTriggerPaths8[] = {
   "Render dirty flag projection",
   "Layout reflow projection",
@@ -3097,6 +3201,9 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs8[] = {
 };
 static const char *const kAppStateEventCoverageMigrationNotes8[] = {
   "Render/reflow is projection-only and must not become restore authority.",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs8[] = {
+  "surface.render-reflow-projection",
 };
 
 static const AppStateEventCoverageMetadata
@@ -3114,6 +3221,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths0) / sizeof(kAppStateEventCoverageTriggerPaths0[0]),
    kAppStateEventCoverageTransitionSequenceRefs0,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs0) / sizeof(kAppStateEventCoverageTransitionSequenceRefs0[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs0) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs0[0]),
    kAppStateEventCoverageMigrationNotes0,
    sizeof(kAppStateEventCoverageMigrationNotes0) / sizeof(kAppStateEventCoverageMigrationNotes0[0])},
   {"event.refresh-rebuild",
@@ -3129,6 +3238,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths1) / sizeof(kAppStateEventCoverageTriggerPaths1[0]),
    kAppStateEventCoverageTransitionSequenceRefs1,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs1) / sizeof(kAppStateEventCoverageTransitionSequenceRefs1[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs1,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs1) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs1[0]),
    kAppStateEventCoverageMigrationNotes1,
    sizeof(kAppStateEventCoverageMigrationNotes1) / sizeof(kAppStateEventCoverageMigrationNotes1[0])},
   {"event.rebuild-rebind-callback",
@@ -3144,6 +3255,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths2) / sizeof(kAppStateEventCoverageTriggerPaths2[0]),
    kAppStateEventCoverageTransitionSequenceRefs2,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs2) / sizeof(kAppStateEventCoverageTransitionSequenceRefs2[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs2,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs2) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs2[0]),
    kAppStateEventCoverageMigrationNotes2,
    sizeof(kAppStateEventCoverageMigrationNotes2) / sizeof(kAppStateEventCoverageMigrationNotes2[0])},
   {"event.filesystem-mutation-result",
@@ -3159,6 +3272,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths3) / sizeof(kAppStateEventCoverageTriggerPaths3[0]),
    kAppStateEventCoverageTransitionSequenceRefs3,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs3) / sizeof(kAppStateEventCoverageTransitionSequenceRefs3[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs3,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs3) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs3[0]),
    kAppStateEventCoverageMigrationNotes3,
    sizeof(kAppStateEventCoverageMigrationNotes3) / sizeof(kAppStateEventCoverageMigrationNotes3[0])},
   {"event.watcher-live-refresh",
@@ -3174,6 +3289,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths4) / sizeof(kAppStateEventCoverageTriggerPaths4[0]),
    kAppStateEventCoverageTransitionSequenceRefs4,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs4) / sizeof(kAppStateEventCoverageTransitionSequenceRefs4[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs4,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs4) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs4[0]),
    kAppStateEventCoverageMigrationNotes4,
    sizeof(kAppStateEventCoverageMigrationNotes4) / sizeof(kAppStateEventCoverageMigrationNotes4[0])},
   {"event.command-completion",
@@ -3189,6 +3306,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths5) / sizeof(kAppStateEventCoverageTriggerPaths5[0]),
    kAppStateEventCoverageTransitionSequenceRefs5,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs5) / sizeof(kAppStateEventCoverageTransitionSequenceRefs5[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs5,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs5) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs5[0]),
    kAppStateEventCoverageMigrationNotes5,
    sizeof(kAppStateEventCoverageMigrationNotes5) / sizeof(kAppStateEventCoverageMigrationNotes5[0])},
   {"event.modal-completion",
@@ -3204,6 +3323,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths6) / sizeof(kAppStateEventCoverageTriggerPaths6[0]),
    kAppStateEventCoverageTransitionSequenceRefs6,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs6) / sizeof(kAppStateEventCoverageTransitionSequenceRefs6[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs6,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs6) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs6[0]),
    kAppStateEventCoverageMigrationNotes6,
    sizeof(kAppStateEventCoverageMigrationNotes6) / sizeof(kAppStateEventCoverageMigrationNotes6[0])},
   {"event.volume-lifecycle",
@@ -3219,6 +3340,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths7) / sizeof(kAppStateEventCoverageTriggerPaths7[0]),
    kAppStateEventCoverageTransitionSequenceRefs7,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs7) / sizeof(kAppStateEventCoverageTransitionSequenceRefs7[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs7) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs7[0]),
    kAppStateEventCoverageMigrationNotes7,
    sizeof(kAppStateEventCoverageMigrationNotes7) / sizeof(kAppStateEventCoverageMigrationNotes7[0])},
   {"event.render-reflow",
@@ -3234,6 +3357,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTriggerPaths8) / sizeof(kAppStateEventCoverageTriggerPaths8[0]),
    kAppStateEventCoverageTransitionSequenceRefs8,
    sizeof(kAppStateEventCoverageTransitionSequenceRefs8) / sizeof(kAppStateEventCoverageTransitionSequenceRefs8[0]),
+   kAppStateEventCoverageDispatchSurfaceRefs8,
+   sizeof(kAppStateEventCoverageDispatchSurfaceRefs8) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs8[0]),
    kAppStateEventCoverageMigrationNotes8,
    sizeof(kAppStateEventCoverageMigrationNotes8) / sizeof(kAppStateEventCoverageMigrationNotes8[0])},
 };
@@ -3251,11 +3376,19 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs0[] = {
   "sequence.split-toggle-f8",
   "sequence.tab-panel-switch",
 };
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs0[] = {
+  "surface.key-decode-input-dispatch",
+  "surface.directory-window-action-dispatch",
+  "surface.file-window-action-dispatch",
+};
 static const char *const kAppStateActionCoverageMigrationNotes1[] = {
   "Esc dismissal for an active modal maps to the modal_action dismiss record; non-modal Esc no-op behavior remains a blocked keybinding outcome for later context-specific runtime coverage.",
 };
 static const char *const kAppStateActionCoverageTransitionSequenceRefs1[] = {
   "sequence.esc-modal-dismissal",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs1[] = {
+  "surface.menu-modal-completion",
 };
 static const char *const kAppStateActionCoverageMigrationNotes2[] = {
   "Covered by the refresh/rebuild foundation record until log, relog, and refresh actions receive dedicated runtime records.",
@@ -3263,11 +3396,17 @@ static const char *const kAppStateActionCoverageMigrationNotes2[] = {
 static const char *const kAppStateActionCoverageTransitionSequenceRefs2[] = {
   "sequence.refresh-rebuild",
 };
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs2[] = {
+  "surface.refresh-rebuild-rebind",
+};
 static const char *const kAppStateActionCoverageMigrationNotes3[] = {
   "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records.",
 };
 static const char *const kAppStateActionCoverageTransitionSequenceRefs3[] = {
   "sequence.search-jump",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs3[] = {
+  "surface.command-completion-dispatch",
 };
 static const char *const kAppStateActionCoverageMigrationNotes4[] = {
   "Covered by the terminal resize foundation record; signal handlers must only set flags before this transition commits.",
@@ -3275,11 +3414,17 @@ static const char *const kAppStateActionCoverageMigrationNotes4[] = {
 static const char *const kAppStateActionCoverageTransitionSequenceRefs4[] = {
   "sequence.terminal-resize-reflow",
 };
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs4[] = {
+  "surface.resize-signal-handling",
+};
 static const char *const kAppStateActionCoverageMigrationNotes5[] = {
   "Covered by the volume menu foundation record until menu selection has a runtime transition boundary.",
 };
 static const char *const kAppStateActionCoverageTransitionSequenceRefs5[] = {
   "sequence.volume-menu-select",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs5[] = {
+  "surface.volume-menu-selection",
 };
 static const char *const kAppStateActionCoverageMigrationNotes6[] = {
   "Covered by the volume operation foundation record until cycle/release actions receive dedicated runtime records.",
@@ -3287,11 +3432,17 @@ static const char *const kAppStateActionCoverageMigrationNotes6[] = {
 static const char *const kAppStateActionCoverageTransitionSequenceRefs6[] = {
   "sequence.volume-cycling-release",
 };
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs6[] = {
+  "surface.volume-operation",
+};
 static const char *const kAppStateActionCoverageMigrationNotes7[] = {
   "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata.",
 };
 static const char *const kAppStateActionCoverageTransitionSequenceRefs7[] = {
   "sequence.filesystem-mutation-result",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs7[] = {
+  "surface.filesystem-mutation-result",
 };
 
 static const AppStateActionCoverageMetadata
@@ -3305,6 +3456,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3317,6 +3470,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3329,6 +3484,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3341,6 +3498,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3353,6 +3512,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3365,6 +3526,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3377,6 +3540,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3389,6 +3554,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3401,6 +3568,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3413,6 +3582,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3425,6 +3596,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3437,6 +3610,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3449,6 +3624,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3461,6 +3638,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3473,6 +3652,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3485,6 +3666,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet2) / sizeof(kAppStateTransitionWriteSet2[0]),
    kAppStateActionCoverageTransitionSequenceRefs1,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs1) / sizeof(kAppStateActionCoverageTransitionSequenceRefs1[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs1,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs1) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs1[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes1,
    sizeof(kAppStateActionCoverageMigrationNotes1) / sizeof(kAppStateActionCoverageMigrationNotes1[0])},
@@ -3497,6 +3680,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet3) / sizeof(kAppStateTransitionWriteSet3[0]),
    kAppStateActionCoverageTransitionSequenceRefs2,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs2) / sizeof(kAppStateActionCoverageTransitionSequenceRefs2[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs2,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs2) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs2[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes2,
    sizeof(kAppStateActionCoverageMigrationNotes2) / sizeof(kAppStateActionCoverageMigrationNotes2[0])},
@@ -3509,6 +3694,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0]),
    kAppStateActionCoverageTransitionSequenceRefs3,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs3,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -3521,6 +3708,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0]),
    kAppStateActionCoverageTransitionSequenceRefs3,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs3,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -3533,6 +3722,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3545,6 +3736,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3557,6 +3750,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3569,6 +3764,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3581,6 +3778,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3593,6 +3792,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3605,6 +3806,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3617,6 +3820,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3629,6 +3834,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet3) / sizeof(kAppStateTransitionWriteSet3[0]),
    kAppStateActionCoverageTransitionSequenceRefs2,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs2) / sizeof(kAppStateActionCoverageTransitionSequenceRefs2[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs2,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs2) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs2[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes2,
    sizeof(kAppStateActionCoverageMigrationNotes2) / sizeof(kAppStateActionCoverageMigrationNotes2[0])},
@@ -3641,6 +3848,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet5) / sizeof(kAppStateTransitionWriteSet5[0]),
    kAppStateActionCoverageTransitionSequenceRefs4,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs4) / sizeof(kAppStateActionCoverageTransitionSequenceRefs4[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs4,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs4) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs4[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes4,
    sizeof(kAppStateActionCoverageMigrationNotes4) / sizeof(kAppStateActionCoverageMigrationNotes4[0])},
@@ -3653,6 +3862,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet1) / sizeof(kAppStateTransitionWriteSet1[0]),
    kAppStateActionCoverageTransitionSequenceRefs5,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs5) / sizeof(kAppStateActionCoverageTransitionSequenceRefs5[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs5,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs5) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs5[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes5,
    sizeof(kAppStateActionCoverageMigrationNotes5) / sizeof(kAppStateActionCoverageMigrationNotes5[0])},
@@ -3665,6 +3876,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet4) / sizeof(kAppStateTransitionWriteSet4[0]),
    kAppStateActionCoverageTransitionSequenceRefs6,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs6) / sizeof(kAppStateActionCoverageTransitionSequenceRefs6[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs6,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs6) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs6[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes6,
    sizeof(kAppStateActionCoverageMigrationNotes6) / sizeof(kAppStateActionCoverageMigrationNotes6[0])},
@@ -3677,6 +3890,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet4) / sizeof(kAppStateTransitionWriteSet4[0]),
    kAppStateActionCoverageTransitionSequenceRefs6,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs6) / sizeof(kAppStateActionCoverageTransitionSequenceRefs6[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs6,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs6) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs6[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes6,
    sizeof(kAppStateActionCoverageMigrationNotes6) / sizeof(kAppStateActionCoverageMigrationNotes6[0])},
@@ -3689,6 +3904,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3701,6 +3918,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3713,6 +3932,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3725,6 +3946,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3737,6 +3960,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3749,6 +3974,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3761,6 +3988,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3773,6 +4002,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3785,6 +4016,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3797,6 +4030,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3809,6 +4044,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3821,6 +4058,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3833,6 +4072,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3845,6 +4086,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3857,6 +4100,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3869,6 +4114,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3881,6 +4128,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0]),
    kAppStateActionCoverageTransitionSequenceRefs3,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs3,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -3893,6 +4142,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3905,6 +4156,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3917,6 +4170,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3929,6 +4184,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3941,6 +4198,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3953,6 +4212,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3965,6 +4226,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3977,6 +4240,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3989,6 +4254,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4001,6 +4268,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4013,6 +4282,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4025,6 +4296,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4037,6 +4310,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4049,6 +4324,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4061,6 +4338,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0]),
    kAppStateActionCoverageTransitionSequenceRefs7,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs7,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4073,6 +4352,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0]),
    kAppStateActionCoverageTransitionSequenceRefs3,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs3,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -4085,6 +4366,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4097,6 +4380,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4109,6 +4394,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4121,6 +4408,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4133,6 +4422,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4145,6 +4436,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4157,6 +4450,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4169,6 +4464,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4181,6 +4478,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4193,6 +4492,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4205,6 +4506,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4217,6 +4520,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4229,6 +4534,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4241,6 +4548,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4253,6 +4562,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4265,6 +4576,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4277,6 +4590,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4289,6 +4604,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0]),
    kAppStateActionCoverageTransitionSequenceRefs0,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs0,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4301,6 +4618,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0]),
    kAppStateActionCoverageTransitionSequenceRefs3,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs3,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -4313,6 +4632,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0]),
    kAppStateActionCoverageTransitionSequenceRefs3,
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
+   kAppStateActionCoverageDispatchSurfaceRefs3,
+   sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -223,6 +223,9 @@ static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
   "surface.volume-operation",
   "surface.watcher-live-refresh",
   "surface.render-reflow-projection",
+  "surface.command-completion-dispatch",
+  "surface.volume-menu-selection",
+  "surface.panel-anchor-rebind",
 };
 
 static const char *const kAppStateRequiredShimIds[] = {
@@ -1024,6 +1027,33 @@ static int AppStateTransitionSequenceRefsReady(const char *const *refs,
   return 1;
 }
 
+static int AppStateDispatchSurfaceRefsReady(const char *const *refs,
+                                            size_t ref_count,
+                                            const char *transition_id) {
+  size_t ref_index;
+
+  if (!NonEmptyString(transition_id) || !NonEmptyStringList(refs, ref_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < ref_count; ref_index++) {
+    const AppStateDispatchSurfaceMetadata *surface =
+        AppStateDispatchSurfaceLookup(refs[ref_index]);
+    size_t previous_index;
+
+    if (surface == NULL)
+      return 0;
+    if (!NonEmptyString(surface->transition_id) ||
+        strcmp(surface->transition_id, transition_id) != 0)
+      return 0;
+    for (previous_index = 0; previous_index < ref_index; previous_index++) {
+      if (strcmp(refs[previous_index], refs[ref_index]) == 0)
+        return 0;
+    }
+  }
+
+  return 1;
+}
+
 static int AppStateDispatchSurfaceSequenceRefsReady(
     const AppStateDispatchSurfaceMetadata *metadata) {
   if (metadata == NULL)
@@ -1671,6 +1701,9 @@ static int AppStateEventCoverageReady(void) {
         !AppStateTransitionSequenceRefsReady(
             coverage->transition_sequence_refs,
             coverage->transition_sequence_ref_count, coverage->transition_id) ||
+        !AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs,
+                                         coverage->dispatch_surface_ref_count,
+                                         coverage->transition_id) ||
         !NonEmptyStringList(coverage->migration_notes,
                             coverage->migration_note_count))
       return 0;
@@ -1748,6 +1781,9 @@ static int AppStateActionCoverageReady(void) {
         !AppStateTransitionSequenceRefsReady(
             coverage->transition_sequence_refs,
             coverage->transition_sequence_ref_count, coverage->transition_id) ||
+        !AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs,
+                                         coverage->dispatch_surface_ref_count,
+                                         coverage->transition_id) ||
         !NonEmptyStringList(coverage->migration_notes,
                             coverage->migration_note_count))
       return 0;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -17,7 +17,21 @@ GUARD_SPEC.loader.exec_module(guard)
 
 REQUIRED_CATEGORIES = sorted(guard.REQUIRED_TRANSITION_CATEGORIES)
 REQUIRED_EVENT_CLASSES = sorted(guard.REQUIRED_EVENT_CLASSES)
-REQUIRED_DISPATCH_SURFACE_CATEGORIES = sorted(guard.REQUIRED_DISPATCH_SURFACE_CATEGORIES)
+REQUIRED_DISPATCH_SURFACE_CATEGORIES = [
+    "key_decode_input_dispatch",
+    "directory_window_action_dispatch",
+    "file_window_action_dispatch",
+    "menu_modal_completion",
+    "resize_signal_handling",
+    "refresh_rebuild_rebind",
+    "filesystem_mutation_result",
+    "volume_operation",
+    "watcher_live_refresh",
+    "render_reflow_projection",
+    "command_completion_dispatch",
+    "volume_menu_selection",
+    "rebuild_rebind_callback",
+]
 REQUIRED_INVARIANT_CATEGORIES = sorted(guard.REQUIRED_INVARIANT_CATEGORIES)
 REQUIRED_GENERATION_DOMAIN_CATEGORIES = sorted(
     guard.REQUIRED_GENERATION_DOMAIN_CATEGORIES
@@ -135,6 +149,9 @@ def _action(
         "owner": "owner",
         "declared_write_set": ["panel.tree_selection_key"],
         "transition_sequence_refs": _sequence_refs_for_transition(transition_id),
+        "dispatch_surface_refs": _dispatch_surface_refs_for_transition(
+            transition_id, action=action
+        ),
         "boundary_status": "test",
         "migration_notes": ["fixture action coverage"],
     }
@@ -168,6 +185,10 @@ def _event(
         "transition_sequence_refs": _sequence_refs_for_transition(
             transition_id or f"transition.{resolved_category}"
         ),
+        "dispatch_surface_refs": _dispatch_surface_refs_for_transition(
+            transition_id or f"transition.{resolved_category}",
+            event_id=f"event.{event_class}",
+        ),
         "boundary_status": "test",
         "trigger_paths": ["fixture trigger"],
         "migration_notes": ["fixture event coverage"],
@@ -191,6 +212,37 @@ def _sequence_refs_for_transition(transition_id: str) -> list[str]:
     }.get(transition_id, ["sequence.split_toggle_f8"])
 
 
+def _dispatch_surface_refs_for_transition(
+    transition_id: str,
+    *,
+    action: str | None = None,
+    event_id: str | None = None,
+) -> list[str]:
+    if transition_id == "transition.keybinding":
+        return [
+            "surface.key_decode_input_dispatch",
+            "surface.directory_window_action_dispatch",
+            "surface.file_window_action_dispatch",
+        ]
+    if transition_id == "transition.refresh_rebuild":
+        if event_id == "event.watcher_live_refresh":
+            return ["surface.watcher_live_refresh"]
+        return ["surface.refresh_rebuild_rebind"]
+    if transition_id == "transition.rebuild_rebind_callback":
+        return ["surface.rebuild_rebind_callback"]
+    if transition_id == "transition.command_completion":
+        return ["surface.command_completion_dispatch"]
+    if transition_id == "transition.menu_action" and action == "ACTION_VOL_MENU":
+        return ["surface.volume_menu_selection"]
+    return {
+        "transition.filesystem_mutation_result": ["surface.filesystem_mutation_result"],
+        "transition.modal_action": ["surface.menu_modal_completion"],
+        "transition.render_reflow": ["surface.render_reflow_projection"],
+        "transition.terminal_signal_or_resize": ["surface.resize_signal_handling"],
+        "transition.volume_operation": ["surface.volume_operation"],
+    }.get(transition_id, ["surface.key_decode_input_dispatch"])
+
+
 def _dispatch_surface(
     category: str,
     transition_id: str | None = None,
@@ -207,6 +259,9 @@ def _dispatch_surface(
         "volume_operation": "transition.volume_operation",
         "watcher_live_refresh": "transition.refresh_rebuild",
         "render_reflow_projection": "transition.render_reflow",
+        "command_completion_dispatch": "transition.command_completion",
+        "volume_menu_selection": "transition.menu_action",
+        "rebuild_rebind_callback": "transition.rebuild_rebind_callback",
     }
     sequence_by_surface_category = {
         "key_decode_input_dispatch": "sequence.split_toggle_f8",
@@ -219,6 +274,9 @@ def _dispatch_surface(
         "volume_operation": "sequence.volume_cycling_release",
         "watcher_live_refresh": "sequence.refresh_rebuild",
         "render_reflow_projection": "sequence.render_reflow_projection",
+        "command_completion_dispatch": "sequence.search_jump",
+        "volume_menu_selection": "sequence.volume_menu_select",
+        "rebuild_rebind_callback": "sequence.refresh_rebuild",
     }
     return {
         "surface_id": surface_id or f"surface.{category}",
@@ -704,6 +762,19 @@ def _runtime_source(
             f"static const char *const {sequence_refs_table}[] = "
             f"{{\n{sequence_ref_rows}\n}};\n"
         )
+        dispatch_surface_refs = record.get("dispatch_surface_refs")
+        if not isinstance(dispatch_surface_refs, list):
+            dispatch_surface_refs = []
+        dispatch_surface_ref_rows = "\n".join(
+            f'  "{ref}",' for ref in dispatch_surface_refs if isinstance(ref, str)
+        )
+        dispatch_surface_refs_table = (
+            f"kAppStateActionCoverageDispatchSurfaceRefs{index}"
+        )
+        action_coverage_arrays.append(
+            f"static const char *const {dispatch_surface_refs_table}[] = "
+            f"{{\n{dispatch_surface_ref_rows}\n}};\n"
+        )
         action = record.get("action", "")
         action_coverage_rows.append(
             f'  {{{action}, "{action}", "{record.get("transition_id", "")}", '
@@ -712,6 +783,8 @@ def _runtime_source(
             f"sizeof({write_set_table}[0]), "
             f"{sequence_refs_table}, sizeof({sequence_refs_table}) / "
             f"sizeof({sequence_refs_table}[0]), "
+            f"{dispatch_surface_refs_table}, sizeof({dispatch_surface_refs_table}) / "
+            f"sizeof({dispatch_surface_refs_table}[0]), "
             f'"{record.get("boundary_status", "")}", '
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
@@ -754,6 +827,19 @@ def _runtime_source(
             f"static const char *const {sequence_refs_table}[] = "
             f"{{\n{sequence_ref_rows}\n}};\n"
         )
+        dispatch_surface_refs = record.get("dispatch_surface_refs")
+        if not isinstance(dispatch_surface_refs, list):
+            dispatch_surface_refs = []
+        dispatch_surface_ref_rows = "\n".join(
+            f'  "{ref}",' for ref in dispatch_surface_refs if isinstance(ref, str)
+        )
+        dispatch_surface_refs_table = (
+            f"kAppStateEventCoverageDispatchSurfaceRefs{index}"
+        )
+        event_coverage_arrays.append(
+            f"static const char *const {dispatch_surface_refs_table}[] = "
+            f"{{\n{dispatch_surface_ref_rows}\n}};\n"
+        )
         transition_index = transition_index_by_id.get(str(record.get("transition_id", "")), 0)
         write_set_table = f"kAppStateTransitionWriteSet{transition_index}"
         event_coverage_rows.append(
@@ -766,6 +852,8 @@ def _runtime_source(
             f"{trigger_table}, sizeof({trigger_table}) / sizeof({trigger_table}[0]), "
             f"{sequence_refs_table}, sizeof({sequence_refs_table}) / "
             f"sizeof({sequence_refs_table}[0]), "
+            f"{dispatch_surface_refs_table}, sizeof({dispatch_surface_refs_table}) / "
+            f"sizeof({dispatch_surface_refs_table}[0]), "
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
     owner_field_arrays = []
@@ -1257,6 +1345,14 @@ def _complete_dispatch_surfaces() -> list[dict[str, object]]:
         _dispatch_surface(category)
         for category in REQUIRED_DISPATCH_SURFACE_CATEGORIES
     ]
+
+
+def _wrong_dispatch_surface_ref(transition_id: str) -> str:
+    for surface in _complete_dispatch_surfaces():
+        surface_transition_id = str(surface["transition_id"])
+        if surface_transition_id != transition_id:
+            return str(surface["surface_id"])
+    raise AssertionError(f"missing mismatched dispatch surface fixture for {transition_id}")
 
 
 def _complete_invariant_dispatch_surface_ids() -> dict[str, list[str]]:
@@ -3242,8 +3338,10 @@ int main(void) {
     return 8;
   if (metadata->declared_write_set == 0 || metadata->declared_write_set_count == 0)
     return 9;
-  if (metadata->migration_notes == 0 || metadata->migration_note_count == 0)
+  if (metadata->dispatch_surface_refs == 0 || metadata->dispatch_surface_ref_count == 0)
     return 10;
+  if (metadata->migration_notes == 0 || metadata->migration_note_count == 0)
+    return 11;
   return 0;
 }
 """,
@@ -4442,6 +4540,41 @@ def test_guard_accepts_empty_dispatch_surface_allowed_writes(
     assert failures == []
 
 
+def test_dispatch_surface_records_document_new_write_authority() -> None:
+    dispatch_doc, doc_failures = guard._load_json(guard.DEFAULT_DISPATCH_SURFACES)
+    runtime_records, runtime_failures = guard._parse_runtime_dispatch_surface_registry(
+        guard.DEFAULT_ACTION_RUNTIME
+    )
+
+    assert doc_failures == []
+    assert runtime_failures == []
+
+    expected_writes = {
+        "surface.volume-menu-selection": [
+            "ctx.active",
+            "panel.volume_key",
+            "panel.restore_snapshot",
+            "panel.panel_generation",
+        ],
+        "surface.panel-anchor-rebind": [
+            "panel.tree_selection_key",
+            "panel.file_selection_key",
+            "panel.tree_cursor_pos",
+            "panel.tree_viewport_origin",
+            "panel.file_viewport_origin",
+            "panel.panel_generation",
+        ],
+    }
+    docs_by_id = {
+        record["surface_id"]: record for record in dispatch_doc["dispatch_surfaces"]
+    }
+    runtime_by_id = {record["surface_id"]: record for record in runtime_records}
+
+    for surface_id, writes in expected_writes.items():
+        assert docs_by_id[surface_id]["allowed_direct_writes"] == writes
+        assert runtime_by_id[surface_id]["allowed_direct_writes"] == writes
+
+
 def test_guard_fails_when_runtime_dispatch_surface_metadata_drifts(
     tmp_path: Path,
 ) -> None:
@@ -4502,7 +4635,7 @@ def test_guard_fails_when_runtime_dispatch_surface_id_is_missing(
 
     assert any(
         "runtime dispatch surface registry missing surface id(s)" in failure
-        and "surface.directory_window_action_dispatch" in failure
+        and "surface.key_decode_input_dispatch" in failure
         for failure in failures
     )
 
@@ -4545,7 +4678,7 @@ def test_guard_fails_when_runtime_dispatch_surface_row_is_malformed(
     failures = _validate(paths)
 
     assert any(
-        "runtime_dispatch_surface[3]" in failure
+        "runtime_dispatch_surface[0]" in failure
         and "malformed runtime dispatch surface registry row" in failure
         for failure in failures
     )
@@ -6894,6 +7027,72 @@ def test_guard_fails_when_action_coverage_sequence_refs_are_invalid(
     assert any("action[0]" in failure and expected in failure for failure in failures)
 
 
+def test_guard_fails_when_action_coverage_dispatch_surface_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0].pop("dispatch_surface_refs")
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure
+        and "missing required field" in failure
+        and "dispatch_surface_refs" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("refs", "expected"),
+    [
+        ([], "dispatch_surface_refs must be non-empty"),
+        ("surface.key_decode_input_dispatch", "dispatch_surface_refs must be a non-empty list"),
+        ([123], "dispatch_surface_refs[0] must be a non-empty string"),
+        (
+            ["surface.key_decode_input_dispatch", "surface.key_decode_input_dispatch"],
+            "duplicate dispatch_surface_refs[1]",
+        ),
+        (["surface.__missing__"], "references unknown dispatch surface"),
+        (["surface.menu_modal_completion"], "transition_id does not match"),
+    ],
+)
+def test_guard_fails_when_action_coverage_dispatch_surface_refs_are_invalid(
+    tmp_path: Path, refs: object, expected: str
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0]["dispatch_surface_refs"] = refs
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any("action[0]" in failure and expected in failure for failure in failures)
+
+
+def test_guard_fails_when_action_coverage_dispatch_surface_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    transition_id = str(actions[0]["transition_id"])
+    valid_ref = str(actions[0]["dispatch_surface_refs"][0])
+    wrong_ref = _wrong_dispatch_surface_ref(transition_id)
+    actions[0]["dispatch_surface_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure
+        and f"dispatch_surface_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_event_coverage_owner_does_not_match_transition(
     tmp_path: Path,
 ) -> None:
@@ -6948,6 +7147,74 @@ def test_guard_fails_when_event_coverage_sequence_refs_are_invalid(
 
     assert any(
         "event[0]" in failure and expected_fragment in failure for failure in failures
+    )
+
+
+def test_guard_fails_when_event_coverage_dispatch_surface_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[0].pop("dispatch_surface_refs")
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure
+        and "missing required field" in failure
+        and "dispatch_surface_refs" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("refs", "expected_fragment"),
+    [
+        ([], "dispatch_surface_refs must be non-empty"),
+        ("surface.resize_signal_handling", "dispatch_surface_refs must be a non-empty list"),
+        ([123], "dispatch_surface_refs[0] must be a non-empty string"),
+        (
+            ["surface.resize_signal_handling", "surface.resize_signal_handling"],
+            "duplicate dispatch_surface_refs[1]",
+        ),
+        (["surface.__missing__"], "references unknown dispatch surface"),
+        (["surface.menu_modal_completion"], "transition_id does not match"),
+    ],
+)
+def test_guard_fails_when_event_coverage_dispatch_surface_refs_are_invalid(
+    tmp_path: Path, refs: object, expected_fragment: str
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[0]["dispatch_surface_refs"] = refs
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure and expected_fragment in failure for failure in failures
+    )
+
+
+def test_guard_fails_when_event_coverage_dispatch_surface_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    transition_id = str(events[0]["transition_id"])
+    valid_ref = str(events[0]["dispatch_surface_refs"][0])
+    wrong_ref = _wrong_dispatch_surface_ref(transition_id)
+    events[0]["dispatch_surface_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure
+        and f"dispatch_surface_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
     )
 
 
@@ -7026,6 +7293,52 @@ def test_guard_fails_when_runtime_action_coverage_sequence_refs_are_mixed(
     )
 
 
+def test_guard_fails_when_runtime_action_coverage_dispatch_surface_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_action_coverages = _complete_actions()
+    runtime_action_coverages[0]["dispatch_surface_refs"] = ["surface.menu_modal_completion"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_action_coverages=runtime_action_coverages,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_action_coverage[0]" in failure
+        and "dispatch_surface_refs does not match action coverage" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_action_coverage_dispatch_surface_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_action_coverages = _complete_actions()
+    transition_id = str(runtime_action_coverages[0]["transition_id"])
+    valid_ref = str(runtime_action_coverages[0]["dispatch_surface_refs"][0])
+    wrong_ref = _wrong_dispatch_surface_ref(transition_id)
+    runtime_action_coverages[0]["dispatch_surface_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_action_coverages=runtime_action_coverages,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_action_coverage[0]" in failure
+        and f"dispatch_surface_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_event_coverage_owner_does_not_match_transition(
     tmp_path: Path,
 ) -> None:
@@ -7047,6 +7360,52 @@ def test_guard_fails_when_runtime_event_coverage_owner_does_not_match_transition
         "runtime_event_coverage[0]" in failure
         and "owner does not match transition" in failure
         and "different owner" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_event_coverage_dispatch_surface_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_events = _complete_events()
+    runtime_events[0]["dispatch_surface_refs"] = ["surface.menu_modal_completion"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_events=runtime_events,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_event_coverage[0]" in failure
+        and "dispatch_surface_refs does not match docs" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_event_coverage_dispatch_surface_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_events = _complete_events()
+    transition_id = str(runtime_events[0]["transition_id"])
+    valid_ref = str(runtime_events[0]["dispatch_surface_refs"][0])
+    wrong_ref = _wrong_dispatch_surface_ref(transition_id)
+    runtime_events[0]["dispatch_surface_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_events=runtime_events,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_event_coverage[0]" in failure
+        and f"dispatch_surface_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
         for failure in failures
     )
 
@@ -7334,6 +7693,9 @@ def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
     runtime_transitions, runtime_transition_failures = guard._parse_runtime_transition_registry(
         runtime_path
     )
+    runtime_dispatch_surfaces, runtime_dispatch_surface_failures = (
+        guard._parse_runtime_dispatch_surface_registry(runtime_path)
+    )
     runtime_events, runtime_event_failures = guard._parse_runtime_event_coverage_registry(
         runtime_path
     )
@@ -7347,6 +7709,7 @@ def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
         transition_failures
         + event_failures
         + runtime_transition_failures
+        + runtime_dispatch_surface_failures
         + runtime_event_failures
         + runtime_sequence_failures
         + guard._validate_runtime_event_coverage_registry(
@@ -7355,6 +7718,7 @@ def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
             event_coverage_doc=event_doc,
             transition_ids=transition_ids,
             runtime_transition_sequence_records=runtime_sequences,
+            runtime_dispatch_surface_records=runtime_dispatch_surfaces,
             runtime_transition_ids={record["id"] for record in runtime_transitions},
         )
     )
@@ -7434,6 +7798,20 @@ def test_runtime_event_coverage_detects_write_set_drift(tmp_path: Path) -> None:
     assert any("declared_write_set does not match transition" in failure for failure in failures)
 
 
+def test_runtime_event_coverage_detects_dispatch_surface_ref_drift(
+    tmp_path: Path,
+) -> None:
+    runtime_path = _mutated_event_runtime(
+        tmp_path,
+        'static const char *const kAppStateEventCoverageDispatchSurfaceRefs8[] = {\n  "surface.render-reflow-projection",',
+        'static const char *const kAppStateEventCoverageDispatchSurfaceRefs8[] = {\n  "surface.menu-modal-completion",',
+    )
+
+    failures = _event_runtime_validation_failures(runtime_path)
+
+    assert any("dispatch_surface_refs does not match docs" in failure for failure in failures)
+
+
 def test_runtime_event_coverage_detects_malformed_lists(tmp_path: Path) -> None:
     runtime_path = _mutated_event_runtime(
         tmp_path,
@@ -7453,6 +7831,8 @@ def test_runtime_event_coverage_startup_checks_fail_closed() -> None:
     assert 'AppStateEventCoverageLookup("event.__ytnova_unknown__") != NULL' in source
     assert "coverage->transition_sequence_refs" in source
     assert "coverage->transition_sequence_ref_count" in source
+    assert "coverage->dispatch_surface_refs" in source
+    assert "coverage->dispatch_surface_ref_count" in source
     assert "!AppStateEventCoverageReady()" in source
 
 
@@ -7470,6 +7850,8 @@ def test_runtime_coverage_startup_validates_owner_alignment() -> None:
 
     assert "strcmp(coverage->owner, transition->owner) != 0" in action_body
     assert "strcmp(coverage->owner, transition->owner) != 0" in event_body
+    assert "AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs" in action_body
+    assert "AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs" in event_body
 
 
 def test_runtime_event_coverage_startup_requires_documented_event_ids() -> None:
@@ -7723,6 +8105,34 @@ def test_runtime_action_coverage_startup_rejects_mixed_sequence_refs() -> None:
     )
 
 
+def test_runtime_action_coverage_startup_rejects_mixed_dispatch_surface_refs() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    action_start = source.index("static int AppStateActionCoverageReady(void)")
+    diff_harness_start = source.index(
+        "static int AppStateDiffHarnessWriteCovered"
+    )
+    helper_start = source.index("static int AppStateDispatchSurfaceRefsReady(")
+    helper_end = source.index("static int AppStateDispatchSurfaceSequenceRefsReady(")
+    action_body = source[action_start:diff_harness_start]
+    helper_body = source[helper_start:helper_end]
+
+    assert "coverage->dispatch_surface_refs" in action_body
+    assert "coverage->dispatch_surface_ref_count" in action_body
+    assert re.search(
+        r"for \(ref_index = 0; ref_index < ref_count; ref_index\+\+\) \{\s*"
+        r"const AppStateDispatchSurfaceMetadata \*surface =\s*"
+        r"AppStateDispatchSurfaceLookup\(refs\[ref_index\]\);",
+        helper_body,
+        re.S,
+    )
+    assert re.search(
+        r"if \(!NonEmptyString\(surface->transition_id\) \|\|\s*"
+        r"strcmp\(surface->transition_id, transition_id\) != 0\)\s*return 0;",
+        helper_body,
+        re.S,
+    )
+
+
 def test_runtime_event_coverage_startup_rejects_mixed_sequence_refs() -> None:
     source = Path("src/core/main.c").read_text(encoding="utf-8")
     event_start = source.index("static int AppStateEventCoverageReady(void)")
@@ -7732,6 +8142,32 @@ def test_runtime_event_coverage_startup_rejects_mixed_sequence_refs() -> None:
     assert "coverage->transition_sequence_refs" in event_body
     assert "coverage->transition_sequence_ref_count" in event_body
     assert "AppStateTransitionSequenceRefsReady(" in event_body
+
+
+def test_runtime_event_coverage_startup_rejects_mixed_dispatch_surface_refs() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    event_start = source.index("static int AppStateEventCoverageReady(void)")
+    action_start = source.index("static int AppStateActionCoverageReady(void)")
+    helper_start = source.index("static int AppStateDispatchSurfaceRefsReady(")
+    helper_end = source.index("static int AppStateDispatchSurfaceSequenceRefsReady(")
+    event_body = source[event_start:action_start]
+    helper_body = source[helper_start:helper_end]
+
+    assert "coverage->dispatch_surface_refs" in event_body
+    assert "coverage->dispatch_surface_ref_count" in event_body
+    assert re.search(
+        r"for \(ref_index = 0; ref_index < ref_count; ref_index\+\+\) \{\s*"
+        r"const AppStateDispatchSurfaceMetadata \*surface =\s*"
+        r"AppStateDispatchSurfaceLookup\(refs\[ref_index\]\);",
+        helper_body,
+        re.S,
+    )
+    assert re.search(
+        r"if \(!NonEmptyString\(surface->transition_id\) \|\|\s*"
+        r"strcmp\(surface->transition_id, transition_id\) != 0\)\s*return 0;",
+        helper_body,
+        re.S,
+    )
 
 
 def test_runtime_dispatch_surface_startup_validates_allowed_write_owner_fields() -> None:


### PR DESCRIPTION
## Summary
- require action and event coverage records to declare dispatch-surface refs
- fail closed when coverage refs are missing, malformed, drifting, unknown, or point at the wrong transition
- register missing command, volume-menu, and panel-anchor dispatch surfaces with truthful write authority

## Validation
- Local mixed-ref/write-authority tests: `pytest -q tests/test_appstate_contract_guard.py -k 'test_dispatch_surface_records_document_new_write_authority or mix_valid_and_wrong_transition or mixed_dispatch_surface_refs'` — PASS
- Local focused guard tests: `pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface_refs or dispatch_ref or action_coverage or event_coverage or startup'` — PASS
- Local AppState guard tests: `pytest -q tests/test_appstate_contract_guard.py` — PASS
- Local contract guard: `python3 scripts/check_appstate_contract.py` — PASS
- Local build: `make clean && make` — PASS with pre-existing warnings
- Local whitespace check: `git diff --check` — PASS
