### PR TITLE
chore(appstate): guard resize signal boundary

### DIFF
--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -698,6 +698,8 @@ int WGetch(ViewContext *ctx, WINDOW *win) {
 
 #ifdef KEY_RESIZE
   if (c == KEY_RESIZE) {
+    if (!AppStateValidatedDispatchSurface("surface.resize-signal-handling"))
+      return ERR;
     if (ctx)
       ctx->resize_request = TRUE;
     c = -1;
@@ -789,6 +791,8 @@ int GetEventOrKey(ViewContext *ctx) {
   struct timeval tv;
 
   if (ctx && ctx->resize_request) {
+    if (!AppStateValidatedDispatchSurface("surface.resize-signal-handling"))
+      return ERR;
     if (!AppStateValidatedEvent("event.terminal-resize-signal"))
       return ERR;
     return KEY_RESIZE;
@@ -808,6 +812,8 @@ int GetEventOrKey(ViewContext *ctx) {
   }
 
   if (ctx && ctx->resize_request) {
+    if (!AppStateValidatedDispatchSurface("surface.resize-signal-handling"))
+      return ERR;
     if (!AppStateValidatedEvent("event.terminal-resize-signal"))
       return ERR;
     return KEY_RESIZE;
@@ -851,6 +857,9 @@ int GetEventOrKey(ViewContext *ctx) {
         if (ch != ERR)
           return NormalizeEscSequence(ch);
         if (ctx && ctx->resize_request) {
+          if (!AppStateValidatedDispatchSurface(
+                  "surface.resize-signal-handling"))
+            return ERR;
           if (!AppStateValidatedEvent("event.terminal-resize-signal"))
             return ERR;
           return KEY_RESIZE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4377,6 +4377,8 @@ int main(void) {
     return 1;
   if (!AppStateValidatedDispatchSurface("surface.menu-modal-completion"))
     return 2;
+  if (!AppStateValidatedDispatchSurface("surface.resize-signal-handling"))
+    return 6;
   if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))
     return 8;
   if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))
@@ -4461,6 +4463,21 @@ def test_input_choice_modal_completion_fails_closed_on_invalid_surface() -> None
         assert body.index(validation) < body.index("ClearHelp(ctx);")
         assert body.index("return ERR;") < body.index("ClearHelp(ctx);")
         assert body.index(validation) < body.index("WGetch(")
+
+
+def test_wgetch_resize_signal_handling_fails_closed_before_mutation() -> None:
+    source = Path("src/ui/key_engine.c").read_text(encoding="utf-8")
+    start = source.index("int WGetch(")
+    end = source.index("\nint Getch(", start)
+    body = source[start:end]
+    validation = (
+        'if (!AppStateValidatedDispatchSurface("surface.resize-signal-handling"))'
+    )
+
+    assert validation in body
+    assert "return ERR;" in body
+    assert body.index(validation) < body.index("ctx->resize_request = TRUE;")
+    assert body.index("return ERR;") < body.index("ctx->resize_request = TRUE;")
 
 
 def test_get_key_action_routes_decoded_actions_through_appstate_boundary() -> None:
@@ -4764,8 +4781,20 @@ def test_get_event_or_key_event_boundary_routes_synthetic_events() -> None:
     )
     assert len(resize_blocks) == 3
     for block in resize_blocks:
-        assert 'AppStateValidatedEvent("event.terminal-resize-signal")' in block
-        assert block.index("return ERR;") < block.index("return KEY_RESIZE;")
+        compact = re.sub(r"\s+", "", block)
+        assert re.search(
+            r'AppStateValidatedDispatchSurface\(\s*"surface\.resize-signal-handling"\s*\)',
+            block,
+        )
+        assert re.search(
+            r'AppStateValidatedEvent\(\s*"event\.terminal-resize-signal"\s*\)',
+            block,
+        )
+        assert (
+            compact.index('AppStateValidatedDispatchSurface("surface.resize-signal-handling")')
+            < compact.index('AppStateValidatedEvent("event.terminal-resize-signal")')
+            < compact.index("returnKEY_RESIZE;")
+        )
 
     assert re.search(
         r'if \(Watcher_ProcessEvents\(ctx\)\) \{\s+'


### PR DESCRIPTION
## Summary
- Add fail-closed AppState dispatch-surface checks before terminal resize signal state is queued or dispatched.
- Keep valid resize dispatch behavior unchanged after metadata validation succeeds.
- Extend AppState contract guards to pin resize-signal boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or resize_signal or terminal_resize or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS

Audit evidence:
- Developer report: `.agent/handoffs/report.1.179.txt` — PASS
- Code auditor report: `.agent/handoffs/report.1.180.txt` — PASS
