### PR TITLE
chore(appstate): guard directory window boundary

### DIFF
--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -7,6 +7,7 @@
 
 #define NO_YTNOVA_MACROS
 #include "watcher.h"
+#include "ytnova_appstate_actions.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -441,6 +442,9 @@ static void HandleDirectoryCompare(ViewContext *ctx, DirEntry *source_dir) {
 }
 
 extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
+  if (!AppStateValidatedDispatchSurface("surface.directory-window-action-dispatch"))
+    return ESC;
+
   DirEntry *dir_entry, *de_ptr;
   int ch, unput_char;
   BOOL need_dsp_help;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4387,6 +4387,8 @@ int main(void) {
     return 11;
   if (!AppStateValidatedDispatchSurface("surface.file-window-action-dispatch"))
     return 12;
+  if (!AppStateValidatedDispatchSurface("surface.directory-window-action-dispatch"))
+    return 13;
   if (AppStateValidatedDispatchSurface(NULL))
     return 3;
   if (AppStateValidatedDispatchSurface(""))
@@ -4555,6 +4557,35 @@ def test_handle_file_window_dispatch_fails_closed_before_file_work() -> None:
         "ctx->active->saved_focus = FOCUS_FILE;",
         "ctx->active->saved_big_file_view =",
         "BuildFileEntryList(",
+        "RefreshView(",
+        "GetEventOrKey(",
+        "GetKeyAction(",
+    ]
+
+    assert 'include "ytnova_appstate_actions.h"' in source
+    assert validation in body
+    assert body.index(validation) < body.index(early_return)
+    for call in boundary_calls:
+        assert body.index(validation) < body.index(call)
+        assert body.index(early_return) < body.index(call)
+
+
+def test_handle_dir_window_dispatch_fails_closed_before_directory_work() -> None:
+    source = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    start = source.index("HandleDirWindow(")
+    body = source[start:]
+    validation = (
+        'if (!AppStateValidatedDispatchSurface("surface.directory-window-action-dispatch"))'
+    )
+    early_return = "return ESC;"
+    boundary_calls = [
+        'DEBUG_LOG("HandleDirWindow:',
+        "Layout_Recalculate(",
+        "DisplayMenu(",
+        "ctx->focused_window =",
+        "SyncActivePanelWindows(",
+        "ctx->preview_mode = FALSE;",
+        "BuildDirEntryList(",
         "RefreshView(",
         "GetEventOrKey(",
         "GetKeyAction(",


### PR DESCRIPTION
## Summary
- Add a fail-closed AppState dispatch-surface check before directory-window action handling.
- Keep existing directory-window behavior unchanged when dispatch metadata is valid.
- Extend the AppState contract guard to pin the directory-window boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or directory_window or dir_window or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS
