### PR TITLE
chore(appstate): guard render event boundary

### DIFF
--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -685,6 +685,8 @@ static void DrawSplitSeparatorRow(ViewContext *ctx, BOOL left_big,
 void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
   if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))
     return;
+  if (!AppStateValidatedEvent("event.render-reflow"))
+    return;
 
   const Statistic *s = &ctx->active->vol->vol_stats;
   BOOL needs_window_recreate = FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4543,6 +4543,7 @@ def test_refresh_view_render_reflow_projection_fails_closed_before_render_work()
     validation = (
         'if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))'
     )
+    event_validation = 'if (!AppStateValidatedEvent("event.render-reflow"))'
     early_return = "return;"
     boundary_calls = [
         "Layout_Recalculate(",
@@ -4561,11 +4562,15 @@ def test_refresh_view_render_reflow_projection_fails_closed_before_render_work()
 
     assert 'include "ytnova_appstate_actions.h"' in source
     assert validation in body
-    assert body.index(validation) < body.index(early_return)
-    assert body.index(early_return) < body.index("&ctx->active->vol->vol_stats")
+    assert event_validation in body
+    validation_idx = body.index(validation)
+    event_validation_idx = body.index(event_validation, validation_idx)
+    early_return_idx = body.index(early_return, event_validation_idx)
+    assert validation_idx < event_validation_idx < early_return_idx
+    assert early_return_idx < body.index("&ctx->active->vol->vol_stats")
     for call in boundary_calls:
         assert body.index(validation) < body.index(call)
-        assert body.index(early_return) < body.index(call)
+        assert early_return_idx < body.index(call)
 
 
 def test_handle_file_window_dispatch_fails_closed_before_file_work() -> None:
@@ -4844,22 +4849,24 @@ int main(void) {
     return 4;
   if (AppStateValidatedEvent("event.__ytnova_missing__"))
     return 5;
-  if (!AppStateValidatedEvent("event.refresh-rebuild"))
+  if (!AppStateValidatedEvent("event.render-reflow"))
     return 6;
+  if (!AppStateValidatedEvent("event.refresh-rebuild"))
+    return 7;
 
   mismatched_event =
       *AppStateEventCoverageLookup("event.terminal-resize-signal");
   mismatched_event.event_id = "event.__ytnova_mismatch__";
   if (AppStateValidateEventCoverage("event.terminal-resize-signal",
                                     &mismatched_event))
-    return 7;
+    return 8;
 
   missing_transition =
       *AppStateEventCoverageLookup("event.terminal-resize-signal");
   missing_transition.transition_id = "transition.__ytnova_missing__";
   if (AppStateValidateEventCoverage("event.terminal-resize-signal",
                                     &missing_transition))
-    return 8;
+    return 9;
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- Add a fail-closed AppState event check before render/reflow projection work in `RefreshView`.
- Keep valid render behavior unchanged after event metadata validation succeeds.
- Extend AppState contract guards to pin render event boundary placement.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'event_boundary or validated_event or render_reflow or render_projection or readiness'` — PASS
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` — PASS
- `make clean && make` — PASS with pre-existing warnings outside changed files
- `git diff --check` — PASS

Audit evidence:
- Developer report: `.agent/handoffs/report.1.193.txt` — PASS
- Code auditor report: `.agent/handoffs/report.1.194.txt` — PASS
