### PR TITLE
chore(appstate): guard event coverage boundary

### DIFF
--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -240,6 +240,7 @@ AppStateActionCoverageLookup(YtreeNovaAction action);
 YtreeNovaAction AppStateValidatedKeyAction(YtreeNovaAction action);
 const AppStateActionCoverageMetadata *AppStateActionCoverageAt(size_t index);
 size_t AppStateActionCoverageCount(void);
+int AppStateValidatedEvent(const char *event_id);
 const AppStateEventCoverageMetadata *
 AppStateEventCoverageLookup(const char *event_id);
 const AppStateEventCoverageMetadata *AppStateEventCoverageAt(size_t index);

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6310,6 +6310,25 @@ YtreeNovaAction AppStateValidatedKeyAction(YtreeNovaAction action) {
                                            AppStateActionCoverageLookup(action));
 }
 
+static int
+AppStateValidateEventCoverage(const char *event_id,
+                              const AppStateEventCoverageMetadata *coverage) {
+  if (event_id == NULL || event_id[0] == '\0')
+    return 0;
+  if (coverage == NULL || coverage->event_id == NULL ||
+      strcmp(coverage->event_id, event_id))
+    return 0;
+  if (AppStateTransitionLookup(coverage->transition_id) == NULL)
+    return 0;
+
+  return 1;
+}
+
+int AppStateValidatedEvent(const char *event_id) {
+  return AppStateValidateEventCoverage(event_id,
+                                       AppStateEventCoverageLookup(event_id));
+}
+
 const AppStateEventCoverageMetadata *
 AppStateEventCoverageLookup(const char *event_id) {
   size_t index;

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -22,9 +22,6 @@
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
-#if !defined(__NeXT__) && !defined(ultrix)
-#endif /* __NeXT__ ultrix */
-
 static long preview_line_offset = 0;
 static int saved_fixed_width = 0;
 

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -779,8 +779,11 @@ int GetEventOrKey(ViewContext *ctx) {
   fd_set fds;
   struct timeval tv;
 
-  if (ctx && ctx->resize_request)
+  if (ctx && ctx->resize_request) {
+    if (!AppStateValidatedEvent("event.terminal-resize-signal"))
+      return ERR;
     return KEY_RESIZE;
+  }
 
   /* Before the select loop, check the shutdown flag */
   if (ytnova_shutdown_flag)
@@ -795,8 +798,11 @@ int GetEventOrKey(ViewContext *ctx) {
     return NormalizeEscSequence(ch);
   }
 
-  if (ctx && ctx->resize_request)
+  if (ctx && ctx->resize_request) {
+    if (!AppStateValidatedEvent("event.terminal-resize-signal"))
+      return ERR;
     return KEY_RESIZE;
+  }
 
   while (1) {
     int max_fd;
@@ -835,8 +841,11 @@ int GetEventOrKey(ViewContext *ctx) {
         nodelay(stdscr, FALSE);
         if (ch != ERR)
           return NormalizeEscSequence(ch);
-        if (ctx && ctx->resize_request)
+        if (ctx && ctx->resize_request) {
+          if (!AppStateValidatedEvent("event.terminal-resize-signal"))
+            return ERR;
           return KEY_RESIZE;
+        }
 
         continue;
       }
@@ -846,6 +855,8 @@ int GetEventOrKey(ViewContext *ctx) {
     if (ctx && (ctx->refresh_mode & REFRESH_WATCHER) && w_fd >= 0 &&
         FD_ISSET(w_fd, &fds)) {
       if (Watcher_ProcessEvents(ctx)) {
+        if (!AppStateValidatedEvent("event.watcher-live-refresh"))
+          return ERR;
         return KEY_F(5);
       }
     }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4370,6 +4370,101 @@ def test_get_key_action_routes_decoded_actions_through_appstate_boundary() -> No
     assert not re.search(r"return\s+ACTION_", body)
 
 
+def test_runtime_event_boundary_validation_requires_coverage_and_transition(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "event_validation_probe.c"
+    binary = tmp_path / "event_validation_probe"
+    probe.write_text(
+        """
+#include "src/core/appstate_actions.c"
+
+int main(void) {
+  AppStateEventCoverageMetadata mismatched_event;
+  AppStateEventCoverageMetadata missing_transition;
+
+  if (!AppStateValidatedEvent("event.terminal-resize-signal"))
+    return 1;
+  if (!AppStateValidatedEvent("event.watcher-live-refresh"))
+    return 2;
+  if (AppStateValidatedEvent(NULL))
+    return 3;
+  if (AppStateValidatedEvent(""))
+    return 4;
+  if (AppStateValidatedEvent("event.__ytnova_missing__"))
+    return 5;
+
+  mismatched_event =
+      *AppStateEventCoverageLookup("event.terminal-resize-signal");
+  mismatched_event.event_id = "event.__ytnova_mismatch__";
+  if (AppStateValidateEventCoverage("event.terminal-resize-signal",
+                                    &mismatched_event))
+    return 6;
+
+  missing_transition =
+      *AppStateEventCoverageLookup("event.terminal-resize-signal");
+  missing_transition.transition_id = "transition.__ytnova_missing__";
+  if (AppStateValidateEventCoverage("event.terminal-resize-signal",
+                                    &missing_transition))
+    return 7;
+
+  return 0;
+}
+""",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            "gcc",
+            "-std=c99",
+            "-I.",
+            "-Iinclude",
+            str(probe),
+            "-o",
+            str(binary),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0, build.stdout + build.stderr
+    run = subprocess.run(
+        [str(binary)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_get_event_or_key_event_boundary_routes_synthetic_events() -> None:
+    source = Path("src/ui/key_engine.c").read_text(encoding="utf-8")
+    start = source.index("int GetEventOrKey(")
+    end = source.index("\nint UI_AskConflict(", start)
+    body = source[start:end]
+
+    resize_blocks = re.findall(
+        r'if \(ctx && ctx->resize_request\) \{\n(?P<body>.*?\n  })',
+        body,
+        flags=re.S,
+    )
+    assert len(resize_blocks) == 3
+    for block in resize_blocks:
+        assert 'AppStateValidatedEvent("event.terminal-resize-signal")' in block
+        assert block.index("return ERR;") < block.index("return KEY_RESIZE;")
+
+    assert re.search(
+        r'if \(Watcher_ProcessEvents\(ctx\)\) \{\s+'
+        r'if \(!AppStateValidatedEvent\("event\.watcher-live-refresh"\)\)\s+'
+        r"return ERR;\s+return KEY_F\(5\);",
+        body,
+    )
+
+
 def test_guard_fails_when_required_generation_domain_category_is_missing(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a narrow AppState validation boundary for synthetic non-key events
- require resize and watcher refresh events to have event coverage and transition metadata before legacy key stand-ins are emitted
- fail closed without synthesizing a legacy key when event metadata is missing or inconsistent

## Validation
- targeted AppState event-boundary tests pass
- full AppState contract guard tests pass
- AppState contract guard script passes
- local build passes with existing unrelated warnings
- code audit passed
