### PR TITLE
chore(appstate): validate compatibility shim boundaries

### DIFF
--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -256,6 +256,7 @@ const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index);
 size_t AppStateDispatchSurfaceCount(void);
 const AppStateCompatibilityShimMetadata *
 AppStateCompatibilityShimLookup(const char *shim_id);
+int AppStateValidatedCompatibilityShim(const char *shim_id);
 const AppStateCompatibilityShimMetadata *
 AppStateCompatibilityShimAt(size_t index);
 size_t AppStateCompatibilityShimCount(void);

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6347,6 +6347,28 @@ int AppStateValidatedDispatchSurface(const char *surface_id) {
       surface_id, AppStateDispatchSurfaceLookup(surface_id));
 }
 
+static int AppStateValidateCompatibilityShim(
+    const char *shim_id, const AppStateCompatibilityShimMetadata *metadata) {
+  if (shim_id == NULL || shim_id[0] == '\0')
+    return 0;
+  if (metadata == NULL || metadata->id == NULL || strcmp(metadata->id, shim_id))
+    return 0;
+  if (AppStateTransitionLookup(metadata->target_transition) == NULL)
+    return 0;
+  if (metadata->write_capability == NULL ||
+      (strcmp(metadata->write_capability, "write_capable") &&
+       strcmp(metadata->write_capability, "read_only_projection") &&
+       strcmp(metadata->write_capability, "no_write")))
+    return 0;
+
+  return 1;
+}
+
+int AppStateValidatedCompatibilityShim(const char *shim_id) {
+  return AppStateValidateCompatibilityShim(
+      shim_id, AppStateCompatibilityShimLookup(shim_id));
+}
+
 const AppStateEventCoverageMetadata *
 AppStateEventCoverageLookup(const char *event_id) {
   size_t index;

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -444,6 +444,8 @@ static void HandleDirectoryCompare(ViewContext *ctx, DirEntry *source_dir) {
 extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   if (!AppStateValidatedDispatchSurface("surface.directory-window-action-dispatch"))
     return ESC;
+  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
+    return ESC;
 
   DirEntry *dir_entry, *de_ptr;
   int ch, unput_char;

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -237,6 +237,8 @@ DirEntry *RefreshFileView(ViewContext *ctx, DirEntry *dir_entry) {
 int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   if (!AppStateValidatedDispatchSurface("surface.file-window-action-dispatch"))
     return ESC;
+  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
+    return ESC;
 
   DEBUG_LOG("HandleFileWindow ENTERED for %s", dir_entry->name);
   FileEntry *fe_ptr;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1744,6 +1744,8 @@ HandleDirWindowVolumeAction(ViewContext *ctx, YtreeNovaAction action,
       !*dir_entry_ptr || !s_ptr || !*s_ptr || !need_dsp_help_ptr) {
     return DIR_WINDOW_DISPATCH_HANDLED;
   }
+  if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))
+    return DIR_WINDOW_DISPATCH_HANDLED;
 
   ctx->active->vol->saved_tree_index =
       ctx->active->disp_begin_pos + ctx->active->cursor_pos;
@@ -1879,6 +1881,8 @@ void ToggleDotFiles(ViewContext *ctx, YtreeNovaPanel *p) {
   const char *preferred_top_path = NULL;
 
   if (!ctx || !p || !p->vol)
+    return;
+  if (!AppStateValidatedCompatibilityShim("shim.viewcontext-hide-dot-files"))
     return;
 
   s = &p->vol->vol_stats;

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -687,6 +687,8 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
     return;
   if (!AppStateValidatedEvent("event.render-reflow"))
     return;
+  if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
+    return;
 
   const Statistic *s = &ctx->active->vol->vol_stats;
   BOOL needs_window_recreate = FALSE;

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -364,6 +364,8 @@ BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *pane
   assert(!panel->vol || panel->vol == vol);
   if (panel->vol && panel->vol != vol)
     return FALSE;
+  if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))
+    return FALSE;
   if (!snapshot->has_selected_dir_path || !snapshot->selected_dir_path[0])
     return FALSE;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4787,6 +4787,91 @@ def test_refresh_tree_safe_fails_closed_before_tree_refresh_work() -> None:
         assert event_return_idx < body.index(call, event_return_idx)
 
 
+def test_appstate_shim_lookup_fails_closed_through_runtime_metadata() -> None:
+    header = Path("include/ytnova_appstate_actions.h").read_text(encoding="utf-8")
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    validation = "int AppStateValidatedCompatibilityShim(const char *shim_id)"
+    body_start = source.index("static int AppStateValidateCompatibilityShim(")
+    body_end = source.index("\nconst AppStateEventCoverageMetadata", body_start)
+    body = source[body_start:body_end]
+
+    assert validation in header
+    assert "static int AppStateValidateCompatibilityShim(" in source
+    assert "AppStateCompatibilityShimLookup(shim_id)" in body
+    assert "AppStateTransitionLookup(metadata->target_transition)" in body
+    assert "metadata->write_capability" in body
+    assert '"read_only_projection"' in body
+    assert "strcmp(metadata->id, shim_id)" in body
+
+
+def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    display = Path("src/ui/display.c").read_text(encoding="utf-8")
+
+    assert 'include "ytnova_appstate_actions.h"' in dir_ops
+    assert 'include "ytnova_appstate_actions.h"' in ctrl_dir
+    assert 'include "ytnova_appstate_actions.h"' in ctrl_file
+    assert 'include "ytnova_appstate_actions.h"' in panel_anchor
+    assert 'include "ytnova_appstate_actions.h"' in display
+
+    toggle_start = dir_ops.index("void ToggleDotFiles(")
+    toggle_end = dir_ops.index("\nDirEntry *RefreshTreeSafe(", toggle_start)
+    toggle_body = dir_ops[toggle_start:toggle_end]
+    hidden_validation = (
+        'if (!AppStateValidatedCompatibilityShim("shim.viewcontext-hide-dot-files"))'
+    )
+    assert hidden_validation in toggle_body
+    assert toggle_body.index(hidden_validation) < toggle_body.index("p->hide_dot_files =")
+    assert toggle_body.index(hidden_validation) < toggle_body.index("ctx->hide_dot_files =")
+
+    volume_start = dir_ops.index("HandleDirWindowVolumeAction(")
+    volume_end = dir_ops.index("\nint RefreshDirWindow(", volume_start)
+    volume_body = dir_ops[volume_start:volume_end]
+    volume_validation = (
+        'if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))'
+    )
+    assert volume_validation in volume_body
+    assert volume_body.index(volume_validation) < volume_body.index(
+        "ctx->active->vol->saved_tree_index ="
+    )
+
+    restore_start = panel_anchor.index("BOOL RestorePanelViewportSnapshot(")
+    restore_end = panel_anchor.index("\nvoid RestorePanelAnchorPath(", restore_start)
+    restore_body = panel_anchor[restore_start:restore_end]
+    assert volume_validation in restore_body
+    assert restore_body.index(volume_validation) < restore_body.index(
+        "ResolvePanelAnchorTarget("
+    )
+    assert restore_body.index(volume_validation) < restore_body.index(
+        "panel->disp_begin_pos ="
+    )
+
+    focus_validation = (
+        'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'
+    )
+    dir_start = ctrl_dir.index("HandleDirWindow(")
+    dir_body = ctrl_dir[dir_start:]
+    assert focus_validation in dir_body
+    assert dir_body.index(focus_validation) < dir_body.index("ctx->focused_window =")
+
+    file_start = ctrl_file.index("int HandleFileWindow(")
+    file_body = ctrl_file[file_start:]
+    assert focus_validation in file_body
+    assert file_body.index(focus_validation) < file_body.index("ctx->focused_window =")
+
+    refresh_start = display.index("void RefreshView(")
+    refresh_body = display[refresh_start:]
+    render_validation = (
+        'if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))'
+    )
+    assert render_validation in refresh_body
+    assert refresh_body.index(render_validation) < refresh_body.index("Layout_Recalculate(")
+    assert refresh_body.index(render_validation) < refresh_body.index("DisplayTree(")
+
+
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     validation = (


### PR DESCRIPTION
## Summary
- add a runtime AppState compatibility-shim validator backed by shim metadata
- fail closed before legacy shim authority paths mutate focus, visibility, saved tree index, or render-derived row state
- extend AppState contract guards for the shim boundary placements

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`