### PR TITLE
chore(appstate): guard panel anchor event boundary

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -417,6 +417,8 @@ void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,
 
   if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))
     return;
+  if (!AppStateValidatedEvent("event.rebuild-rebind-callback"))
+    return;
   if (!vol || !panel || !anchor_path || !*anchor_path)
     return;
   assert(!panel->vol || panel->vol == vol);
@@ -628,6 +630,8 @@ void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
   BOOL changed = FALSE;
 
   if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))
+    return;
+  if (!AppStateValidatedEvent("event.rebuild-rebind-callback"))
     return;
   if (!ctx || !vol || !panel)
     return;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4629,6 +4629,9 @@ def test_panel_anchor_rebind_fails_closed_before_anchor_state_work() -> None:
     validation = (
         'if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))'
     )
+    event_validation = (
+        'if (!AppStateValidatedEvent("event.rebuild-rebind-callback"))'
+    )
     early_return = "return;"
 
     assert 'include "ytnova_appstate_actions.h"' in source
@@ -4645,11 +4648,13 @@ def test_panel_anchor_rebind_fails_closed_before_anchor_state_work() -> None:
     ]
 
     assert validation in restore_body
+    assert event_validation in restore_body
     validation_idx = restore_body.index(validation)
-    early_return_idx = restore_body.index(early_return, validation_idx)
-    assert validation_idx < early_return_idx
+    event_validation_idx = restore_body.index(event_validation)
+    early_return_idx = restore_body.index(early_return, event_validation_idx)
+    assert validation_idx < event_validation_idx < early_return_idx
     for call in restore_boundary_calls:
-        assert validation_idx < restore_body.index(call)
+        assert event_validation_idx < restore_body.index(call)
         assert early_return_idx < restore_body.index(call)
 
     ensure_start = source.index("void EnsurePanelAnchorVisible(")
@@ -4665,11 +4670,13 @@ def test_panel_anchor_rebind_fails_closed_before_anchor_state_work() -> None:
     ]
 
     assert validation in ensure_body
+    assert event_validation in ensure_body
     validation_idx = ensure_body.index(validation)
-    early_return_idx = ensure_body.index(early_return, validation_idx)
-    assert validation_idx < early_return_idx
+    event_validation_idx = ensure_body.index(event_validation)
+    early_return_idx = ensure_body.index(early_return, event_validation_idx)
+    assert validation_idx < event_validation_idx < early_return_idx
     for call in ensure_boundary_calls:
-        assert validation_idx < ensure_body.index(call)
+        assert event_validation_idx < ensure_body.index(call)
         assert early_return_idx < ensure_body.index(call)
 
 


### PR DESCRIPTION
## Summary
- Add fail-closed AppState event checks before panel-anchor restore/rebind callbacks mutate state.
- Keep valid panel-anchor restore/rebind behavior unchanged after event metadata validation succeeds.
- Extend AppState contract guards to pin panel-anchor event boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'event_boundary or validated_event or panel_anchor or rebuild_rebind or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS

Audit evidence:
- Developer report: `.agent/handoffs/report.1.191.txt` — PASS
- Code auditor report: `.agent/handoffs/report.1.192.txt` — PASS
