### PR TITLE
chore(appstate): guard filesystem mutation boundary

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -850,6 +850,8 @@ BOOL HandleDirMakeFile(ViewContext *ctx, DirEntry *dir_entry) {
   DEBUG_LOG("ACTION_CMD_MKFILE reached in ctrl_dir.c. mode=%d", ctx->view_mode);
   if (ctx->view_mode != DISK_MODE)
     return FALSE;
+  if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))
+    return FALSE;
 
   ClearHelp(ctx);
   *file_name = '\0';
@@ -889,6 +891,8 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
   PathList *inactive_tagged_snapshot = NULL;
 
   if (!ctx || !ctx->active || !ctx->active->vol || !dir_entry)
+    return;
+  if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))
     return;
 
   DebugLogSplitState("HandleDirMakeDirectory:entry", ctx);
@@ -1004,6 +1008,9 @@ DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   InactiveFallbackSnapshot inactive_snapshot;
   PanelViewportSnapshot active_viewport;
 
+  if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))
+    return dir_entry;
+
   CaptureInactiveFallbackSnapshot(ctx, ctx->active, &inactive_snapshot);
   CapturePanelViewportSnapshot(ctx->active, ctx->active->vol, &active_viewport);
 
@@ -1050,6 +1057,9 @@ DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
 
 DirEntry *HandleDirRenameDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   char new_name[PATH_LENGTH + 1];
+
+  if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))
+    return dir_entry;
 
   if (!GetRenameParameter(ctx, dir_entry->name, new_name)) {
     int rename_result = RenameDirectory(ctx, dir_entry, new_name);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4395,6 +4395,8 @@ int main(void) {
     return 13;
   if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))
     return 14;
+  if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))
+    return 16;
   if (AppStateValidatedDispatchSurface(NULL))
     return 3;
   if (AppStateValidatedDispatchSurface(""))
@@ -4697,6 +4699,82 @@ def test_refresh_tree_safe_fails_closed_before_tree_refresh_work() -> None:
     for call in boundary_calls:
         assert validation_idx < body.index(call)
         assert early_return_idx < body.index(call)
+
+
+def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
+    source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    validation = (
+        'if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))'
+    )
+
+    assert 'include "ytnova_appstate_actions.h"' in source
+
+    make_file_start = source.index("BOOL HandleDirMakeFile(")
+    make_dir_start = source.index("void HandleDirMakeDirectory(", make_file_start)
+    make_file_body = source[make_file_start:make_dir_start]
+    assert validation in make_file_body
+    validation_idx = make_file_body.index(validation)
+    early_return_idx = make_file_body.index("return FALSE;", validation_idx)
+    assert validation_idx < early_return_idx
+    for call in ["ClearHelp(ctx);", "MakeFile(ctx,", "DisplayFileWindow(", "RefreshView(", "MESSAGE("]:
+        assert validation_idx < make_file_body.index(call)
+        assert early_return_idx < make_file_body.index(call)
+
+    delete_dir_start = source.index("DirEntry *HandleDirDeleteDirectory(", make_dir_start)
+    make_dir_body = source[make_dir_start:delete_dir_start]
+    assert validation in make_dir_body
+    validation_idx = make_dir_body.index(validation)
+    early_return_idx = make_dir_body.index("return;", validation_idx)
+    assert validation_idx < early_return_idx
+    for call in [
+        'DebugLogSplitState("HandleDirMakeDirectory:entry", ctx);',
+        "GetPath(",
+        "ClearHelp(ctx);",
+        "CaptureInactiveFallback(",
+        "MakeDirectory(ctx,",
+        "volume_generation++",
+        "BuildDirEntryList(",
+        "ReanchorPanelToDir(",
+        "RefreshView(",
+        "wmove(ctx->ctx_border_window",
+    ]:
+        assert validation_idx < make_dir_body.index(call)
+        assert early_return_idx < make_dir_body.index(call)
+
+    rename_dir_start = source.index("DirEntry *HandleDirRenameDirectory(", delete_dir_start)
+    delete_dir_body = source[delete_dir_start:rename_dir_start]
+    assert validation in delete_dir_body
+    validation_idx = delete_dir_body.index(validation)
+    early_return_idx = delete_dir_body.index("return dir_entry;", validation_idx)
+    assert validation_idx < early_return_idx
+    for call in [
+        "CaptureInactiveFallbackSnapshot(",
+        "CapturePanelViewportSnapshot(",
+        "DeleteDirectory(ctx,",
+        "volume_generation++",
+        "BuildDirEntryList(",
+        "RestorePanelViewportSnapshot(",
+        "ReanchorPanelToDir(",
+        "RefreshView(",
+    ]:
+        assert validation_idx < delete_dir_body.index(call)
+        assert early_return_idx < delete_dir_body.index(call)
+
+    show_all_start = source.index("void HandleShowAll(", rename_dir_start)
+    rename_dir_body = source[rename_dir_start:show_all_start]
+    assert validation in rename_dir_body
+    validation_idx = rename_dir_body.index(validation)
+    early_return_idx = rename_dir_body.index("return dir_entry;", validation_idx)
+    assert validation_idx < early_return_idx
+    for call in [
+        "GetRenameParameter(",
+        "RenameDirectory(ctx,",
+        "volume_generation++",
+        "BuildDirEntryList(",
+        "RefreshView(",
+    ]:
+        assert validation_idx < rename_dir_body.index(call)
+        assert early_return_idx < rename_dir_body.index(call)
 
 
 def test_select_loaded_volume_validates_volume_surfaces_before_menu_work() -> None:


### PR DESCRIPTION
## Summary
- Add fail-closed AppState dispatch-surface checks before directory filesystem mutation result handlers commit state.
- Keep valid directory mutation behavior unchanged after metadata validation succeeds.
- Extend AppState contract guards to pin filesystem mutation boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or DispatchSurface or filesystem_mutation or mutation_result or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS

Audit evidence:
- Developer report: `.agent/handoffs/report.1.185.txt` — PASS
- Code auditor report: `.agent/handoffs/report.1.186.txt` — PASS
