### PR TITLE
chore(appstate): guard watcher refresh boundary

### DIFF
--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -873,6 +873,9 @@ int GetEventOrKey(ViewContext *ctx) {
     if (ctx && (ctx->refresh_mode & REFRESH_WATCHER) && w_fd >= 0 &&
         FD_ISSET(w_fd, &fds)) {
       if (Watcher_ProcessEvents(ctx)) {
+        if (!AppStateValidatedDispatchSurface(
+                "surface.watcher-live-refresh"))
+          return ERR;
         if (!AppStateValidatedEvent("event.watcher-live-refresh"))
           return ERR;
         return KEY_F(5);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4381,6 +4381,8 @@ int main(void) {
     return 6;
   if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))
     return 8;
+  if (!AppStateValidatedDispatchSurface("surface.watcher-live-refresh"))
+    return 15;
   if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))
     return 9;
   if (!AppStateValidatedDispatchSurface("surface.volume-menu-selection"))
@@ -4798,6 +4800,8 @@ def test_get_event_or_key_event_boundary_routes_synthetic_events() -> None:
 
     assert re.search(
         r'if \(Watcher_ProcessEvents\(ctx\)\) \{\s+'
+        r'if \(!AppStateValidatedDispatchSurface\(\s*"surface\.watcher-live-refresh"\s*\)\)\s+'
+        r'return ERR;\s+'
         r'if \(!AppStateValidatedEvent\("event\.watcher-live-refresh"\)\)\s+'
         r"return ERR;\s+return KEY_F\(5\);",
         body,


### PR DESCRIPTION
## Summary
- Add a fail-closed AppState dispatch-surface check before watcher live-refresh dispatch.
- Keep valid watcher refresh behavior unchanged after metadata validation succeeds.
- Extend AppState contract guards to pin watcher refresh boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or watcher_live_refresh or watcher_refresh or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS

Audit evidence:
- Developer report: `.agent/handoffs/report.1.181.txt` — PASS
- Code auditor report: `.agent/handoffs/report.1.182.txt` — PASS
