### PR TITLE
chore(appstate): guard panel anchor boundary

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -5,6 +5,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_actions.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include "ytnova_ui.h"
@@ -414,6 +415,8 @@ void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,
   char target_path[PATH_LENGTH + 1];
   int idx;
 
+  if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))
+    return;
   if (!vol || !panel || !anchor_path || !*anchor_path)
     return;
   assert(!panel->vol || panel->vol == vol);
@@ -624,6 +627,8 @@ void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
   DirEntry *ancestor;
   BOOL changed = FALSE;
 
+  if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))
+    return;
   if (!ctx || !vol || !panel)
     return;
   assert(!panel->vol || panel->vol == vol);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4389,6 +4389,8 @@ int main(void) {
     return 12;
   if (!AppStateValidatedDispatchSurface("surface.directory-window-action-dispatch"))
     return 13;
+  if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))
+    return 14;
   if (AppStateValidatedDispatchSurface(NULL))
     return 3;
   if (AppStateValidatedDispatchSurface(""))
@@ -4597,6 +4599,55 @@ def test_handle_dir_window_dispatch_fails_closed_before_directory_work() -> None
     for call in boundary_calls:
         assert body.index(validation) < body.index(call)
         assert body.index(early_return) < body.index(call)
+
+
+def test_panel_anchor_rebind_fails_closed_before_anchor_state_work() -> None:
+    source = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    validation = (
+        'if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))'
+    )
+    early_return = "return;"
+
+    assert 'include "ytnova_appstate_actions.h"' in source
+
+    restore_start = source.index("void RestorePanelAnchorPath(")
+    restore_end = source.index("\nstatic void FreePanelVolumeFileState(", restore_start)
+    restore_body = source[restore_start:restore_end]
+    restore_boundary_calls = [
+        "CapturePanelViewportSnapshot(",
+        "ResolvePanelAnchorTarget(",
+        "RestorePanelViewportSnapshot(",
+        "PositionPanelAtIndex(",
+        "panel->file_dir_entry =",
+    ]
+
+    assert validation in restore_body
+    validation_idx = restore_body.index(validation)
+    early_return_idx = restore_body.index(early_return, validation_idx)
+    assert validation_idx < early_return_idx
+    for call in restore_boundary_calls:
+        assert validation_idx < restore_body.index(call)
+        assert early_return_idx < restore_body.index(call)
+
+    ensure_start = source.index("void EnsurePanelAnchorVisible(")
+    ensure_end = source.index("\nvoid DebugLogDirLoopState(", ensure_start)
+    ensure_body = source[ensure_start:ensure_end]
+    ensure_boundary_calls = [
+        "FindDirByPathInTree(",
+        "FindDirByPathOrAncestor(",
+        "BuildDirEntryList(",
+        "ResolvePanelAnchorTarget(",
+        "PositionPanelAtIndex(",
+        "panel->file_dir_entry =",
+    ]
+
+    assert validation in ensure_body
+    validation_idx = ensure_body.index(validation)
+    early_return_idx = ensure_body.index(early_return, validation_idx)
+    assert validation_idx < early_return_idx
+    for call in ensure_boundary_calls:
+        assert validation_idx < ensure_body.index(call)
+        assert early_return_idx < ensure_body.index(call)
 
 
 def test_select_loaded_volume_validates_volume_surfaces_before_menu_work() -> None:


### PR DESCRIPTION
## Summary
- Add fail-closed AppState dispatch-surface checks before panel-anchor restore/rebind entry points mutate panel state.
- Keep existing restore behavior unchanged when dispatch metadata is valid.
- Extend the AppState contract guard to pin the panel-anchor boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or panel_anchor or anchor_rebind or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS
