### PR TITLE
chore(appstate): guard volume menu boundary

### DIFF
--- a/src/ui/volume_menu.c
+++ b/src/ui/volume_menu.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_cmd.h"
+#include "ytnova_appstate_actions.h"
 #include "ytnova_fs.h"
 #include "ytnova_ui.h"
 
@@ -92,6 +93,11 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
 
   /* Scrolling variables */
   int visible_lines;
+
+  if (!AppStateValidatedDispatchSurface("surface.volume-menu-selection"))
+    return -1;
+  if (!AppStateValidatedDispatchSurface("surface.volume-operation"))
+    return -1;
 
   ClearHelp(ctx);
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4381,6 +4381,10 @@ int main(void) {
     return 8;
   if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))
     return 9;
+  if (!AppStateValidatedDispatchSurface("surface.volume-menu-selection"))
+    return 10;
+  if (!AppStateValidatedDispatchSurface("surface.volume-operation"))
+    return 11;
   if (AppStateValidatedDispatchSurface(NULL))
     return 3;
   if (AppStateValidatedDispatchSurface(""))
@@ -4533,6 +4537,36 @@ def test_refresh_view_render_reflow_projection_fails_closed_before_render_work()
     for call in boundary_calls:
         assert body.index(validation) < body.index(call)
         assert body.index(early_return) < body.index(call)
+
+
+def test_select_loaded_volume_validates_volume_surfaces_before_menu_work() -> None:
+    source = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
+    start = source.index("int SelectLoadedVolume(")
+    body = source[start:]
+    validations = [
+        'if (!AppStateValidatedDispatchSurface("surface.volume-menu-selection"))',
+        'if (!AppStateValidatedDispatchSurface("surface.volume-operation"))',
+    ]
+    boundary_calls = [
+        "ClearHelp(ctx);",
+        "xmalloc(",
+        "newwin(",
+        "LogDisk(",
+        "Volume_Delete(",
+        "BuildDirEntryList(",
+        "EnsurePanelsReferenceActiveVolume(",
+        "*return_key =",
+    ]
+
+    assert 'include "ytnova_appstate_actions.h"' in source
+    for validation in validations:
+        validation_idx = body.index(validation)
+        early_return_idx = body.index("return -1;", validation_idx)
+
+        assert validation_idx < early_return_idx
+        for call in boundary_calls:
+            assert validation_idx < body.index(call)
+            assert early_return_idx < body.index(call)
 
 
 def test_runtime_event_boundary_validation_requires_coverage_and_transition(


### PR DESCRIPTION
## Summary
- Add fail-closed AppState dispatch-surface checks before volume menu selection and volume operation handling.
- Keep existing SelectLoadedVolume behavior unchanged when dispatch metadata is valid.
- Extend the AppState contract guard to pin the volume menu boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or volume_menu or volume_operation or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS
