### PR TITLE
chore(appstate): require coverage invariant refs

### DIFF
--- a/docs/appstate_action_coverage.json
+++ b/docs/appstate_action_coverage.json
@@ -33,6 +33,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -65,6 +68,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -97,6 +103,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -129,6 +138,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -161,6 +173,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -193,6 +208,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -225,6 +243,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -257,6 +278,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -289,6 +313,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -321,6 +348,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -353,6 +383,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -385,6 +418,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -417,6 +453,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -449,6 +488,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -481,6 +523,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -503,6 +548,10 @@
       ],
       "dispatch_surface_refs": [
         "surface.menu-modal-completion"
+      ],
+      "invariant_refs": [
+        "invariant.panel-local-focus-restore",
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -526,6 +575,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.refresh-rebuild-rebind"
+      ],
+      "invariant_refs": [
+        "invariant.hidden-entry-visible-navigation"
       ]
     },
     {
@@ -548,6 +600,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.command-completion-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -570,6 +625,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.command-completion-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -602,6 +660,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -634,6 +695,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -666,6 +730,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -698,6 +765,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -730,6 +800,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -762,6 +835,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -794,6 +870,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -826,6 +905,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -849,6 +931,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.refresh-rebuild-rebind"
+      ],
+      "invariant_refs": [
+        "invariant.hidden-entry-visible-navigation"
       ]
     },
     {
@@ -872,6 +957,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.resize-signal-handling"
+      ],
+      "invariant_refs": [
+        "invariant.render-projection-read-only"
       ]
     },
     {
@@ -894,6 +982,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.volume-menu-selection"
+      ],
+      "invariant_refs": [
+        "invariant.shared-state-panel-local-isolation"
       ]
     },
     {
@@ -917,6 +1008,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.volume-operation"
+      ],
+      "invariant_refs": [
+        "invariant.shared-state-panel-local-isolation"
       ]
     },
     {
@@ -940,6 +1034,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.volume-operation"
+      ],
+      "invariant_refs": [
+        "invariant.shared-state-panel-local-isolation"
       ]
     },
     {
@@ -964,6 +1061,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -988,6 +1088,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1012,6 +1115,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1036,6 +1142,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1060,6 +1169,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1084,6 +1196,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1108,6 +1223,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1132,6 +1250,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1156,6 +1277,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1180,6 +1304,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1204,6 +1331,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1228,6 +1358,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1252,6 +1385,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1276,6 +1412,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1300,6 +1439,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1324,6 +1466,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1346,6 +1491,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.command-completion-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1378,6 +1526,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -1410,6 +1561,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -1434,6 +1588,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1458,6 +1615,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1482,6 +1642,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1506,6 +1669,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1530,6 +1696,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1554,6 +1723,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1578,6 +1750,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1602,6 +1777,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1626,6 +1804,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1650,6 +1831,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1674,6 +1858,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1698,6 +1885,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1722,6 +1912,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1744,6 +1937,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.command-completion-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -1776,6 +1972,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -1808,6 +2007,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -1840,6 +2042,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -1872,6 +2077,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -1904,6 +2112,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -1936,6 +2147,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -1968,6 +2182,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2000,6 +2217,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2032,6 +2252,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2064,6 +2287,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2096,6 +2322,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2128,6 +2357,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2160,6 +2392,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2192,6 +2427,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2224,6 +2462,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2256,6 +2497,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2288,6 +2532,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2320,6 +2567,9 @@
         "surface.key-decode-input-dispatch",
         "surface.directory-window-action-dispatch",
         "surface.file-window-action-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.inactive-panel-frozen"
       ]
     },
     {
@@ -2342,6 +2592,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.command-completion-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -2364,6 +2617,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.command-completion-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     }
   ]

--- a/docs/appstate_event_coverage.json
+++ b/docs/appstate_event_coverage.json
@@ -41,6 +41,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.resize-signal-handling"
+      ],
+      "invariant_refs": [
+        "invariant.render-projection-read-only"
       ]
     },
     {
@@ -70,6 +73,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.refresh-rebuild-rebind"
+      ],
+      "invariant_refs": [
+        "invariant.hidden-entry-visible-navigation"
       ]
     },
     {
@@ -101,6 +107,10 @@
       ],
       "dispatch_surface_refs": [
         "surface.panel-anchor-rebind"
+      ],
+      "invariant_refs": [
+        "invariant.hidden-entry-visible-navigation",
+        "invariant.viewport-identity-rebind"
       ]
     },
     {
@@ -132,6 +142,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.filesystem-mutation-result"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -162,6 +175,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.watcher-live-refresh"
+      ],
+      "invariant_refs": [
+        "invariant.hidden-entry-visible-navigation"
       ]
     },
     {
@@ -191,6 +207,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.command-completion-dispatch"
+      ],
+      "invariant_refs": [
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -220,6 +239,10 @@
       ],
       "dispatch_surface_refs": [
         "surface.menu-modal-completion"
+      ],
+      "invariant_refs": [
+        "invariant.panel-local-focus-restore",
+        "invariant.blocked-transition-determinism"
       ]
     },
     {
@@ -250,6 +273,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.volume-operation"
+      ],
+      "invariant_refs": [
+        "invariant.shared-state-panel-local-isolation"
       ]
     },
     {
@@ -277,6 +303,9 @@
       ],
       "dispatch_surface_refs": [
         "surface.render-reflow-projection"
+      ],
+      "invariant_refs": [
+        "invariant.render-projection-read-only"
       ]
     }
   ]

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -29,6 +29,8 @@ typedef struct {
   size_t transition_sequence_ref_count;
   const char *const *dispatch_surface_refs;
   size_t dispatch_surface_ref_count;
+  const char *const *invariant_refs;
+  size_t invariant_ref_count;
   const char *boundary_status;
   const char *const *migration_notes;
   size_t migration_note_count;
@@ -50,6 +52,8 @@ typedef struct {
   size_t transition_sequence_ref_count;
   const char *const *dispatch_surface_refs;
   size_t dispatch_surface_ref_count;
+  const char *const *invariant_refs;
+  size_t invariant_ref_count;
   const char *const *migration_notes;
   size_t migration_note_count;
 } AppStateEventCoverageMetadata;

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -79,6 +79,7 @@ REQUIRED_ACTION_FIELDS = {
     "declared_write_set",
     "transition_sequence_refs",
     "dispatch_surface_refs",
+    "invariant_refs",
     "boundary_status",
     "migration_notes",
 }
@@ -200,6 +201,7 @@ REQUIRED_EVENT_FIELDS = {
     "declared_write_set",
     "transition_sequence_refs",
     "dispatch_surface_refs",
+    "invariant_refs",
     "boundary_status",
     "trigger_paths",
     "migration_notes",
@@ -298,11 +300,16 @@ LIST_FIELDS = {
     "migration_notes",
 }
 
-ACTION_LIST_FIELDS = LIST_FIELDS | {"transition_sequence_refs", "dispatch_surface_refs"}
+ACTION_LIST_FIELDS = LIST_FIELDS | {
+    "transition_sequence_refs",
+    "dispatch_surface_refs",
+    "invariant_refs",
+}
 EVENT_LIST_FIELDS = LIST_FIELDS | {
     "trigger_paths",
     "transition_sequence_refs",
     "dispatch_surface_refs",
+    "invariant_refs",
 }
 SHIM_LIST_FIELDS = LIST_FIELDS | {
     "owner_field_refs",
@@ -625,7 +632,7 @@ def _parse_runtime_action_coverage_registry(
     arrays: dict[str, list[str]] = {}
     array_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateActionCoverage(?:TransitionSequenceRefs|DispatchSurfaceRefs|MigrationNotes)[0-9]+)"
+        r"(kAppStateActionCoverage(?:TransitionSequenceRefs|DispatchSurfaceRefs|InvariantRefs|MigrationNotes)[0-9]+)"
         r"\[\]\s*=\s*\{(?P<body>.*?)\};",
         re.S,
     )
@@ -661,6 +668,9 @@ def _parse_runtime_action_coverage_registry(
         r"\s*(?P<dispatch_surface_refs>kAppStateActionCoverageDispatchSurfaceRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=dispatch_surface_refs)\)\s*/"
         r"\s*sizeof\((?P=dispatch_surface_refs)\[0\]\)\s*,"
+        r"\s*(?P<invariant_refs>kAppStateActionCoverageInvariantRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=invariant_refs)\)\s*/"
+        r"\s*sizeof\((?P=invariant_refs)\[0\]\)\s*,"
         r"\s*\"(?P<boundary_status>[^\"]*)\"\s*,"
         r"\s*(?P<migration_notes>kAppStateActionCoverageMigrationNotes[0-9]+)\s*,"
         r"\s*sizeof\((?P=migration_notes)\)\s*/"
@@ -704,6 +714,14 @@ def _parse_runtime_action_coverage_registry(
                 f"table: {dispatch_surface_refs_name}"
             )
             dispatch_surface_refs = []
+        invariant_refs_name = row_match.group("invariant_refs")
+        invariant_refs = arrays.get(invariant_refs_name)
+        if invariant_refs is None:
+            failures.append(
+                f"runtime_action_coverage[{index}]: unknown invariant-refs "
+                f"table: {invariant_refs_name}"
+            )
+            invariant_refs = []
         notes_name = row_match.group("migration_notes")
         notes = arrays.get(notes_name)
         if notes is None:
@@ -722,6 +740,7 @@ def _parse_runtime_action_coverage_registry(
                 "declared_write_set": declared_write_set,
                 "transition_sequence_refs": sequence_refs,
                 "dispatch_surface_refs": dispatch_surface_refs,
+                "invariant_refs": invariant_refs,
                 "boundary_status": row_match.group("boundary_status"),
                 "migration_notes": notes,
             }
@@ -746,7 +765,7 @@ def _parse_runtime_event_coverage_registry(
     arrays: dict[str, list[str]] = {}
     array_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppState(?:TransitionWriteSet|EventCoverageTriggerPaths|EventCoverageTransitionSequenceRefs|EventCoverageDispatchSurfaceRefs|EventCoverageMigrationNotes)[0-9]+)"
+        r"(kAppState(?:TransitionWriteSet|EventCoverageTriggerPaths|EventCoverageTransitionSequenceRefs|EventCoverageDispatchSurfaceRefs|EventCoverageInvariantRefs|EventCoverageMigrationNotes)[0-9]+)"
         r"\[\]\s*=\s*\{(?P<body>.*?)\};",
         re.S,
     )
@@ -784,6 +803,8 @@ def _parse_runtime_event_coverage_registry(
         r"\s*sizeof\((?P=transition_sequence_refs)\)\s*/\s*sizeof\((?P=transition_sequence_refs)\[0\]\)\s*,"
         r"\s*(?P<dispatch_surface_refs>kAppStateEventCoverageDispatchSurfaceRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=dispatch_surface_refs)\)\s*/\s*sizeof\((?P=dispatch_surface_refs)\[0\]\)\s*,"
+        r"\s*(?P<invariant_refs>kAppStateEventCoverageInvariantRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=invariant_refs)\)\s*/\s*sizeof\((?P=invariant_refs)\[0\]\)\s*,"
         r"\s*(?P<migration_notes>kAppStateEventCoverageMigrationNotes[0-9]+)\s*,"
         r"\s*sizeof\((?P=migration_notes)\)\s*/\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
         re.S,
@@ -830,6 +851,13 @@ def _parse_runtime_event_coverage_registry(
                 f"{row_match.group('dispatch_surface_refs')}"
             )
             dispatch_surface_refs = []
+        invariant_refs = arrays.get(row_match.group("invariant_refs"))
+        if invariant_refs is None:
+            failures.append(
+                f"runtime_event_coverage[{index}]: unknown invariant-refs table: "
+                f"{row_match.group('invariant_refs')}"
+            )
+            invariant_refs = []
         if migration_notes is None:
             failures.append(
                 f"runtime_event_coverage[{index}]: unknown migration-notes table: "
@@ -849,6 +877,7 @@ def _parse_runtime_event_coverage_registry(
                 "trigger_paths": trigger_paths,
                 "transition_sequence_refs": transition_sequence_refs,
                 "dispatch_surface_refs": dispatch_surface_refs,
+                "invariant_refs": invariant_refs,
                 "migration_notes": migration_notes,
             }
         )
@@ -1939,6 +1968,9 @@ def _validate_runtime_action_coverage_registry(
     runtime_action_transitions: list[dict[str, str]],
     runtime_dispatch_surface_records: list[Any],
     registered_owner_fields: set[str],
+    runtime_invariant_ids: set[str],
+    runtime_invariant_transition_ids: dict[str, set[str]],
+    runtime_invariant_protected_fields: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     expected_actions = set(enum_actions)
@@ -2003,6 +2035,17 @@ def _validate_runtime_action_coverage_registry(
                 label=label,
             )
         )
+        failures.extend(
+            _validate_record_invariant_refs(
+                invariant_refs=record.get("invariant_refs"),
+                invariant_ids=runtime_invariant_ids,
+                invariant_transition_ids=runtime_invariant_transition_ids,
+                invariant_protected_fields=runtime_invariant_protected_fields,
+                transition_id=record.get("transition_id"),
+                declared_write_set=record.get("declared_write_set"),
+                label=label,
+            )
+        )
 
         transition_id = record.get("transition_id")
         transition_record = None
@@ -2053,6 +2096,7 @@ def _validate_runtime_action_coverage_registry(
                     "declared_write_set",
                     "transition_sequence_refs",
                     "dispatch_surface_refs",
+                    "invariant_refs",
                     "boundary_status",
                     "migration_notes",
                 ):
@@ -3524,6 +3568,63 @@ def _validate_invariant_check_refs(
     return failures
 
 
+def _validate_record_invariant_refs(
+    *,
+    invariant_refs: Any,
+    invariant_ids: set[str],
+    invariant_transition_ids: dict[str, set[str]],
+    invariant_protected_fields: dict[str, set[str]],
+    transition_id: Any,
+    declared_write_set: Any,
+    label: str,
+) -> list[str]:
+    if not isinstance(invariant_refs, list):
+        return []
+
+    failures: list[str] = []
+    seen: set[str] = set()
+    protected_fields: set[str] = set()
+    has_transition_id = isinstance(transition_id, str) and bool(transition_id.strip())
+
+    for index, invariant_id in enumerate(invariant_refs):
+        if not isinstance(invariant_id, str) or not invariant_id.strip():
+            continue
+        if invariant_id in seen:
+            failures.append(f"{label}: invariant_refs[{index}] duplicates {invariant_id}")
+            continue
+        seen.add(invariant_id)
+        if invariant_id not in invariant_ids:
+            failures.append(
+                f"{label}: invariant_refs[{index}] does not match invariant registry: "
+                f"{invariant_id}"
+            )
+            continue
+        if (
+            has_transition_id
+            and transition_id not in invariant_transition_ids.get(invariant_id, set())
+        ):
+            failures.append(
+                f"{label}: invariant_refs[{index}] transition_id does not match "
+                f"{transition_id}: {invariant_id}"
+            )
+            continue
+        protected_fields.update(invariant_protected_fields.get(invariant_id, set()))
+
+    if not isinstance(declared_write_set, list):
+        return failures
+
+    for index, field in enumerate(declared_write_set):
+        if not isinstance(field, str) or not field.strip():
+            continue
+        if field not in protected_fields:
+            failures.append(
+                f"{label}: invariant_refs lack collective coverage for "
+                f"declared_write_set[{index}] owner field: {field}"
+            )
+
+    return failures
+
+
 def _validate_allowed_direct_writes(
     *,
     record: dict[str, Any],
@@ -4401,6 +4502,9 @@ def _validate_runtime_event_coverage_registry(
     runtime_transition_sequence_records: list[Any],
     runtime_dispatch_surface_records: list[Any],
     runtime_transition_ids: set[str],
+    runtime_invariant_ids: set[str],
+    runtime_invariant_transition_ids: dict[str, set[str]],
+    runtime_invariant_protected_fields: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     doc_records = event_coverage_doc.get("events") if isinstance(event_coverage_doc, dict) else []
@@ -4434,6 +4538,17 @@ def _validate_runtime_event_coverage_registry(
             _validate_dispatch_surface_refs(
                 record=record,
                 dispatch_surface_records=runtime_dispatch_surface_records,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_record_invariant_refs(
+                invariant_refs=record.get("invariant_refs"),
+                invariant_ids=runtime_invariant_ids,
+                invariant_transition_ids=runtime_invariant_transition_ids,
+                invariant_protected_fields=runtime_invariant_protected_fields,
+                transition_id=record.get("transition_id"),
+                declared_write_set=record.get("declared_write_set"),
                 label=label,
             )
         )
@@ -4502,6 +4617,9 @@ def _validate_event_coverage(
     transition_sequence_records: list[Any],
     dispatch_surface_records: list[Any],
     registered_owner_fields: set[str],
+    invariant_ids: set[str],
+    invariant_transition_ids: dict[str, set[str]],
+    invariant_protected_fields: dict[str, set[str]],
 ) -> list[str]:
     failures: list[str] = []
     if not isinstance(event_coverage_doc, dict):
@@ -4555,6 +4673,17 @@ def _validate_event_coverage(
             _validate_dispatch_surface_refs(
                 record=record,
                 dispatch_surface_records=dispatch_surface_records,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_record_invariant_refs(
+                invariant_refs=record.get("invariant_refs"),
+                invariant_ids=invariant_ids,
+                invariant_transition_ids=invariant_transition_ids,
+                invariant_protected_fields=invariant_protected_fields,
+                transition_id=record.get("transition_id"),
+                declared_write_set=record.get("declared_write_set"),
                 label=label,
             )
         )
@@ -5741,6 +5870,9 @@ def validate_contract(
     runtime_invariant_ids = {
         record["invariant_id"] for record in runtime_invariant_records
     }
+    runtime_invariant_transition_ids = _invariant_transition_ids_by_invariant(
+        runtime_invariant_records
+    )
     runtime_invariant_protected_fields = _invariant_protected_fields_by_invariant(
         runtime_invariant_records
     )
@@ -5758,6 +5890,14 @@ def validate_contract(
         invariant_records = invariants_doc["invariants"]
     else:
         invariant_records = []
+    invariant_ids = _collect_string_ids(
+        invariants_doc,
+        collection_key="invariants",
+        id_field="invariant_id",
+    )
+    invariant_transition_ids = _invariant_transition_ids_by_invariant(
+        invariant_records
+    )
     invariant_protected_fields = _invariant_protected_fields_by_invariant(
         invariant_records
     )
@@ -5979,9 +6119,6 @@ def validate_contract(
             failures.append(f"{shims_path}: shims must be a non-empty list")
             shims = []
 
-    invariant_transition_ids = _invariant_transition_ids_by_invariant(
-        invariant_records
-    )
     shim_ids: set[str] = set()
     for index, record in enumerate(shims):
         label = f"shim[{index}]"
@@ -6163,6 +6300,17 @@ def validate_contract(
                 label=label,
             )
         )
+        failures.extend(
+            _validate_record_invariant_refs(
+                invariant_refs=record.get("invariant_refs"),
+                invariant_ids=invariant_ids,
+                invariant_transition_ids=invariant_transition_ids,
+                invariant_protected_fields=invariant_protected_fields,
+                transition_id=record.get("transition_id"),
+                declared_write_set=record.get("declared_write_set"),
+                label=label,
+            )
+        )
 
         action = record.get("action")
         if isinstance(action, str) and action.strip():
@@ -6240,6 +6388,9 @@ def validate_contract(
             runtime_action_transitions=runtime_action_records,
             runtime_dispatch_surface_records=runtime_dispatch_surface_records,
             registered_owner_fields=registered_owner_fields,
+            runtime_invariant_ids=runtime_invariant_ids,
+            runtime_invariant_transition_ids=runtime_invariant_transition_ids,
+            runtime_invariant_protected_fields=runtime_invariant_protected_fields,
         )
     )
 
@@ -6256,6 +6407,9 @@ def validate_contract(
             ),
             dispatch_surface_records=dispatch_surface_records,
             registered_owner_fields=registered_owner_fields,
+            invariant_ids=invariant_ids,
+            invariant_transition_ids=invariant_transition_ids,
+            invariant_protected_fields=invariant_protected_fields,
         )
     )
     failures.extend(
@@ -6267,6 +6421,9 @@ def validate_contract(
             runtime_transition_sequence_records=runtime_transition_sequence_records,
             runtime_dispatch_surface_records=runtime_dispatch_surface_records,
             runtime_transition_ids={record["id"] for record in runtime_transition_records},
+            runtime_invariant_ids=runtime_invariant_ids,
+            runtime_invariant_transition_ids=runtime_invariant_transition_ids,
+            runtime_invariant_protected_fields=runtime_invariant_protected_fields,
         )
     )
     failures.extend(
@@ -6352,11 +6509,6 @@ def validate_contract(
                 runtime_diff_harness_owner_field_refs
             ),
         )
-    )
-    invariant_ids = _collect_string_ids(
-        invariants_doc,
-        collection_key="invariants",
-        id_field="invariant_id",
     )
     generation_domain_ids = _collect_string_ids(
         generation_domains_doc,

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -3094,6 +3094,9 @@ static const char *const kAppStateEventCoverageMigrationNotes0[] = {
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs0[] = {
   "surface.resize-signal-handling",
 };
+static const char *const kAppStateEventCoverageInvariantRefs0[] = {
+  "invariant.render-projection-read-only",
+};
 static const char *const kAppStateEventCoverageTriggerPaths1[] = {
   "Manual refresh command",
   "Explicit relog of the current path",
@@ -3106,6 +3109,9 @@ static const char *const kAppStateEventCoverageMigrationNotes1[] = {
 };
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs1[] = {
   "surface.refresh-rebuild-rebind",
+};
+static const char *const kAppStateEventCoverageInvariantRefs1[] = {
+  "invariant.hidden-entry-visible-navigation",
 };
 static const char *const kAppStateEventCoverageTriggerPaths2[] = {
   "Post-refresh restore",
@@ -3121,6 +3127,10 @@ static const char *const kAppStateEventCoverageMigrationNotes2[] = {
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs2[] = {
   "surface.panel-anchor-rebind",
 };
+static const char *const kAppStateEventCoverageInvariantRefs2[] = {
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.viewport-identity-rebind",
+};
 static const char *const kAppStateEventCoverageTriggerPaths3[] = {
   "Create directory result",
   "Copy or move result",
@@ -3134,6 +3144,9 @@ static const char *const kAppStateEventCoverageMigrationNotes3[] = {
 };
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs3[] = {
   "surface.filesystem-mutation-result",
+};
+static const char *const kAppStateEventCoverageInvariantRefs3[] = {
+  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateEventCoverageTriggerPaths4[] = {
   "Watcher notification",
@@ -3149,6 +3162,9 @@ static const char *const kAppStateEventCoverageMigrationNotes4[] = {
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs4[] = {
   "surface.watcher-live-refresh",
 };
+static const char *const kAppStateEventCoverageInvariantRefs4[] = {
+  "invariant.hidden-entry-visible-navigation",
+};
 static const char *const kAppStateEventCoverageTriggerPaths5[] = {
   "External command completion",
   "User command menu completion",
@@ -3162,6 +3178,9 @@ static const char *const kAppStateEventCoverageMigrationNotes5[] = {
 };
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs5[] = {
   "surface.command-completion-dispatch",
+};
+static const char *const kAppStateEventCoverageInvariantRefs5[] = {
+  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateEventCoverageTriggerPaths6[] = {
   "Modal Enter completion",
@@ -3177,6 +3196,10 @@ static const char *const kAppStateEventCoverageMigrationNotes6[] = {
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs6[] = {
   "surface.menu-modal-completion",
 };
+static const char *const kAppStateEventCoverageInvariantRefs6[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.blocked-transition-determinism",
+};
 static const char *const kAppStateEventCoverageTriggerPaths7[] = {
   "Cycle loaded volume",
   "Release volume",
@@ -3191,6 +3214,9 @@ static const char *const kAppStateEventCoverageMigrationNotes7[] = {
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs7[] = {
   "surface.volume-operation",
 };
+static const char *const kAppStateEventCoverageInvariantRefs7[] = {
+  "invariant.shared-state-panel-local-isolation",
+};
 static const char *const kAppStateEventCoverageTriggerPaths8[] = {
   "Render dirty flag projection",
   "Layout reflow projection",
@@ -3204,6 +3230,9 @@ static const char *const kAppStateEventCoverageMigrationNotes8[] = {
 };
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs8[] = {
   "surface.render-reflow-projection",
+};
+static const char *const kAppStateEventCoverageInvariantRefs8[] = {
+  "invariant.render-projection-read-only",
 };
 
 static const AppStateEventCoverageMetadata
@@ -3223,6 +3252,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs0) / sizeof(kAppStateEventCoverageTransitionSequenceRefs0[0]),
    kAppStateEventCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs0) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs0[0]),
+   kAppStateEventCoverageInvariantRefs0,
+   sizeof(kAppStateEventCoverageInvariantRefs0) / sizeof(kAppStateEventCoverageInvariantRefs0[0]),
    kAppStateEventCoverageMigrationNotes0,
    sizeof(kAppStateEventCoverageMigrationNotes0) / sizeof(kAppStateEventCoverageMigrationNotes0[0])},
   {"event.refresh-rebuild",
@@ -3240,6 +3271,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs1) / sizeof(kAppStateEventCoverageTransitionSequenceRefs1[0]),
    kAppStateEventCoverageDispatchSurfaceRefs1,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs1) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs1[0]),
+   kAppStateEventCoverageInvariantRefs1,
+   sizeof(kAppStateEventCoverageInvariantRefs1) / sizeof(kAppStateEventCoverageInvariantRefs1[0]),
    kAppStateEventCoverageMigrationNotes1,
    sizeof(kAppStateEventCoverageMigrationNotes1) / sizeof(kAppStateEventCoverageMigrationNotes1[0])},
   {"event.rebuild-rebind-callback",
@@ -3257,6 +3290,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs2) / sizeof(kAppStateEventCoverageTransitionSequenceRefs2[0]),
    kAppStateEventCoverageDispatchSurfaceRefs2,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs2) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs2[0]),
+   kAppStateEventCoverageInvariantRefs2,
+   sizeof(kAppStateEventCoverageInvariantRefs2) / sizeof(kAppStateEventCoverageInvariantRefs2[0]),
    kAppStateEventCoverageMigrationNotes2,
    sizeof(kAppStateEventCoverageMigrationNotes2) / sizeof(kAppStateEventCoverageMigrationNotes2[0])},
   {"event.filesystem-mutation-result",
@@ -3274,6 +3309,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs3) / sizeof(kAppStateEventCoverageTransitionSequenceRefs3[0]),
    kAppStateEventCoverageDispatchSurfaceRefs3,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs3) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs3[0]),
+   kAppStateEventCoverageInvariantRefs3,
+   sizeof(kAppStateEventCoverageInvariantRefs3) / sizeof(kAppStateEventCoverageInvariantRefs3[0]),
    kAppStateEventCoverageMigrationNotes3,
    sizeof(kAppStateEventCoverageMigrationNotes3) / sizeof(kAppStateEventCoverageMigrationNotes3[0])},
   {"event.watcher-live-refresh",
@@ -3291,6 +3328,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs4) / sizeof(kAppStateEventCoverageTransitionSequenceRefs4[0]),
    kAppStateEventCoverageDispatchSurfaceRefs4,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs4) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs4[0]),
+   kAppStateEventCoverageInvariantRefs4,
+   sizeof(kAppStateEventCoverageInvariantRefs4) / sizeof(kAppStateEventCoverageInvariantRefs4[0]),
    kAppStateEventCoverageMigrationNotes4,
    sizeof(kAppStateEventCoverageMigrationNotes4) / sizeof(kAppStateEventCoverageMigrationNotes4[0])},
   {"event.command-completion",
@@ -3308,6 +3347,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs5) / sizeof(kAppStateEventCoverageTransitionSequenceRefs5[0]),
    kAppStateEventCoverageDispatchSurfaceRefs5,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs5) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs5[0]),
+   kAppStateEventCoverageInvariantRefs5,
+   sizeof(kAppStateEventCoverageInvariantRefs5) / sizeof(kAppStateEventCoverageInvariantRefs5[0]),
    kAppStateEventCoverageMigrationNotes5,
    sizeof(kAppStateEventCoverageMigrationNotes5) / sizeof(kAppStateEventCoverageMigrationNotes5[0])},
   {"event.modal-completion",
@@ -3325,6 +3366,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs6) / sizeof(kAppStateEventCoverageTransitionSequenceRefs6[0]),
    kAppStateEventCoverageDispatchSurfaceRefs6,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs6) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs6[0]),
+   kAppStateEventCoverageInvariantRefs6,
+   sizeof(kAppStateEventCoverageInvariantRefs6) / sizeof(kAppStateEventCoverageInvariantRefs6[0]),
    kAppStateEventCoverageMigrationNotes6,
    sizeof(kAppStateEventCoverageMigrationNotes6) / sizeof(kAppStateEventCoverageMigrationNotes6[0])},
   {"event.volume-lifecycle",
@@ -3342,6 +3385,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs7) / sizeof(kAppStateEventCoverageTransitionSequenceRefs7[0]),
    kAppStateEventCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs7) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs7[0]),
+   kAppStateEventCoverageInvariantRefs7,
+   sizeof(kAppStateEventCoverageInvariantRefs7) / sizeof(kAppStateEventCoverageInvariantRefs7[0]),
    kAppStateEventCoverageMigrationNotes7,
    sizeof(kAppStateEventCoverageMigrationNotes7) / sizeof(kAppStateEventCoverageMigrationNotes7[0])},
   {"event.render-reflow",
@@ -3359,6 +3404,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageTransitionSequenceRefs8) / sizeof(kAppStateEventCoverageTransitionSequenceRefs8[0]),
    kAppStateEventCoverageDispatchSurfaceRefs8,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs8) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs8[0]),
+   kAppStateEventCoverageInvariantRefs8,
+   sizeof(kAppStateEventCoverageInvariantRefs8) / sizeof(kAppStateEventCoverageInvariantRefs8[0]),
    kAppStateEventCoverageMigrationNotes8,
    sizeof(kAppStateEventCoverageMigrationNotes8) / sizeof(kAppStateEventCoverageMigrationNotes8[0])},
 };
@@ -3381,6 +3428,9 @@ static const char *const kAppStateActionCoverageDispatchSurfaceRefs0[] = {
   "surface.directory-window-action-dispatch",
   "surface.file-window-action-dispatch",
 };
+static const char *const kAppStateActionCoverageInvariantRefs0[] = {
+  "invariant.inactive-panel-frozen",
+};
 static const char *const kAppStateActionCoverageMigrationNotes1[] = {
   "Esc dismissal for an active modal maps to the modal_action dismiss record; non-modal Esc no-op behavior remains a blocked keybinding outcome for later context-specific runtime coverage.",
 };
@@ -3389,6 +3439,10 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs1[] = {
 };
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs1[] = {
   "surface.menu-modal-completion",
+};
+static const char *const kAppStateActionCoverageInvariantRefs1[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateActionCoverageMigrationNotes2[] = {
   "Covered by the refresh/rebuild foundation record until log, relog, and refresh actions receive dedicated runtime records.",
@@ -3399,6 +3453,9 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs2[] = {
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs2[] = {
   "surface.refresh-rebuild-rebind",
 };
+static const char *const kAppStateActionCoverageInvariantRefs2[] = {
+  "invariant.hidden-entry-visible-navigation",
+};
 static const char *const kAppStateActionCoverageMigrationNotes3[] = {
   "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records.",
 };
@@ -3407,6 +3464,9 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs3[] = {
 };
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs3[] = {
   "surface.command-completion-dispatch",
+};
+static const char *const kAppStateActionCoverageInvariantRefs3[] = {
+  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateActionCoverageMigrationNotes4[] = {
   "Covered by the terminal resize foundation record; signal handlers must only set flags before this transition commits.",
@@ -3417,6 +3477,9 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs4[] = {
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs4[] = {
   "surface.resize-signal-handling",
 };
+static const char *const kAppStateActionCoverageInvariantRefs4[] = {
+  "invariant.render-projection-read-only",
+};
 static const char *const kAppStateActionCoverageMigrationNotes5[] = {
   "Covered by the volume menu foundation record until menu selection has a runtime transition boundary.",
 };
@@ -3425,6 +3488,9 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs5[] = {
 };
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs5[] = {
   "surface.volume-menu-selection",
+};
+static const char *const kAppStateActionCoverageInvariantRefs5[] = {
+  "invariant.shared-state-panel-local-isolation",
 };
 static const char *const kAppStateActionCoverageMigrationNotes6[] = {
   "Covered by the volume operation foundation record until cycle/release actions receive dedicated runtime records.",
@@ -3435,6 +3501,9 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs6[] = {
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs6[] = {
   "surface.volume-operation",
 };
+static const char *const kAppStateActionCoverageInvariantRefs6[] = {
+  "invariant.shared-state-panel-local-isolation",
+};
 static const char *const kAppStateActionCoverageMigrationNotes7[] = {
   "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata.",
 };
@@ -3443,6 +3512,9 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs7[] = {
 };
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs7[] = {
   "surface.filesystem-mutation-result",
+};
+static const char *const kAppStateActionCoverageInvariantRefs7[] = {
+  "invariant.blocked-transition-determinism",
 };
 
 static const AppStateActionCoverageMetadata
@@ -3458,6 +3530,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3472,6 +3546,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3486,6 +3562,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3500,6 +3578,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3514,6 +3594,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3528,6 +3610,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3542,6 +3626,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3556,6 +3642,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3570,6 +3658,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3584,6 +3674,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3598,6 +3690,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3612,6 +3706,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3626,6 +3722,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3640,6 +3738,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3654,6 +3754,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3668,6 +3770,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs1) / sizeof(kAppStateActionCoverageTransitionSequenceRefs1[0]),
    kAppStateActionCoverageDispatchSurfaceRefs1,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs1) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs1[0]),
+   kAppStateActionCoverageInvariantRefs1,
+   sizeof(kAppStateActionCoverageInvariantRefs1) / sizeof(kAppStateActionCoverageInvariantRefs1[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes1,
    sizeof(kAppStateActionCoverageMigrationNotes1) / sizeof(kAppStateActionCoverageMigrationNotes1[0])},
@@ -3682,6 +3786,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs2) / sizeof(kAppStateActionCoverageTransitionSequenceRefs2[0]),
    kAppStateActionCoverageDispatchSurfaceRefs2,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs2) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs2[0]),
+   kAppStateActionCoverageInvariantRefs2,
+   sizeof(kAppStateActionCoverageInvariantRefs2) / sizeof(kAppStateActionCoverageInvariantRefs2[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes2,
    sizeof(kAppStateActionCoverageMigrationNotes2) / sizeof(kAppStateActionCoverageMigrationNotes2[0])},
@@ -3696,6 +3802,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
    kAppStateActionCoverageDispatchSurfaceRefs3,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -3710,6 +3818,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
    kAppStateActionCoverageDispatchSurfaceRefs3,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -3724,6 +3834,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3738,6 +3850,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3752,6 +3866,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3766,6 +3882,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3780,6 +3898,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3794,6 +3914,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3808,6 +3930,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3822,6 +3946,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3836,6 +3962,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs2) / sizeof(kAppStateActionCoverageTransitionSequenceRefs2[0]),
    kAppStateActionCoverageDispatchSurfaceRefs2,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs2) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs2[0]),
+   kAppStateActionCoverageInvariantRefs2,
+   sizeof(kAppStateActionCoverageInvariantRefs2) / sizeof(kAppStateActionCoverageInvariantRefs2[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes2,
    sizeof(kAppStateActionCoverageMigrationNotes2) / sizeof(kAppStateActionCoverageMigrationNotes2[0])},
@@ -3850,6 +3978,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs4) / sizeof(kAppStateActionCoverageTransitionSequenceRefs4[0]),
    kAppStateActionCoverageDispatchSurfaceRefs4,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs4) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs4[0]),
+   kAppStateActionCoverageInvariantRefs4,
+   sizeof(kAppStateActionCoverageInvariantRefs4) / sizeof(kAppStateActionCoverageInvariantRefs4[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes4,
    sizeof(kAppStateActionCoverageMigrationNotes4) / sizeof(kAppStateActionCoverageMigrationNotes4[0])},
@@ -3864,6 +3994,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs5) / sizeof(kAppStateActionCoverageTransitionSequenceRefs5[0]),
    kAppStateActionCoverageDispatchSurfaceRefs5,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs5) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs5[0]),
+   kAppStateActionCoverageInvariantRefs5,
+   sizeof(kAppStateActionCoverageInvariantRefs5) / sizeof(kAppStateActionCoverageInvariantRefs5[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes5,
    sizeof(kAppStateActionCoverageMigrationNotes5) / sizeof(kAppStateActionCoverageMigrationNotes5[0])},
@@ -3878,6 +4010,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs6) / sizeof(kAppStateActionCoverageTransitionSequenceRefs6[0]),
    kAppStateActionCoverageDispatchSurfaceRefs6,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs6) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs6[0]),
+   kAppStateActionCoverageInvariantRefs6,
+   sizeof(kAppStateActionCoverageInvariantRefs6) / sizeof(kAppStateActionCoverageInvariantRefs6[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes6,
    sizeof(kAppStateActionCoverageMigrationNotes6) / sizeof(kAppStateActionCoverageMigrationNotes6[0])},
@@ -3892,6 +4026,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs6) / sizeof(kAppStateActionCoverageTransitionSequenceRefs6[0]),
    kAppStateActionCoverageDispatchSurfaceRefs6,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs6) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs6[0]),
+   kAppStateActionCoverageInvariantRefs6,
+   sizeof(kAppStateActionCoverageInvariantRefs6) / sizeof(kAppStateActionCoverageInvariantRefs6[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes6,
    sizeof(kAppStateActionCoverageMigrationNotes6) / sizeof(kAppStateActionCoverageMigrationNotes6[0])},
@@ -3906,6 +4042,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3920,6 +4058,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3934,6 +4074,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3948,6 +4090,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3962,6 +4106,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3976,6 +4122,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -3990,6 +4138,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4004,6 +4154,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4018,6 +4170,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4032,6 +4186,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4046,6 +4202,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4060,6 +4218,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4074,6 +4234,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4088,6 +4250,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4102,6 +4266,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4116,6 +4282,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4130,6 +4298,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
    kAppStateActionCoverageDispatchSurfaceRefs3,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -4144,6 +4314,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4158,6 +4330,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4172,6 +4346,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4186,6 +4362,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4200,6 +4378,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4214,6 +4394,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4228,6 +4410,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4242,6 +4426,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4256,6 +4442,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4270,6 +4458,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4284,6 +4474,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4298,6 +4490,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4312,6 +4506,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4326,6 +4522,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4340,6 +4538,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
+   kAppStateActionCoverageInvariantRefs7,
+   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4354,6 +4554,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
    kAppStateActionCoverageDispatchSurfaceRefs3,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -4368,6 +4570,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4382,6 +4586,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4396,6 +4602,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4410,6 +4618,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4424,6 +4634,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4438,6 +4650,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4452,6 +4666,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4466,6 +4682,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4480,6 +4698,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4494,6 +4714,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4508,6 +4730,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4522,6 +4746,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4536,6 +4762,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4550,6 +4778,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4564,6 +4794,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4578,6 +4810,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4592,6 +4826,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4606,6 +4842,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs0) / sizeof(kAppStateActionCoverageTransitionSequenceRefs0[0]),
    kAppStateActionCoverageDispatchSurfaceRefs0,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
+   kAppStateActionCoverageInvariantRefs0,
+   sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4620,6 +4858,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
    kAppStateActionCoverageDispatchSurfaceRefs3,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -4634,6 +4874,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs3) / sizeof(kAppStateActionCoverageTransitionSequenceRefs3[0]),
    kAppStateActionCoverageDispatchSurfaceRefs3,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1592,6 +1592,54 @@ static int AppStateCompatibilityShimsReady(void) {
   return 1;
 }
 
+static int AppStateInvariantRefsReady(const char *const *refs, size_t ref_count,
+                                      const char *transition_id,
+                                      const char *const *declared_write_set,
+                                      size_t declared_write_set_count) {
+  size_t ref_index;
+  size_t write_index;
+
+  if (!NonEmptyString(transition_id) || !NonEmptyStringList(refs, ref_count) ||
+      !NonEmptyStringList(declared_write_set, declared_write_set_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < ref_count; ref_index++) {
+    const AppStateInvariantMetadata *invariant =
+        AppStateInvariantLookup(refs[ref_index]);
+    size_t previous_index;
+
+    if (invariant == NULL)
+      return 0;
+    if (!NonEmptyStringList(invariant->transition_ids,
+                            invariant->transition_id_count) ||
+        !NonEmptyStringList(invariant->protected_fields,
+                            invariant->protected_field_count))
+      return 0;
+    if (!StringListContains(invariant->transition_ids,
+                            invariant->transition_id_count, transition_id))
+      return 0;
+    for (previous_index = 0; previous_index < ref_index; previous_index++) {
+      if (strcmp(refs[previous_index], refs[ref_index]) == 0)
+        return 0;
+    }
+  }
+
+  for (write_index = 0; write_index < declared_write_set_count; write_index++) {
+    if (!AppStateTransitionWriteHasInvariantCoverage(transition_id,
+                                                     declared_write_set[write_index]))
+      return 0;
+    for (ref_index = 0; ref_index < ref_count; ref_index++) {
+      if (AppStateInvariantProtectsField(refs[ref_index],
+                                         declared_write_set[write_index]))
+        break;
+    }
+    if (ref_index == ref_count)
+      return 0;
+  }
+
+  return 1;
+}
+
 static int AppStateActionTransitionsReady(void) {
   size_t index;
 
@@ -1704,6 +1752,11 @@ static int AppStateEventCoverageReady(void) {
         !AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs,
                                          coverage->dispatch_surface_ref_count,
                                          coverage->transition_id) ||
+        !AppStateInvariantRefsReady(coverage->invariant_refs,
+                                    coverage->invariant_ref_count,
+                                    coverage->transition_id,
+                                    coverage->declared_write_set,
+                                    coverage->declared_write_set_count) ||
         !NonEmptyStringList(coverage->migration_notes,
                             coverage->migration_note_count))
       return 0;
@@ -1784,6 +1837,11 @@ static int AppStateActionCoverageReady(void) {
         !AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs,
                                          coverage->dispatch_surface_ref_count,
                                          coverage->transition_id) ||
+        !AppStateInvariantRefsReady(coverage->invariant_refs,
+                                    coverage->invariant_ref_count,
+                                    coverage->transition_id,
+                                    coverage->declared_write_set,
+                                    coverage->declared_write_set_count) ||
         !NonEmptyStringList(coverage->migration_notes,
                             coverage->migration_note_count))
       return 0;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -46,8 +46,10 @@ FIXTURE_ACTIONS = [
 ]
 REQUIRED_LIST_FIELD_CASES = [
     ("action", "declared_write_set", "action[0]"),
+    ("action", "invariant_refs", "action[0]"),
     ("action", "migration_notes", "action[0]"),
     ("event", "declared_write_set", "event[0]"),
+    ("event", "invariant_refs", "event[0]"),
     ("event", "migration_notes", "event[0]"),
     ("event", "trigger_paths", "event[0]"),
     ("transition", "declared_write_set", "transition[0]"),
@@ -152,6 +154,7 @@ def _action(
         "dispatch_surface_refs": _dispatch_surface_refs_for_transition(
             transition_id, action=action
         ),
+        "invariant_refs": _invariant_refs_for_transition(transition_id),
         "boundary_status": "test",
         "migration_notes": ["fixture action coverage"],
     }
@@ -188,6 +191,9 @@ def _event(
         "dispatch_surface_refs": _dispatch_surface_refs_for_transition(
             transition_id or f"transition.{resolved_category}",
             event_id=f"event.{event_class}",
+        ),
+        "invariant_refs": _invariant_refs_for_transition(
+            transition_id or f"transition.{resolved_category}"
         ),
         "boundary_status": "test",
         "trigger_paths": ["fixture trigger"],
@@ -241,6 +247,33 @@ def _dispatch_surface_refs_for_transition(
         "transition.terminal_signal_or_resize": ["surface.resize_signal_handling"],
         "transition.volume_operation": ["surface.volume_operation"],
     }.get(transition_id, ["surface.key_decode_input_dispatch"])
+
+
+def _invariant_refs_for_transition(transition_id: str) -> list[str]:
+    return {
+        "transition.command_completion": ["invariant.blocked_transition_determinism"],
+        "transition.filesystem_mutation_result": [
+            "invariant.blocked_transition_determinism"
+        ],
+        "transition.keybinding": ["invariant.inactive_panel_frozen"],
+        "transition.menu_action": ["invariant.shared_state_panel_local_isolation"],
+        "transition.modal_action": [
+            "invariant.panel_local_focus_restore",
+            "invariant.blocked_transition_determinism",
+        ],
+        "transition.rebuild_rebind_callback": [
+            "invariant.hidden_entry_visible_navigation",
+            "invariant.viewport_identity_rebind",
+        ],
+        "transition.refresh_rebuild": ["invariant.hidden_entry_visible_navigation"],
+        "transition.render_reflow": ["invariant.render_projection_read_only"],
+        "transition.terminal_signal_or_resize": [
+            "invariant.render_projection_read_only"
+        ],
+        "transition.volume_operation": [
+            "invariant.shared_state_panel_local_isolation"
+        ],
+    }.get(transition_id, ["invariant.inactive_panel_frozen"])
 
 
 def _dispatch_surface(
@@ -775,6 +808,17 @@ def _runtime_source(
             f"static const char *const {dispatch_surface_refs_table}[] = "
             f"{{\n{dispatch_surface_ref_rows}\n}};\n"
         )
+        invariant_refs = record.get("invariant_refs")
+        if not isinstance(invariant_refs, list):
+            invariant_refs = []
+        invariant_ref_rows = "\n".join(
+            f'  "{ref}",' for ref in invariant_refs if isinstance(ref, str)
+        )
+        invariant_refs_table = f"kAppStateActionCoverageInvariantRefs{index}"
+        action_coverage_arrays.append(
+            f"static const char *const {invariant_refs_table}[] = "
+            f"{{\n{invariant_ref_rows}\n}};\n"
+        )
         action = record.get("action", "")
         action_coverage_rows.append(
             f'  {{{action}, "{action}", "{record.get("transition_id", "")}", '
@@ -785,6 +829,8 @@ def _runtime_source(
             f"sizeof({sequence_refs_table}[0]), "
             f"{dispatch_surface_refs_table}, sizeof({dispatch_surface_refs_table}) / "
             f"sizeof({dispatch_surface_refs_table}[0]), "
+            f"{invariant_refs_table}, sizeof({invariant_refs_table}) / "
+            f"sizeof({invariant_refs_table}[0]), "
             f'"{record.get("boundary_status", "")}", '
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
@@ -840,6 +886,17 @@ def _runtime_source(
             f"static const char *const {dispatch_surface_refs_table}[] = "
             f"{{\n{dispatch_surface_ref_rows}\n}};\n"
         )
+        invariant_refs = record.get("invariant_refs")
+        if not isinstance(invariant_refs, list):
+            invariant_refs = []
+        invariant_ref_rows = "\n".join(
+            f'  "{ref}",' for ref in invariant_refs if isinstance(ref, str)
+        )
+        invariant_refs_table = f"kAppStateEventCoverageInvariantRefs{index}"
+        event_coverage_arrays.append(
+            f"static const char *const {invariant_refs_table}[] = "
+            f"{{\n{invariant_ref_rows}\n}};\n"
+        )
         transition_index = transition_index_by_id.get(str(record.get("transition_id", "")), 0)
         write_set_table = f"kAppStateTransitionWriteSet{transition_index}"
         event_coverage_rows.append(
@@ -854,6 +911,8 @@ def _runtime_source(
             f"sizeof({sequence_refs_table}[0]), "
             f"{dispatch_surface_refs_table}, sizeof({dispatch_surface_refs_table}) / "
             f"sizeof({dispatch_surface_refs_table}[0]), "
+            f"{invariant_refs_table}, sizeof({invariant_refs_table}) / "
+            f"sizeof({invariant_refs_table}[0]), "
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
     owner_field_arrays = []
@@ -1355,6 +1414,21 @@ def _wrong_dispatch_surface_ref(transition_id: str) -> str:
     raise AssertionError(f"missing mismatched dispatch surface fixture for {transition_id}")
 
 
+def _wrong_invariant_ref(transition_id: str) -> str:
+    for invariant in _complete_invariants():
+        transition_ids = invariant.get("transition_ids")
+        if isinstance(transition_ids, list) and transition_id not in transition_ids:
+            return str(invariant["invariant_id"])
+    raise AssertionError(f"missing mismatched invariant fixture for {transition_id}")
+
+
+def _event_index(event_id: str) -> int:
+    for index, event in enumerate(_complete_events()):
+        if event["event_id"] == event_id:
+            return index
+    raise AssertionError(f"missing fixture event {event_id}")
+
+
 def _complete_invariant_dispatch_surface_ids() -> dict[str, list[str]]:
     categories = REQUIRED_INVARIANT_CATEGORIES
     surface_ids = [str(record["surface_id"]) for record in _complete_dispatch_surfaces()]
@@ -1370,14 +1444,53 @@ def _complete_invariant_dispatch_surface_ids() -> dict[str, list[str]]:
 
 def _complete_invariants() -> list[dict[str, object]]:
     dispatch_surface_ids_by_category = _complete_invariant_dispatch_surface_ids()
+    transition_ids_by_category = {
+        "inactive_panel_frozen": [
+            "transition.keybinding",
+            "transition.menu_action",
+            "transition.modal_action",
+            "transition.refresh_rebuild",
+            "transition.terminal_signal_or_resize",
+        ],
+        "render_projection_read_only": [
+            "transition.render_reflow",
+            "transition.terminal_signal_or_resize",
+        ],
+        "hidden_entry_visible_navigation": [
+            "transition.keybinding",
+            "transition.refresh_rebuild",
+            "transition.rebuild_rebind_callback",
+        ],
+        "panel_local_focus_restore": [
+            "transition.keybinding",
+            "transition.menu_action",
+            "transition.modal_action",
+            "transition.rebuild_rebind_callback",
+        ],
+        "viewport_identity_rebind": [
+            "transition.refresh_rebuild",
+            "transition.terminal_signal_or_resize",
+            "transition.filesystem_mutation_result",
+            "transition.rebuild_rebind_callback",
+        ],
+        "shared_state_panel_local_isolation": [
+            "transition.menu_action",
+            "transition.refresh_rebuild",
+            "transition.volume_operation",
+            "transition.filesystem_mutation_result",
+        ],
+        "stale_snapshot_fail_closed": [
+            "transition.refresh_rebuild",
+            "transition.volume_operation",
+            "transition.filesystem_mutation_result",
+            "transition.rebuild_rebind_callback",
+        ],
+        "blocked_transition_determinism": _complete_transition_ids(),
+    }
     return [
         _invariant(
             category,
-            transition_ids=(
-                _complete_transition_ids()
-                if category == "blocked_transition_determinism"
-                else None
-            ),
+            transition_ids=transition_ids_by_category[category],
             dispatch_surface_ids=dispatch_surface_ids_by_category[category],
         )
         for category in REQUIRED_INVARIANT_CATEGORIES
@@ -7093,6 +7206,77 @@ def test_guard_fails_when_action_coverage_dispatch_surface_refs_mix_valid_and_wr
     )
 
 
+@pytest.mark.parametrize(
+    ("refs", "expected"),
+    [
+        ([], "invariant_refs must be non-empty"),
+        ("invariant.inactive_panel_frozen", "invariant_refs must be a non-empty list"),
+        ([123], "invariant_refs[0] must be a non-empty string"),
+        (
+            ["invariant.inactive_panel_frozen", "invariant.inactive_panel_frozen"],
+            "invariant_refs[1] duplicates invariant.inactive_panel_frozen",
+        ),
+        (["invariant.__missing__"], "invariant_refs[0] does not match invariant registry"),
+        (["invariant.render_projection_read_only"], "transition_id does not match"),
+    ],
+)
+def test_guard_fails_when_action_coverage_invariant_refs_are_invalid(
+    tmp_path: Path, refs: object, expected: str
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0]["invariant_refs"] = refs
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any("action[0]" in failure and expected in failure for failure in failures)
+
+
+def test_guard_fails_when_action_coverage_invariant_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    transition_id = str(actions[0]["transition_id"])
+    valid_ref = str(actions[0]["invariant_refs"][0])
+    wrong_ref = _wrong_invariant_ref(transition_id)
+    actions[0]["invariant_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure
+        and f"invariant_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_action_coverage_invariant_refs_do_not_cover_declared_writes(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    invariants = _complete_invariants()
+    _split_transition_invariant_coverage(
+        invariants,
+        "transition.keybinding",
+        "transition.refresh_rebuild",
+        "panel.tree_selection_key",
+    )
+    paths = _write_fixture(tmp_path, transitions=transitions, invariants=invariants)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure
+        and "invariant_refs lack collective coverage" in failure
+        and "panel.tree_selection_key" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_event_coverage_owner_does_not_match_transition(
     tmp_path: Path,
 ) -> None:
@@ -7147,6 +7331,89 @@ def test_guard_fails_when_event_coverage_sequence_refs_are_invalid(
 
     assert any(
         "event[0]" in failure and expected_fragment in failure for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("refs", "expected"),
+    [
+        ([], "invariant_refs must be non-empty"),
+        ("invariant.inactive_panel_frozen", "invariant_refs must be a non-empty list"),
+        ([123], "invariant_refs[0] must be a non-empty string"),
+        (
+            ["invariant.render_projection_read_only", "invariant.render_projection_read_only"],
+            "invariant_refs[1] duplicates invariant.render_projection_read_only",
+        ),
+        (["invariant.__missing__"], "invariant_refs[0] does not match invariant registry"),
+        (["invariant.inactive_panel_frozen"], "transition_id does not match"),
+    ],
+)
+def test_guard_fails_when_event_coverage_invariant_refs_are_invalid(
+    tmp_path: Path, refs: object, expected: str
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    event_index = _event_index("event.render_reflow")
+    events[event_index]["invariant_refs"] = refs
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        f"event[{event_index}]" in failure and expected in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_event_coverage_invariant_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    event_index = _event_index("event.render_reflow")
+    transition_id = str(events[event_index]["transition_id"])
+    valid_ref = str(events[event_index]["invariant_refs"][0])
+    wrong_ref = _wrong_invariant_ref(transition_id)
+    events[event_index]["invariant_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        f"event[{event_index}]" in failure
+        and f"invariant_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_event_coverage_invariant_refs_do_not_cover_declared_writes(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    event_index = _event_index("event.render_reflow")
+    invariants = _complete_invariants()
+    _split_transition_invariant_coverage(
+        invariants,
+        "transition.render_reflow",
+        "transition.keybinding",
+        "field",
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        events=events,
+        invariants=invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        f"event[{event_index}]" in failure
+        and "invariant_refs lack collective coverage" in failure
+        and "field" in failure
+        for failure in failures
     )
 
 
@@ -7339,6 +7606,54 @@ def test_guard_fails_when_runtime_action_coverage_dispatch_surface_refs_mix_vali
     )
 
 
+def test_guard_fails_when_runtime_action_coverage_invariant_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_action_coverages = _complete_actions()
+    runtime_action_coverages[0]["invariant_refs"] = [
+        "invariant.blocked_transition_determinism"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_action_coverages=runtime_action_coverages,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_action_coverage[0]" in failure
+        and "runtime invariant_refs does not match action coverage" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_action_coverage_invariant_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_action_coverages = _complete_actions()
+    transition_id = str(runtime_action_coverages[0]["transition_id"])
+    valid_ref = str(runtime_action_coverages[0]["invariant_refs"][0])
+    wrong_ref = _wrong_invariant_ref(transition_id)
+    runtime_action_coverages[0]["invariant_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_action_coverages=runtime_action_coverages,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_action_coverage[0]" in failure
+        and f"invariant_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_event_coverage_owner_does_not_match_transition(
     tmp_path: Path,
 ) -> None:
@@ -7405,6 +7720,54 @@ def test_guard_fails_when_runtime_event_coverage_dispatch_surface_refs_mix_valid
     assert any(
         "runtime_event_coverage[0]" in failure
         and f"dispatch_surface_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_event_coverage_invariant_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_events = _complete_events()
+    event_index = _event_index("event.render_reflow")
+    runtime_events[event_index]["invariant_refs"] = ["invariant.inactive_panel_frozen"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_events=runtime_events,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        f"runtime_event_coverage[{event_index}]" in failure
+        and "invariant_refs does not match docs" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_event_coverage_invariant_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_events = _complete_events()
+    event_index = _event_index("event.render_reflow")
+    transition_id = str(runtime_events[event_index]["transition_id"])
+    valid_ref = str(runtime_events[event_index]["invariant_refs"][0])
+    wrong_ref = _wrong_invariant_ref(transition_id)
+    runtime_events[event_index]["invariant_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_events=runtime_events,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        f"runtime_event_coverage[{event_index}]" in failure
+        and f"invariant_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
         in failure
         for failure in failures
     )
@@ -7690,6 +8053,7 @@ def _event_runtime_records_and_failures(runtime_path: Path = guard.DEFAULT_ACTIO
 def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
     transitions_doc, transition_failures = guard._load_json(guard.DEFAULT_TRANSITIONS)
     event_doc, event_failures = guard._load_json(guard.DEFAULT_EVENT_COVERAGE)
+    invariant_doc, invariant_failures = guard._load_json(guard.DEFAULT_INVARIANTS)
     runtime_transitions, runtime_transition_failures = guard._parse_runtime_transition_registry(
         runtime_path
     )
@@ -7702,16 +8066,21 @@ def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
     runtime_sequences, runtime_sequence_failures = (
         guard._parse_runtime_transition_sequence_registry(runtime_path)
     )
+    runtime_invariants, runtime_invariant_failures = (
+        guard._parse_runtime_invariant_registry(runtime_path)
+    )
     transition_ids = {
         record["id"]: record for record in transitions_doc.get("transitions", [])
     }
     return (
         transition_failures
         + event_failures
+        + invariant_failures
         + runtime_transition_failures
         + runtime_dispatch_surface_failures
         + runtime_event_failures
         + runtime_sequence_failures
+        + runtime_invariant_failures
         + guard._validate_runtime_event_coverage_registry(
             runtime_records=runtime_events,
             runtime_path=runtime_path,
@@ -7720,6 +8089,15 @@ def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
             runtime_transition_sequence_records=runtime_sequences,
             runtime_dispatch_surface_records=runtime_dispatch_surfaces,
             runtime_transition_ids={record["id"] for record in runtime_transitions},
+            runtime_invariant_ids={
+                record["invariant_id"] for record in runtime_invariants
+            },
+            runtime_invariant_transition_ids=guard._invariant_transition_ids_by_invariant(
+                runtime_invariants
+            ),
+            runtime_invariant_protected_fields=guard._invariant_protected_fields_by_invariant(
+                runtime_invariants
+            ),
         )
     )
 
@@ -7833,6 +8211,8 @@ def test_runtime_event_coverage_startup_checks_fail_closed() -> None:
     assert "coverage->transition_sequence_ref_count" in source
     assert "coverage->dispatch_surface_refs" in source
     assert "coverage->dispatch_surface_ref_count" in source
+    assert "coverage->invariant_refs" in source
+    assert "coverage->invariant_ref_count" in source
     assert "!AppStateEventCoverageReady()" in source
 
 
@@ -7852,6 +8232,8 @@ def test_runtime_coverage_startup_validates_owner_alignment() -> None:
     assert "strcmp(coverage->owner, transition->owner) != 0" in event_body
     assert "AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs" in action_body
     assert "AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs" in event_body
+    assert "AppStateInvariantRefsReady(coverage->invariant_refs" in action_body
+    assert "AppStateInvariantRefsReady(coverage->invariant_refs" in event_body
 
 
 def test_runtime_event_coverage_startup_requires_documented_event_ids() -> None:


### PR DESCRIPTION
## Summary
- require action and event coverage records to declare invariant refs
- fail closed when invariant coverage refs are missing, malformed, drifting, unknown, wrong-transition, or insufficient for declared writes
- extend startup readiness and focused guard tests for action/event invariant coverage

## Validation
- Local focused guard tests: `pytest -q tests/test_appstate_contract_guard.py -k 'action_coverage or event_coverage or invariant_ref or invariant'` — PASS
- Local AppState guard tests: `pytest -q tests/test_appstate_contract_guard.py` — PASS
- Local contract guard: `python3 scripts/check_appstate_contract.py` — PASS
- Local build: `make clean && make` — PASS with pre-existing warnings
- Local whitespace check: `git diff --check` — PASS
