### PR TITLE
chore(appstate): guard command completion event boundary

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -38,8 +38,8 @@ These instructions apply to all AI agents used in this repository.
 ## User Notification
 
 - When finishing a long-running mission or when explicitly requesting user review via `notify_user`, you SHOULD trigger a desktop notification on the Windows host.
-- Execute: `/home/rob/ytreenova/scripts/wsl-notify.sh "ytnova" "<Context-specific message>"`
-- Example: `/home/rob/ytreenova/scripts/wsl-notify.sh "ytnova" "Implementation complete, ready for review."`
+- Execute: `/home/rob/ytreenova/scripts/wsl-notify.sh "ytnova" "<Context-specific milestone>"`
+- Use a concrete milestone string, not a placeholder. Examples: `Draft PR created.` or `Implementation complete, ready for review.`
 
 ## Persona Skill Auto-Load
 

--- a/scripts/wsl-notify.sh
+++ b/scripts/wsl-notify.sh
@@ -4,6 +4,39 @@
 TITLE="${1:-ytnova}"
 MESSAGE="${2:-Task completed}"
 
+is_placeholder_message() {
+    case "$1" in
+        ""|"Task completed"|"This is a notification."|"Notification"|"Task complete")
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+infer_context_message() {
+    local inferred_message=""
+
+    inferred_message=$(git log -1 --pretty=%s 2>/dev/null || true)
+    if [ -n "$inferred_message" ]; then
+        printf '%s\n' "$inferred_message"
+        return 0
+    fi
+
+    inferred_message=$(git branch --show-current 2>/dev/null || true)
+    if [ -n "$inferred_message" ]; then
+        printf 'Milestone reached on %s\n' "$inferred_message"
+        return 0
+    fi
+
+    printf '%s\n' "Task completed"
+}
+
+if is_placeholder_message "$MESSAGE"; then
+    MESSAGE="$(infer_context_message)"
+fi
+
 powershell_script=$(cat <<'POWERSHELL'
 $ErrorActionPreference = 'Stop'
 

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -531,6 +531,8 @@ BOOL handle_file_window_command_action(ViewContext *ctx, YtreeNovaAction action,
 
   if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))
     return FALSE;
+  if (!AppStateValidatedEvent("event.command-completion"))
+    return FALSE;
 
   dir_entry = *dir_entry_ptr;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4529,6 +4529,7 @@ def test_command_completion_dispatch_fails_closed_before_command_work() -> None:
     validation = (
         'if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))'
     )
+    event_validation = 'if (!AppStateValidatedEvent("event.command-completion"))'
     early_return = "return FALSE;"
     boundary_calls = [
         "switch (action)",
@@ -4547,11 +4548,17 @@ def test_command_completion_dispatch_fails_closed_before_command_work() -> None:
 
     assert 'include "ytnova_appstate_actions.h"' in source
     assert validation in body
+    assert event_validation in body
     assert early_return in body
-    assert body.index(validation) < body.index(early_return)
-    assert body.index(early_return) < body.index("switch (action)")
+    validation_index = body.index(validation)
+    event_validation_index = body.index(event_validation)
+    switch_index = body.index("switch (action)")
+    assert validation_index < event_validation_index
+    assert body.index(early_return, validation_index) < event_validation_index
+    assert body.index(early_return, event_validation_index) < switch_index
     for call in boundary_calls:
-        assert body.index(validation) < body.index(call)
+        assert validation_index < body.index(call)
+        assert event_validation_index < body.index(call)
 
 
 def test_refresh_view_render_reflow_projection_fails_closed_before_render_work() -> None:
@@ -4886,6 +4893,8 @@ int main(void) {
     return 8;
   if (!AppStateValidatedEvent("event.modal-completion"))
     return 9;
+  if (!AppStateValidatedEvent("event.command-completion"))
+    return 12;
 
   mismatched_event =
       *AppStateEventCoverageLookup("event.terminal-resize-signal");

--- a/tests/test_wsl_notify.py
+++ b/tests/test_wsl_notify.py
@@ -1,0 +1,98 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def _init_git_repo(repo_dir: Path, commit_subject: str) -> None:
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "codex@example.com"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Codex"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    note_path = repo_dir / "note.txt"
+    note_path.write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "note.txt"], cwd=repo_dir, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", commit_subject],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_powershell_stub(bin_dir: Path, capture_file: Path) -> Path:
+    stub_path = bin_dir / "powershell.exe"
+    stub_path.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -eu\n"
+        'printf "%s" "$WSL_NOTIFY_MESSAGE" > "$WSL_NOTIFY_CAPTURE_FILE"\n',
+        encoding="utf-8",
+    )
+    stub_path.chmod(0o755)
+    capture_file.write_text("", encoding="utf-8")
+    return stub_path
+
+
+def _run_notify_script(repo_root: Path, cwd: Path, message: str, tmp_path: Path) -> str:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    capture_file = tmp_path / "message.txt"
+    _write_powershell_stub(bin_dir, capture_file)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["WSL_NOTIFY_CAPTURE_FILE"] = str(capture_file)
+
+    subprocess.run(
+        [str(repo_root / "scripts" / "wsl-notify.sh"), "ytnova", message],
+        cwd=cwd,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return capture_file.read_text(encoding="utf-8")
+
+
+def test_wsl_notify_replaces_generic_placeholder_with_repo_context(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    git_repo = tmp_path / "repo"
+    git_repo.mkdir()
+    _init_git_repo(git_repo, "Draft PR created.")
+
+    captured_message = _run_notify_script(
+        repo_root,
+        git_repo,
+        "This is a notification.",
+        tmp_path,
+    )
+
+    assert captured_message == "Draft PR created."
+
+
+def test_wsl_notify_preserves_explicit_milestone_message(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    git_repo = tmp_path / "repo"
+    git_repo.mkdir()
+    _init_git_repo(git_repo, "Implementation complete, ready for review.")
+
+    captured_message = _run_notify_script(
+        repo_root,
+        git_repo,
+        "Draft PR created.",
+        tmp_path,
+    )
+
+    assert captured_message == "Draft PR created."


### PR DESCRIPTION
## Summary
- require the registered command-completion AppState event before file-window command completion dispatch can perform command work
- extend the AppState guard regression to prove the event boundary fails closed before command handlers run
- include the command-completion event in the runtime event validation probe

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'command_completion_dispatch or runtime_event_boundary_validation'` failed before the implementation guard and passes after it
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
