### PR TITLE
chore(appstate): guard refresh rebuild boundary

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -7,6 +7,7 @@
  ***************************************************************************/
 
 #include "watcher.h"
+#include "ytnova_appstate_actions.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -1968,6 +1969,8 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
   PanelViewportSnapshot viewport;
 
   if (!p || !p->vol)
+    return entry;
+  if (!AppStateValidatedDispatchSurface("surface.refresh-rebuild-rebind"))
     return entry;
 
   s = &p->vol->vol_stats;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4669,6 +4669,36 @@ def test_panel_anchor_rebind_fails_closed_before_anchor_state_work() -> None:
         assert early_return_idx < ensure_body.index(call)
 
 
+def test_refresh_tree_safe_fails_closed_before_tree_refresh_work() -> None:
+    source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    validation = (
+        'if (!AppStateValidatedDispatchSurface("surface.refresh-rebuild-rebind"))'
+    )
+
+    assert 'include "ytnova_appstate_actions.h"' in source
+
+    start = source.index("DirEntry *RefreshTreeSafe(")
+    end = source.index("\nint RefreshDirWindow(", start)
+    body = source[start:end]
+    boundary_calls = [
+        "CapturePanelViewportSnapshot(",
+        "InvalidateVolumePanels(",
+        "RescanDir(",
+        "BuildDirEntryList(",
+        "RestorePanelViewportSnapshot(",
+        "DisplayTree(",
+        "DisplayFileWindow(",
+    ]
+
+    assert validation in body
+    validation_idx = body.index(validation)
+    early_return_idx = body.index("return entry;", validation_idx)
+    assert validation_idx < early_return_idx
+    for call in boundary_calls:
+        assert validation_idx < body.index(call)
+        assert early_return_idx < body.index(call)
+
+
 def test_select_loaded_volume_validates_volume_surfaces_before_menu_work() -> None:
     source = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
     start = source.index("int SelectLoadedVolume(")


### PR DESCRIPTION
## Summary
- Add a fail-closed AppState dispatch-surface check before manual refresh/rebuild work in `RefreshTreeSafe`.
- Keep valid refresh/rebuild behavior unchanged after metadata validation succeeds.
- Extend AppState contract guards to pin refresh/rebuild boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or refresh_rebuild or refresh_rebuild_rebind or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS

Audit evidence:
- Developer report: `.agent/handoffs/report.1.183.txt` — PASS
- Code auditor report: `.agent/handoffs/report.1.184.txt` — PASS
