### PR TITLE
chore(appstate): guard modal dispatch boundary

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1414,3 +1414,10 @@ Ordering policy (for all editors, including AI editors):
 *   **Config:** Add a `ytnova.conf` switch for trash-delete with default `1` (enabled).
 *   **Fallback:** If trash-delete is disabled or unsupported for the active backend, use permanent delete with explicit confirmation.
 *   - [ ] **Status:** Not Started.
+
+### **Idea FE-41: Port to other platforms**
+*   **Validation:** Currently practical via WSL and QEMU
+*   **Possible:** OmniOS (illumos)
+*   **Possible but impractical for maintainers right now:**  macOS, AIX, OpenVMS, Solaris
+*   **Out of scope:** Windows (ZTreeWin exists), legacy UNIXes including HP-UX
+*   - [ ] **Status:** Not Started.

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -231,6 +231,9 @@ int VisualPositionToBytePosition(const char *str, int visual_pos) {
 int InputChoice(ViewContext *ctx, const char *msg, const char *term) {
   int c;
 
+  if (!AppStateValidatedDispatchSurface("surface.menu-modal-completion"))
+    return ERR;
+
   ClearHelp(ctx);
 
   curs_set(1);
@@ -261,6 +264,9 @@ int InputChoice(ViewContext *ctx, const char *msg, const char *term) {
 
 int InputChoiceLiteral(ViewContext *ctx, const char *msg, const char *term) {
   int c;
+
+  if (!AppStateValidatedDispatchSurface("surface.menu-modal-completion"))
+    return ERR;
 
   ClearHelp(ctx);
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4375,26 +4375,28 @@ int main(void) {
 
   if (!AppStateValidatedDispatchSurface("surface.key-decode-input-dispatch"))
     return 1;
-  if (AppStateValidatedDispatchSurface(NULL))
+  if (!AppStateValidatedDispatchSurface("surface.menu-modal-completion"))
     return 2;
-  if (AppStateValidatedDispatchSurface(""))
+  if (AppStateValidatedDispatchSurface(NULL))
     return 3;
-  if (AppStateValidatedDispatchSurface("surface.__ytnova_missing__"))
+  if (AppStateValidatedDispatchSurface(""))
     return 4;
+  if (AppStateValidatedDispatchSurface("surface.__ytnova_missing__"))
+    return 5;
 
   mismatched_surface =
       *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
   mismatched_surface.surface_id = "surface.__ytnova_mismatch__";
   if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
                                       &mismatched_surface))
-    return 5;
+    return 6;
 
   missing_transition =
       *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
   missing_transition.transition_id = "transition.__ytnova_missing__";
   if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
                                       &missing_transition))
-    return 6;
+    return 7;
 
   return 0;
 }
@@ -4426,6 +4428,25 @@ int main(void) {
         check=False,
     )
     assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_input_choice_modal_completion_fails_closed_on_invalid_surface() -> None:
+    source = Path("src/ui/key_engine.c").read_text(encoding="utf-8")
+
+    assert 'include "ytnova_appstate_actions.h"' in source
+    for function_name in ("InputChoice", "InputChoiceLiteral"):
+        start = source.index(f"int {function_name}(")
+        next_function = source.index("\nint ", start + 1)
+        body = source[start:next_function]
+        validation = (
+            'if (!AppStateValidatedDispatchSurface("surface.menu-modal-completion"))'
+        )
+
+        assert validation in body
+        assert "return ERR;" in body
+        assert body.index(validation) < body.index("ClearHelp(ctx);")
+        assert body.index("return ERR;") < body.index("ClearHelp(ctx);")
+        assert body.index(validation) < body.index("WGetch(")
 
 
 def test_get_key_action_routes_decoded_actions_through_appstate_boundary() -> None:


### PR DESCRIPTION
## Summary
- Guard modal/menu choice dispatch with the existing AppState dispatch-surface validation helper.
- Fail closed before modal prompt rendering or key dispatch when modal dispatch metadata is invalid.
- Add focused contract/source guards for the modal dispatch boundary.

## Validation
- `pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or modal or menu or readiness'` — PASS, 77 passed / 548 deselected
- `python3 scripts/check_appstate_contract.py` — PASS
- `git diff --check` — PASS
- `make clean && make` — PASS with pre-existing warnings
