### PR TITLE
chore(appstate): guard command dispatch boundary

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1417,7 +1417,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Idea FE-41: Port to other platforms**
 *   **Validation:** Currently practical via WSL and QEMU
-*   **Possible:** OmniOS (illumos)
+*   **Possible:** OmniOS (illumos), GNU Hurd
 *   **Possible but impractical for maintainers right now:**  macOS, AIX, OpenVMS, Solaris
 *   **Out of scope:** Windows (ZTreeWin exists), legacy UNIXes including HP-UX
 *   - [ ] **Status:** Not Started.

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #define NO_YTNOVA_MACROS
+#include "ytnova_appstate_actions.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -516,7 +517,7 @@ BOOL handle_file_window_command_action(ViewContext *ctx, YtreeNovaAction action,
   FileEntry *new_fe_ptr = NULL;
   DirEntry *de_ptr = NULL;
   DirEntry *dest_dir_entry = NULL;
-  DirEntry *dir_entry = *dir_entry_ptr;
+  DirEntry *dir_entry = NULL;
   BOOL path_copy = FALSE;
   int term = 0;
   int get_dir_ret = 0;
@@ -527,6 +528,11 @@ BOOL handle_file_window_command_action(ViewContext *ctx, YtreeNovaAction action,
 
 #define need_dsp_help (*need_dsp_help_ptr)
 #define maybe_change_x_step (*maybe_change_x_step_ptr)
+
+  if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))
+    return FALSE;
+
+  dir_entry = *dir_entry_ptr;
 
   switch (action) {
   case ACTION_CMD_Y:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4377,6 +4377,8 @@ int main(void) {
     return 1;
   if (!AppStateValidatedDispatchSurface("surface.menu-modal-completion"))
     return 2;
+  if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))
+    return 8;
   if (AppStateValidatedDispatchSurface(NULL))
     return 3;
   if (AppStateValidatedDispatchSurface(""))
@@ -4464,6 +4466,39 @@ def test_get_key_action_routes_decoded_actions_through_appstate_boundary() -> No
     assert body.index("return ACTION_NONE;") < body.index("switch (ch)")
     assert "AppStateValidatedKeyAction(" in body
     assert not re.search(r"return\s+ACTION_(?!NONE;)", body)
+
+
+def test_command_completion_dispatch_fails_closed_before_command_work() -> None:
+    source = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    start = source.index("BOOL handle_file_window_command_action(")
+    end = source.index("\nBOOL handle_file_window_misc_dispatch_action(", start)
+    body = source[start:end]
+    validation = (
+        'if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))'
+    )
+    early_return = "return FALSE;"
+    boundary_calls = [
+        "switch (action)",
+        "GetActivePanelSelectedFile(",
+        "GetCopyParameter(",
+        "GetMoveParameter(",
+        "InputChoice(",
+        "CopyFile(",
+        "MoveFile(",
+        "DeleteFile(",
+        "RenameFile(",
+        "GetPipeCommand(",
+        "GetCommandLine(",
+        "*dir_entry_ptr =",
+    ]
+
+    assert 'include "ytnova_appstate_actions.h"' in source
+    assert validation in body
+    assert early_return in body
+    assert body.index(validation) < body.index(early_return)
+    assert body.index(early_return) < body.index("switch (action)")
+    for call in boundary_calls:
+        assert body.index(validation) < body.index(call)
 
 
 def test_runtime_event_boundary_validation_requires_coverage_and_transition(


### PR DESCRIPTION
## Summary
- Add a fail-closed AppState dispatch-surface check before file-window command handling.
- Keep existing command behavior unchanged when dispatch metadata is valid.
- Extend the AppState contract guard to pin the command dispatch boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or command_completion or command_dispatch or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS
