### PR TITLE
chore(appstate): guard render projection boundary

### DIFF
--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -10,6 +10,7 @@
 #include "../../include/ytnova_fs.h"
 #include "../../include/ytnova_panel_anchor.h"
 #include "../../include/ytnova_ui.h"
+#include "ytnova_appstate_actions.h"
 #include <assert.h>
 
 /* PrintMenuLine is removed as its functionality for drawing the static stats
@@ -682,6 +683,9 @@ static void DrawSplitSeparatorRow(ViewContext *ctx, BOOL left_big,
  * Use this to ensure all borders, stats, and content are consistent.
  */
 void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
+  if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))
+    return;
+
   const Statistic *s = &ctx->active->vol->vol_stats;
   BOOL needs_window_recreate = FALSE;
   BOOL active_big_mode;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4379,6 +4379,8 @@ int main(void) {
     return 2;
   if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))
     return 8;
+  if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))
+    return 9;
   if (AppStateValidatedDispatchSurface(NULL))
     return 3;
   if (AppStateValidatedDispatchSurface(""))
@@ -4499,6 +4501,38 @@ def test_command_completion_dispatch_fails_closed_before_command_work() -> None:
     assert body.index(early_return) < body.index("switch (action)")
     for call in boundary_calls:
         assert body.index(validation) < body.index(call)
+
+
+def test_refresh_view_render_reflow_projection_fails_closed_before_render_work() -> None:
+    source = Path("src/ui/display.c").read_text(encoding="utf-8")
+    start = source.index("void RefreshView(")
+    body = source[start:]
+    validation = (
+        'if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))'
+    )
+    early_return = "return;"
+    boundary_calls = [
+        "Layout_Recalculate(",
+        "ReCreateWindows(",
+        "DisplayMenu(",
+        "DisplayDiskStatistic(",
+        "UpdateStatsPanel(",
+        "DisplayHeaderPath(",
+        "DisplayTree(",
+        "DisplayFileWindow(",
+        "RenderInactivePanel(",
+        "UI_Dialog_RefreshAll(",
+        "ClockHandler(",
+        "doupdate(",
+    ]
+
+    assert 'include "ytnova_appstate_actions.h"' in source
+    assert validation in body
+    assert body.index(validation) < body.index(early_return)
+    assert body.index(early_return) < body.index("&ctx->active->vol->vol_stats")
+    for call in boundary_calls:
+        assert body.index(validation) < body.index(call)
+        assert body.index(early_return) < body.index(call)
 
 
 def test_runtime_event_boundary_validation_requires_coverage_and_transition(


### PR DESCRIPTION
## Summary
- Add a fail-closed AppState dispatch-surface check before render/reflow projection work.
- Keep existing RefreshView behavior unchanged when dispatch metadata is valid.
- Extend the AppState contract guard to pin the render projection boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or render_projection or render_reflow or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS
