### PR TITLE
chore(appstate): require coverage generation refs

### DIFF
--- a/docs/appstate_action_coverage.json
+++ b/docs/appstate_action_coverage.json
@@ -36,6 +36,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -71,6 +76,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -106,6 +116,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -141,6 +156,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -176,6 +196,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -211,6 +236,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -246,6 +276,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -281,6 +316,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -316,6 +356,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -351,6 +396,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -386,6 +436,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -421,6 +476,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -456,6 +516,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -491,6 +556,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -526,6 +596,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -552,6 +627,11 @@
       "invariant_refs": [
         "invariant.panel-local-focus-restore",
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "target.modal-command.session"
       ]
     },
     {
@@ -578,6 +658,16 @@
       ],
       "invariant_refs": [
         "invariant.hidden-entry-visible-navigation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.visibility-filter.panel-volume",
+        "state.topology.volume",
+        "state.file-payload.volume",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -603,6 +693,9 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "target.modal-command.session"
       ]
     },
     {
@@ -628,6 +721,9 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "target.modal-command.session"
       ]
     },
     {
@@ -663,6 +759,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -698,6 +799,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -733,6 +839,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -768,6 +879,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -803,6 +919,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -838,6 +959,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -873,6 +999,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -908,6 +1039,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -934,6 +1070,16 @@
       ],
       "invariant_refs": [
         "invariant.hidden-entry-visible-navigation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.visibility-filter.panel-volume",
+        "state.topology.volume",
+        "state.file-payload.volume",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -960,6 +1106,10 @@
       ],
       "invariant_refs": [
         "invariant.render-projection-read-only"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "reflow.layout.projection"
       ]
     },
     {
@@ -985,6 +1135,11 @@
       ],
       "invariant_refs": [
         "invariant.shared-state-panel-local-isolation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -1011,6 +1166,13 @@
       ],
       "invariant_refs": [
         "invariant.shared-state-panel-local-isolation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "state.topology.volume",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -1037,6 +1199,13 @@
       ],
       "invariant_refs": [
         "invariant.shared-state-panel-local-isolation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "state.topology.volume",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -1064,6 +1233,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1091,6 +1268,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1118,6 +1303,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1145,6 +1338,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1172,6 +1373,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1199,6 +1408,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1226,6 +1443,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1253,6 +1478,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1280,6 +1513,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1307,6 +1548,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1334,6 +1583,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1361,6 +1618,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1388,6 +1653,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1415,6 +1688,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1442,6 +1723,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1469,6 +1758,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1494,6 +1791,9 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "target.modal-command.session"
       ]
     },
     {
@@ -1529,6 +1829,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -1564,6 +1869,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -1591,6 +1901,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1618,6 +1936,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1645,6 +1971,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1672,6 +2006,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1699,6 +2041,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1726,6 +2076,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1753,6 +2111,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1780,6 +2146,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1807,6 +2181,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1834,6 +2216,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1861,6 +2251,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1888,6 +2286,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1915,6 +2321,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -1940,6 +2354,9 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "target.modal-command.session"
       ]
     },
     {
@@ -1975,6 +2392,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2010,6 +2432,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2045,6 +2472,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2080,6 +2512,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2115,6 +2552,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2150,6 +2592,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2185,6 +2632,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2220,6 +2672,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2255,6 +2712,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2290,6 +2752,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2325,6 +2792,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2360,6 +2832,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2395,6 +2872,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2430,6 +2912,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2465,6 +2952,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2500,6 +2992,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2535,6 +3032,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2570,6 +3072,11 @@
       ],
       "invariant_refs": [
         "invariant.inactive-panel-frozen"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume"
       ]
     },
     {
@@ -2595,6 +3102,9 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "target.modal-command.session"
       ]
     },
     {
@@ -2620,6 +3130,9 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "target.modal-command.session"
       ]
     }
   ]

--- a/docs/appstate_event_coverage.json
+++ b/docs/appstate_event_coverage.json
@@ -44,6 +44,10 @@
       ],
       "invariant_refs": [
         "invariant.render-projection-read-only"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "reflow.layout.projection"
       ]
     },
     {
@@ -76,6 +80,16 @@
       ],
       "invariant_refs": [
         "invariant.hidden-entry-visible-navigation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.visibility-filter.panel-volume",
+        "state.topology.volume",
+        "state.file-payload.volume",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -111,6 +125,14 @@
       "invariant_refs": [
         "invariant.hidden-entry-visible-navigation",
         "invariant.viewport-identity-rebind"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "shape.panel.focus",
+        "state.visibility-filter.panel-volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -145,6 +167,14 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.topology.volume",
+        "state.file-payload.volume"
       ]
     },
     {
@@ -178,6 +208,16 @@
       ],
       "invariant_refs": [
         "invariant.hidden-entry-visible-navigation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "identity.file.stable-key",
+        "state.visibility-filter.panel-volume",
+        "state.topology.volume",
+        "state.file-payload.volume",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -210,6 +250,9 @@
       ],
       "invariant_refs": [
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "target.modal-command.session"
       ]
     },
     {
@@ -243,6 +286,11 @@
       "invariant_refs": [
         "invariant.panel-local-focus-restore",
         "invariant.blocked-transition-determinism"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "shape.panel.focus",
+        "target.modal-command.session"
       ]
     },
     {
@@ -276,6 +324,13 @@
       ],
       "invariant_refs": [
         "invariant.shared-state-panel-local-isolation"
+      ],
+      "generation_domain_refs": [
+        "generation.panel.local-authority",
+        "generation.volume.shared-authority",
+        "identity.directory.stable-key",
+        "state.topology.volume",
+        "lifecycle.volume.registry"
       ]
     },
     {
@@ -306,6 +361,9 @@
       ],
       "invariant_refs": [
         "invariant.render-projection-read-only"
+      ],
+      "generation_domain_refs": [
+        "reflow.layout.projection"
       ]
     }
   ]

--- a/docs/appstate_generation_domains.json
+++ b/docs/appstate_generation_domains.json
@@ -16,6 +16,16 @@
         "panel.focus_shape",
         "panel.restore_snapshot"
       ],
+      "coverage_transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.menu-action.volume-select",
+        "transition.modal-action.dismiss",
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.terminal-signal-resize",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
       "advances_on_transition_ids": [
         "transition.keybinding.navigate-tree",
         "transition.menu-action.volume-select",
@@ -46,6 +56,11 @@
         "volume.payload_cache",
         "panel.volume_key"
       ],
+      "coverage_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.filesystem-mutation-result.mkdir-copy-delete"
+      ],
       "advances_on_transition_ids": [
         "transition.refresh-rebuild.manual-refresh",
         "transition.volume-operation.release-cycle",
@@ -70,6 +85,12 @@
         "panel.tree_viewport_origin",
         "volume.dir_tree",
         "volume.logged_state"
+      ],
+      "coverage_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.volume-operation.release-cycle",
+        "transition.rebuild-rebind-callback.panel-anchor"
       ],
       "advances_on_transition_ids": [
         "transition.refresh-rebuild.manual-refresh",
@@ -96,6 +117,11 @@
         "volume.payload_cache",
         "volume.dir_tree"
       ],
+      "coverage_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
       "advances_on_transition_ids": [
         "transition.refresh-rebuild.manual-refresh",
         "transition.filesystem-mutation-result.mkdir-copy-delete",
@@ -117,6 +143,12 @@
       "identity_fields": [
         "panel.focus_shape",
         "panel.restore_snapshot"
+      ],
+      "coverage_transition_ids": [
+        "transition.keybinding.navigate-tree",
+        "transition.modal-action.dismiss",
+        "transition.menu-action.volume-select",
+        "transition.rebuild-rebind-callback.panel-anchor"
       ],
       "advances_on_transition_ids": [
         "transition.keybinding.navigate-tree",
@@ -143,6 +175,10 @@
         "ctx.pending_transition",
         "ctx.message_state"
       ],
+      "coverage_transition_ids": [
+        "transition.modal-action.dismiss",
+        "transition.command-completion.user-command"
+      ],
       "advances_on_transition_ids": [
         "transition.modal-action.dismiss",
         "transition.command-completion.user-command"
@@ -167,6 +203,11 @@
         "panel.file_viewport_origin",
         "volume.logged_state"
       ],
+      "coverage_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.keybinding.navigate-tree",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
       "advances_on_transition_ids": [
         "transition.refresh-rebuild.manual-refresh",
         "transition.keybinding.navigate-tree",
@@ -189,6 +230,11 @@
         "volume.dir_tree",
         "volume.logged_state",
         "ctx.volumes_head"
+      ],
+      "coverage_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.volume-operation.release-cycle",
+        "transition.filesystem-mutation-result.mkdir-copy-delete"
       ],
       "advances_on_transition_ids": [
         "transition.refresh-rebuild.manual-refresh",
@@ -213,6 +259,11 @@
         "panel.file_selection_key",
         "panel.file_viewport_origin"
       ],
+      "coverage_transition_ids": [
+        "transition.refresh-rebuild.manual-refresh",
+        "transition.filesystem-mutation-result.mkdir-copy-delete",
+        "transition.rebuild-rebind-callback.panel-anchor"
+      ],
       "advances_on_transition_ids": [
         "transition.refresh-rebuild.manual-refresh",
         "transition.filesystem-mutation-result.mkdir-copy-delete",
@@ -236,6 +287,11 @@
         "panel.volume_key",
         "panel.restore_snapshot",
         "volume.logged_state"
+      ],
+      "coverage_transition_ids": [
+        "transition.volume-operation.release-cycle",
+        "transition.menu-action.volume-select",
+        "transition.refresh-rebuild.manual-refresh"
       ],
       "advances_on_transition_ids": [
         "transition.volume-operation.release-cycle",
@@ -262,6 +318,10 @@
         "panel.tree_viewport_origin",
         "panel.file_viewport_origin"
       ],
+      "coverage_transition_ids": [
+        "transition.terminal-signal-resize",
+        "transition.render-reflow.project-state"
+      ],
       "advances_on_transition_ids": [
         "transition.terminal-signal-resize"
       ],
@@ -270,7 +330,8 @@
       "restore_boundary": "Resize handling runs in the main loop and commits any viewport correction before render projection.",
       "enforcement_status": "documented_foundation_only",
       "migration_notes": [
-        "Render projection itself is read-only/projection-only and does not advance generations; terminal resize uses panel.panel_generation only when saved viewport origins are corrected."
+        "Render projection itself is read-only/projection-only and does not advance generations; terminal resize uses panel.panel_generation only when saved viewport origins are corrected.",
+        "Render projection-only coverage is explicit here even when no generation counter advances."
       ]
     }
   ]

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -31,6 +31,8 @@ typedef struct {
   size_t dispatch_surface_ref_count;
   const char *const *invariant_refs;
   size_t invariant_ref_count;
+  const char *const *generation_domain_refs;
+  size_t generation_domain_ref_count;
   const char *boundary_status;
   const char *const *migration_notes;
   size_t migration_note_count;
@@ -54,6 +56,8 @@ typedef struct {
   size_t dispatch_surface_ref_count;
   const char *const *invariant_refs;
   size_t invariant_ref_count;
+  const char *const *generation_domain_refs;
+  size_t generation_domain_ref_count;
   const char *const *migration_notes;
   size_t migration_note_count;
 } AppStateEventCoverageMetadata;
@@ -137,6 +141,8 @@ typedef struct {
   const char *generation_owner_field;
   const char *const *identity_fields;
   size_t identity_field_count;
+  const char *const *coverage_transition_ids;
+  size_t coverage_transition_id_count;
   const char *const *advances_on_transition_ids;
   size_t advances_on_transition_id_count;
   const char *stale_snapshot_policy;

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -79,6 +79,7 @@ REQUIRED_ACTION_FIELDS = {
     "declared_write_set",
     "transition_sequence_refs",
     "dispatch_surface_refs",
+    "generation_domain_refs",
     "invariant_refs",
     "boundary_status",
     "migration_notes",
@@ -201,6 +202,7 @@ REQUIRED_EVENT_FIELDS = {
     "declared_write_set",
     "transition_sequence_refs",
     "dispatch_surface_refs",
+    "generation_domain_refs",
     "invariant_refs",
     "boundary_status",
     "trigger_paths",
@@ -236,6 +238,7 @@ REQUIRED_GENERATION_DOMAIN_FIELDS = {
     "owner_region",
     "generation_owner_field",
     "identity_fields",
+    "coverage_transition_ids",
     "advances_on_transition_ids",
     "stale_snapshot_policy",
     "fail_closed_fallback",
@@ -303,12 +306,14 @@ LIST_FIELDS = {
 ACTION_LIST_FIELDS = LIST_FIELDS | {
     "transition_sequence_refs",
     "dispatch_surface_refs",
+    "generation_domain_refs",
     "invariant_refs",
 }
 EVENT_LIST_FIELDS = LIST_FIELDS | {
     "trigger_paths",
     "transition_sequence_refs",
     "dispatch_surface_refs",
+    "generation_domain_refs",
     "invariant_refs",
 }
 SHIM_LIST_FIELDS = LIST_FIELDS | {
@@ -327,7 +332,11 @@ INVARIANT_LIST_FIELDS = {
     "transition_ids",
     "migration_notes",
 }
-GENERATION_DOMAIN_LIST_FIELDS = {"identity_fields", "migration_notes"}
+GENERATION_DOMAIN_LIST_FIELDS = {
+    "identity_fields",
+    "coverage_transition_ids",
+    "migration_notes",
+}
 DIFF_HARNESS_LIST_FIELDS = {
     "snapshot_phases",
     "snapshot_regions",
@@ -632,7 +641,7 @@ def _parse_runtime_action_coverage_registry(
     arrays: dict[str, list[str]] = {}
     array_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateActionCoverage(?:TransitionSequenceRefs|DispatchSurfaceRefs|InvariantRefs|MigrationNotes)[0-9]+)"
+        r"(kAppStateActionCoverage(?:TransitionSequenceRefs|DispatchSurfaceRefs|InvariantRefs|GenerationDomainRefs|MigrationNotes)[0-9]+)"
         r"\[\]\s*=\s*\{(?P<body>.*?)\};",
         re.S,
     )
@@ -671,6 +680,9 @@ def _parse_runtime_action_coverage_registry(
         r"\s*(?P<invariant_refs>kAppStateActionCoverageInvariantRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=invariant_refs)\)\s*/"
         r"\s*sizeof\((?P=invariant_refs)\[0\]\)\s*,"
+        r"\s*(?P<generation_domain_refs>kAppStateActionCoverageGenerationDomainRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=generation_domain_refs)\)\s*/"
+        r"\s*sizeof\((?P=generation_domain_refs)\[0\]\)\s*,"
         r"\s*\"(?P<boundary_status>[^\"]*)\"\s*,"
         r"\s*(?P<migration_notes>kAppStateActionCoverageMigrationNotes[0-9]+)\s*,"
         r"\s*sizeof\((?P=migration_notes)\)\s*/"
@@ -722,6 +734,14 @@ def _parse_runtime_action_coverage_registry(
                 f"table: {invariant_refs_name}"
             )
             invariant_refs = []
+        generation_domain_refs_name = row_match.group("generation_domain_refs")
+        generation_domain_refs = arrays.get(generation_domain_refs_name)
+        if generation_domain_refs is None:
+            failures.append(
+                f"runtime_action_coverage[{index}]: unknown generation-domain-refs "
+                f"table: {generation_domain_refs_name}"
+            )
+            generation_domain_refs = []
         notes_name = row_match.group("migration_notes")
         notes = arrays.get(notes_name)
         if notes is None:
@@ -741,6 +761,7 @@ def _parse_runtime_action_coverage_registry(
                 "transition_sequence_refs": sequence_refs,
                 "dispatch_surface_refs": dispatch_surface_refs,
                 "invariant_refs": invariant_refs,
+                "generation_domain_refs": generation_domain_refs,
                 "boundary_status": row_match.group("boundary_status"),
                 "migration_notes": notes,
             }
@@ -765,7 +786,7 @@ def _parse_runtime_event_coverage_registry(
     arrays: dict[str, list[str]] = {}
     array_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppState(?:TransitionWriteSet|EventCoverageTriggerPaths|EventCoverageTransitionSequenceRefs|EventCoverageDispatchSurfaceRefs|EventCoverageInvariantRefs|EventCoverageMigrationNotes)[0-9]+)"
+        r"(kAppState(?:TransitionWriteSet|EventCoverageTriggerPaths|EventCoverageTransitionSequenceRefs|EventCoverageDispatchSurfaceRefs|EventCoverageInvariantRefs|EventCoverageGenerationDomainRefs|EventCoverageMigrationNotes)[0-9]+)"
         r"\[\]\s*=\s*\{(?P<body>.*?)\};",
         re.S,
     )
@@ -805,6 +826,8 @@ def _parse_runtime_event_coverage_registry(
         r"\s*sizeof\((?P=dispatch_surface_refs)\)\s*/\s*sizeof\((?P=dispatch_surface_refs)\[0\]\)\s*,"
         r"\s*(?P<invariant_refs>kAppStateEventCoverageInvariantRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=invariant_refs)\)\s*/\s*sizeof\((?P=invariant_refs)\[0\]\)\s*,"
+        r"\s*(?P<generation_domain_refs>kAppStateEventCoverageGenerationDomainRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=generation_domain_refs)\)\s*/\s*sizeof\((?P=generation_domain_refs)\[0\]\)\s*,"
         r"\s*(?P<migration_notes>kAppStateEventCoverageMigrationNotes[0-9]+)\s*,"
         r"\s*sizeof\((?P=migration_notes)\)\s*/\s*sizeof\((?P=migration_notes)\[0\]\)\s*\}",
         re.S,
@@ -858,6 +881,13 @@ def _parse_runtime_event_coverage_registry(
                 f"{row_match.group('invariant_refs')}"
             )
             invariant_refs = []
+        generation_domain_refs = arrays.get(row_match.group("generation_domain_refs"))
+        if generation_domain_refs is None:
+            failures.append(
+                f"runtime_event_coverage[{index}]: unknown generation-domain-refs table: "
+                f"{row_match.group('generation_domain_refs')}"
+            )
+            generation_domain_refs = []
         if migration_notes is None:
             failures.append(
                 f"runtime_event_coverage[{index}]: unknown migration-notes table: "
@@ -878,6 +908,7 @@ def _parse_runtime_event_coverage_registry(
                 "transition_sequence_refs": transition_sequence_refs,
                 "dispatch_surface_refs": dispatch_surface_refs,
                 "invariant_refs": invariant_refs,
+                "generation_domain_refs": generation_domain_refs,
                 "migration_notes": migration_notes,
             }
         )
@@ -1251,6 +1282,7 @@ def _parse_runtime_generation_domain_registry(
 
     array_fields = {
         "IdentityFields": "identity_fields",
+        "CoverageTransitionIds": "coverage_transition_ids",
         "AdvancesOnTransitionIds": "advances_on_transition_ids",
         "MigrationNotes": "migration_notes",
     }
@@ -1289,6 +1321,10 @@ def _parse_runtime_generation_domain_registry(
         r"\s*(?P<identity_fields>kAppStateGenerationDomainIdentityFields[0-9]+)\s*,"
         r"\s*sizeof\((?P=identity_fields)\)\s*/"
         r"\s*sizeof\((?P=identity_fields)\[0\]\)\s*,"
+        r"\s*(?P<coverage_transition_ids>"
+        r"kAppStateGenerationDomainCoverageTransitionIds[0-9]+)\s*,"
+        r"\s*sizeof\((?P=coverage_transition_ids)\)\s*/"
+        r"\s*sizeof\((?P=coverage_transition_ids)\[0\]\)\s*,"
         r"\s*(?P<advances_on_transition_ids>"
         r"kAppStateGenerationDomainAdvancesOnTransitionIds[0-9]+)\s*,"
         r"\s*sizeof\((?P=advances_on_transition_ids)\)\s*/"
@@ -1967,6 +2003,7 @@ def _validate_runtime_action_coverage_registry(
     runtime_transition_sequence_records: list[Any],
     runtime_action_transitions: list[dict[str, str]],
     runtime_dispatch_surface_records: list[Any],
+    runtime_generation_domain_records: list[Any],
     registered_owner_fields: set[str],
     runtime_invariant_ids: set[str],
     runtime_invariant_transition_ids: dict[str, set[str]],
@@ -2036,6 +2073,14 @@ def _validate_runtime_action_coverage_registry(
             )
         )
         failures.extend(
+            _validate_generation_domain_refs(
+                generation_domain_refs=record.get("generation_domain_refs"),
+                generation_domain_records=runtime_generation_domain_records,
+                transition_id=record.get("transition_id"),
+                label=label,
+            )
+        )
+        failures.extend(
             _validate_record_invariant_refs(
                 invariant_refs=record.get("invariant_refs"),
                 invariant_ids=runtime_invariant_ids,
@@ -2096,6 +2141,7 @@ def _validate_runtime_action_coverage_registry(
                     "declared_write_set",
                     "transition_sequence_refs",
                     "dispatch_surface_refs",
+                    "generation_domain_refs",
                     "invariant_refs",
                     "boundary_status",
                     "migration_notes",
@@ -2728,6 +2774,7 @@ def _validate_runtime_generation_domain_registry(
                 "owner_region",
                 "generation_owner_field",
                 "identity_fields",
+                "coverage_transition_ids",
                 "advances_on_transition_ids",
                 "stale_snapshot_policy",
                 "fail_closed_fallback",
@@ -2755,7 +2802,7 @@ def _validate_runtime_generation_domain_registry(
             if not isinstance(value, str) or not value.strip():
                 failures.append(f"{label}: {field} must be a non-empty string")
 
-        for field in ("identity_fields", "migration_notes"):
+        for field in ("identity_fields", "coverage_transition_ids", "migration_notes"):
             values = record.get(field)
             if not isinstance(values, list) or not values:
                 failures.append(f"{label}: {field} must be non-empty")
@@ -2766,17 +2813,51 @@ def _validate_runtime_generation_domain_registry(
                         f"{label}: {field}[{value_index}] must be a non-empty string"
                     )
 
-        transition_refs = record.get("advances_on_transition_ids")
-        if not isinstance(transition_refs, list):
-            failures.append(f"{label}: advances_on_transition_ids must be a list")
-        else:
+        for transition_field in (
+            "coverage_transition_ids",
+            "advances_on_transition_ids",
+        ):
+            transition_refs = record.get(transition_field)
+            if not isinstance(transition_refs, list):
+                failures.append(f"{label}: {transition_field} must be a list")
+                continue
             for transition_index, transition_id in enumerate(transition_refs):
                 if not isinstance(transition_id, str) or not transition_id.strip():
                     failures.append(
-                        f"{label}: advances_on_transition_ids[{transition_index}] "
+                        f"{label}: {transition_field}[{transition_index}] "
                         "must be a non-empty string"
                     )
+            for transition_id in transition_refs:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in runtime_transition_ids
+                ):
+                    failures.append(
+                        f"{label}: {transition_field} does not match "
+                        f"runtime transition registry: {transition_id}"
+                    )
 
+        coverage_transition_refs = record.get("coverage_transition_ids")
+        transition_refs = record.get("advances_on_transition_ids")
+        if isinstance(coverage_transition_refs, list) and isinstance(
+            transition_refs, list
+        ):
+            declared_coverage = {
+                transition_id
+                for transition_id in coverage_transition_refs
+                if isinstance(transition_id, str) and transition_id.strip()
+            }
+            for transition_id in transition_refs:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in declared_coverage
+                ):
+                    failures.append(
+                        f"{label}: advances_on_transition_ids must be covered by "
+                        f"coverage_transition_ids: {transition_id}"
+                    )
         generation_owner_field = record.get("generation_owner_field")
         if (
             isinstance(generation_owner_field, str)
@@ -2799,18 +2880,6 @@ def _validate_runtime_generation_domain_registry(
                     failures.append(
                         f"{label}: identity_fields does not match runtime owner "
                         f"field registry: {field}"
-                    )
-
-        if isinstance(transition_refs, list):
-            for transition_id in transition_refs:
-                if (
-                    isinstance(transition_id, str)
-                    and transition_id.strip()
-                    and transition_id not in runtime_transition_ids
-                ):
-                    failures.append(
-                        f"{label}: advances_on_transition_ids does not match "
-                        f"runtime transition registry: {transition_id}"
                     )
 
     missing_ids = sorted(expected_ids - covered_ids)
@@ -3774,6 +3843,75 @@ def _dispatch_surfaces_by_id(
     }
 
 
+def _generation_domains_by_id(
+    generation_domain_records: list[Any],
+) -> dict[str, dict[str, Any]]:
+    return {
+        domain["domain_id"]: domain
+        for domain in generation_domain_records
+        if isinstance(domain, dict)
+        and isinstance(domain.get("domain_id"), str)
+        and domain["domain_id"].strip()
+    }
+
+
+def _generation_domain_covers_transition(
+    domain: dict[str, Any], transition_id: Any
+) -> bool:
+    coverage_transition_ids = domain.get("coverage_transition_ids")
+    return (
+        isinstance(transition_id, str)
+        and transition_id.strip()
+        and isinstance(coverage_transition_ids, list)
+        and transition_id in coverage_transition_ids
+    )
+
+
+def _validate_generation_domain_refs(
+    *,
+    generation_domain_refs: Any,
+    generation_domain_records: list[Any],
+    transition_id: Any,
+    label: str,
+) -> list[str]:
+    failures = _validate_list_field(
+        value=generation_domain_refs,
+        label=label,
+        field="generation_domain_refs",
+    )
+    if failures:
+        return failures
+
+    assert isinstance(generation_domain_refs, list)
+    domains = _generation_domains_by_id(generation_domain_records)
+    seen: set[str] = set()
+
+    for index, domain_id in enumerate(generation_domain_refs):
+        if not isinstance(domain_id, str) or not domain_id.strip():
+            failures.append(
+                f"{label}: generation_domain_refs[{index}] must be a non-empty string"
+            )
+            continue
+        if domain_id in seen:
+            failures.append(
+                f"{label}: duplicate generation_domain_refs[{index}]: {domain_id}"
+            )
+        seen.add(domain_id)
+        domain = domains.get(domain_id)
+        if domain is None:
+            failures.append(
+                f"{label}: generation_domain_refs references unknown generation domain: {domain_id}"
+            )
+            continue
+        if not _generation_domain_covers_transition(domain, transition_id):
+            failures.append(
+                f"{label}: generation_domain_refs[{index}] transition_id does not match "
+                f"{transition_id}: {domain_id}"
+            )
+
+    return failures
+
+
 def _validate_dispatch_surface_refs(
     *,
     record: dict[str, Any],
@@ -4340,9 +4478,9 @@ def _validate_generation_transition_refs(
     label: str,
     transition_ids: dict[str, dict[str, Any]],
     migration_notes: Any,
+    field: str,
 ) -> list[str]:
     failures: list[str] = []
-    field = "advances_on_transition_ids"
     if not isinstance(value, list):
         return [f"{label}: {field} must be a list"]
 
@@ -4355,7 +4493,7 @@ def _validate_generation_transition_refs(
                 f"{label}: {field} references unknown transition id: {transition_id}"
             )
 
-    if not value:
+    if field == "advances_on_transition_ids" and not value:
         has_projection_note = (
             isinstance(migration_notes, list)
             and any(
@@ -4422,6 +4560,22 @@ def _validate_generation_domains(
                     label=label,
                     transition_ids=transition_ids,
                     migration_notes=record.get("migration_notes"),
+                    field="advances_on_transition_ids",
+                )
+            )
+
+        if "coverage_transition_ids" not in record:
+            failures.append(
+                f"{label}: missing required field(s): coverage_transition_ids"
+            )
+        else:
+            failures.extend(
+                _validate_generation_transition_refs(
+                    value=record.get("coverage_transition_ids"),
+                    label=label,
+                    transition_ids=transition_ids,
+                    migration_notes=record.get("migration_notes"),
+                    field="coverage_transition_ids",
                 )
             )
 
@@ -4455,6 +4609,27 @@ def _validate_generation_domains(
                 ):
                     failures.append(
                         f"{label}: identity_fields references unregistered owner field: {field}"
+                    )
+
+        coverage_transition_ids = record.get("coverage_transition_ids")
+        advances_on_transition_ids = record.get("advances_on_transition_ids")
+        if isinstance(coverage_transition_ids, list) and isinstance(
+            advances_on_transition_ids, list
+        ):
+            declared_coverage = {
+                transition_id
+                for transition_id in coverage_transition_ids
+                if isinstance(transition_id, str) and transition_id.strip()
+            }
+            for transition_id in advances_on_transition_ids:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in declared_coverage
+                ):
+                    failures.append(
+                        f"{label}: advances_on_transition_ids must be covered by "
+                        f"coverage_transition_ids: {transition_id}"
                     )
 
     missing_categories = sorted(
@@ -4501,6 +4676,7 @@ def _validate_runtime_event_coverage_registry(
     transition_ids: dict[str, dict[str, Any]],
     runtime_transition_sequence_records: list[Any],
     runtime_dispatch_surface_records: list[Any],
+    runtime_generation_domain_records: list[Any],
     runtime_transition_ids: set[str],
     runtime_invariant_ids: set[str],
     runtime_invariant_transition_ids: dict[str, set[str]],
@@ -4538,6 +4714,14 @@ def _validate_runtime_event_coverage_registry(
             _validate_dispatch_surface_refs(
                 record=record,
                 dispatch_surface_records=runtime_dispatch_surface_records,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_generation_domain_refs(
+                generation_domain_refs=record.get("generation_domain_refs"),
+                generation_domain_records=runtime_generation_domain_records,
+                transition_id=record.get("transition_id"),
                 label=label,
             )
         )
@@ -4616,6 +4800,7 @@ def _validate_event_coverage(
     transition_ids: dict[str, dict[str, Any]],
     transition_sequence_records: list[Any],
     dispatch_surface_records: list[Any],
+    generation_domain_records: list[Any],
     registered_owner_fields: set[str],
     invariant_ids: set[str],
     invariant_transition_ids: dict[str, set[str]],
@@ -4673,6 +4858,14 @@ def _validate_event_coverage(
             _validate_dispatch_surface_refs(
                 record=record,
                 dispatch_surface_records=dispatch_surface_records,
+                label=label,
+            )
+        )
+        failures.extend(
+            _validate_generation_domain_refs(
+                generation_domain_refs=record.get("generation_domain_refs"),
+                generation_domain_records=generation_domain_records,
+                transition_id=record.get("transition_id"),
                 label=label,
             )
         )
@@ -6301,6 +6494,14 @@ def validate_contract(
             )
         )
         failures.extend(
+            _validate_generation_domain_refs(
+                generation_domain_refs=record.get("generation_domain_refs"),
+                generation_domain_records=generation_domain_records,
+                transition_id=record.get("transition_id"),
+                label=label,
+            )
+        )
+        failures.extend(
             _validate_record_invariant_refs(
                 invariant_refs=record.get("invariant_refs"),
                 invariant_ids=invariant_ids,
@@ -6387,6 +6588,7 @@ def validate_contract(
             runtime_transition_sequence_records=runtime_transition_sequence_records,
             runtime_action_transitions=runtime_action_records,
             runtime_dispatch_surface_records=runtime_dispatch_surface_records,
+            runtime_generation_domain_records=runtime_generation_domain_records,
             registered_owner_fields=registered_owner_fields,
             runtime_invariant_ids=runtime_invariant_ids,
             runtime_invariant_transition_ids=runtime_invariant_transition_ids,
@@ -6406,6 +6608,7 @@ def validate_contract(
                 else []
             ),
             dispatch_surface_records=dispatch_surface_records,
+            generation_domain_records=generation_domain_records,
             registered_owner_fields=registered_owner_fields,
             invariant_ids=invariant_ids,
             invariant_transition_ids=invariant_transition_ids,
@@ -6420,6 +6623,7 @@ def validate_contract(
             transition_ids=transition_ids,
             runtime_transition_sequence_records=runtime_transition_sequence_records,
             runtime_dispatch_surface_records=runtime_dispatch_surface_records,
+            runtime_generation_domain_records=runtime_generation_domain_records,
             runtime_transition_ids={record["id"] for record in runtime_transition_records},
             runtime_invariant_ids=runtime_invariant_ids,
             runtime_invariant_transition_ids=runtime_invariant_transition_ids,

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -366,7 +366,126 @@ static const char *const kAppStateGenerationDomainIdentityFields0[] = {
   "panel.focus_shape",
   "panel.restore_snapshot",
 };
-
+static const char *const kAppStateGenerationDomainIdentityFields1[] = {
+  "ctx.volumes_head",
+  "volume.dir_tree",
+  "volume.logged_state",
+  "volume.payload_cache",
+  "panel.volume_key",
+};
+static const char *const kAppStateGenerationDomainIdentityFields2[] = {
+  "panel.tree_selection_key",
+  "panel.tree_cursor_pos",
+  "panel.tree_viewport_origin",
+  "volume.dir_tree",
+  "volume.logged_state",
+};
+static const char *const kAppStateGenerationDomainIdentityFields3[] = {
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+  "volume.payload_cache",
+  "volume.dir_tree",
+};
+static const char *const kAppStateGenerationDomainIdentityFields4[] = {
+  "panel.focus_shape",
+  "panel.restore_snapshot",
+};
+static const char *const kAppStateGenerationDomainIdentityFields5[] = {
+  "ctx.modal_state",
+  "ctx.command_state",
+  "ctx.pending_transition",
+  "ctx.message_state",
+};
+static const char *const kAppStateGenerationDomainIdentityFields6[] = {
+  "panel.tree_selection_key",
+  "panel.tree_viewport_origin",
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+  "volume.logged_state",
+};
+static const char *const kAppStateGenerationDomainIdentityFields7[] = {
+  "volume.dir_tree",
+  "volume.logged_state",
+  "ctx.volumes_head",
+};
+static const char *const kAppStateGenerationDomainIdentityFields8[] = {
+  "volume.payload_cache",
+  "panel.file_selection_key",
+  "panel.file_viewport_origin",
+};
+static const char *const kAppStateGenerationDomainIdentityFields9[] = {
+  "ctx.volumes_head",
+  "panel.volume_key",
+  "panel.restore_snapshot",
+  "volume.logged_state",
+};
+static const char *const kAppStateGenerationDomainIdentityFields10[] = {
+  "ctx.layout",
+  "ctx.window_handles",
+  "ctx.render_dirty_flags",
+  "panel.tree_viewport_origin",
+  "panel.file_viewport_origin",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds0[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.menu-action.volume-select",
+  "transition.modal-action.dismiss",
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.terminal-signal-resize",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds1[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds2[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.volume-operation.release-cycle",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds3[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds4[] = {
+  "transition.keybinding.navigate-tree",
+  "transition.modal-action.dismiss",
+  "transition.menu-action.volume-select",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds5[] = {
+  "transition.modal-action.dismiss",
+  "transition.command-completion.user-command",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds6[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.keybinding.navigate-tree",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds7[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.volume-operation.release-cycle",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds8[] = {
+  "transition.refresh-rebuild.manual-refresh",
+  "transition.filesystem-mutation-result.mkdir-copy-delete",
+  "transition.rebuild-rebind-callback.panel-anchor",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds9[] = {
+  "transition.volume-operation.release-cycle",
+  "transition.menu-action.volume-select",
+  "transition.refresh-rebuild.manual-refresh",
+};
+static const char *const kAppStateGenerationDomainCoverageTransitionIds10[] = {
+  "transition.terminal-signal-resize",
+  "transition.render-reflow.project-state",
+};
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds0[] = {
   "transition.keybinding.navigate-tree",
   "transition.menu-action.volume-select",
@@ -377,178 +496,88 @@ static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds0[] = {
   "transition.filesystem-mutation-result.mkdir-copy-delete",
   "transition.rebuild-rebind-callback.panel-anchor",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes0[] = {
-  "Runtime panel_generation is still documented foundation; later runtime migration must wire this field to the canonical panel UI state record.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields1[] = {
-  "ctx.volumes_head",
-  "volume.dir_tree",
-  "volume.logged_state",
-  "volume.payload_cache",
-  "panel.volume_key",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds1[] = {
   "transition.refresh-rebuild.manual-refresh",
   "transition.volume-operation.release-cycle",
   "transition.filesystem-mutation-result.mkdir-copy-delete",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes1[] = {
-  "Runtime volume_generation is still documented foundation; later runtime migration must attach it to Volume topology and payload commits.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields2[] = {
-  "panel.tree_selection_key",
-  "panel.tree_cursor_pos",
-  "panel.tree_viewport_origin",
-  "volume.dir_tree",
-  "volume.logged_state",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds2[] = {
   "transition.refresh-rebuild.manual-refresh",
   "transition.filesystem-mutation-result.mkdir-copy-delete",
   "transition.volume-operation.release-cycle",
   "transition.rebuild-rebind-callback.panel-anchor",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes2[] = {
-  "Directory identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative invalidation owner for topology changes.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields3[] = {
-  "panel.file_selection_key",
-  "panel.file_viewport_origin",
-  "volume.payload_cache",
-  "volume.dir_tree",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds3[] = {
   "transition.refresh-rebuild.manual-refresh",
   "transition.filesystem-mutation-result.mkdir-copy-delete",
   "transition.rebuild-rebind-callback.panel-anchor",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes3[] = {
-  "File identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative owner for payload and namespace invalidation.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields4[] = {
-  "panel.focus_shape",
-  "panel.restore_snapshot",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds4[] = {
   "transition.keybinding.navigate-tree",
   "transition.modal-action.dismiss",
   "transition.menu-action.volume-select",
   "transition.rebuild-rebind-callback.panel-anchor",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes4[] = {
-  "Focus-shape invalidation is represented by panel.panel_generation until a narrower runtime focus-shape generation exists.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields5[] = {
-  "ctx.modal_state",
-  "ctx.command_state",
-  "ctx.pending_transition",
-  "ctx.message_state",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds5[] = {
   "transition.modal-action.dismiss",
   "transition.command-completion.user-command",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes5[] = {
-  "No dedicated ctx command/modal generation exists yet; panel.panel_generation is the closest guard for command paths that restore focus or queue panel-local follow-up work.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields6[] = {
-  "panel.tree_selection_key",
-  "panel.tree_viewport_origin",
-  "panel.file_selection_key",
-  "panel.file_viewport_origin",
-  "volume.logged_state",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds6[] = {
   "transition.refresh-rebuild.manual-refresh",
   "transition.keybinding.navigate-tree",
   "transition.rebuild-rebind-callback.panel-anchor",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes6[] = {
-  "Dedicated filter and dotfile visibility owner fields are not registered yet; panel.panel_generation is the closest panel-local invalidation owner.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields7[] = {
-  "volume.dir_tree",
-  "volume.logged_state",
-  "ctx.volumes_head",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds7[] = {
   "transition.refresh-rebuild.manual-refresh",
   "transition.volume-operation.release-cycle",
   "transition.filesystem-mutation-result.mkdir-copy-delete",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes7[] = {
-  "Topology generation is represented by volume.volume_generation until runtime Volume commit hooks are migrated.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields8[] = {
-  "volume.payload_cache",
-  "panel.file_selection_key",
-  "panel.file_viewport_origin",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds8[] = {
   "transition.refresh-rebuild.manual-refresh",
   "transition.filesystem-mutation-result.mkdir-copy-delete",
   "transition.rebuild-rebind-callback.panel-anchor",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes8[] = {
-  "File payload invalidation uses volume.volume_generation until a narrower payload generation field is registered.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields9[] = {
-  "ctx.volumes_head",
-  "panel.volume_key",
-  "panel.restore_snapshot",
-  "volume.logged_state",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds9[] = {
   "transition.volume-operation.release-cycle",
   "transition.menu-action.volume-select",
   "transition.refresh-rebuild.manual-refresh",
 };
-
-static const char *const kAppStateGenerationDomainMigrationNotes9[] = {
-  "Volume lifecycle has no separate registry generation yet; volume.volume_generation is the closest shared invalidation owner while ctx.volumes_head remains the registry identity field.",
-};
-
-static const char *const kAppStateGenerationDomainIdentityFields10[] = {
-  "ctx.layout",
-  "ctx.window_handles",
-  "ctx.render_dirty_flags",
-  "panel.tree_viewport_origin",
-  "panel.file_viewport_origin",
-};
-
 static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds10[] = {
   "transition.terminal-signal-resize",
 };
-
+static const char *const kAppStateGenerationDomainMigrationNotes0[] = {
+  "Runtime panel_generation is still documented foundation; later runtime migration must wire this field to the canonical panel UI state record.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes1[] = {
+  "Runtime volume_generation is still documented foundation; later runtime migration must attach it to Volume topology and payload commits.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes2[] = {
+  "Directory identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative invalidation owner for topology changes.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes3[] = {
+  "File identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative owner for payload and namespace invalidation.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes4[] = {
+  "Focus-shape invalidation is represented by panel.panel_generation until a narrower runtime focus-shape generation exists.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes5[] = {
+  "No dedicated ctx command/modal generation exists yet; panel.panel_generation is the closest guard for command paths that restore focus or queue panel-local follow-up work.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes6[] = {
+  "Dedicated filter and dotfile visibility owner fields are not registered yet; panel.panel_generation is the closest panel-local invalidation owner.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes7[] = {
+  "Topology generation is represented by volume.volume_generation until runtime Volume commit hooks are migrated.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes8[] = {
+  "File payload invalidation uses volume.volume_generation until a narrower payload generation field is registered.",
+};
+static const char *const kAppStateGenerationDomainMigrationNotes9[] = {
+  "Volume lifecycle has no separate registry generation yet; volume.volume_generation is the closest shared invalidation owner while ctx.volumes_head remains the registry identity field.",
+};
 static const char *const kAppStateGenerationDomainMigrationNotes10[] = {
   "Render projection itself is read-only/projection-only and does not advance generations; terminal resize uses panel.panel_generation only when saved viewport origins are corrected.",
+  "Render projection-only coverage is explicit here even when no generation counter advances.",
 };
 
 static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
@@ -557,188 +586,177 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "panel-local state",
    "panel.panel_generation",
    kAppStateGenerationDomainIdentityFields0,
-   sizeof(kAppStateGenerationDomainIdentityFields0) /
-       sizeof(kAppStateGenerationDomainIdentityFields0[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields0) / sizeof(kAppStateGenerationDomainIdentityFields0[0]),
+   kAppStateGenerationDomainCoverageTransitionIds0,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds0) / sizeof(kAppStateGenerationDomainCoverageTransitionIds0[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds0,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds0) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds0[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds0) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds0[0]),
    "Reject snapshots whose saved panel_generation does not match the panel-local generation marker before restore authority is applied.",
    "Re-resolve by stable identity, then nearest visible ancestor, next visible sibling, previous visible sibling, and finally root visible node.",
    "Canonical panel-anchor restore helpers commit panel-local selection, viewport, focus shape, and snapshot generation together.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes0,
-   sizeof(kAppStateGenerationDomainMigrationNotes0) /
-       sizeof(kAppStateGenerationDomainMigrationNotes0[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes0) / sizeof(kAppStateGenerationDomainMigrationNotes0[0])},
   {"generation.volume.shared-authority",
    "volume_generation",
    "volume/shared topology and payload state",
    "volume.volume_generation",
    kAppStateGenerationDomainIdentityFields1,
-   sizeof(kAppStateGenerationDomainIdentityFields1) /
-       sizeof(kAppStateGenerationDomainIdentityFields1[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields1) / sizeof(kAppStateGenerationDomainIdentityFields1[0]),
+   kAppStateGenerationDomainCoverageTransitionIds1,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds1) / sizeof(kAppStateGenerationDomainCoverageTransitionIds1[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds1,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds1) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds1[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds1) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds1[0]),
    "Treat any saved volume_generation mismatch as stale and require topology/payload identity re-resolution before panel snapshots are reused.",
    "Keep the previous settled topology on blocked transitions; after invalidation, rebind panels through stable identities or fall back to root visible node.",
    "Refresh/rebuild and mutation-result commits advance volume generation before panel restore consumers can observe the changed volume.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes1,
-   sizeof(kAppStateGenerationDomainMigrationNotes1) /
-       sizeof(kAppStateGenerationDomainMigrationNotes1[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes1) / sizeof(kAppStateGenerationDomainMigrationNotes1[0])},
   {"identity.directory.stable-key",
    "directory_identity",
    "panel-local state plus volume/shared topology and payload state",
    "volume.volume_generation",
    kAppStateGenerationDomainIdentityFields2,
-   sizeof(kAppStateGenerationDomainIdentityFields2) /
-       sizeof(kAppStateGenerationDomainIdentityFields2[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields2) / sizeof(kAppStateGenerationDomainIdentityFields2[0]),
+   kAppStateGenerationDomainCoverageTransitionIds2,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds2) / sizeof(kAppStateGenerationDomainCoverageTransitionIds2[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds2,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds2) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds2[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds2) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds2[0]),
    "Directory snapshots must compare stable path identity against the current volume generation before row or cursor state is trusted.",
    "Exact directory identity, nearest visible ancestor, next visible sibling, previous visible sibling, then root visible node.",
    "Directory rebind runs through panel-anchor helpers after the shared topology generation has settled.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes2,
-   sizeof(kAppStateGenerationDomainMigrationNotes2) /
-       sizeof(kAppStateGenerationDomainMigrationNotes2[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes2) / sizeof(kAppStateGenerationDomainMigrationNotes2[0])},
   {"identity.file.stable-key",
    "file_identity",
    "panel-local state plus volume/shared topology and payload state",
    "volume.volume_generation",
    kAppStateGenerationDomainIdentityFields3,
-   sizeof(kAppStateGenerationDomainIdentityFields3) /
-       sizeof(kAppStateGenerationDomainIdentityFields3[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields3) / sizeof(kAppStateGenerationDomainIdentityFields3[0]),
+   kAppStateGenerationDomainCoverageTransitionIds3,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds3) / sizeof(kAppStateGenerationDomainCoverageTransitionIds3[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds3,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds3) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds3[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds3) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds3[0]),
    "File snapshots must revalidate path/name identity and payload membership when volume generation changes.",
    "Preserve the directory anchor when possible and choose a valid visible file only after exact file identity is unavailable.",
    "File identity restore is committed with the panel snapshot after topology or payload mutation has settled.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes3,
-   sizeof(kAppStateGenerationDomainMigrationNotes3) /
-       sizeof(kAppStateGenerationDomainMigrationNotes3[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes3) / sizeof(kAppStateGenerationDomainMigrationNotes3[0])},
   {"shape.panel.focus",
    "focus_shape",
    "panel-local state",
    "panel.panel_generation",
    kAppStateGenerationDomainIdentityFields4,
-   sizeof(kAppStateGenerationDomainIdentityFields4) /
-       sizeof(kAppStateGenerationDomainIdentityFields4[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields4) / sizeof(kAppStateGenerationDomainIdentityFields4[0]),
+   kAppStateGenerationDomainCoverageTransitionIds4,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds4) / sizeof(kAppStateGenerationDomainCoverageTransitionIds4[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds4,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds4) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds4[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds4) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds4[0]),
    "Saved focus shape is stale when panel_generation differs and must not be restored by transient render shape.",
    "Restore the recorded panel shape directly or keep the current settled shape without rendering an intermediate guess.",
    "Modal dismissal, panel reactivation, and rebind callbacks commit focus shape only through panel-local state.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes4,
-   sizeof(kAppStateGenerationDomainMigrationNotes4) /
-       sizeof(kAppStateGenerationDomainMigrationNotes4[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes4) / sizeof(kAppStateGenerationDomainMigrationNotes4[0])},
   {"target.modal-command.session",
    "modal_command_target",
    "ctx/session state",
    "panel.panel_generation",
    kAppStateGenerationDomainIdentityFields5,
-   sizeof(kAppStateGenerationDomainIdentityFields5) /
-       sizeof(kAppStateGenerationDomainIdentityFields5[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields5) / sizeof(kAppStateGenerationDomainIdentityFields5[0]),
+   kAppStateGenerationDomainCoverageTransitionIds5,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds5) / sizeof(kAppStateGenerationDomainCoverageTransitionIds5[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds5,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds5) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds5[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds5) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds5[0]),
    "Modal and command targets may write panel or volume state only through a declared follow-up transition boundary.",
    "On blocked or failed command completion, preserve authoritative panel and volume state and write only declared message/modal fields.",
    "Modal dismissal and command completion settle session state before any panel restore or refresh follow-up observes the result.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes5,
-   sizeof(kAppStateGenerationDomainMigrationNotes5) /
-       sizeof(kAppStateGenerationDomainMigrationNotes5[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes5) / sizeof(kAppStateGenerationDomainMigrationNotes5[0])},
   {"state.visibility-filter.panel-volume",
    "visibility_filter_state",
    "panel-local state plus volume/shared topology and payload state",
    "panel.panel_generation",
    kAppStateGenerationDomainIdentityFields6,
-   sizeof(kAppStateGenerationDomainIdentityFields6) /
-       sizeof(kAppStateGenerationDomainIdentityFields6[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields6) / sizeof(kAppStateGenerationDomainIdentityFields6[0]),
+   kAppStateGenerationDomainCoverageTransitionIds6,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds6) / sizeof(kAppStateGenerationDomainCoverageTransitionIds6[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds6,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds6) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds6[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds6) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds6[0]),
    "Visibility/filter changes that alter rendered rows invalidate saved panel anchors before any snapshot can be reused.",
    "Rebind visible identity through the deterministic fallback order rather than deriving from hidden or filtered row indexes.",
    "Visibility-filter commits update panel generation before rebind and render projection.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes6,
-   sizeof(kAppStateGenerationDomainMigrationNotes6) /
-       sizeof(kAppStateGenerationDomainMigrationNotes6[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes6) / sizeof(kAppStateGenerationDomainMigrationNotes6[0])},
   {"state.topology.volume",
    "topology_state",
    "volume/shared topology and payload state",
    "volume.volume_generation",
    kAppStateGenerationDomainIdentityFields7,
-   sizeof(kAppStateGenerationDomainIdentityFields7) /
-       sizeof(kAppStateGenerationDomainIdentityFields7[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields7) / sizeof(kAppStateGenerationDomainIdentityFields7[0]),
+   kAppStateGenerationDomainCoverageTransitionIds7,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds7) / sizeof(kAppStateGenerationDomainCoverageTransitionIds7[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds7,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds7) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds7[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds7) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds7[0]),
    "Topology snapshots are invalid after any volume_generation advance and must be rebuilt or rebound by identity.",
    "Blocked topology changes retain the previous settled tree; completed invalidation falls back panel anchors only after exact identity fails.",
    "Topology rebuild commits settle volume.dir_tree and volume.logged_state before panel rebind callbacks run.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes7,
-   sizeof(kAppStateGenerationDomainMigrationNotes7) /
-       sizeof(kAppStateGenerationDomainMigrationNotes7[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes7) / sizeof(kAppStateGenerationDomainMigrationNotes7[0])},
   {"state.file-payload.volume",
    "file_payload_state",
    "volume/shared topology and payload state",
    "volume.volume_generation",
    kAppStateGenerationDomainIdentityFields8,
-   sizeof(kAppStateGenerationDomainIdentityFields8) /
-       sizeof(kAppStateGenerationDomainIdentityFields8[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields8) / sizeof(kAppStateGenerationDomainIdentityFields8[0]),
+   kAppStateGenerationDomainCoverageTransitionIds8,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds8) / sizeof(kAppStateGenerationDomainCoverageTransitionIds8[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds8,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds8) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds8[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds8) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds8[0]),
    "Payload cache identity must be revalidated on generation mismatch before saved file selection is restored.",
    "If payload cannot be loaded safely, preserve directory selection and leave file authority unchanged or empty according to current AppState.",
    "Payload changes settle in Volume before panel file anchors are rebound.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes8,
-   sizeof(kAppStateGenerationDomainMigrationNotes8) /
-       sizeof(kAppStateGenerationDomainMigrationNotes8[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes8) / sizeof(kAppStateGenerationDomainMigrationNotes8[0])},
   {"lifecycle.volume.registry",
    "volume_lifecycle",
    "ctx/session state plus volume/shared topology and payload state",
    "volume.volume_generation",
    kAppStateGenerationDomainIdentityFields9,
-   sizeof(kAppStateGenerationDomainIdentityFields9) /
-       sizeof(kAppStateGenerationDomainIdentityFields9[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields9) / sizeof(kAppStateGenerationDomainIdentityFields9[0]),
+   kAppStateGenerationDomainCoverageTransitionIds9,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds9) / sizeof(kAppStateGenerationDomainCoverageTransitionIds9[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds9,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds9) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds9[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds9) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds9[0]),
    "Panel volume bindings must resolve to an existing volume identity before per-volume snapshots can be restored.",
    "Do not orphan panel bindings; use deterministic volume fallback and then panel identity fallback after release or cycle invalidation.",
    "Volume lifecycle transitions update registry/binding state before panel-local restore snapshots are applied.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes9,
-   sizeof(kAppStateGenerationDomainMigrationNotes9) /
-       sizeof(kAppStateGenerationDomainMigrationNotes9[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes9) / sizeof(kAppStateGenerationDomainMigrationNotes9[0])},
   {"reflow.layout.projection",
    "layout_reflow",
    "render/projection/invalidation state",
    "panel.panel_generation",
    kAppStateGenerationDomainIdentityFields10,
-   sizeof(kAppStateGenerationDomainIdentityFields10) /
-       sizeof(kAppStateGenerationDomainIdentityFields10[0]),
+   sizeof(kAppStateGenerationDomainIdentityFields10) / sizeof(kAppStateGenerationDomainIdentityFields10[0]),
+   kAppStateGenerationDomainCoverageTransitionIds10,
+   sizeof(kAppStateGenerationDomainCoverageTransitionIds10) / sizeof(kAppStateGenerationDomainCoverageTransitionIds10[0]),
    kAppStateGenerationDomainAdvancesOnTransitionIds10,
-   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds10) /
-       sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds10[0]),
+   sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds10) / sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds10[0]),
    "Layout reflow must project from settled AppState and may advance panel generation only for viewport bounds correction.",
    "If safe projection cannot be computed, degrade or skip render without choosing new authoritative identities.",
    "Resize handling runs in the main loop and commits any viewport correction before render projection.",
    "documented_foundation_only",
    kAppStateGenerationDomainMigrationNotes10,
-   sizeof(kAppStateGenerationDomainMigrationNotes10) /
-       sizeof(kAppStateGenerationDomainMigrationNotes10[0])},
+   sizeof(kAppStateGenerationDomainMigrationNotes10) / sizeof(kAppStateGenerationDomainMigrationNotes10[0])},
 };
 
 static const char *const kAppStateDiffHarnessSnapshotPhases0[] = {
@@ -3085,154 +3103,187 @@ static const char *const kAppStateEventCoverageTriggerPaths0[] = {
   "Signal flag set outside curses work",
   "Main-loop resize/reflow handling",
 };
-static const char *const kAppStateEventCoverageTransitionSequenceRefs0[] = {
-  "sequence.terminal-resize-reflow",
-};
-static const char *const kAppStateEventCoverageMigrationNotes0[] = {
-  "Signal handlers may only set flags; resize commits through the main-loop transition boundary.",
-};
-static const char *const kAppStateEventCoverageDispatchSurfaceRefs0[] = {
-  "surface.resize-signal-handling",
-};
-static const char *const kAppStateEventCoverageInvariantRefs0[] = {
-  "invariant.render-projection-read-only",
-};
 static const char *const kAppStateEventCoverageTriggerPaths1[] = {
   "Manual refresh command",
   "Explicit relog of the current path",
-};
-static const char *const kAppStateEventCoverageTransitionSequenceRefs1[] = {
-  "sequence.refresh-rebuild",
-};
-static const char *const kAppStateEventCoverageMigrationNotes1[] = {
-  "Rebuild must settle topology, advance generation, then rebind panels by stable identity.",
-};
-static const char *const kAppStateEventCoverageDispatchSurfaceRefs1[] = {
-  "surface.refresh-rebuild-rebind",
-};
-static const char *const kAppStateEventCoverageInvariantRefs1[] = {
-  "invariant.hidden-entry-visible-navigation",
 };
 static const char *const kAppStateEventCoverageTriggerPaths2[] = {
   "Post-refresh restore",
   "Post-mutation restore",
   "Visibility or topology generation mismatch rebind",
 };
-static const char *const kAppStateEventCoverageTransitionSequenceRefs2[] = {
-  "sequence.refresh-rebuild",
-};
-static const char *const kAppStateEventCoverageMigrationNotes2[] = {
-  "Callback coverage points to the existing rebuild/rebind transition rather than inventing a separate runtime event.",
-};
-static const char *const kAppStateEventCoverageDispatchSurfaceRefs2[] = {
-  "surface.panel-anchor-rebind",
-};
-static const char *const kAppStateEventCoverageInvariantRefs2[] = {
-  "invariant.hidden-entry-visible-navigation",
-  "invariant.viewport-identity-rebind",
-};
 static const char *const kAppStateEventCoverageTriggerPaths3[] = {
   "Create directory result",
   "Copy or move result",
   "Delete or chmod-like result",
-};
-static const char *const kAppStateEventCoverageTransitionSequenceRefs3[] = {
-  "sequence.filesystem-mutation-result",
-};
-static const char *const kAppStateEventCoverageMigrationNotes3[] = {
-  "Command side effects remain outside AppState commit; only completed results may update AppState metadata.",
-};
-static const char *const kAppStateEventCoverageDispatchSurfaceRefs3[] = {
-  "surface.filesystem-mutation-result",
-};
-static const char *const kAppStateEventCoverageInvariantRefs3[] = {
-  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateEventCoverageTriggerPaths4[] = {
   "Watcher notification",
   "Live refresh scheduling",
   "Settled topology refresh",
 };
-static const char *const kAppStateEventCoverageTransitionSequenceRefs4[] = {
-  "sequence.refresh-rebuild",
-};
-static const char *const kAppStateEventCoverageMigrationNotes4[] = {
-  "Watcher/live-refresh intentionally maps to the broad refresh_rebuild transition until a dedicated watcher runtime boundary exists.",
-};
-static const char *const kAppStateEventCoverageDispatchSurfaceRefs4[] = {
-  "surface.watcher-live-refresh",
-};
-static const char *const kAppStateEventCoverageInvariantRefs4[] = {
-  "invariant.hidden-entry-visible-navigation",
-};
 static const char *const kAppStateEventCoverageTriggerPaths5[] = {
   "External command completion",
   "User command menu completion",
   "Command failure or cancellation outcome",
-};
-static const char *const kAppStateEventCoverageTransitionSequenceRefs5[] = {
-  "sequence.search-jump",
-};
-static const char *const kAppStateEventCoverageMigrationNotes5[] = {
-  "Command completion may schedule refresh only when the command contract declares filesystem impact.",
-};
-static const char *const kAppStateEventCoverageDispatchSurfaceRefs5[] = {
-  "surface.command-completion-dispatch",
-};
-static const char *const kAppStateEventCoverageInvariantRefs5[] = {
-  "invariant.blocked-transition-determinism",
 };
 static const char *const kAppStateEventCoverageTriggerPaths6[] = {
   "Modal Enter completion",
   "Modal Esc cancellation",
   "Neutral dialog dismissal",
 };
-static const char *const kAppStateEventCoverageTransitionSequenceRefs6[] = {
-  "sequence.esc-modal-dismissal",
-};
-static const char *const kAppStateEventCoverageMigrationNotes6[] = {
-  "Modal completion maps to the modal_action dismiss record while destructive confirmations remain governed by their own command transitions.",
-};
-static const char *const kAppStateEventCoverageDispatchSurfaceRefs6[] = {
-  "surface.menu-modal-completion",
-};
-static const char *const kAppStateEventCoverageInvariantRefs6[] = {
-  "invariant.panel-local-focus-restore",
-  "invariant.blocked-transition-determinism",
-};
 static const char *const kAppStateEventCoverageTriggerPaths7[] = {
   "Cycle loaded volume",
   "Release volume",
   "Bind active panel to selected volume",
-};
-static const char *const kAppStateEventCoverageTransitionSequenceRefs7[] = {
-  "sequence.volume-cycling-release",
-};
-static const char *const kAppStateEventCoverageMigrationNotes7[] = {
-  "Lifecycle coverage keeps inactive panels from inheriting stale volume pointers during migration.",
-};
-static const char *const kAppStateEventCoverageDispatchSurfaceRefs7[] = {
-  "surface.volume-operation",
-};
-static const char *const kAppStateEventCoverageInvariantRefs7[] = {
-  "invariant.shared-state-panel-local-isolation",
 };
 static const char *const kAppStateEventCoverageTriggerPaths8[] = {
   "Render dirty flag projection",
   "Layout reflow projection",
   "doupdate-ready render tick",
 };
-static const char *const kAppStateEventCoverageTransitionSequenceRefs8[] = {
+static const char *const kAppStateEventCoverageTransitionSequenceRefs0[] = {
+  "sequence.terminal-resize-reflow",
+};
+static const char *const kAppStateEventCoverageTransitionSequenceRefs1[] = {
+  "sequence.refresh-rebuild",
+};
+static const char *const kAppStateEventCoverageTransitionSequenceRefs2[] = {
+  "sequence.filesystem-mutation-result",
+};
+static const char *const kAppStateEventCoverageTransitionSequenceRefs3[] = {
+  "sequence.search-jump",
+};
+static const char *const kAppStateEventCoverageTransitionSequenceRefs4[] = {
+  "sequence.esc-modal-dismissal",
+};
+static const char *const kAppStateEventCoverageTransitionSequenceRefs5[] = {
+  "sequence.volume-cycling-release",
+};
+static const char *const kAppStateEventCoverageTransitionSequenceRefs6[] = {
   "sequence.render-reflow-projection",
 };
-static const char *const kAppStateEventCoverageMigrationNotes8[] = {
-  "Render/reflow is projection-only and must not become restore authority.",
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs0[] = {
+  "surface.resize-signal-handling",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs1[] = {
+  "surface.refresh-rebuild-rebind",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs2[] = {
+  "surface.panel-anchor-rebind",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs3[] = {
+  "surface.filesystem-mutation-result",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs4[] = {
+  "surface.watcher-live-refresh",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs5[] = {
+  "surface.command-completion-dispatch",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs6[] = {
+  "surface.menu-modal-completion",
+};
+static const char *const kAppStateEventCoverageDispatchSurfaceRefs7[] = {
+  "surface.volume-operation",
 };
 static const char *const kAppStateEventCoverageDispatchSurfaceRefs8[] = {
   "surface.render-reflow-projection",
 };
-static const char *const kAppStateEventCoverageInvariantRefs8[] = {
+static const char *const kAppStateEventCoverageInvariantRefs0[] = {
   "invariant.render-projection-read-only",
+};
+static const char *const kAppStateEventCoverageInvariantRefs1[] = {
+  "invariant.hidden-entry-visible-navigation",
+};
+static const char *const kAppStateEventCoverageInvariantRefs2[] = {
+  "invariant.hidden-entry-visible-navigation",
+  "invariant.viewport-identity-rebind",
+};
+static const char *const kAppStateEventCoverageInvariantRefs3[] = {
+  "invariant.blocked-transition-determinism",
+};
+static const char *const kAppStateEventCoverageInvariantRefs4[] = {
+  "invariant.panel-local-focus-restore",
+  "invariant.blocked-transition-determinism",
+};
+static const char *const kAppStateEventCoverageInvariantRefs5[] = {
+  "invariant.shared-state-panel-local-isolation",
+};
+static const char *const kAppStateEventCoverageGenerationDomainRefs0[] = {
+  "generation.panel.local-authority",
+  "reflow.layout.projection",
+};
+static const char *const kAppStateEventCoverageGenerationDomainRefs1[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+  "state.visibility-filter.panel-volume",
+  "state.topology.volume",
+  "state.file-payload.volume",
+  "lifecycle.volume.registry",
+};
+static const char *const kAppStateEventCoverageGenerationDomainRefs2[] = {
+  "generation.panel.local-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+  "shape.panel.focus",
+  "state.visibility-filter.panel-volume",
+  "state.file-payload.volume",
+};
+static const char *const kAppStateEventCoverageGenerationDomainRefs3[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+  "state.topology.volume",
+  "state.file-payload.volume",
+};
+static const char *const kAppStateEventCoverageGenerationDomainRefs4[] = {
+  "target.modal-command.session",
+};
+static const char *const kAppStateEventCoverageGenerationDomainRefs5[] = {
+  "generation.panel.local-authority",
+  "shape.panel.focus",
+  "target.modal-command.session",
+};
+static const char *const kAppStateEventCoverageGenerationDomainRefs6[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "state.topology.volume",
+  "lifecycle.volume.registry",
+};
+static const char *const kAppStateEventCoverageGenerationDomainRefs7[] = {
+  "reflow.layout.projection",
+};
+static const char *const kAppStateEventCoverageMigrationNotes0[] = {
+  "Signal handlers may only set flags; resize commits through the main-loop transition boundary.",
+};
+static const char *const kAppStateEventCoverageMigrationNotes1[] = {
+  "Rebuild must settle topology, advance generation, then rebind panels by stable identity.",
+};
+static const char *const kAppStateEventCoverageMigrationNotes2[] = {
+  "Callback coverage points to the existing rebuild/rebind transition rather than inventing a separate runtime event.",
+};
+static const char *const kAppStateEventCoverageMigrationNotes3[] = {
+  "Command side effects remain outside AppState commit; only completed results may update AppState metadata.",
+};
+static const char *const kAppStateEventCoverageMigrationNotes4[] = {
+  "Watcher/live-refresh intentionally maps to the broad refresh_rebuild transition until a dedicated watcher runtime boundary exists.",
+};
+static const char *const kAppStateEventCoverageMigrationNotes5[] = {
+  "Command completion may schedule refresh only when the command contract declares filesystem impact.",
+};
+static const char *const kAppStateEventCoverageMigrationNotes6[] = {
+  "Modal completion maps to the modal_action dismiss record while destructive confirmations remain governed by their own command transitions.",
+};
+static const char *const kAppStateEventCoverageMigrationNotes7[] = {
+  "Lifecycle coverage keeps inactive panels from inheriting stale volume pointers during migration.",
+};
+static const char *const kAppStateEventCoverageMigrationNotes8[] = {
+  "Render/reflow is projection-only and must not become restore authority.",
 };
 
 static const AppStateEventCoverageMetadata
@@ -3254,6 +3305,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs0) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs0[0]),
    kAppStateEventCoverageInvariantRefs0,
    sizeof(kAppStateEventCoverageInvariantRefs0) / sizeof(kAppStateEventCoverageInvariantRefs0[0]),
+   kAppStateEventCoverageGenerationDomainRefs0,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs0) / sizeof(kAppStateEventCoverageGenerationDomainRefs0[0]),
    kAppStateEventCoverageMigrationNotes0,
    sizeof(kAppStateEventCoverageMigrationNotes0) / sizeof(kAppStateEventCoverageMigrationNotes0[0])},
   {"event.refresh-rebuild",
@@ -3273,6 +3326,8 @@ static const AppStateEventCoverageMetadata
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs1) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs1[0]),
    kAppStateEventCoverageInvariantRefs1,
    sizeof(kAppStateEventCoverageInvariantRefs1) / sizeof(kAppStateEventCoverageInvariantRefs1[0]),
+   kAppStateEventCoverageGenerationDomainRefs1,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs1) / sizeof(kAppStateEventCoverageGenerationDomainRefs1[0]),
    kAppStateEventCoverageMigrationNotes1,
    sizeof(kAppStateEventCoverageMigrationNotes1) / sizeof(kAppStateEventCoverageMigrationNotes1[0])},
   {"event.rebuild-rebind-callback",
@@ -3286,12 +3341,14 @@ static const AppStateEventCoverageMetadata
    "covered_by_transition_record",
    kAppStateEventCoverageTriggerPaths2,
    sizeof(kAppStateEventCoverageTriggerPaths2) / sizeof(kAppStateEventCoverageTriggerPaths2[0]),
-   kAppStateEventCoverageTransitionSequenceRefs2,
-   sizeof(kAppStateEventCoverageTransitionSequenceRefs2) / sizeof(kAppStateEventCoverageTransitionSequenceRefs2[0]),
+   kAppStateEventCoverageTransitionSequenceRefs1,
+   sizeof(kAppStateEventCoverageTransitionSequenceRefs1) / sizeof(kAppStateEventCoverageTransitionSequenceRefs1[0]),
    kAppStateEventCoverageDispatchSurfaceRefs2,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs2) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs2[0]),
    kAppStateEventCoverageInvariantRefs2,
    sizeof(kAppStateEventCoverageInvariantRefs2) / sizeof(kAppStateEventCoverageInvariantRefs2[0]),
+   kAppStateEventCoverageGenerationDomainRefs2,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs2) / sizeof(kAppStateEventCoverageGenerationDomainRefs2[0]),
    kAppStateEventCoverageMigrationNotes2,
    sizeof(kAppStateEventCoverageMigrationNotes2) / sizeof(kAppStateEventCoverageMigrationNotes2[0])},
   {"event.filesystem-mutation-result",
@@ -3305,12 +3362,14 @@ static const AppStateEventCoverageMetadata
    "covered_by_transition_record",
    kAppStateEventCoverageTriggerPaths3,
    sizeof(kAppStateEventCoverageTriggerPaths3) / sizeof(kAppStateEventCoverageTriggerPaths3[0]),
-   kAppStateEventCoverageTransitionSequenceRefs3,
-   sizeof(kAppStateEventCoverageTransitionSequenceRefs3) / sizeof(kAppStateEventCoverageTransitionSequenceRefs3[0]),
+   kAppStateEventCoverageTransitionSequenceRefs2,
+   sizeof(kAppStateEventCoverageTransitionSequenceRefs2) / sizeof(kAppStateEventCoverageTransitionSequenceRefs2[0]),
    kAppStateEventCoverageDispatchSurfaceRefs3,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs3) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs3[0]),
    kAppStateEventCoverageInvariantRefs3,
    sizeof(kAppStateEventCoverageInvariantRefs3) / sizeof(kAppStateEventCoverageInvariantRefs3[0]),
+   kAppStateEventCoverageGenerationDomainRefs3,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs3) / sizeof(kAppStateEventCoverageGenerationDomainRefs3[0]),
    kAppStateEventCoverageMigrationNotes3,
    sizeof(kAppStateEventCoverageMigrationNotes3) / sizeof(kAppStateEventCoverageMigrationNotes3[0])},
   {"event.watcher-live-refresh",
@@ -3324,12 +3383,14 @@ static const AppStateEventCoverageMetadata
    "mapped_to_existing_broad_transition",
    kAppStateEventCoverageTriggerPaths4,
    sizeof(kAppStateEventCoverageTriggerPaths4) / sizeof(kAppStateEventCoverageTriggerPaths4[0]),
-   kAppStateEventCoverageTransitionSequenceRefs4,
-   sizeof(kAppStateEventCoverageTransitionSequenceRefs4) / sizeof(kAppStateEventCoverageTransitionSequenceRefs4[0]),
+   kAppStateEventCoverageTransitionSequenceRefs1,
+   sizeof(kAppStateEventCoverageTransitionSequenceRefs1) / sizeof(kAppStateEventCoverageTransitionSequenceRefs1[0]),
    kAppStateEventCoverageDispatchSurfaceRefs4,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs4) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs4[0]),
-   kAppStateEventCoverageInvariantRefs4,
-   sizeof(kAppStateEventCoverageInvariantRefs4) / sizeof(kAppStateEventCoverageInvariantRefs4[0]),
+   kAppStateEventCoverageInvariantRefs1,
+   sizeof(kAppStateEventCoverageInvariantRefs1) / sizeof(kAppStateEventCoverageInvariantRefs1[0]),
+   kAppStateEventCoverageGenerationDomainRefs1,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs1) / sizeof(kAppStateEventCoverageGenerationDomainRefs1[0]),
    kAppStateEventCoverageMigrationNotes4,
    sizeof(kAppStateEventCoverageMigrationNotes4) / sizeof(kAppStateEventCoverageMigrationNotes4[0])},
   {"event.command-completion",
@@ -3343,12 +3404,14 @@ static const AppStateEventCoverageMetadata
    "covered_by_transition_record",
    kAppStateEventCoverageTriggerPaths5,
    sizeof(kAppStateEventCoverageTriggerPaths5) / sizeof(kAppStateEventCoverageTriggerPaths5[0]),
-   kAppStateEventCoverageTransitionSequenceRefs5,
-   sizeof(kAppStateEventCoverageTransitionSequenceRefs5) / sizeof(kAppStateEventCoverageTransitionSequenceRefs5[0]),
+   kAppStateEventCoverageTransitionSequenceRefs3,
+   sizeof(kAppStateEventCoverageTransitionSequenceRefs3) / sizeof(kAppStateEventCoverageTransitionSequenceRefs3[0]),
    kAppStateEventCoverageDispatchSurfaceRefs5,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs5) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs5[0]),
-   kAppStateEventCoverageInvariantRefs5,
-   sizeof(kAppStateEventCoverageInvariantRefs5) / sizeof(kAppStateEventCoverageInvariantRefs5[0]),
+   kAppStateEventCoverageInvariantRefs3,
+   sizeof(kAppStateEventCoverageInvariantRefs3) / sizeof(kAppStateEventCoverageInvariantRefs3[0]),
+   kAppStateEventCoverageGenerationDomainRefs4,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs4) / sizeof(kAppStateEventCoverageGenerationDomainRefs4[0]),
    kAppStateEventCoverageMigrationNotes5,
    sizeof(kAppStateEventCoverageMigrationNotes5) / sizeof(kAppStateEventCoverageMigrationNotes5[0])},
   {"event.modal-completion",
@@ -3362,12 +3425,14 @@ static const AppStateEventCoverageMetadata
    "mapped_to_existing_broad_transition",
    kAppStateEventCoverageTriggerPaths6,
    sizeof(kAppStateEventCoverageTriggerPaths6) / sizeof(kAppStateEventCoverageTriggerPaths6[0]),
-   kAppStateEventCoverageTransitionSequenceRefs6,
-   sizeof(kAppStateEventCoverageTransitionSequenceRefs6) / sizeof(kAppStateEventCoverageTransitionSequenceRefs6[0]),
+   kAppStateEventCoverageTransitionSequenceRefs4,
+   sizeof(kAppStateEventCoverageTransitionSequenceRefs4) / sizeof(kAppStateEventCoverageTransitionSequenceRefs4[0]),
    kAppStateEventCoverageDispatchSurfaceRefs6,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs6) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs6[0]),
-   kAppStateEventCoverageInvariantRefs6,
-   sizeof(kAppStateEventCoverageInvariantRefs6) / sizeof(kAppStateEventCoverageInvariantRefs6[0]),
+   kAppStateEventCoverageInvariantRefs4,
+   sizeof(kAppStateEventCoverageInvariantRefs4) / sizeof(kAppStateEventCoverageInvariantRefs4[0]),
+   kAppStateEventCoverageGenerationDomainRefs5,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs5) / sizeof(kAppStateEventCoverageGenerationDomainRefs5[0]),
    kAppStateEventCoverageMigrationNotes6,
    sizeof(kAppStateEventCoverageMigrationNotes6) / sizeof(kAppStateEventCoverageMigrationNotes6[0])},
   {"event.volume-lifecycle",
@@ -3381,12 +3446,14 @@ static const AppStateEventCoverageMetadata
    "covered_by_transition_record",
    kAppStateEventCoverageTriggerPaths7,
    sizeof(kAppStateEventCoverageTriggerPaths7) / sizeof(kAppStateEventCoverageTriggerPaths7[0]),
-   kAppStateEventCoverageTransitionSequenceRefs7,
-   sizeof(kAppStateEventCoverageTransitionSequenceRefs7) / sizeof(kAppStateEventCoverageTransitionSequenceRefs7[0]),
+   kAppStateEventCoverageTransitionSequenceRefs5,
+   sizeof(kAppStateEventCoverageTransitionSequenceRefs5) / sizeof(kAppStateEventCoverageTransitionSequenceRefs5[0]),
    kAppStateEventCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs7) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs7[0]),
-   kAppStateEventCoverageInvariantRefs7,
-   sizeof(kAppStateEventCoverageInvariantRefs7) / sizeof(kAppStateEventCoverageInvariantRefs7[0]),
+   kAppStateEventCoverageInvariantRefs5,
+   sizeof(kAppStateEventCoverageInvariantRefs5) / sizeof(kAppStateEventCoverageInvariantRefs5[0]),
+   kAppStateEventCoverageGenerationDomainRefs6,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs6) / sizeof(kAppStateEventCoverageGenerationDomainRefs6[0]),
    kAppStateEventCoverageMigrationNotes7,
    sizeof(kAppStateEventCoverageMigrationNotes7) / sizeof(kAppStateEventCoverageMigrationNotes7[0])},
   {"event.render-reflow",
@@ -3400,18 +3467,41 @@ static const AppStateEventCoverageMetadata
    "covered_by_transition_record",
    kAppStateEventCoverageTriggerPaths8,
    sizeof(kAppStateEventCoverageTriggerPaths8) / sizeof(kAppStateEventCoverageTriggerPaths8[0]),
-   kAppStateEventCoverageTransitionSequenceRefs8,
-   sizeof(kAppStateEventCoverageTransitionSequenceRefs8) / sizeof(kAppStateEventCoverageTransitionSequenceRefs8[0]),
+   kAppStateEventCoverageTransitionSequenceRefs6,
+   sizeof(kAppStateEventCoverageTransitionSequenceRefs6) / sizeof(kAppStateEventCoverageTransitionSequenceRefs6[0]),
    kAppStateEventCoverageDispatchSurfaceRefs8,
    sizeof(kAppStateEventCoverageDispatchSurfaceRefs8) / sizeof(kAppStateEventCoverageDispatchSurfaceRefs8[0]),
-   kAppStateEventCoverageInvariantRefs8,
-   sizeof(kAppStateEventCoverageInvariantRefs8) / sizeof(kAppStateEventCoverageInvariantRefs8[0]),
+   kAppStateEventCoverageInvariantRefs0,
+   sizeof(kAppStateEventCoverageInvariantRefs0) / sizeof(kAppStateEventCoverageInvariantRefs0[0]),
+   kAppStateEventCoverageGenerationDomainRefs7,
+   sizeof(kAppStateEventCoverageGenerationDomainRefs7) / sizeof(kAppStateEventCoverageGenerationDomainRefs7[0]),
    kAppStateEventCoverageMigrationNotes8,
    sizeof(kAppStateEventCoverageMigrationNotes8) / sizeof(kAppStateEventCoverageMigrationNotes8[0])},
 };
 
 static const char *const kAppStateActionCoverageMigrationNotes0[] = {
   "Covered by the current keybinding foundation record until runtime transition objects are split per action.",
+};
+static const char *const kAppStateActionCoverageMigrationNotes1[] = {
+  "Esc dismissal for an active modal maps to the modal_action dismiss record; non-modal Esc no-op behavior remains a blocked keybinding outcome for later context-specific runtime coverage.",
+};
+static const char *const kAppStateActionCoverageMigrationNotes2[] = {
+  "Covered by the refresh/rebuild foundation record until log, relog, and refresh actions receive dedicated runtime records.",
+};
+static const char *const kAppStateActionCoverageMigrationNotes3[] = {
+  "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records.",
+};
+static const char *const kAppStateActionCoverageMigrationNotes4[] = {
+  "Covered by the terminal resize foundation record; signal handlers must only set flags before this transition commits.",
+};
+static const char *const kAppStateActionCoverageMigrationNotes5[] = {
+  "Covered by the volume menu foundation record until menu selection has a runtime transition boundary.",
+};
+static const char *const kAppStateActionCoverageMigrationNotes6[] = {
+  "Covered by the volume operation foundation record until cycle/release actions receive dedicated runtime records.",
+};
+static const char *const kAppStateActionCoverageMigrationNotes7[] = {
+  "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata.",
 };
 static const char *const kAppStateActionCoverageTransitionSequenceRefs0[] = {
   "sequence.dotfile-reveal-conceal",
@@ -3423,98 +3513,118 @@ static const char *const kAppStateActionCoverageTransitionSequenceRefs0[] = {
   "sequence.split-toggle-f8",
   "sequence.tab-panel-switch",
 };
+static const char *const kAppStateActionCoverageTransitionSequenceRefs1[] = {
+  "sequence.esc-modal-dismissal",
+};
+static const char *const kAppStateActionCoverageTransitionSequenceRefs2[] = {
+  "sequence.refresh-rebuild",
+};
+static const char *const kAppStateActionCoverageTransitionSequenceRefs3[] = {
+  "sequence.search-jump",
+};
+static const char *const kAppStateActionCoverageTransitionSequenceRefs4[] = {
+  "sequence.terminal-resize-reflow",
+};
+static const char *const kAppStateActionCoverageTransitionSequenceRefs5[] = {
+  "sequence.volume-menu-select",
+};
+static const char *const kAppStateActionCoverageTransitionSequenceRefs6[] = {
+  "sequence.volume-cycling-release",
+};
+static const char *const kAppStateActionCoverageTransitionSequenceRefs7[] = {
+  "sequence.filesystem-mutation-result",
+};
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs0[] = {
   "surface.key-decode-input-dispatch",
   "surface.directory-window-action-dispatch",
   "surface.file-window-action-dispatch",
 };
-static const char *const kAppStateActionCoverageInvariantRefs0[] = {
-  "invariant.inactive-panel-frozen",
-};
-static const char *const kAppStateActionCoverageMigrationNotes1[] = {
-  "Esc dismissal for an active modal maps to the modal_action dismiss record; non-modal Esc no-op behavior remains a blocked keybinding outcome for later context-specific runtime coverage.",
-};
-static const char *const kAppStateActionCoverageTransitionSequenceRefs1[] = {
-  "sequence.esc-modal-dismissal",
-};
 static const char *const kAppStateActionCoverageDispatchSurfaceRefs1[] = {
   "surface.menu-modal-completion",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs2[] = {
+  "surface.refresh-rebuild-rebind",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs3[] = {
+  "surface.command-completion-dispatch",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs4[] = {
+  "surface.resize-signal-handling",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs5[] = {
+  "surface.volume-menu-selection",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs6[] = {
+  "surface.volume-operation",
+};
+static const char *const kAppStateActionCoverageDispatchSurfaceRefs7[] = {
+  "surface.filesystem-mutation-result",
+};
+static const char *const kAppStateActionCoverageInvariantRefs0[] = {
+  "invariant.inactive-panel-frozen",
 };
 static const char *const kAppStateActionCoverageInvariantRefs1[] = {
   "invariant.panel-local-focus-restore",
   "invariant.blocked-transition-determinism",
 };
-static const char *const kAppStateActionCoverageMigrationNotes2[] = {
-  "Covered by the refresh/rebuild foundation record until log, relog, and refresh actions receive dedicated runtime records.",
-};
-static const char *const kAppStateActionCoverageTransitionSequenceRefs2[] = {
-  "sequence.refresh-rebuild",
-};
-static const char *const kAppStateActionCoverageDispatchSurfaceRefs2[] = {
-  "surface.refresh-rebuild-rebind",
-};
 static const char *const kAppStateActionCoverageInvariantRefs2[] = {
   "invariant.hidden-entry-visible-navigation",
-};
-static const char *const kAppStateActionCoverageMigrationNotes3[] = {
-  "Covered by the command completion foundation record until external and session command actions receive dedicated runtime records.",
-};
-static const char *const kAppStateActionCoverageTransitionSequenceRefs3[] = {
-  "sequence.search-jump",
-};
-static const char *const kAppStateActionCoverageDispatchSurfaceRefs3[] = {
-  "surface.command-completion-dispatch",
 };
 static const char *const kAppStateActionCoverageInvariantRefs3[] = {
   "invariant.blocked-transition-determinism",
 };
-static const char *const kAppStateActionCoverageMigrationNotes4[] = {
-  "Covered by the terminal resize foundation record; signal handlers must only set flags before this transition commits.",
-};
-static const char *const kAppStateActionCoverageTransitionSequenceRefs4[] = {
-  "sequence.terminal-resize-reflow",
-};
-static const char *const kAppStateActionCoverageDispatchSurfaceRefs4[] = {
-  "surface.resize-signal-handling",
-};
 static const char *const kAppStateActionCoverageInvariantRefs4[] = {
   "invariant.render-projection-read-only",
-};
-static const char *const kAppStateActionCoverageMigrationNotes5[] = {
-  "Covered by the volume menu foundation record until menu selection has a runtime transition boundary.",
-};
-static const char *const kAppStateActionCoverageTransitionSequenceRefs5[] = {
-  "sequence.volume-menu-select",
-};
-static const char *const kAppStateActionCoverageDispatchSurfaceRefs5[] = {
-  "surface.volume-menu-selection",
 };
 static const char *const kAppStateActionCoverageInvariantRefs5[] = {
   "invariant.shared-state-panel-local-isolation",
 };
-static const char *const kAppStateActionCoverageMigrationNotes6[] = {
-  "Covered by the volume operation foundation record until cycle/release actions receive dedicated runtime records.",
+static const char *const kAppStateActionCoverageGenerationDomainRefs0[] = {
+  "generation.panel.local-authority",
+  "shape.panel.focus",
+  "state.visibility-filter.panel-volume",
 };
-static const char *const kAppStateActionCoverageTransitionSequenceRefs6[] = {
-  "sequence.volume-cycling-release",
+static const char *const kAppStateActionCoverageGenerationDomainRefs1[] = {
+  "generation.panel.local-authority",
+  "shape.panel.focus",
+  "target.modal-command.session",
 };
-static const char *const kAppStateActionCoverageDispatchSurfaceRefs6[] = {
-  "surface.volume-operation",
+static const char *const kAppStateActionCoverageGenerationDomainRefs2[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+  "state.visibility-filter.panel-volume",
+  "state.topology.volume",
+  "state.file-payload.volume",
+  "lifecycle.volume.registry",
 };
-static const char *const kAppStateActionCoverageInvariantRefs6[] = {
-  "invariant.shared-state-panel-local-isolation",
+static const char *const kAppStateActionCoverageGenerationDomainRefs3[] = {
+  "target.modal-command.session",
 };
-static const char *const kAppStateActionCoverageMigrationNotes7[] = {
-  "Covered by the filesystem mutation result foundation record until command actions declare per-operation commit metadata.",
+static const char *const kAppStateActionCoverageGenerationDomainRefs4[] = {
+  "generation.panel.local-authority",
+  "reflow.layout.projection",
 };
-static const char *const kAppStateActionCoverageTransitionSequenceRefs7[] = {
-  "sequence.filesystem-mutation-result",
+static const char *const kAppStateActionCoverageGenerationDomainRefs5[] = {
+  "generation.panel.local-authority",
+  "shape.panel.focus",
+  "lifecycle.volume.registry",
 };
-static const char *const kAppStateActionCoverageDispatchSurfaceRefs7[] = {
-  "surface.filesystem-mutation-result",
+static const char *const kAppStateActionCoverageGenerationDomainRefs6[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "state.topology.volume",
+  "lifecycle.volume.registry",
 };
-static const char *const kAppStateActionCoverageInvariantRefs7[] = {
-  "invariant.blocked-transition-determinism",
+static const char *const kAppStateActionCoverageGenerationDomainRefs7[] = {
+  "generation.panel.local-authority",
+  "generation.volume.shared-authority",
+  "identity.directory.stable-key",
+  "identity.file.stable-key",
+  "state.topology.volume",
+  "state.file-payload.volume",
 };
 
 static const AppStateActionCoverageMetadata
@@ -3532,6 +3642,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3548,6 +3660,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3564,6 +3678,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3580,6 +3696,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3596,6 +3714,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3612,6 +3732,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3628,6 +3750,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3644,6 +3768,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3660,6 +3786,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3676,6 +3804,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3692,6 +3822,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3708,6 +3840,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3724,6 +3858,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3740,6 +3876,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3756,6 +3894,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3772,6 +3912,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs1) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs1[0]),
    kAppStateActionCoverageInvariantRefs1,
    sizeof(kAppStateActionCoverageInvariantRefs1) / sizeof(kAppStateActionCoverageInvariantRefs1[0]),
+   kAppStateActionCoverageGenerationDomainRefs1,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs1) / sizeof(kAppStateActionCoverageGenerationDomainRefs1[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes1,
    sizeof(kAppStateActionCoverageMigrationNotes1) / sizeof(kAppStateActionCoverageMigrationNotes1[0])},
@@ -3788,6 +3930,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs2) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs2[0]),
    kAppStateActionCoverageInvariantRefs2,
    sizeof(kAppStateActionCoverageInvariantRefs2) / sizeof(kAppStateActionCoverageInvariantRefs2[0]),
+   kAppStateActionCoverageGenerationDomainRefs2,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs2) / sizeof(kAppStateActionCoverageGenerationDomainRefs2[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes2,
    sizeof(kAppStateActionCoverageMigrationNotes2) / sizeof(kAppStateActionCoverageMigrationNotes2[0])},
@@ -3804,6 +3948,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    kAppStateActionCoverageInvariantRefs3,
    sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs3,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs3) / sizeof(kAppStateActionCoverageGenerationDomainRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -3820,6 +3966,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    kAppStateActionCoverageInvariantRefs3,
    sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs3,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs3) / sizeof(kAppStateActionCoverageGenerationDomainRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -3836,6 +3984,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3852,6 +4002,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3868,6 +4020,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3884,6 +4038,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3900,6 +4056,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3916,6 +4074,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3932,6 +4092,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3948,6 +4110,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -3964,6 +4128,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs2) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs2[0]),
    kAppStateActionCoverageInvariantRefs2,
    sizeof(kAppStateActionCoverageInvariantRefs2) / sizeof(kAppStateActionCoverageInvariantRefs2[0]),
+   kAppStateActionCoverageGenerationDomainRefs2,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs2) / sizeof(kAppStateActionCoverageGenerationDomainRefs2[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes2,
    sizeof(kAppStateActionCoverageMigrationNotes2) / sizeof(kAppStateActionCoverageMigrationNotes2[0])},
@@ -3980,6 +4146,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs4) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs4[0]),
    kAppStateActionCoverageInvariantRefs4,
    sizeof(kAppStateActionCoverageInvariantRefs4) / sizeof(kAppStateActionCoverageInvariantRefs4[0]),
+   kAppStateActionCoverageGenerationDomainRefs4,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs4) / sizeof(kAppStateActionCoverageGenerationDomainRefs4[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes4,
    sizeof(kAppStateActionCoverageMigrationNotes4) / sizeof(kAppStateActionCoverageMigrationNotes4[0])},
@@ -3996,6 +4164,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs5) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs5[0]),
    kAppStateActionCoverageInvariantRefs5,
    sizeof(kAppStateActionCoverageInvariantRefs5) / sizeof(kAppStateActionCoverageInvariantRefs5[0]),
+   kAppStateActionCoverageGenerationDomainRefs5,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs5) / sizeof(kAppStateActionCoverageGenerationDomainRefs5[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes5,
    sizeof(kAppStateActionCoverageMigrationNotes5) / sizeof(kAppStateActionCoverageMigrationNotes5[0])},
@@ -4010,8 +4180,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs6) / sizeof(kAppStateActionCoverageTransitionSequenceRefs6[0]),
    kAppStateActionCoverageDispatchSurfaceRefs6,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs6) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs6[0]),
-   kAppStateActionCoverageInvariantRefs6,
-   sizeof(kAppStateActionCoverageInvariantRefs6) / sizeof(kAppStateActionCoverageInvariantRefs6[0]),
+   kAppStateActionCoverageInvariantRefs5,
+   sizeof(kAppStateActionCoverageInvariantRefs5) / sizeof(kAppStateActionCoverageInvariantRefs5[0]),
+   kAppStateActionCoverageGenerationDomainRefs6,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs6) / sizeof(kAppStateActionCoverageGenerationDomainRefs6[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes6,
    sizeof(kAppStateActionCoverageMigrationNotes6) / sizeof(kAppStateActionCoverageMigrationNotes6[0])},
@@ -4026,8 +4198,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs6) / sizeof(kAppStateActionCoverageTransitionSequenceRefs6[0]),
    kAppStateActionCoverageDispatchSurfaceRefs6,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs6) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs6[0]),
-   kAppStateActionCoverageInvariantRefs6,
-   sizeof(kAppStateActionCoverageInvariantRefs6) / sizeof(kAppStateActionCoverageInvariantRefs6[0]),
+   kAppStateActionCoverageInvariantRefs5,
+   sizeof(kAppStateActionCoverageInvariantRefs5) / sizeof(kAppStateActionCoverageInvariantRefs5[0]),
+   kAppStateActionCoverageGenerationDomainRefs6,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs6) / sizeof(kAppStateActionCoverageGenerationDomainRefs6[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes6,
    sizeof(kAppStateActionCoverageMigrationNotes6) / sizeof(kAppStateActionCoverageMigrationNotes6[0])},
@@ -4042,8 +4216,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4058,8 +4234,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4074,8 +4252,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4090,8 +4270,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4106,8 +4288,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4122,8 +4306,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4138,8 +4324,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4154,8 +4342,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4170,8 +4360,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4186,8 +4378,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4202,8 +4396,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4218,8 +4414,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4234,8 +4432,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4250,8 +4450,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4266,8 +4468,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4282,8 +4486,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4300,6 +4506,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    kAppStateActionCoverageInvariantRefs3,
    sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs3,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs3) / sizeof(kAppStateActionCoverageGenerationDomainRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -4316,6 +4524,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4332,6 +4542,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4346,8 +4558,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4362,8 +4576,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4378,8 +4594,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4394,8 +4612,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4410,8 +4630,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4426,8 +4648,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4442,8 +4666,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4458,8 +4684,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4474,8 +4702,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4490,8 +4720,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4506,8 +4738,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4522,8 +4756,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4538,8 +4774,10 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageTransitionSequenceRefs7) / sizeof(kAppStateActionCoverageTransitionSequenceRefs7[0]),
    kAppStateActionCoverageDispatchSurfaceRefs7,
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs7) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs7[0]),
-   kAppStateActionCoverageInvariantRefs7,
-   sizeof(kAppStateActionCoverageInvariantRefs7) / sizeof(kAppStateActionCoverageInvariantRefs7[0]),
+   kAppStateActionCoverageInvariantRefs3,
+   sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs7,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs7) / sizeof(kAppStateActionCoverageGenerationDomainRefs7[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes7,
    sizeof(kAppStateActionCoverageMigrationNotes7) / sizeof(kAppStateActionCoverageMigrationNotes7[0])},
@@ -4556,6 +4794,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    kAppStateActionCoverageInvariantRefs3,
    sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs3,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs3) / sizeof(kAppStateActionCoverageGenerationDomainRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -4572,6 +4812,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4588,6 +4830,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4604,6 +4848,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4620,6 +4866,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4636,6 +4884,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4652,6 +4902,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4668,6 +4920,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4684,6 +4938,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4700,6 +4956,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4716,6 +4974,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4732,6 +4992,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4748,6 +5010,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4764,6 +5028,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4780,6 +5046,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4796,6 +5064,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4812,6 +5082,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4828,6 +5100,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4844,6 +5118,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs0) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs0[0]),
    kAppStateActionCoverageInvariantRefs0,
    sizeof(kAppStateActionCoverageInvariantRefs0) / sizeof(kAppStateActionCoverageInvariantRefs0[0]),
+   kAppStateActionCoverageGenerationDomainRefs0,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs0) / sizeof(kAppStateActionCoverageGenerationDomainRefs0[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes0,
    sizeof(kAppStateActionCoverageMigrationNotes0) / sizeof(kAppStateActionCoverageMigrationNotes0[0])},
@@ -4860,6 +5136,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    kAppStateActionCoverageInvariantRefs3,
    sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs3,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs3) / sizeof(kAppStateActionCoverageGenerationDomainRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
@@ -4876,6 +5154,8 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageDispatchSurfaceRefs3) / sizeof(kAppStateActionCoverageDispatchSurfaceRefs3[0]),
    kAppStateActionCoverageInvariantRefs3,
    sizeof(kAppStateActionCoverageInvariantRefs3) / sizeof(kAppStateActionCoverageInvariantRefs3[0]),
+   kAppStateActionCoverageGenerationDomainRefs3,
+   sizeof(kAppStateActionCoverageGenerationDomainRefs3) / sizeof(kAppStateActionCoverageGenerationDomainRefs3[0]),
    "documented_foundation_only",
    kAppStateActionCoverageMigrationNotes3,
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -859,8 +859,11 @@ static int AppStateGenerationDomainsReady(void) {
         !NonEmptyString(metadata->enforcement_status) ||
         !NonEmptyStringList(metadata->identity_fields,
                             metadata->identity_field_count) ||
-        !NonEmptyStringList(metadata->advances_on_transition_ids,
-                            metadata->advances_on_transition_id_count) ||
+        !NonEmptyStringList(metadata->coverage_transition_ids,
+                            metadata->coverage_transition_id_count) ||
+        (metadata->advances_on_transition_id_count > 0 &&
+         !NonEmptyStringList(metadata->advances_on_transition_ids,
+                             metadata->advances_on_transition_id_count)) ||
         !NonEmptyStringList(metadata->migration_notes,
                             metadata->migration_note_count))
       return 0;
@@ -885,10 +888,22 @@ static int AppStateGenerationDomainsReady(void) {
         return 0;
     }
     for (transition_index = 0;
+         transition_index < metadata->coverage_transition_id_count;
+         transition_index++) {
+      if (AppStateTransitionLookup(
+              metadata->coverage_transition_ids[transition_index]) == NULL)
+        return 0;
+    }
+    for (transition_index = 0;
          transition_index < metadata->advances_on_transition_id_count;
          transition_index++) {
       if (AppStateTransitionLookup(
               metadata->advances_on_transition_ids[transition_index]) == NULL)
+        return 0;
+      if (!StringListContains(metadata->coverage_transition_ids,
+                              metadata->coverage_transition_id_count,
+                              metadata->advances_on_transition_ids
+                                  [transition_index]))
         return 0;
     }
   }
@@ -1640,6 +1655,35 @@ static int AppStateInvariantRefsReady(const char *const *refs, size_t ref_count,
   return 1;
 }
 
+static int AppStateGenerationDomainRefsReady(const char *const *refs,
+                                             size_t ref_count,
+                                             const char *transition_id) {
+  size_t ref_index;
+
+  if (!NonEmptyString(transition_id) || !NonEmptyStringList(refs, ref_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < ref_count; ref_index++) {
+    const AppStateGenerationDomainMetadata *domain =
+        AppStateGenerationDomainLookup(refs[ref_index]);
+    size_t previous_index;
+
+    if (domain == NULL || !NonEmptyStringList(domain->coverage_transition_ids,
+                                              domain->coverage_transition_id_count))
+      return 0;
+    if (!StringListContains(domain->coverage_transition_ids,
+                            domain->coverage_transition_id_count,
+                            transition_id))
+      return 0;
+    for (previous_index = 0; previous_index < ref_index; previous_index++) {
+      if (strcmp(refs[previous_index], refs[ref_index]) == 0)
+        return 0;
+    }
+  }
+
+  return 1;
+}
+
 static int AppStateActionTransitionsReady(void) {
   size_t index;
 
@@ -1752,6 +1796,9 @@ static int AppStateEventCoverageReady(void) {
         !AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs,
                                          coverage->dispatch_surface_ref_count,
                                          coverage->transition_id) ||
+        !AppStateGenerationDomainRefsReady(
+            coverage->generation_domain_refs,
+            coverage->generation_domain_ref_count, coverage->transition_id) ||
         !AppStateInvariantRefsReady(coverage->invariant_refs,
                                     coverage->invariant_ref_count,
                                     coverage->transition_id,
@@ -1837,6 +1884,9 @@ static int AppStateActionCoverageReady(void) {
         !AppStateDispatchSurfaceRefsReady(coverage->dispatch_surface_refs,
                                          coverage->dispatch_surface_ref_count,
                                          coverage->transition_id) ||
+        !AppStateGenerationDomainRefsReady(
+            coverage->generation_domain_refs,
+            coverage->generation_domain_ref_count, coverage->transition_id) ||
         !AppStateInvariantRefsReady(coverage->invariant_refs,
                                     coverage->invariant_ref_count,
                                     coverage->transition_id,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import json
 import re
 import subprocess
 from pathlib import Path
@@ -46,9 +47,11 @@ FIXTURE_ACTIONS = [
 ]
 REQUIRED_LIST_FIELD_CASES = [
     ("action", "declared_write_set", "action[0]"),
+    ("action", "generation_domain_refs", "action[0]"),
     ("action", "invariant_refs", "action[0]"),
     ("action", "migration_notes", "action[0]"),
     ("event", "declared_write_set", "event[0]"),
+    ("event", "generation_domain_refs", "event[0]"),
     ("event", "invariant_refs", "event[0]"),
     ("event", "migration_notes", "event[0]"),
     ("event", "trigger_paths", "event[0]"),
@@ -92,6 +95,11 @@ def _write(path: Path, content: str) -> None:
 
 
 def _transition(category: str, transition_id: str | None = None) -> dict[str, object]:
+    declared_write_set = ["field"]
+    generation_effect = "generation"
+    if category == "render_reflow":
+        declared_write_set = ["panel.tree_selection_key"]
+        generation_effect = "projection_only"
     return {
         "id": transition_id or f"transition.{category}",
         "category": category,
@@ -102,8 +110,8 @@ def _transition(category: str, transition_id: str | None = None) -> dict[str, ob
         "blocked_result": "blocked",
         "target_state": "AppState.target",
         "owner": "owner",
-        "declared_write_set": ["field"],
-        "generation_effect": "generation",
+        "declared_write_set": declared_write_set,
+        "generation_effect": generation_effect,
         "side_effects": ["none"],
         "render_invalidation": "view",
         "boundary_status": "test",
@@ -154,6 +162,9 @@ def _action(
         "dispatch_surface_refs": _dispatch_surface_refs_for_transition(
             transition_id, action=action
         ),
+        "generation_domain_refs": _generation_domain_refs_for_transition(
+            transition_id
+        ),
         "invariant_refs": _invariant_refs_for_transition(transition_id),
         "boundary_status": "test",
         "migration_notes": ["fixture action coverage"],
@@ -177,23 +188,30 @@ def _event(
         "render_reflow": "render_reflow",
     }
     resolved_category = category or event_categories.get(event_class, "refresh_rebuild")
+    resolved_transition_id = transition_id or f"transition.{resolved_category}"
+    declared_write_set = ["field"]
+    if resolved_category == "render_reflow":
+        declared_write_set = ["panel.tree_selection_key"]
     return {
         "event_id": f"event.{event_class}",
         "event_class": event_class,
-        "transition_id": transition_id or f"transition.{resolved_category}",
+        "transition_id": resolved_transition_id,
         "category": resolved_category,
         "source": "fixture source",
         "owner": "owner",
-        "declared_write_set": ["field"],
+        "declared_write_set": declared_write_set,
         "transition_sequence_refs": _sequence_refs_for_transition(
-            transition_id or f"transition.{resolved_category}"
+            resolved_transition_id
         ),
         "dispatch_surface_refs": _dispatch_surface_refs_for_transition(
-            transition_id or f"transition.{resolved_category}",
+            resolved_transition_id,
             event_id=f"event.{event_class}",
         ),
+        "generation_domain_refs": _generation_domain_refs_for_transition(
+            resolved_transition_id
+        ),
         "invariant_refs": _invariant_refs_for_transition(
-            transition_id or f"transition.{resolved_category}"
+            resolved_transition_id
         ),
         "boundary_status": "test",
         "trigger_paths": ["fixture trigger"],
@@ -276,6 +294,75 @@ def _invariant_refs_for_transition(transition_id: str) -> list[str]:
     }.get(transition_id, ["invariant.inactive_panel_frozen"])
 
 
+def _generation_domain_refs_for_transition(transition_id: str) -> list[str]:
+    return {
+        "transition.command_completion": ["domain.modal_command_target"],
+        "transition.filesystem_mutation_result": [
+            "domain.panel_generation",
+            "domain.volume_generation",
+            "domain.directory_identity",
+            "domain.file_identity",
+            "domain.topology_state",
+            "domain.file_payload_state",
+        ],
+        "transition.keybinding": [
+            "domain.panel_generation",
+            "domain.focus_shape",
+            "domain.visibility_filter_state",
+        ],
+        "transition.menu_action": [
+            "domain.panel_generation",
+            "domain.focus_shape",
+            "domain.volume_lifecycle",
+        ],
+        "transition.modal_action": [
+            "domain.panel_generation",
+            "domain.focus_shape",
+            "domain.modal_command_target",
+        ],
+        "transition.rebuild_rebind_callback": [
+            "domain.panel_generation",
+            "domain.directory_identity",
+            "domain.file_identity",
+            "domain.focus_shape",
+            "domain.visibility_filter_state",
+            "domain.file_payload_state",
+        ],
+        "transition.refresh_rebuild": [
+            "domain.panel_generation",
+            "domain.volume_generation",
+            "domain.directory_identity",
+            "domain.file_identity",
+            "domain.visibility_filter_state",
+            "domain.topology_state",
+            "domain.file_payload_state",
+            "domain.volume_lifecycle",
+        ],
+        "transition.render_reflow": ["domain.layout_reflow"],
+        "transition.terminal_signal_or_resize": [
+            "domain.panel_generation",
+            "domain.layout_reflow",
+        ],
+        "transition.volume_operation": [
+            "domain.panel_generation",
+            "domain.volume_generation",
+            "domain.directory_identity",
+            "domain.volume_lifecycle",
+        ],
+    }.get(transition_id, ["domain.panel_generation"])
+
+
+def _wrong_generation_domain_ref(transition_id: str) -> str:
+    valid_refs = set(_generation_domain_refs_for_transition(transition_id))
+    for domain in _complete_generation_domains():
+        domain_id = str(domain["domain_id"])
+        if domain_id not in valid_refs:
+            return domain_id
+    raise AssertionError(
+        f"missing mismatched generation domain fixture for {transition_id}"
+    )
+
+
 def _dispatch_surface(
     category: str,
     transition_id: str | None = None,
@@ -311,14 +398,18 @@ def _dispatch_surface(
         "volume_menu_selection": "sequence.volume_menu_select",
         "rebuild_rebind_callback": "sequence.refresh_rebuild",
     }
+    resolved_transition_id = transition_id or transition_by_surface_category[category]
+    allowed_direct_writes = ["field"]
+    if resolved_transition_id == "transition.render_reflow":
+        allowed_direct_writes = ["panel.tree_selection_key"]
     return {
         "surface_id": surface_id or f"surface.{category}",
         "category": category,
         "source_path": "src/ui/key_engine.c",
         "entry_symbol_or_path": "GetEventOrKey",
-        "transition_id": transition_id or transition_by_surface_category[category],
+        "transition_id": resolved_transition_id,
         "boundary_status": "test",
-        "allowed_direct_writes": ["field"],
+        "allowed_direct_writes": allowed_direct_writes,
         "transition_sequence_refs": [sequence_by_surface_category[category]],
         "migration_notes": ["fixture coverage"],
     }
@@ -349,17 +440,27 @@ def _invariant(
 def _generation_domain(
     category: str,
     domain_id: str | None = None,
+    coverage_transition_ids: list[str] | None = None,
     advances_on_transition_ids: list[str] | None = None,
 ) -> dict[str, object]:
+    resolved_coverage_transition_ids = (
+        coverage_transition_ids
+        if coverage_transition_ids is not None
+        else ["transition.keybinding"]
+    )
+    resolved_advances_on_transition_ids = (
+        advances_on_transition_ids
+        if advances_on_transition_ids is not None
+        else ["transition.keybinding"]
+    )
     return {
         "domain_id": domain_id or f"domain.{category}",
         "category": category,
         "owner_region": "panel-local state",
         "generation_owner_field": "field",
         "identity_fields": ["field"],
-        "advances_on_transition_ids": (
-            advances_on_transition_ids or ["transition.keybinding"]
-        ),
+        "coverage_transition_ids": resolved_coverage_transition_ids,
+        "advances_on_transition_ids": resolved_advances_on_transition_ids,
         "stale_snapshot_policy": "fixture stale snapshot policy",
         "fail_closed_fallback": "fixture fail-closed fallback",
         "restore_boundary": "fixture restore boundary",
@@ -819,6 +920,21 @@ def _runtime_source(
             f"static const char *const {invariant_refs_table}[] = "
             f"{{\n{invariant_ref_rows}\n}};\n"
         )
+        generation_domain_refs = record.get("generation_domain_refs")
+        if not isinstance(generation_domain_refs, list):
+            generation_domain_refs = []
+        generation_domain_ref_rows = "\n".join(
+            f'  "{ref}",'
+            for ref in generation_domain_refs
+            if isinstance(ref, str)
+        )
+        generation_domain_refs_table = (
+            f"kAppStateActionCoverageGenerationDomainRefs{index}"
+        )
+        action_coverage_arrays.append(
+            f"static const char *const {generation_domain_refs_table}[] = "
+            f"{{\n{generation_domain_ref_rows}\n}};\n"
+        )
         action = record.get("action", "")
         action_coverage_rows.append(
             f'  {{{action}, "{action}", "{record.get("transition_id", "")}", '
@@ -831,6 +947,9 @@ def _runtime_source(
             f"sizeof({dispatch_surface_refs_table}[0]), "
             f"{invariant_refs_table}, sizeof({invariant_refs_table}) / "
             f"sizeof({invariant_refs_table}[0]), "
+            f"{generation_domain_refs_table}, "
+            f"sizeof({generation_domain_refs_table}) / "
+            f"sizeof({generation_domain_refs_table}[0]), "
             f'"{record.get("boundary_status", "")}", '
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
@@ -897,6 +1016,21 @@ def _runtime_source(
             f"static const char *const {invariant_refs_table}[] = "
             f"{{\n{invariant_ref_rows}\n}};\n"
         )
+        generation_domain_refs = record.get("generation_domain_refs")
+        if not isinstance(generation_domain_refs, list):
+            generation_domain_refs = []
+        generation_domain_ref_rows = "\n".join(
+            f'  "{ref}",'
+            for ref in generation_domain_refs
+            if isinstance(ref, str)
+        )
+        generation_domain_refs_table = (
+            f"kAppStateEventCoverageGenerationDomainRefs{index}"
+        )
+        event_coverage_arrays.append(
+            f"static const char *const {generation_domain_refs_table}[] = "
+            f"{{\n{generation_domain_ref_rows}\n}};\n"
+        )
         transition_index = transition_index_by_id.get(str(record.get("transition_id", "")), 0)
         write_set_table = f"kAppStateTransitionWriteSet{transition_index}"
         event_coverage_rows.append(
@@ -913,6 +1047,9 @@ def _runtime_source(
             f"sizeof({dispatch_surface_refs_table}[0]), "
             f"{invariant_refs_table}, sizeof({invariant_refs_table}) / "
             f"sizeof({invariant_refs_table}[0]), "
+            f"{generation_domain_refs_table}, "
+            f"sizeof({generation_domain_refs_table}) / "
+            f"sizeof({generation_domain_refs_table}[0]), "
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
     owner_field_arrays = []
@@ -1112,6 +1249,7 @@ def _runtime_source(
     generation_domain_rows = []
     generation_domain_list_fields = (
         ("identity_fields", "IdentityFields"),
+        ("coverage_transition_ids", "CoverageTransitionIds"),
         ("advances_on_transition_ids", "AdvancesOnTransitionIds"),
         ("migration_notes", "MigrationNotes"),
     )
@@ -1135,6 +1273,9 @@ def _runtime_source(
             f"kAppStateGenerationDomainIdentityFields{index}, "
             f"sizeof(kAppStateGenerationDomainIdentityFields{index}) / "
             f"sizeof(kAppStateGenerationDomainIdentityFields{index}[0]), "
+            f"kAppStateGenerationDomainCoverageTransitionIds{index}, "
+            f"sizeof(kAppStateGenerationDomainCoverageTransitionIds{index}) / "
+            f"sizeof(kAppStateGenerationDomainCoverageTransitionIds{index}[0]), "
             f"kAppStateGenerationDomainAdvancesOnTransitionIds{index}, "
             f"sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds{index}) / "
             f"sizeof(kAppStateGenerationDomainAdvancesOnTransitionIds{index}[0]), "
@@ -1498,11 +1639,78 @@ def _complete_invariants() -> list[dict[str, object]]:
 
 
 def _complete_generation_domains() -> list[dict[str, object]]:
+    coverage_transition_ids_by_category = {
+        "panel_generation": [
+            "transition.keybinding",
+            "transition.menu_action",
+            "transition.modal_action",
+            "transition.refresh_rebuild",
+            "transition.volume_operation",
+            "transition.terminal_signal_or_resize",
+            "transition.rebuild_rebind_callback",
+            "transition.filesystem_mutation_result",
+        ],
+        "volume_generation": [
+            "transition.refresh_rebuild",
+            "transition.volume_operation",
+            "transition.filesystem_mutation_result",
+        ],
+        "directory_identity": [
+            "transition.refresh_rebuild",
+            "transition.volume_operation",
+            "transition.filesystem_mutation_result",
+            "transition.rebuild_rebind_callback",
+        ],
+        "file_identity": [
+            "transition.refresh_rebuild",
+            "transition.filesystem_mutation_result",
+            "transition.rebuild_rebind_callback",
+        ],
+        "focus_shape": [
+            "transition.keybinding",
+            "transition.menu_action",
+            "transition.modal_action",
+            "transition.rebuild_rebind_callback",
+        ],
+        "modal_command_target": [
+            "transition.modal_action",
+            "transition.command_completion",
+        ],
+        "visibility_filter_state": [
+            "transition.keybinding",
+            "transition.refresh_rebuild",
+            "transition.rebuild_rebind_callback",
+        ],
+        "topology_state": [
+            "transition.refresh_rebuild",
+            "transition.volume_operation",
+            "transition.filesystem_mutation_result",
+        ],
+        "file_payload_state": [
+            "transition.refresh_rebuild",
+            "transition.filesystem_mutation_result",
+            "transition.rebuild_rebind_callback",
+        ],
+        "volume_lifecycle": [
+            "transition.menu_action",
+            "transition.refresh_rebuild",
+            "transition.volume_operation",
+        ],
+        "layout_reflow": [
+            "transition.terminal_signal_or_resize",
+            "transition.render_reflow",
+        ],
+    }
+    advances_on_transition_ids_by_category = {
+        **coverage_transition_ids_by_category,
+        "layout_reflow": ["transition.terminal_signal_or_resize"],
+    }
     return [
         _generation_domain(
             category,
             "domain.panel_generation" if category == "panel_generation" else None,
-            _complete_transition_ids(),
+            coverage_transition_ids_by_category[category],
+            advances_on_transition_ids_by_category[category],
         )
         for category in REQUIRED_GENERATION_DOMAIN_CATEGORIES
     ]
@@ -1657,6 +1865,35 @@ def test_guard_passes_complete_temporary_fixtures(tmp_path: Path) -> None:
     failures = _validate(paths)
 
     assert failures == []
+
+
+def test_current_generation_domain_docs_keep_projection_transitions_out_of_advances() -> None:
+    generation_domains = json.loads(
+        Path("docs/appstate_generation_domains.json").read_text(encoding="utf-8")
+    )["generation_domains"]
+    projection_domain = next(
+        record
+        for record in generation_domains
+        if record["domain_id"] == "reflow.layout.projection"
+    )
+
+    assert "transition.render-reflow.project-state" not in projection_domain[
+        "advances_on_transition_ids"
+    ]
+    assert "transition.render-reflow.project-state" in projection_domain[
+        "coverage_transition_ids"
+    ]
+
+
+def test_runtime_generation_domain_ref_readiness_uses_coverage_transitions() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index("static int AppStateGenerationDomainRefsReady(")
+    action_start = source.index("static int AppStateActionTransitionsReady(void)")
+    helper_body = source[helper_start:action_start]
+
+    assert "domain->coverage_transition_ids" in helper_body
+    assert "domain->coverage_transition_id_count" in helper_body
+    assert "domain->advances_on_transition_ids" not in helper_body
 
 
 def test_guard_accepts_invariant_registry_cli_override(tmp_path: Path) -> None:
@@ -3716,12 +3953,46 @@ def test_guard_accepts_empty_generation_domain_advances_with_projection_note(
 ) -> None:
     transitions = _complete_transitions()
     generation_domains = _complete_generation_domains()
-    generation_domains[0]["advances_on_transition_ids"] = []
-    generation_domains[0]["migration_notes"] = [
+    generation_domains.append(
+        _generation_domain(
+            "layout_reflow",
+            "domain.projection_only_unused",
+            ["transition.render_reflow"],
+            [],
+        )
+    )
+    generation_domains[-1]["migration_notes"] = [
         "read-only/projection-only fixture domain"
     ]
     paths = _write_fixture(
         tmp_path, transitions=transitions, generation_domains=generation_domains
+    )
+
+    failures = _validate(paths)
+
+    assert failures == []
+
+
+def test_guard_accepts_projection_only_generation_domain_refs_with_split_coverage(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    generation_domains = _complete_generation_domains()
+    render_domain = next(
+        record
+        for record in generation_domains
+        if record["domain_id"] == "domain.layout_reflow"
+    )
+
+    assert "transition.render_reflow" in render_domain["coverage_transition_ids"]
+    assert "transition.render_reflow" not in render_domain["advances_on_transition_ids"]
+
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        events=events,
+        generation_domains=generation_domains,
     )
 
     failures = _validate(paths)
@@ -7606,6 +7877,122 @@ def test_guard_fails_when_runtime_action_coverage_dispatch_surface_refs_mix_vali
     )
 
 
+def test_guard_fails_when_action_coverage_generation_domain_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0].pop("generation_domain_refs")
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure
+        and "missing required field" in failure
+        and "generation_domain_refs" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("refs", "expected_fragment"),
+    [
+        ([], "generation_domain_refs must be non-empty"),
+        ("domain.panel_generation", "generation_domain_refs must be a non-empty list"),
+        ([123], "generation_domain_refs[0] must be a non-empty string"),
+        (
+            ["domain.panel_generation", "domain.panel_generation"],
+            "duplicate generation_domain_refs[1]",
+        ),
+        (["domain.__missing__"], "references unknown generation domain"),
+        (["domain.modal_command_target"], "transition_id does not match"),
+    ],
+)
+def test_guard_fails_when_action_coverage_generation_domain_refs_are_invalid(
+    tmp_path: Path, refs: object, expected_fragment: str
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    actions[0]["generation_domain_refs"] = refs
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure and expected_fragment in failure for failure in failures
+    )
+
+
+def test_guard_fails_when_action_coverage_generation_domain_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    transition_id = str(actions[0]["transition_id"])
+    valid_ref = str(actions[0]["generation_domain_refs"][0])
+    wrong_ref = _wrong_generation_domain_ref(transition_id)
+    actions[0]["generation_domain_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions)
+
+    failures = _validate(paths)
+
+    assert any(
+        "action[0]" in failure
+        and f"generation_domain_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_action_coverage_generation_domain_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_action_coverages = _complete_actions()
+    runtime_action_coverages[0]["generation_domain_refs"] = [
+        str(runtime_action_coverages[0]["generation_domain_refs"][0])
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_action_coverages=runtime_action_coverages,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_action_coverage[0]" in failure
+        and "generation_domain_refs does not match action coverage" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_action_coverage_generation_domain_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_action_coverages = _complete_actions()
+    transition_id = str(runtime_action_coverages[0]["transition_id"])
+    valid_ref = str(runtime_action_coverages[0]["generation_domain_refs"][0])
+    wrong_ref = _wrong_generation_domain_ref(transition_id)
+    runtime_action_coverages[0]["generation_domain_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_action_coverages=runtime_action_coverages,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_action_coverage[0]" in failure
+        and f"generation_domain_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_action_coverage_invariant_refs_drift(
     tmp_path: Path,
 ) -> None:
@@ -7720,6 +8107,125 @@ def test_guard_fails_when_runtime_event_coverage_dispatch_surface_refs_mix_valid
     assert any(
         "runtime_event_coverage[0]" in failure
         and f"dispatch_surface_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_event_coverage_generation_domain_refs_are_missing(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    events[0].pop("generation_domain_refs")
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure
+        and "missing required field" in failure
+        and "generation_domain_refs" in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("refs", "expected_fragment"),
+    [
+        ([], "generation_domain_refs must be non-empty"),
+        ("domain.panel_generation", "generation_domain_refs must be a non-empty list"),
+        ([123], "generation_domain_refs[0] must be a non-empty string"),
+        (
+            ["domain.panel_generation", "domain.panel_generation"],
+            "duplicate generation_domain_refs[1]",
+        ),
+        (["domain.__missing__"], "references unknown generation domain"),
+        (["domain.modal_command_target"], "transition_id does not match"),
+    ],
+)
+def test_guard_fails_when_event_coverage_generation_domain_refs_are_invalid(
+    tmp_path: Path, refs: object, expected_fragment: str
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    if refs == ["domain.modal_command_target"]:
+        refs = [_wrong_generation_domain_ref(str(events[0]["transition_id"]))]
+    events[0]["generation_domain_refs"] = refs
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure and expected_fragment in failure for failure in failures
+    )
+
+
+def test_guard_fails_when_event_coverage_generation_domain_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    events = _complete_events()
+    transition_id = str(events[0]["transition_id"])
+    valid_ref = str(events[0]["generation_domain_refs"][0])
+    wrong_ref = _wrong_generation_domain_ref(transition_id)
+    events[0]["generation_domain_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(tmp_path, transitions=transitions, events=events)
+
+    failures = _validate(paths)
+
+    assert any(
+        "event[0]" in failure
+        and f"generation_domain_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_event_coverage_generation_domain_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_events = _complete_events()
+    event_index = _event_index("event.terminal_resize_signal")
+    runtime_events[event_index]["generation_domain_refs"] = [
+        str(runtime_events[event_index]["generation_domain_refs"][0])
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_events=runtime_events,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        f"runtime_event_coverage[{event_index}]" in failure
+        and "generation_domain_refs does not match docs" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_event_coverage_generation_domain_refs_mix_valid_and_wrong_transition(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_events = _complete_events()
+    transition_id = str(runtime_events[0]["transition_id"])
+    valid_ref = str(runtime_events[0]["generation_domain_refs"][0])
+    wrong_ref = _wrong_generation_domain_ref(transition_id)
+    runtime_events[0]["generation_domain_refs"] = [valid_ref, wrong_ref]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_events=runtime_events,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_event_coverage[0]" in failure
+        and f"generation_domain_refs[1] transition_id does not match {transition_id}: {wrong_ref}"
         in failure
         for failure in failures
     )
@@ -7972,7 +8478,7 @@ def test_guard_fails_when_runtime_action_coverage_write_set_is_malformed(
     failures = _validate(paths)
 
     assert any(
-        "kAppStateActionCoverageWriteSet0[0]" in failure
+        "WriteSet" in failure
         and "malformed string literal entry" in failure
         for failure in failures
     )
@@ -8066,6 +8572,9 @@ def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
     runtime_sequences, runtime_sequence_failures = (
         guard._parse_runtime_transition_sequence_registry(runtime_path)
     )
+    runtime_generation_domains, runtime_generation_domain_failures = (
+        guard._parse_runtime_generation_domain_registry(runtime_path)
+    )
     runtime_invariants, runtime_invariant_failures = (
         guard._parse_runtime_invariant_registry(runtime_path)
     )
@@ -8080,6 +8589,7 @@ def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
         + runtime_dispatch_surface_failures
         + runtime_event_failures
         + runtime_sequence_failures
+        + runtime_generation_domain_failures
         + runtime_invariant_failures
         + guard._validate_runtime_event_coverage_registry(
             runtime_records=runtime_events,
@@ -8088,6 +8598,7 @@ def _event_runtime_validation_failures(runtime_path: Path) -> list[str]:
             transition_ids=transition_ids,
             runtime_transition_sequence_records=runtime_sequences,
             runtime_dispatch_surface_records=runtime_dispatch_surfaces,
+            runtime_generation_domain_records=runtime_generation_domains,
             runtime_transition_ids={record["id"] for record in runtime_transitions},
             runtime_invariant_ids={
                 record["invariant_id"] for record in runtime_invariants
@@ -8431,6 +8942,26 @@ def test_runtime_generation_domain_startup_requires_documented_domain_ids() -> N
         r"AppStateGenerationDomainLookup\(\s*"
         r"kAppStateRequiredGenerationDomainIds\[index\]\s*\)",
         source,
+        re.S,
+    )
+
+
+def test_runtime_generation_domain_startup_separates_coverage_from_advances() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    generation_start = source.index("static int AppStateGenerationDomainsReady(void)")
+    dispatch_start = source.index(
+        "static int AppStateDispatchSurfaceWriteHasInvariantCoverage("
+    )
+    ready_body = source[generation_start:dispatch_start]
+
+    assert "metadata->coverage_transition_ids" in ready_body
+    assert "metadata->coverage_transition_id_count" in ready_body
+    assert "metadata->advances_on_transition_ids" in ready_body
+    assert re.search(
+        r"StringListContains\(metadata->coverage_transition_ids,\s*"
+        r"metadata->coverage_transition_id_count,\s*"
+        r"metadata->advances_on_transition_ids\s*\[transition_index\]\)",
+        ready_body,
         re.S,
     )
 


### PR DESCRIPTION
## Summary
- Require AppState action and event coverage records to declare generation-domain refs.
- Split generation-domain transition coverage from true generation advancement so projection-only render coverage stays truthful.
- Extend runtime metadata, startup readiness checks, and contract-guard tests for the new coverage refs.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'generation_domain_refs or generation_ref or generation_domain or readiness'` — PASS
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing unrelated warnings
- `git diff --check` — PASS
