### PR TITLE
chore(appstate): require sequence coverage refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ sudo make uninstall
 
 *Note: Developers can compile with AddressSanitizer enabled by running `make DEBUG=1`.*
 
+## Compiles and Runs On
+
+> **Note on Development:**
+> YtreeNova is developed using **VScodium** with the **Codex extension**, targeting **WSL Ubuntu 24.04.4 LTS** and **GCC 13.3.0**.
+
+**Verified Platforms (via WSL):**
+- Arch Linux, GCC 16.1.1
+- Fedora Linux 45 (WSL Prerelease), GCC 16.1.1
+- Ubuntu 26.04 LTS, GCC 15.2.0
+
 ## Documentation Guide
 
 The project documentation is split into several focused files.

--- a/docs/appstate_transition_sequences.json
+++ b/docs/appstate_transition_sequences.json
@@ -14,6 +14,10 @@
           "stimulus": {
             "action_id": "ACTION_SPLIT_SCREEN"
           },
+          "action_coverage_refs": [
+            "ACTION_SPLIT_SCREEN"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.inactive-panel-frozen",
@@ -45,6 +49,10 @@
           "stimulus": {
             "action_id": "ACTION_SPLIT_SCREEN"
           },
+          "action_coverage_refs": [
+            "ACTION_SPLIT_SCREEN"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "blocked",
           "invariant_ids": [
             "invariant.blocked-transition-determinism",
@@ -83,6 +91,10 @@
           "stimulus": {
             "action_id": "ACTION_SWITCH_PANEL"
           },
+          "action_coverage_refs": [
+            "ACTION_SWITCH_PANEL"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.inactive-panel-frozen",
@@ -111,6 +123,10 @@
           "stimulus": {
             "action_id": "ACTION_SWITCH_PANEL"
           },
+          "action_coverage_refs": [
+            "ACTION_SWITCH_PANEL"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.inactive-panel-frozen",
@@ -146,8 +162,13 @@
           "stimulus": {
             "action_id": "ACTION_ENTER"
           },
+          "action_coverage_refs": [
+            "ACTION_ENTER"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.hidden-entry-visible-navigation",
             "invariant.viewport-identity-rebind"
           ],
@@ -177,8 +198,13 @@
           "stimulus": {
             "action_id": "ACTION_TO_DIR"
           },
+          "action_coverage_refs": [
+            "ACTION_TO_DIR"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.panel-local-focus-restore",
             "invariant.viewport-identity-rebind"
           ],
@@ -217,6 +243,12 @@
             "action_id": "ACTION_ESCAPE",
             "event_id": "event.modal-completion"
           },
+          "action_coverage_refs": [
+            "ACTION_ESCAPE"
+          ],
+          "event_coverage_refs": [
+            "event.modal-completion"
+          ],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.panel-local-focus-restore",
@@ -252,8 +284,13 @@
           "stimulus": {
             "action_id": "ACTION_TOGGLE_HIDDEN"
           },
+          "action_coverage_refs": [
+            "ACTION_TOGGLE_HIDDEN"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.hidden-entry-visible-navigation",
             "invariant.panel-local-focus-restore"
           ],
@@ -283,8 +320,13 @@
           "stimulus": {
             "action_id": "ACTION_TOGGLE_HIDDEN"
           },
+          "action_coverage_refs": [
+            "ACTION_TOGGLE_HIDDEN"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.hidden-entry-visible-navigation",
             "invariant.viewport-identity-rebind"
           ],
@@ -322,8 +364,13 @@
           "stimulus": {
             "action_id": "ACTION_REFRESH"
           },
+          "action_coverage_refs": [
+            "ACTION_REFRESH"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.hidden-entry-visible-navigation",
             "invariant.viewport-identity-rebind",
             "invariant.shared-state-panel-local-isolation"
           ],
@@ -357,6 +404,10 @@
           "stimulus": {
             "event_id": "event.rebuild-rebind-callback"
           },
+          "action_coverage_refs": [],
+          "event_coverage_refs": [
+            "event.rebuild-rebind-callback"
+          ],
           "expected_result": "fallback",
           "invariant_ids": [
             "invariant.stale-snapshot-fail-closed",
@@ -406,8 +457,13 @@
           "stimulus": {
             "event_id": "event.filesystem-mutation-result"
           },
+          "action_coverage_refs": [],
+          "event_coverage_refs": [
+            "event.filesystem-mutation-result"
+          ],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.blocked-transition-determinism",
             "invariant.viewport-identity-rebind",
             "invariant.shared-state-panel-local-isolation"
           ],
@@ -442,6 +498,12 @@
             "action_id": "ACTION_CMD_D",
             "event_id": "event.filesystem-mutation-result"
           },
+          "action_coverage_refs": [
+            "ACTION_CMD_D"
+          ],
+          "event_coverage_refs": [
+            "event.filesystem-mutation-result"
+          ],
           "expected_result": "fallback",
           "invariant_ids": [
             "invariant.stale-snapshot-fail-closed",
@@ -490,8 +552,13 @@
           "stimulus": {
             "action_id": "ACTION_LIST_JUMP"
           },
+          "action_coverage_refs": [
+            "ACTION_LIST_JUMP"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.hidden-entry-visible-navigation",
             "invariant.panel-local-focus-restore"
           ],
@@ -521,6 +588,10 @@
           "stimulus": {
             "event_id": "event.command-completion"
           },
+          "action_coverage_refs": [],
+          "event_coverage_refs": [
+            "event.command-completion"
+          ],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.panel-local-focus-restore",
@@ -556,8 +627,13 @@
           "stimulus": {
             "action_id": "ACTION_TOGGLE_TAGGED_MODE"
           },
+          "action_coverage_refs": [
+            "ACTION_TOGGLE_TAGGED_MODE"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.shared-state-panel-local-isolation",
             "invariant.hidden-entry-visible-navigation"
           ],
@@ -583,8 +659,13 @@
           "stimulus": {
             "action_id": "ACTION_ASTERISK"
           },
+          "action_coverage_refs": [
+            "ACTION_ASTERISK"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.shared-state-panel-local-isolation",
             "invariant.hidden-entry-visible-navigation",
             "invariant.render-projection-read-only"
@@ -623,8 +704,13 @@
           "stimulus": {
             "action_id": "ACTION_TOGGLE_MODE"
           },
+          "action_coverage_refs": [
+            "ACTION_TOGGLE_MODE"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.panel-local-focus-restore",
             "invariant.render-projection-read-only"
           ],
@@ -654,8 +740,13 @@
           "stimulus": {
             "action_id": "ACTION_VIEW_PREVIEW"
           },
+          "action_coverage_refs": [
+            "ACTION_VIEW_PREVIEW"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
+            "invariant.inactive-panel-frozen",
             "invariant.panel-local-focus-restore",
             "invariant.render-projection-read-only"
           ],
@@ -693,6 +784,10 @@
           "stimulus": {
             "action_id": "ACTION_VOL_NEXT"
           },
+          "action_coverage_refs": [
+            "ACTION_VOL_NEXT"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.shared-state-panel-local-isolation",
@@ -724,6 +819,10 @@
           "stimulus": {
             "event_id": "event.volume-lifecycle"
           },
+          "action_coverage_refs": [],
+          "event_coverage_refs": [
+            "event.volume-lifecycle"
+          ],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.stale-snapshot-fail-closed",
@@ -763,6 +862,10 @@
           "stimulus": {
             "action_id": "ACTION_SPLIT_SCREEN"
           },
+          "action_coverage_refs": [
+            "ACTION_SPLIT_SCREEN"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.inactive-panel-frozen",
@@ -795,6 +898,10 @@
           "stimulus": {
             "action_id": "ACTION_SPLIT_SCREEN"
           },
+          "action_coverage_refs": [
+            "ACTION_SPLIT_SCREEN"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.inactive-panel-frozen",
@@ -835,6 +942,10 @@
           "stimulus": {
             "event_id": "event.terminal-resize-signal"
           },
+          "action_coverage_refs": [],
+          "event_coverage_refs": [
+            "event.terminal-resize-signal"
+          ],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.render-projection-read-only",
@@ -877,6 +988,10 @@
           "stimulus": {
             "event_id": "event.render-reflow"
           },
+          "action_coverage_refs": [],
+          "event_coverage_refs": [
+            "event.render-reflow"
+          ],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.render-projection-read-only",
@@ -915,6 +1030,10 @@
           "stimulus": {
             "action_id": "ACTION_VOL_MENU"
           },
+          "action_coverage_refs": [
+            "ACTION_VOL_MENU"
+          ],
+          "event_coverage_refs": [],
           "expected_result": "allowed",
           "invariant_ids": [
             "invariant.inactive-panel-frozen",

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -204,6 +204,10 @@ typedef struct {
   const char *transition_id;
   const char *stimulus_action_id;
   const char *stimulus_event_id;
+  const char *const *action_coverage_refs;
+  size_t action_coverage_ref_count;
+  const char *const *event_coverage_refs;
+  size_t event_coverage_ref_count;
   const char *expected_result;
   const char *const *invariant_ids;
   size_t invariant_id_count;

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -355,6 +355,8 @@ DIFF_HARNESS_LIST_FIELDS = {
     "migration_notes",
 }
 SEQUENCE_LIST_FIELDS = {
+    "action_coverage_refs",
+    "event_coverage_refs",
     "invariant_ids",
     "diff_harness_ids",
     "generation_domain_expectations",
@@ -1564,7 +1566,7 @@ def _parse_runtime_transition_sequence_registry(
     string_arrays: dict[str, list[str]] = {}
     string_array_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateTransitionSequenceStep(?:InvariantIds|DiffHarnessIds)[0-9]+_[0-9]+)"
+        r"(kAppStateTransitionSequenceStep(?:ActionCoverageRefs|EventCoverageRefs|InvariantIds|DiffHarnessIds)[0-9]+_[0-9]+)"
         r"\[\]\s*=\s*\{(?P<body>.*?)\};",
         re.S,
     )
@@ -1652,6 +1654,10 @@ def _parse_runtime_transition_sequence_registry(
         r"\s*\"(?P<transition_id>[^\"]*)\"\s*,"
         r"\s*(?P<stimulus_action_id>NULL|\"[^\"]*\")\s*,"
         r"\s*(?P<stimulus_event_id>NULL|\"[^\"]*\")\s*,"
+        r"\s*(?P<action_coverage_refs>NULL|kAppStateTransitionSequenceStepActionCoverageRefs[0-9]+_[0-9]+)\s*,"
+        r"\s*(?P<action_coverage_ref_count>0|sizeof\((?P=action_coverage_refs)\)\s*/\s*sizeof\((?P=action_coverage_refs)\[0\]\))\s*,"
+        r"\s*(?P<event_coverage_refs>NULL|kAppStateTransitionSequenceStepEventCoverageRefs[0-9]+_[0-9]+)\s*,"
+        r"\s*(?P<event_coverage_ref_count>0|sizeof\((?P=event_coverage_refs)\)\s*/\s*sizeof\((?P=event_coverage_refs)\[0\]\))\s*,"
         r"\s*\"(?P<expected_result>[^\"]*)\"\s*,"
         r"\s*(?P<invariant_ids>kAppStateTransitionSequenceStepInvariantIds[0-9]+_[0-9]+)\s*,"
         r"\s*sizeof\((?P=invariant_ids)\)\s*/\s*sizeof\((?P=invariant_ids)\[0\]\)\s*,"
@@ -1686,10 +1692,22 @@ def _parse_runtime_transition_sequence_registry(
 
             invariant_table = row_match.group("invariant_ids")
             diff_harness_table = row_match.group("diff_harness_ids")
+            action_coverage_table = row_match.group("action_coverage_refs")
+            event_coverage_table = row_match.group("event_coverage_refs")
             generation_table = row_match.group("generation_domain_expectations")
             no_unrelated_table = row_match.group("no_unrelated_mutation").lstrip("&")
             fallback_table = row_match.group("deterministic_fallback").lstrip("&")
 
+            if action_coverage_table != "NULL" and action_coverage_table not in string_arrays:
+                failures.append(
+                    f"runtime_transition_sequence_step[{table_name}][{index}]: "
+                    f"unknown action_coverage_refs table: {action_coverage_table}"
+                )
+            if event_coverage_table != "NULL" and event_coverage_table not in string_arrays:
+                failures.append(
+                    f"runtime_transition_sequence_step[{table_name}][{index}]: "
+                    f"unknown event_coverage_refs table: {event_coverage_table}"
+                )
             if invariant_table not in string_arrays:
                 failures.append(
                     f"runtime_transition_sequence_step[{table_name}][{index}]: "
@@ -1736,6 +1754,12 @@ def _parse_runtime_transition_sequence_registry(
                     ),
                     "stimulus_event_id": _parse_runtime_nullable_string(
                         row_match.group("stimulus_event_id")
+                    ),
+                    "action_coverage_refs": string_arrays.get(
+                        action_coverage_table, []
+                    ),
+                    "event_coverage_refs": string_arrays.get(
+                        event_coverage_table, []
                     ),
                     "expected_result": row_match.group("expected_result"),
                     "invariant_ids": string_arrays.get(invariant_table, []),
@@ -5289,6 +5313,155 @@ def _validate_step_reference_list(
     return failures
 
 
+def _non_empty_string_set(value: Any) -> set[str] | None:
+    if not isinstance(value, list):
+        return None
+    refs: set[str] = set()
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            return None
+        refs.add(item)
+    return refs
+
+
+def _step_generation_domain_ids(value: Any) -> set[str] | None:
+    if not isinstance(value, list):
+        return None
+    domain_ids: set[str] = set()
+    for record in value:
+        if not isinstance(record, dict):
+            return None
+        domain_id = record.get("domain_id")
+        if not isinstance(domain_id, str) or not domain_id.strip():
+            return None
+        domain_ids.add(domain_id)
+    return domain_ids
+
+
+def _validate_step_coverage_ref_overlap(
+    *,
+    label: str,
+    field: str,
+    index: int,
+    ref: str,
+    coverage_record: dict[str, Any],
+    step_invariant_ids: Any,
+    step_diff_harness_ids: Any,
+    step_generation_domain_expectations: Any,
+) -> list[str]:
+    failures: list[str] = []
+    overlap_checks = (
+        (
+            "invariant_refs",
+            _non_empty_string_set(step_invariant_ids),
+            _non_empty_string_set(coverage_record.get("invariant_refs")),
+            "step invariant_ids",
+        ),
+        (
+            "diff_harness_refs",
+            _non_empty_string_set(step_diff_harness_ids),
+            _non_empty_string_set(coverage_record.get("diff_harness_refs")),
+            "step diff_harness_ids",
+        ),
+        (
+            "generation_domain_refs",
+            _step_generation_domain_ids(step_generation_domain_expectations),
+            _non_empty_string_set(coverage_record.get("generation_domain_refs")),
+            "step generation_domain_expectations",
+        ),
+    )
+    for coverage_field, step_refs, coverage_refs, step_field in overlap_checks:
+        if step_refs is None or coverage_refs is None:
+            continue
+        if not step_refs or not coverage_refs or not step_refs.intersection(coverage_refs):
+            failures.append(
+                f"{label}: {field}[{index}] {ref} {coverage_field} must overlap "
+                f"{step_field}"
+            )
+    return failures
+
+
+def _validate_step_coverage_refs(
+    *,
+    value: Any,
+    valid_ids: set[str],
+    coverage_records_by_id: dict[str, dict[str, Any]],
+    label: str,
+    field: str,
+    reference_label: str,
+    stimulus_id: Any,
+    transition_id: Any,
+    step_invariant_ids: Any,
+    step_diff_harness_ids: Any,
+    step_generation_domain_expectations: Any,
+) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{label}: {field} must be a list"]
+
+    failures: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            failures.append(f"{label}: {field}[{index}] must be a non-empty string")
+            continue
+        if item in seen:
+            failures.append(f"{label}: duplicate {field}[{index}]: {item}")
+        seen.add(item)
+        if item not in valid_ids:
+            failures.append(
+                f"{label}: {field} references unknown {reference_label}: {item}"
+            )
+    if not isinstance(stimulus_id, str) or not stimulus_id.strip():
+        if value:
+            failures.append(
+                f"{label}: {field} must be empty when the step has no matching stimulus"
+            )
+        return failures
+    if failures:
+        return failures
+
+    if not value:
+        failures.append(
+            f"{label}: {field} must include coverage for stimulus {stimulus_id}"
+        )
+        return failures
+
+    for index, ref in enumerate(value):
+        assert isinstance(ref, str)
+        if ref != stimulus_id:
+            failures.append(
+                f"{label}: {field}[{index}] {ref} does not match stimulus {stimulus_id}"
+            )
+            continue
+        coverage_record = coverage_records_by_id.get(ref)
+        if coverage_record is None:
+            continue
+        coverage_transition_id = coverage_record.get("transition_id")
+        if (
+            isinstance(transition_id, str)
+            and transition_id.strip()
+            and coverage_transition_id != transition_id
+        ):
+            failures.append(
+                f"{label}: {field}[{index}] transition_id does not match "
+                f"step.transition_id {transition_id}: {coverage_transition_id}"
+            )
+        failures.extend(
+            _validate_step_coverage_ref_overlap(
+                label=label,
+                field=field,
+                index=index,
+                ref=ref,
+                coverage_record=coverage_record,
+                step_invariant_ids=step_invariant_ids,
+                step_diff_harness_ids=step_diff_harness_ids,
+                step_generation_domain_expectations=step_generation_domain_expectations,
+            )
+        )
+
+    return failures
+
+
 def _diff_harness_transition_ids_by_harness(
     diff_harness_records: list[Any],
 ) -> dict[str, set[str]]:
@@ -5798,8 +5971,10 @@ def _validate_appstate_transition_sequences(
     transition_ids: dict[str, dict[str, Any]],
     action_ids: set[str],
     action_transition_ids: dict[str, str],
+    action_coverage_by_action: dict[str, dict[str, Any]],
     event_ids: set[str],
     event_transition_ids: dict[str, str],
+    event_coverage_by_event_id: dict[str, dict[str, Any]],
     invariant_ids: set[str],
     invariant_transition_ids: dict[str, set[str]],
     diff_harness_ids: set[str],
@@ -5861,7 +6036,12 @@ def _validate_appstate_transition_sequences(
                 _validate_required_fields(
                     record=step,
                     required_fields=REQUIRED_SEQUENCE_STEP_FIELDS,
-                    list_fields=SEQUENCE_LIST_FIELDS - {"generation_domain_expectations"},
+                    list_fields=SEQUENCE_LIST_FIELDS
+                    - {
+                        "action_coverage_refs",
+                        "event_coverage_refs",
+                        "generation_domain_expectations",
+                    },
                     label=label,
                 )
             )
@@ -5895,6 +6075,43 @@ def _validate_appstate_transition_sequences(
                     action_transition_ids=action_transition_ids,
                     event_ids=event_ids,
                     event_transition_ids=event_transition_ids,
+                )
+            )
+            stimulus = step.get("stimulus")
+            if not isinstance(stimulus, dict):
+                stimulus = {}
+            failures.extend(
+                _validate_step_coverage_refs(
+                    value=step.get("action_coverage_refs"),
+                    valid_ids=action_ids,
+                    coverage_records_by_id=action_coverage_by_action,
+                    label=label,
+                    field="action_coverage_refs",
+                    reference_label="action coverage record",
+                    stimulus_id=stimulus.get("action_id"),
+                    transition_id=transition_id,
+                    step_invariant_ids=step.get("invariant_ids"),
+                    step_diff_harness_ids=step.get("diff_harness_ids"),
+                    step_generation_domain_expectations=step.get(
+                        "generation_domain_expectations"
+                    ),
+                )
+            )
+            failures.extend(
+                _validate_step_coverage_refs(
+                    value=step.get("event_coverage_refs"),
+                    valid_ids=event_ids,
+                    coverage_records_by_id=event_coverage_by_event_id,
+                    label=label,
+                    field="event_coverage_refs",
+                    reference_label="event coverage record",
+                    stimulus_id=stimulus.get("event_id"),
+                    transition_id=transition_id,
+                    step_invariant_ids=step.get("invariant_ids"),
+                    step_diff_harness_ids=step.get("diff_harness_ids"),
+                    step_generation_domain_expectations=step.get(
+                        "generation_domain_expectations"
+                    ),
                 )
             )
             failures.extend(
@@ -5998,6 +6215,8 @@ def _normalize_transition_sequence_records(records: list[Any]) -> dict[str, dict
                     "transition_id": step.get("transition_id"),
                     "stimulus_action_id": stimulus.get("action_id"),
                     "stimulus_event_id": stimulus.get("event_id"),
+                    "action_coverage_refs": step.get("action_coverage_refs"),
+                    "event_coverage_refs": step.get("event_coverage_refs"),
                     "expected_result": step.get("expected_result"),
                     "invariant_ids": step.get("invariant_ids"),
                     "diff_harness_ids": step.get("diff_harness_ids"),
@@ -6027,8 +6246,10 @@ def _validate_runtime_transition_sequence_registry(
     runtime_transition_ids: set[str],
     action_ids: set[str],
     action_transition_ids: dict[str, str],
+    action_coverage_by_action: dict[str, dict[str, Any]],
     event_ids: set[str],
     event_transition_ids: dict[str, str],
+    event_coverage_by_event_id: dict[str, dict[str, Any]],
     runtime_invariant_ids: set[str],
     runtime_invariant_transition_ids: dict[str, set[str]],
     runtime_diff_harness_ids: set[str],
@@ -6160,6 +6381,41 @@ def _validate_runtime_transition_sequence_registry(
                             f"transition_id {event_transition_id}, not "
                             f"step.transition_id {transition_id}"
                         )
+
+            failures.extend(
+                _validate_step_coverage_refs(
+                    value=step.get("action_coverage_refs"),
+                    valid_ids=action_ids,
+                    coverage_records_by_id=action_coverage_by_action,
+                    label=step_label,
+                    field="action_coverage_refs",
+                    reference_label="action coverage record",
+                    stimulus_id=action_id,
+                    transition_id=transition_id,
+                    step_invariant_ids=step.get("invariant_ids"),
+                    step_diff_harness_ids=step.get("diff_harness_ids"),
+                    step_generation_domain_expectations=step.get(
+                        "generation_domain_expectations"
+                    ),
+                )
+            )
+            failures.extend(
+                _validate_step_coverage_refs(
+                    value=step.get("event_coverage_refs"),
+                    valid_ids=event_ids,
+                    coverage_records_by_id=event_coverage_by_event_id,
+                    label=step_label,
+                    field="event_coverage_refs",
+                    reference_label="event coverage record",
+                    stimulus_id=event_id,
+                    transition_id=transition_id,
+                    step_invariant_ids=step.get("invariant_ids"),
+                    step_diff_harness_ids=step.get("diff_harness_ids"),
+                    step_generation_domain_expectations=step.get(
+                        "generation_domain_expectations"
+                    ),
+                )
+            )
 
             for field, valid_ids, reference_label in (
                 ("invariant_ids", runtime_invariant_ids, "runtime invariant id"),
@@ -7150,6 +7406,18 @@ def validate_contract(
         collection_key="events",
         id_field="event_id",
     )
+    if isinstance(event_coverage_doc, dict) and isinstance(
+        event_coverage_doc.get("events"), list
+    ):
+        event_coverage_by_event_id = {
+            record["event_id"]: record
+            for record in event_coverage_doc["events"]
+            if isinstance(record, dict)
+            and isinstance(record.get("event_id"), str)
+            and record["event_id"].strip()
+        }
+    else:
+        event_coverage_by_event_id = {}
     failures.extend(
         _validate_appstate_transition_sequences(
             transition_sequences_doc=transition_sequences_doc,
@@ -7157,8 +7425,10 @@ def validate_contract(
             transition_ids=transition_ids,
             action_ids=action_ids,
             action_transition_ids=action_transition_ids,
+            action_coverage_by_action=action_coverage_by_action,
             event_ids=event_ids,
             event_transition_ids=event_transition_ids,
+            event_coverage_by_event_id=event_coverage_by_event_id,
             invariant_ids=invariant_ids,
             invariant_transition_ids=_invariant_transition_ids_by_invariant(
                 invariant_records
@@ -7186,8 +7456,10 @@ def validate_contract(
             },
             action_ids=action_ids,
             action_transition_ids=action_transition_ids,
+            action_coverage_by_action=action_coverage_by_action,
             event_ids=event_ids,
             event_transition_ids=event_transition_ids,
+            event_coverage_by_event_id=event_coverage_by_event_id,
             runtime_invariant_ids={
                 record["invariant_id"] for record in runtime_invariant_records
             },

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -1118,6 +1118,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds0_0[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs0_0[] = {
+  "ACTION_SPLIT_SCREEN",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations0_0[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
@@ -1133,6 +1137,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds0_1[] = {
   "harness.blocked-transition-no-unrelated-mutation",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs0_1[] = {
+  "ACTION_SPLIT_SCREEN",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations0_1[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"reflow.layout.projection", "Layout reflow generation is projection-only unless resize transition declares it."},
@@ -1146,6 +1154,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_SPLIT_SCREEN",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs0_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs0_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs0_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds0_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds0_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds0_0[0]),
@@ -1161,6 +1173,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_SPLIT_SCREEN",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs0_1,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs0_1) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs0_1[0]),
+   NULL,
+   0,
    "blocked",
    kAppStateTransitionSequenceStepInvariantIds0_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds0_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds0_1[0]),
@@ -1184,6 +1200,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds1_0[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs1_0[] = {
+  "ACTION_SWITCH_PANEL",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations1_0[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
@@ -1199,6 +1219,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds1_1[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs1_1[] = {
+  "ACTION_SWITCH_PANEL",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations1_1[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
@@ -1210,6 +1234,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_SWITCH_PANEL",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs1_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs1_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs1_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds1_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds1_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds1_0[0]),
@@ -1225,6 +1253,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_SWITCH_PANEL",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs1_1,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs1_1) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs1_1[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds1_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds1_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds1_1[0]),
@@ -1238,6 +1270,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds2_0[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.hidden-entry-visible-navigation",
   "invariant.viewport-identity-rebind",
 };
@@ -1247,6 +1280,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds2_0[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs2_0[] = {
+  "ACTION_ENTER",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations2_0[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
@@ -1254,6 +1291,7 @@ static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTr
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds2_1[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.panel-local-focus-restore",
   "invariant.viewport-identity-rebind",
 };
@@ -1261,6 +1299,10 @@ static const char *const kAppStateTransitionSequenceStepInvariantIds2_1[] = {
 static const char *const kAppStateTransitionSequenceStepDiffHarnessIds2_1[] = {
   "harness.transition-before-after-snapshot",
   "harness.declared-write-set-diff",
+};
+
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs2_1[] = {
+  "ACTION_TO_DIR",
 };
 
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations2_1[] = {
@@ -1275,6 +1317,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_ENTER",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs2_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs2_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs2_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds2_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds2_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds2_0[0]),
@@ -1290,6 +1336,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_TO_DIR",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs2_1,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs2_1) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs2_1[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds2_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds2_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds2_1[0]),
@@ -1312,6 +1362,14 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds3_0[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs3_0[] = {
+  "ACTION_ESCAPE",
+};
+
+static const char *const kAppStateTransitionSequenceStepEventCoverageRefs3_0[] = {
+  "event.modal-completion",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations3_0[] = {
   {"target.modal-command.session", "Modal target generation validates before applying completion or dismissal."},
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
@@ -1323,6 +1381,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.modal-action.dismiss",
    "ACTION_ESCAPE",
    "event.modal-completion",
+   kAppStateTransitionSequenceStepActionCoverageRefs3_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs3_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs3_0[0]),
+   kAppStateTransitionSequenceStepEventCoverageRefs3_0,
+   sizeof(kAppStateTransitionSequenceStepEventCoverageRefs3_0) / sizeof(kAppStateTransitionSequenceStepEventCoverageRefs3_0[0]),
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds3_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds3_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds3_0[0]),
@@ -1336,6 +1398,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds4_0[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.hidden-entry-visible-navigation",
   "invariant.panel-local-focus-restore",
 };
@@ -1345,6 +1408,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds4_0[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs4_0[] = {
+  "ACTION_TOGGLE_HIDDEN",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations4_0[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"state.visibility-filter.panel-volume", "Visibility/filter generation matches the selected panel after the transition."},
@@ -1352,6 +1419,7 @@ static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTr
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds4_1[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.hidden-entry-visible-navigation",
   "invariant.viewport-identity-rebind",
 };
@@ -1359,6 +1427,10 @@ static const char *const kAppStateTransitionSequenceStepInvariantIds4_1[] = {
 static const char *const kAppStateTransitionSequenceStepDiffHarnessIds4_1[] = {
   "harness.transition-before-after-snapshot",
   "harness.declared-write-set-diff",
+};
+
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs4_1[] = {
+  "ACTION_TOGGLE_HIDDEN",
 };
 
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations4_1[] = {
@@ -1373,6 +1445,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_TOGGLE_HIDDEN",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs4_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs4_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs4_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds4_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds4_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds4_0[0]),
@@ -1388,6 +1464,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_TOGGLE_HIDDEN",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs4_1,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs4_1) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs4_1[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds4_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds4_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds4_1[0]),
@@ -1401,6 +1481,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds5_0[] = {
+  "invariant.hidden-entry-visible-navigation",
   "invariant.viewport-identity-rebind",
   "invariant.shared-state-panel-local-isolation",
 };
@@ -1408,6 +1489,10 @@ static const char *const kAppStateTransitionSequenceStepInvariantIds5_0[] = {
 static const char *const kAppStateTransitionSequenceStepDiffHarnessIds5_0[] = {
   "harness.transition-before-after-snapshot",
   "harness.generation-mismatch-check",
+};
+
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs5_0[] = {
+  "ACTION_REFRESH",
 };
 
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations5_0[] = {
@@ -1428,6 +1513,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds5_1[] = {
   "harness.blocked-transition-no-unrelated-mutation",
 };
 
+static const char *const kAppStateTransitionSequenceStepEventCoverageRefs5_1[] = {
+  "event.rebuild-rebind-callback",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations5_1[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"identity.directory.stable-key", "Directory identity remains durable across rebuild/rebind."},
@@ -1444,6 +1533,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.refresh-rebuild.manual-refresh",
    "ACTION_REFRESH",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs5_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs5_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs5_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds5_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds5_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds5_0[0]),
@@ -1459,6 +1552,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.rebuild-rebind-callback.panel-anchor",
    NULL,
    "event.rebuild-rebind-callback",
+   NULL,
+   0,
+   kAppStateTransitionSequenceStepEventCoverageRefs5_1,
+   sizeof(kAppStateTransitionSequenceStepEventCoverageRefs5_1) / sizeof(kAppStateTransitionSequenceStepEventCoverageRefs5_1[0]),
    "fallback",
    kAppStateTransitionSequenceStepInvariantIds5_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds5_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds5_1[0]),
@@ -1472,6 +1569,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds6_0[] = {
+  "invariant.blocked-transition-determinism",
   "invariant.viewport-identity-rebind",
   "invariant.shared-state-panel-local-isolation",
 };
@@ -1479,6 +1577,10 @@ static const char *const kAppStateTransitionSequenceStepInvariantIds6_0[] = {
 static const char *const kAppStateTransitionSequenceStepDiffHarnessIds6_0[] = {
   "harness.transition-before-after-snapshot",
   "harness.generation-mismatch-check",
+};
+
+static const char *const kAppStateTransitionSequenceStepEventCoverageRefs6_0[] = {
+  "event.filesystem-mutation-result",
 };
 
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations6_0[] = {
@@ -1498,6 +1600,14 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds6_1[] = {
   "harness.blocked-transition-no-unrelated-mutation",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs6_1[] = {
+  "ACTION_CMD_D",
+};
+
+static const char *const kAppStateTransitionSequenceStepEventCoverageRefs6_1[] = {
+  "event.filesystem-mutation-result",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations6_1[] = {
   {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
   {"state.topology.volume", "Topology generation advances only for declared topology changes."},
@@ -1514,6 +1624,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.filesystem-mutation-result.mkdir-copy-delete",
    NULL,
    "event.filesystem-mutation-result",
+   NULL,
+   0,
+   kAppStateTransitionSequenceStepEventCoverageRefs6_0,
+   sizeof(kAppStateTransitionSequenceStepEventCoverageRefs6_0) / sizeof(kAppStateTransitionSequenceStepEventCoverageRefs6_0[0]),
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds6_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds6_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds6_0[0]),
@@ -1529,6 +1643,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.filesystem-mutation-result.mkdir-copy-delete",
    "ACTION_CMD_D",
    "event.filesystem-mutation-result",
+   kAppStateTransitionSequenceStepActionCoverageRefs6_1,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs6_1) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs6_1[0]),
+   kAppStateTransitionSequenceStepEventCoverageRefs6_1,
+   sizeof(kAppStateTransitionSequenceStepEventCoverageRefs6_1) / sizeof(kAppStateTransitionSequenceStepEventCoverageRefs6_1[0]),
    "fallback",
    kAppStateTransitionSequenceStepInvariantIds6_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds6_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds6_1[0]),
@@ -1542,6 +1660,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds7_0[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.hidden-entry-visible-navigation",
   "invariant.panel-local-focus-restore",
 };
@@ -1549,6 +1668,10 @@ static const char *const kAppStateTransitionSequenceStepInvariantIds7_0[] = {
 static const char *const kAppStateTransitionSequenceStepDiffHarnessIds7_0[] = {
   "harness.transition-before-after-snapshot",
   "harness.declared-write-set-diff",
+};
+
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs7_0[] = {
+  "ACTION_LIST_JUMP",
 };
 
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations7_0[] = {
@@ -1567,6 +1690,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds7_1[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepEventCoverageRefs7_1[] = {
+  "event.command-completion",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations7_1[] = {
   {"target.modal-command.session", "Modal target generation validates before applying completion or dismissal."},
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
@@ -1578,6 +1705,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_LIST_JUMP",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs7_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs7_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs7_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds7_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds7_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds7_0[0]),
@@ -1593,6 +1724,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.command-completion.user-command",
    NULL,
    "event.command-completion",
+   NULL,
+   0,
+   kAppStateTransitionSequenceStepEventCoverageRefs7_1,
+   sizeof(kAppStateTransitionSequenceStepEventCoverageRefs7_1) / sizeof(kAppStateTransitionSequenceStepEventCoverageRefs7_1[0]),
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds7_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds7_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds7_1[0]),
@@ -1606,6 +1741,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds8_0[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.shared-state-panel-local-isolation",
   "invariant.hidden-entry-visible-navigation",
 };
@@ -1615,12 +1751,17 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds8_0[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs8_0[] = {
+  "ACTION_TOGGLE_TAGGED_MODE",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations8_0[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"state.visibility-filter.panel-volume", "Visibility/filter generation matches the selected panel after the transition."},
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds8_1[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.shared-state-panel-local-isolation",
   "invariant.hidden-entry-visible-navigation",
   "invariant.render-projection-read-only",
@@ -1629,6 +1770,10 @@ static const char *const kAppStateTransitionSequenceStepInvariantIds8_1[] = {
 static const char *const kAppStateTransitionSequenceStepDiffHarnessIds8_1[] = {
   "harness.declared-write-set-diff",
   "harness.render-projection-read-only-diff",
+};
+
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs8_1[] = {
+  "ACTION_ASTERISK",
 };
 
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations8_1[] = {
@@ -1643,6 +1788,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_TOGGLE_TAGGED_MODE",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs8_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs8_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs8_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds8_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds8_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds8_0[0]),
@@ -1658,6 +1807,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_ASTERISK",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs8_1,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs8_1) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs8_1[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds8_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds8_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds8_1[0]),
@@ -1671,6 +1824,7 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds9_0[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.panel-local-focus-restore",
   "invariant.render-projection-read-only",
 };
@@ -1680,6 +1834,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds9_0[] = {
   "harness.render-projection-read-only-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs9_0[] = {
+  "ACTION_TOGGLE_MODE",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations9_0[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"identity.file.stable-key", "File identity remains durable across payload or view-shape changes."},
@@ -1687,6 +1845,7 @@ static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTr
 };
 
 static const char *const kAppStateTransitionSequenceStepInvariantIds9_1[] = {
+  "invariant.inactive-panel-frozen",
   "invariant.panel-local-focus-restore",
   "invariant.render-projection-read-only",
 };
@@ -1694,6 +1853,10 @@ static const char *const kAppStateTransitionSequenceStepInvariantIds9_1[] = {
 static const char *const kAppStateTransitionSequenceStepDiffHarnessIds9_1[] = {
   "harness.declared-write-set-diff",
   "harness.render-projection-read-only-diff",
+};
+
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs9_1[] = {
+  "ACTION_VIEW_PREVIEW",
 };
 
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations9_1[] = {
@@ -1708,6 +1871,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_TOGGLE_MODE",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs9_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs9_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs9_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds9_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds9_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds9_0[0]),
@@ -1723,6 +1890,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_VIEW_PREVIEW",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs9_1,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs9_1) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs9_1[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds9_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds9_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds9_1[0]),
@@ -1745,6 +1916,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds10_0[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs10_0[] = {
+  "ACTION_VOL_NEXT",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations10_0[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
@@ -1761,6 +1936,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds10_1[] = {
   "harness.generation-mismatch-check",
 };
 
+static const char *const kAppStateTransitionSequenceStepEventCoverageRefs10_1[] = {
+  "event.volume-lifecycle",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations10_1[] = {
   {"generation.volume.shared-authority", "Volume generation advances only for declared shared-volume mutations."},
   {"lifecycle.volume.registry", "Volume lifecycle generation validates before rebinding panels."},
@@ -1773,6 +1952,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.volume-operation.release-cycle",
    "ACTION_VOL_NEXT",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs10_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs10_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs10_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds10_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds10_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds10_0[0]),
@@ -1788,6 +1971,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.volume-operation.release-cycle",
    NULL,
    "event.volume-lifecycle",
+   NULL,
+   0,
+   kAppStateTransitionSequenceStepEventCoverageRefs10_1,
+   sizeof(kAppStateTransitionSequenceStepEventCoverageRefs10_1) / sizeof(kAppStateTransitionSequenceStepEventCoverageRefs10_1[0]),
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds10_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds10_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds10_1[0]),
@@ -1811,6 +1998,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds11_0[] = {
   "harness.render-projection-read-only-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs11_0[] = {
+  "ACTION_SPLIT_SCREEN",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations11_0[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
@@ -1828,6 +2019,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds11_1[] = {
   "harness.declared-write-set-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs11_1[] = {
+  "ACTION_SPLIT_SCREEN",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations11_1[] = {
   {"generation.panel.local-authority", "Validate panel generation before and after the step; advance only when the transition declares panel-local writes."},
   {"shape.panel.focus", "Preserve or rebind focus shape only through the transition result."},
@@ -1840,6 +2035,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_SPLIT_SCREEN",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs11_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs11_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs11_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds11_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds11_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds11_0[0]),
@@ -1855,6 +2054,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.keybinding.navigate-tree",
    "ACTION_SPLIT_SCREEN",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs11_1,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs11_1) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs11_1[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds11_1,
    sizeof(kAppStateTransitionSequenceStepInvariantIds11_1) / sizeof(kAppStateTransitionSequenceStepInvariantIds11_1[0]),
@@ -1876,6 +2079,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds12_0[] = {
   "harness.generation-mismatch-check",
 };
 
+static const char *const kAppStateTransitionSequenceStepEventCoverageRefs12_0[] = {
+  "event.terminal-resize-signal",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations12_0[] = {
   {"reflow.layout.projection", "Layout reflow generation changes only through the resize transition."},
   {"generation.panel.local-authority", "Panel generation validates before viewport rebind after resize."},
@@ -1889,6 +2096,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.terminal-signal-resize",
    NULL,
    "event.terminal-resize-signal",
+   NULL,
+   0,
+   kAppStateTransitionSequenceStepEventCoverageRefs12_0,
+   sizeof(kAppStateTransitionSequenceStepEventCoverageRefs12_0) / sizeof(kAppStateTransitionSequenceStepEventCoverageRefs12_0[0]),
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds12_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds12_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds12_0[0]),
@@ -1910,6 +2121,10 @@ static const char *const kAppStateTransitionSequenceStepDiffHarnessIds13_0[] = {
   "harness.render-projection-read-only-diff",
 };
 
+static const char *const kAppStateTransitionSequenceStepEventCoverageRefs13_0[] = {
+  "event.render-reflow",
+};
+
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations13_0[] = {
   {"reflow.layout.projection", "Render projection consumes layout reflow state without claiming owner authority."},
   {"generation.panel.local-authority", "Panel generation remains an input to projection, not a render-owned mutation."},
@@ -1922,6 +2137,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.render-reflow.project-state",
    NULL,
    "event.render-reflow",
+   NULL,
+   0,
+   kAppStateTransitionSequenceStepEventCoverageRefs13_0,
+   sizeof(kAppStateTransitionSequenceStepEventCoverageRefs13_0) / sizeof(kAppStateTransitionSequenceStepEventCoverageRefs13_0[0]),
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds13_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds13_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds13_0[0]),
@@ -1934,7 +2153,6 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    NULL},
 };
 
-
 static const char *const kAppStateTransitionSequenceStepInvariantIds14_0[] = {
   "invariant.inactive-panel-frozen",
   "invariant.panel-local-focus-restore",
@@ -1943,6 +2161,10 @@ static const char *const kAppStateTransitionSequenceStepInvariantIds14_0[] = {
 
 static const char *const kAppStateTransitionSequenceStepDiffHarnessIds14_0[] = {
   "harness.declared-write-set-diff",
+};
+
+static const char *const kAppStateTransitionSequenceStepActionCoverageRefs14_0[] = {
+  "ACTION_VOL_MENU",
 };
 
 static const AppStateTransitionSequenceGenerationExpectationMetadata kAppStateTransitionSequenceStepGenerationExpectations14_0[] = {
@@ -1957,6 +2179,10 @@ static const AppStateTransitionSequenceStepMetadata kAppStateTransitionSequenceS
    "transition.menu-action.volume-select",
    "ACTION_VOL_MENU",
    NULL,
+   kAppStateTransitionSequenceStepActionCoverageRefs14_0,
+   sizeof(kAppStateTransitionSequenceStepActionCoverageRefs14_0) / sizeof(kAppStateTransitionSequenceStepActionCoverageRefs14_0[0]),
+   NULL,
+   0,
    "allowed",
    kAppStateTransitionSequenceStepInvariantIds14_0,
    sizeof(kAppStateTransitionSequenceStepInvariantIds14_0) / sizeof(kAppStateTransitionSequenceStepInvariantIds14_0[0]),

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -287,6 +287,22 @@ static int StringListContains(const char *const *values, size_t count,
   return 0;
 }
 
+static int StringListsOverlap(const char *const *left, size_t left_count,
+                              const char *const *right, size_t right_count) {
+  size_t index;
+
+  if (!NonEmptyStringList(left, left_count) ||
+      !NonEmptyStringList(right, right_count))
+    return 0;
+
+  for (index = 0; index < left_count; index++) {
+    if (StringListContains(right, right_count, left[index]))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateExpectedResultValid(const char *expected_result) {
   return strcmp(expected_result, "allowed") == 0 ||
          strcmp(expected_result, "blocked") == 0 ||
@@ -318,6 +334,22 @@ static const char *AppStateEventTransitionLookup(const char *event_id) {
     return NULL;
 
   return coverage->transition_id;
+}
+
+static const AppStateActionCoverageMetadata *
+AppStateActionCoverageIdLookup(const char *action_id) {
+  size_t index;
+
+  if (!NonEmptyString(action_id))
+    return NULL;
+
+  for (index = 0; index < sizeof(kAppStateActionIds) / sizeof(kAppStateActionIds[0]);
+       index++) {
+    if (strcmp(kAppStateActionIds[index].action_id, action_id) == 0)
+      return AppStateActionCoverageLookup(kAppStateActionIds[index].action);
+  }
+
+  return NULL;
 }
 
 static int AppStateFallbackPreconditionValid(const char *precondition) {
@@ -372,6 +404,56 @@ static int AppStateTransitionSequenceStepInvariantCoversTransition(
   }
 
   return 0;
+}
+
+static int AppStateTransitionSequenceStepGenerationDomainOverlaps(
+    const AppStateTransitionSequenceStepMetadata *step,
+    const char *const *coverage_domain_refs, size_t coverage_domain_ref_count) {
+  size_t ref_index;
+
+  if (step == NULL || step->generation_domain_expectations == NULL ||
+      step->generation_domain_expectation_count == 0 ||
+      !NonEmptyStringList(coverage_domain_refs, coverage_domain_ref_count))
+    return 0;
+
+  for (ref_index = 0; ref_index < step->generation_domain_expectation_count;
+       ref_index++) {
+    const AppStateTransitionSequenceGenerationExpectationMetadata *expectation =
+        &step->generation_domain_expectations[ref_index];
+
+    if (!NonEmptyString(expectation->domain_id))
+      return 0;
+    if (StringListContains(coverage_domain_refs, coverage_domain_ref_count,
+                           expectation->domain_id))
+      return 1;
+  }
+
+  return 0;
+}
+
+static int AppStateTransitionSequenceStepCoverageOverlaps(
+    const AppStateTransitionSequenceStepMetadata *step,
+    const char *const *coverage_invariant_refs, size_t coverage_invariant_ref_count,
+    const char *const *coverage_diff_harness_refs,
+    size_t coverage_diff_harness_ref_count,
+    const char *const *coverage_generation_domain_refs,
+    size_t coverage_generation_domain_ref_count) {
+  if (step == NULL)
+    return 0;
+  if (!StringListsOverlap(step->invariant_ids, step->invariant_id_count,
+                          coverage_invariant_refs,
+                          coverage_invariant_ref_count))
+    return 0;
+  if (!StringListsOverlap(step->diff_harness_ids, step->diff_harness_id_count,
+                          coverage_diff_harness_refs,
+                          coverage_diff_harness_ref_count))
+    return 0;
+  if (!AppStateTransitionSequenceStepGenerationDomainOverlaps(
+          step, coverage_generation_domain_refs,
+          coverage_generation_domain_ref_count))
+    return 0;
+
+  return 1;
 }
 
 static int AppStateTransitionSequenceStepRequiresNoUnrelatedMutation(
@@ -443,12 +525,63 @@ static int AppStateTransitionSequenceStepReady(
     if (action_metadata == NULL ||
         strcmp(action_metadata->transition_id, step->transition_id) != 0)
       return 0;
+    if (!NonEmptyStringList(step->action_coverage_refs,
+                            step->action_coverage_ref_count))
+      return 0;
+  } else if (step->action_coverage_refs != NULL ||
+             step->action_coverage_ref_count != 0) {
+    return 0;
   }
   if (step->stimulus_event_id != NULL) {
     const char *event_transition =
         AppStateEventTransitionLookup(step->stimulus_event_id);
 
     if (event_transition == NULL || strcmp(event_transition, step->transition_id) != 0)
+      return 0;
+    if (!NonEmptyStringList(step->event_coverage_refs,
+                            step->event_coverage_ref_count))
+      return 0;
+  } else if (step->event_coverage_refs != NULL ||
+             step->event_coverage_ref_count != 0) {
+    return 0;
+  }
+
+  for (ref_index = 0; ref_index < step->action_coverage_ref_count; ref_index++) {
+    const AppStateActionCoverageMetadata *coverage =
+        AppStateActionCoverageIdLookup(step->action_coverage_refs[ref_index]);
+
+    if (coverage == NULL ||
+        strcmp(step->action_coverage_refs[ref_index],
+               step->stimulus_action_id) != 0 ||
+        strcmp(coverage->transition_id, step->transition_id) != 0)
+      return 0;
+    if (!AppStateTransitionSequenceStepCoverageOverlaps(
+            step, coverage->invariant_refs, coverage->invariant_ref_count,
+            coverage->diff_harness_refs, coverage->diff_harness_ref_count,
+            coverage->generation_domain_refs,
+            coverage->generation_domain_ref_count))
+      return 0;
+    if (StringListContains(step->action_coverage_refs, ref_index,
+                           step->action_coverage_refs[ref_index]))
+      return 0;
+  }
+  for (ref_index = 0; ref_index < step->event_coverage_ref_count; ref_index++) {
+    const AppStateEventCoverageMetadata *coverage =
+        AppStateEventCoverageLookup(step->event_coverage_refs[ref_index]);
+
+    if (coverage == NULL ||
+        strcmp(step->event_coverage_refs[ref_index], step->stimulus_event_id) !=
+            0 ||
+        strcmp(coverage->transition_id, step->transition_id) != 0)
+      return 0;
+    if (!AppStateTransitionSequenceStepCoverageOverlaps(
+            step, coverage->invariant_refs, coverage->invariant_ref_count,
+            coverage->diff_harness_refs, coverage->diff_harness_ref_count,
+            coverage->generation_domain_refs,
+            coverage->generation_domain_ref_count))
+      return 0;
+    if (StringListContains(step->event_coverage_refs, ref_index,
+                           step->event_coverage_refs[ref_index]))
       return 0;
   }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -592,6 +592,8 @@ def _sequence_step(
     event_id: str | None = None,
     invariant_ids: list[str] | None = None,
     diff_harness_ids: list[str] | None = None,
+    action_coverage_refs: list[str] | None = None,
+    event_coverage_refs: list[str] | None = None,
     generation_domain_id: str = "domain.panel_generation",
     expected_result: str = "allowed",
 ) -> dict[str, object]:
@@ -605,6 +607,16 @@ def _sequence_step(
         "step_id": f"step.{ordinal}",
         "transition_id": transition_id,
         "stimulus": stimulus,
+        "action_coverage_refs": (
+            action_coverage_refs
+            if action_coverage_refs is not None
+            else ([action_id] if action_id is not None else [])
+        ),
+        "event_coverage_refs": (
+            event_coverage_refs
+            if event_coverage_refs is not None
+            else ([event_id] if event_id is not None else [])
+        ),
         "expected_result": expected_result,
         "invariant_ids": invariant_ids or ["invariant.inactive_panel_frozen"],
         "diff_harness_ids": diff_harness_ids
@@ -634,6 +646,7 @@ def _complete_transition_sequences() -> list[dict[str, object]]:
             action_id=None,
             event_id="event.modal_completion",
             invariant_ids=["invariant.blocked_transition_determinism"],
+            diff_harness_ids=["harness.declared_write_set_diff"],
         ),
         "filesystem_mutation_result": _sequence_step(
             transition_id="transition.filesystem_mutation_result",
@@ -646,42 +659,55 @@ def _complete_transition_sequences() -> list[dict[str, object]]:
             action_id=None,
             event_id="event.command_completion",
             invariant_ids=["invariant.blocked_transition_determinism"],
+            diff_harness_ids=["harness.declared_write_set_diff"],
+            generation_domain_id="domain.modal_command_target",
         ),
         "volume_menu_select": _sequence_step(
             transition_id="transition.menu_action",
             action_id="ACTION_VOL_MENU",
-            invariant_ids=["invariant.blocked_transition_determinism"],
+            invariant_ids=["invariant.shared_state_panel_local_isolation"],
+            diff_harness_ids=["harness.declared_write_set_diff"],
         ),
         "refresh_rebuild": _sequence_step(
             transition_id="transition.refresh_rebuild",
             action_id=None,
             event_id="event.refresh_rebuild",
-            invariant_ids=["invariant.blocked_transition_determinism"],
+            invariant_ids=[
+                "invariant.blocked_transition_determinism",
+                "invariant.hidden_entry_visible_navigation",
+            ],
         ),
         "rebuild_rebind_callback": _sequence_step(
             ordinal=2,
             transition_id="transition.rebuild_rebind_callback",
             action_id=None,
             event_id="event.rebuild_rebind_callback",
-            invariant_ids=["invariant.blocked_transition_determinism"],
+            invariant_ids=[
+                "invariant.blocked_transition_determinism",
+                "invariant.hidden_entry_visible_navigation",
+            ],
         ),
         "render_reflow_projection": _sequence_step(
             transition_id="transition.render_reflow",
             action_id=None,
             event_id="event.render_reflow",
-            invariant_ids=["invariant.blocked_transition_determinism"],
+            invariant_ids=["invariant.render_projection_read_only"],
+            diff_harness_ids=["harness.render_projection_read_only_diff"],
+            generation_domain_id="domain.layout_reflow",
         ),
         "terminal_resize_reflow": _sequence_step(
             transition_id="transition.terminal_signal_or_resize",
             action_id=None,
             event_id="event.terminal_resize_signal",
-            invariant_ids=["invariant.blocked_transition_determinism"],
+            invariant_ids=["invariant.render_projection_read_only"],
+            diff_harness_ids=["harness.generation_mismatch_check"],
+            generation_domain_id="domain.layout_reflow",
         ),
         "volume_cycling_release": _sequence_step(
             transition_id="transition.volume_operation",
             action_id=None,
             event_id="event.volume_lifecycle",
-            invariant_ids=["invariant.blocked_transition_determinism"],
+            invariant_ids=["invariant.shared_state_panel_local_isolation"],
         ),
     }
     return [
@@ -1562,6 +1588,48 @@ def _runtime_source(
             event_id = stimulus.get("event_id")
             action_expr = f'"{action_id}"' if isinstance(action_id, str) else "NULL"
             event_expr = f'"{event_id}"' if isinstance(event_id, str) else "NULL"
+            action_coverage_refs = step.get("action_coverage_refs")
+            if isinstance(action_coverage_refs, list) and action_coverage_refs:
+                action_sequence_ref_rows = "\n".join(
+                    f'  "{ref}",'
+                    for ref in action_coverage_refs
+                    if isinstance(ref, str)
+                )
+                action_coverage_table = (
+                    "kAppStateTransitionSequenceStepActionCoverageRefs"
+                    f"{sequence_index}_{step_index}"
+                )
+                transition_sequence_arrays.append(
+                    f"static const char *const {action_coverage_table}[] = "
+                    f"{{\n{action_sequence_ref_rows}\n}};\n"
+                )
+                action_coverage_ref_expr = (
+                    f"{action_coverage_table}, sizeof({action_coverage_table}) / "
+                    f"sizeof({action_coverage_table}[0])"
+                )
+            else:
+                action_coverage_ref_expr = "NULL, 0"
+            event_coverage_refs = step.get("event_coverage_refs")
+            if isinstance(event_coverage_refs, list) and event_coverage_refs:
+                event_sequence_ref_rows = "\n".join(
+                    f'  "{ref}",'
+                    for ref in event_coverage_refs
+                    if isinstance(ref, str)
+                )
+                event_coverage_table = (
+                    "kAppStateTransitionSequenceStepEventCoverageRefs"
+                    f"{sequence_index}_{step_index}"
+                )
+                transition_sequence_arrays.append(
+                    f"static const char *const {event_coverage_table}[] = "
+                    f"{{\n{event_sequence_ref_rows}\n}};\n"
+                )
+                event_coverage_ref_expr = (
+                    f"{event_coverage_table}, sizeof({event_coverage_table}) / "
+                    f"sizeof({event_coverage_table}[0])"
+                )
+            else:
+                event_coverage_ref_expr = "NULL, 0"
             precondition = step.get("precondition")
             precondition_expr = (
                 f'"{precondition}"' if isinstance(precondition, str) else "NULL"
@@ -1569,6 +1637,7 @@ def _runtime_source(
             step_rows.append(
                 f'  {{{step.get("ordinal", 0)}, "{step.get("step_id", "")}", '
                 f'"{step.get("transition_id", "")}", {action_expr}, {event_expr}, '
+                f"{action_coverage_ref_expr}, {event_coverage_ref_expr}, "
                 f'"{step.get("expected_result", "")}", '
                 f"{invariant_table}, sizeof({invariant_table}) / "
                 f"sizeof({invariant_table}[0]), "
@@ -2449,6 +2518,238 @@ def test_guard_fails_when_transition_sequence_event_mismatches_transition(
     )
 
 
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    (
+        ("missing_action", "action_coverage_refs must be a list"),
+        ("malformed_action", "action_coverage_refs must be a list"),
+        ("duplicate_action", "duplicate action_coverage_refs"),
+        ("unknown_action", "unknown action coverage record"),
+        ("wrong_kind_action", "event_coverage_refs must be empty"),
+        ("stimulus_mismatch_action", "does not match stimulus ACTION_NONE"),
+        ("mixed_action", "does not match stimulus ACTION_NONE"),
+        ("missing_event", "event_coverage_refs must be a list"),
+        ("malformed_event", "event_coverage_refs must be a list"),
+        ("duplicate_event", "duplicate event_coverage_refs"),
+        ("unknown_event", "unknown event coverage record"),
+        ("wrong_kind_event", "action_coverage_refs must be empty"),
+        ("stimulus_mismatch_event", "does not match stimulus event.modal_completion"),
+        ("mixed_event", "does not match stimulus event.modal_completion"),
+    ),
+)
+def test_guard_fails_on_transition_sequence_step_coverage_refs(
+    tmp_path: Path, mutation: str, expected: str
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    action_step = transition_sequences[0]["steps"][0]
+    event_step = transition_sequences[0]["steps"][0] = _sequence_step(
+        transition_id="transition.modal_action",
+        action_id=None,
+        event_id="event.modal_completion",
+        invariant_ids=["invariant.blocked_transition_determinism"],
+    )
+    target_step = action_step
+
+    if mutation == "missing_action":
+        action_step.pop("action_coverage_refs")
+        target_step = action_step
+    elif mutation == "malformed_action":
+        action_step["action_coverage_refs"] = "ACTION_NONE"
+        target_step = action_step
+    elif mutation == "duplicate_action":
+        action_step["action_coverage_refs"] = ["ACTION_NONE", "ACTION_NONE"]
+        target_step = action_step
+    elif mutation == "unknown_action":
+        action_step["action_coverage_refs"] = ["ACTION_MISSING"]
+        target_step = action_step
+    elif mutation == "wrong_kind_action":
+        action_step["event_coverage_refs"] = ["event.modal_completion"]
+        target_step = action_step
+    elif mutation == "stimulus_mismatch_action":
+        action_step["action_coverage_refs"] = ["ACTION_VOL_MENU"]
+        target_step = action_step
+    elif mutation == "mixed_action":
+        action_step["action_coverage_refs"] = ["ACTION_NONE", "ACTION_VOL_MENU"]
+        target_step = action_step
+    elif mutation == "missing_event":
+        event_step.pop("event_coverage_refs")
+    elif mutation == "malformed_event":
+        event_step["event_coverage_refs"] = "event.modal_completion"
+    elif mutation == "duplicate_event":
+        event_step["event_coverage_refs"] = [
+            "event.modal_completion",
+            "event.modal_completion",
+        ]
+    elif mutation == "unknown_event":
+        event_step["event_coverage_refs"] = ["event.missing"]
+    elif mutation == "wrong_kind_event":
+        event_step["action_coverage_refs"] = ["ACTION_NONE"]
+    elif mutation == "stimulus_mismatch_event":
+        event_step["event_coverage_refs"] = ["event.refresh_rebuild"]
+    elif mutation == "mixed_event":
+        event_step["event_coverage_refs"] = [
+            "event.modal_completion",
+            "event.refresh_rebuild",
+        ]
+    else:
+        raise AssertionError(mutation)
+
+    if mutation.endswith("action"):
+        transition_sequences[0]["steps"][0] = target_step
+
+    paths = _write_fixture(
+        tmp_path, transitions=transitions, transition_sequences=transition_sequences
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure and expected in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("record_type", "expected"),
+    (
+        ("action", "action_coverage_refs[0] transition_id does not match"),
+        ("event", "event_coverage_refs[0] transition_id does not match"),
+    ),
+)
+def test_guard_fails_when_sequence_step_coverage_ref_transition_mismatches(
+    tmp_path: Path, record_type: str, expected: str
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    actions = _complete_actions()
+    events = _complete_events()
+    if record_type == "action":
+        for action in actions:
+            if action["action"] == "ACTION_NONE":
+                action["transition_id"] = "transition.refresh_rebuild"
+                break
+    else:
+        transition_sequences[0]["steps"][0] = _sequence_step(
+            transition_id="transition.modal_action",
+            action_id=None,
+            event_id="event.modal_completion",
+            invariant_ids=["invariant.blocked_transition_determinism"],
+        )
+        for event in events:
+            if event["event_id"] == "event.modal_completion":
+                event["transition_id"] = "transition.refresh_rebuild"
+                break
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        actions=actions,
+        events=events,
+        transition_sequences=transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure and expected in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("coverage_field", "replacement_refs", "expected"),
+    (
+        (
+            "invariant_refs",
+            ["invariant.blocked_transition_determinism"],
+            "invariant_refs must overlap step invariant_ids",
+        ),
+        (
+            "diff_harness_refs",
+            ["harness.generation_mismatch_check"],
+            "diff_harness_refs must overlap step diff_harness_ids",
+        ),
+        (
+            "generation_domain_refs",
+            ["domain.focus_shape"],
+            "generation_domain_refs must overlap step generation_domain_expectations",
+        ),
+    ),
+)
+def test_guard_fails_when_sequence_step_action_coverage_lacks_semantic_overlap(
+    tmp_path: Path,
+    coverage_field: str,
+    replacement_refs: list[str],
+    expected: str,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    for action in actions:
+        if action["action"] == "ACTION_NONE":
+            action[coverage_field] = replacement_refs
+            break
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        actions=actions,
+        transition_sequences=_complete_transition_sequences(),
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "action_coverage_refs[0] ACTION_NONE" in failure
+        and expected in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_mixed_sequence_step_coverage_lacks_semantic_overlap(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    for action in actions:
+        if action["action"] == "ACTION_NONE":
+            action["transition_id"] = "transition.modal_action"
+            action["category"] = "modal_action"
+            action["invariant_refs"] = ["invariant.blocked_transition_determinism"]
+            action["diff_harness_refs"] = ["harness.declared_write_set_diff"]
+            action["generation_domain_refs"] = ["domain.panel_generation"]
+            break
+    events = _complete_events()
+    for event in events:
+        if event["event_id"] == "event.modal_completion":
+            event["invariant_refs"] = ["invariant.inactive_panel_frozen"]
+            break
+    transition_sequences = _complete_transition_sequences()
+    transition_sequences[0]["steps"][0] = _sequence_step(
+        transition_id="transition.modal_action",
+        action_id="ACTION_NONE",
+        event_id="event.modal_completion",
+        invariant_ids=["invariant.blocked_transition_determinism"],
+        diff_harness_ids=["harness.declared_write_set_diff"],
+        generation_domain_id="domain.panel_generation",
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        actions=actions,
+        events=events,
+        transition_sequences=transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition_sequence[0].step[0]" in failure
+        and "event_coverage_refs[0] event.modal_completion" in failure
+        and "invariant_refs must overlap step invariant_ids" in failure
+        for failure in failures
+    )
+
+
 @pytest.mark.parametrize("precondition", ("stale_snapshot", "generation_mismatch"))
 def test_guard_fails_when_transition_sequence_fallback_expectation_is_missing(
     tmp_path: Path, precondition: str
@@ -2761,6 +3062,128 @@ def test_guard_fails_on_runtime_transition_sequence_invalid_links(
 
     assert any(
         "runtime_transition_sequence[0].step[0]" in failure
+        and expected in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_coverage_refs_drift(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences = copy.deepcopy(transition_sequences)
+    runtime_transition_sequences[0]["steps"][0]["action_coverage_refs"] = [
+        "ACTION_VOL_MENU"
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        transition_sequences=transition_sequences,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0]" in failure
+        and "runtime steps does not match transition sequence" in failure
+        and "ACTION_VOL_MENU" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_coverage_ref_is_malformed(
+    tmp_path: Path,
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    runtime_path = paths[-1]
+    runtime_path.write_text(
+        runtime_path.read_text(encoding="utf-8").replace(
+            'static const char *const kAppStateTransitionSequenceStepActionCoverageRefs0_0[] = {\n'
+            '  "ACTION_NONE",',
+            'static const char *const kAppStateTransitionSequenceStepActionCoverageRefs0_0[] = {\n'
+            "  NULL,\n"
+            '  "ACTION_NONE",',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "kAppStateTransitionSequenceStepActionCoverageRefs0_0[0]" in failure
+        and "malformed string literal entry" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_sequence_coverage_ref_mismatches_stimulus(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences = copy.deepcopy(transition_sequences)
+    for sequences in (transition_sequences, runtime_transition_sequences):
+        sequences[0]["steps"][0]["action_coverage_refs"] = ["ACTION_VOL_MENU"]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        transition_sequences=transition_sequences,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0].step[0]" in failure
+        and "action_coverage_refs[0] ACTION_VOL_MENU does not match stimulus ACTION_NONE"
+        in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    (
+        (
+            "invariant_ids",
+            ["invariant.blocked_transition_determinism"],
+            "invariant_refs must overlap step invariant_ids",
+        ),
+        (
+            "diff_harness_ids",
+            ["harness.generation_mismatch_check"],
+            "diff_harness_refs must overlap step diff_harness_ids",
+        ),
+        (
+            "generation_domain_expectations",
+            [{"domain_id": "domain.modal_command_target", "expectation": "fixture"}],
+            "generation_domain_refs must overlap step generation_domain_expectations",
+        ),
+    ),
+)
+def test_guard_fails_when_runtime_transition_sequence_coverage_lacks_semantic_overlap(
+    tmp_path: Path, field: str, value: object, expected: str
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences = copy.deepcopy(transition_sequences)
+    for sequences in (transition_sequences, runtime_transition_sequences):
+        sequences[0]["steps"][0][field] = value
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        transition_sequences=transition_sequences,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition_sequence[0].step[0]" in failure
+        and "action_coverage_refs[0] ACTION_NONE" in failure
         and expected in failure
         for failure in failures
     )
@@ -3096,6 +3519,23 @@ def test_runtime_transition_sequence_startup_checks_fail_closed() -> None:
     assert "AppStateTransitionSequenceStepDiffHarnessCoversTransition" in source
     assert "!AppStateTransitionSequenceStepDiffHarnessCoversTransition(step)" in source
     assert "AppStateGenerationDomainLookup(expectation->domain_id) == NULL" in source
+    assert "AppStateActionCoverageIdLookup(step->action_coverage_refs[ref_index])" in source
+    assert "AppStateEventCoverageLookup(step->event_coverage_refs[ref_index])" in source
+    assert "AppStateTransitionSequenceStepCoverageOverlaps" in source
+    assert "StringListsOverlap(step->invariant_ids, step->invariant_id_count" in source
+    assert "StringListsOverlap(step->diff_harness_ids, step->diff_harness_id_count" in source
+    assert "AppStateTransitionSequenceStepGenerationDomainOverlaps" in source
+    assert "coverage->generation_domain_refs" in source
+    assert "step->action_coverage_ref_count" in source
+    assert "step->event_coverage_ref_count" in source
+    assert (
+        "step->action_coverage_refs != NULL ||\n"
+        "             step->action_coverage_ref_count != 0"
+    ) in source
+    assert (
+        "step->event_coverage_refs != NULL ||\n"
+        "             step->event_coverage_ref_count != 0"
+    ) in source
     assert "!AppStateTransitionSequencesReady()" in source
 
 


### PR DESCRIPTION
## Summary
- Require AppState transition-sequence steps to reference canonical action/event coverage records.
- Add semantic overlap checks for sequence-step invariants, diff harnesses, and generation-domain expectations.
- Extend runtime metadata, startup readiness checks, and drift guards for sequence-step coverage refs.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'sequence_coverage_refs or sequence_step or transition_sequence or action_coverage or event_coverage or readiness'` — PASS
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing unrelated warnings
- `git diff --check` — PASS
