### PR TITLE
chore(appstate): validate registry metadata boundaries

### DIFF
--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -247,6 +247,7 @@ const AppStateEventCoverageMetadata *AppStateEventCoverageAt(size_t index);
 size_t AppStateEventCoverageCount(void);
 const AppStateTransitionMetadata *
 AppStateTransitionLookup(const char *transition_id);
+int AppStateValidatedTransition(const char *transition_id);
 const AppStateTransitionMetadata *AppStateTransitionAt(size_t index);
 size_t AppStateTransitionCount(void);
 const AppStateDispatchSurfaceMetadata *
@@ -262,21 +263,26 @@ AppStateCompatibilityShimAt(size_t index);
 size_t AppStateCompatibilityShimCount(void);
 const AppStateInvariantMetadata *
 AppStateInvariantLookup(const char *invariant_id);
+int AppStateValidatedInvariant(const char *invariant_id);
 const AppStateInvariantMetadata *AppStateInvariantAt(size_t index);
 size_t AppStateInvariantCount(void);
 const AppStateOwnerFieldMetadata *AppStateOwnerFieldLookup(const char *field);
+int AppStateValidatedOwnerField(const char *field);
 const AppStateOwnerFieldMetadata *AppStateOwnerFieldAt(size_t index);
 size_t AppStateOwnerFieldCount(void);
 const AppStateGenerationDomainMetadata *
 AppStateGenerationDomainLookup(const char *domain_id);
+int AppStateValidatedGenerationDomain(const char *domain_id);
 const AppStateGenerationDomainMetadata *AppStateGenerationDomainAt(size_t index);
 size_t AppStateGenerationDomainCount(void);
 const AppStateDiffHarnessMetadata *
 AppStateDiffHarnessLookup(const char *harness_id);
+int AppStateValidatedDiffHarness(const char *harness_id);
 const AppStateDiffHarnessMetadata *AppStateDiffHarnessAt(size_t index);
 size_t AppStateDiffHarnessCount(void);
 const AppStateTransitionSequenceMetadata *
 AppStateTransitionSequenceLookup(const char *scenario_id);
+int AppStateValidatedTransitionSequence(const char *scenario_id);
 const AppStateTransitionSequenceMetadata *
 AppStateTransitionSequenceAt(size_t index);
 size_t AppStateTransitionSequenceCount(void);

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6293,13 +6293,351 @@ AppStateActionCoverageLookup(YtreeNovaAction action) {
   return metadata;
 }
 
+static int AppStateNonEmptyString(const char *value) {
+  return value != NULL && value[0] != '\0';
+}
+
+static int AppStateNonEmptyStringList(const char *const *values,
+                                      size_t value_count) {
+  size_t index;
+
+  if (values == NULL || value_count == 0)
+    return 0;
+
+  for (index = 0; index < value_count; index++) {
+    if (!AppStateNonEmptyString(values[index]))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int AppStateTransitionFieldsRegistered(const char *const *fields,
+                                              size_t field_count) {
+  size_t index;
+
+  if (!AppStateNonEmptyStringList(fields, field_count))
+    return 0;
+
+  for (index = 0; index < field_count; index++) {
+    if (AppStateOwnerFieldLookup(fields[index]) == NULL)
+      return 0;
+  }
+
+  return 1;
+}
+
+static int
+AppStateTransitionIdsRegistered(const char *const *transition_ids,
+                                size_t transition_id_count) {
+  size_t index;
+
+  if (!AppStateNonEmptyStringList(transition_ids, transition_id_count))
+    return 0;
+
+  for (index = 0; index < transition_id_count; index++) {
+    if (!AppStateValidatedTransition(transition_ids[index]))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int
+AppStateValidateTransition(const char *transition_id,
+                           const AppStateTransitionMetadata *metadata) {
+  if (!AppStateNonEmptyString(transition_id))
+    return 0;
+  if (metadata == NULL || !AppStateNonEmptyString(metadata->id) ||
+      strcmp(metadata->id, transition_id))
+    return 0;
+  if (!AppStateNonEmptyString(metadata->category) ||
+      !AppStateNonEmptyString(metadata->owner))
+    return 0;
+  if (!AppStateTransitionFieldsRegistered(metadata->declared_write_set,
+                                          metadata->declared_write_set_count))
+    return 0;
+
+  return 1;
+}
+
+int AppStateValidatedTransition(const char *transition_id) {
+  return AppStateValidateTransition(transition_id,
+                                    AppStateTransitionLookup(transition_id));
+}
+
+static int AppStateInvariantIdsRegistered(const char *const *invariant_ids,
+                                          size_t invariant_id_count) {
+  size_t index;
+
+  if (!AppStateNonEmptyStringList(invariant_ids, invariant_id_count))
+    return 0;
+
+  for (index = 0; index < invariant_id_count; index++) {
+    if (!AppStateValidatedInvariant(invariant_ids[index]))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int
+AppStateValidateOwnerField(const char *field,
+                           const AppStateOwnerFieldMetadata *metadata) {
+  if (!AppStateNonEmptyString(field))
+    return 0;
+  if (metadata == NULL || !AppStateNonEmptyString(metadata->field) ||
+      strcmp(metadata->field, field))
+    return 0;
+  if (!AppStateNonEmptyString(metadata->owner_region) ||
+      !AppStateNonEmptyString(metadata->canonical_owner) ||
+      !AppStateNonEmptyString(metadata->runtime_carrier) ||
+      !AppStateNonEmptyString(metadata->mutation_rule) ||
+      !AppStateNonEmptyString(metadata->migration_status))
+    return 0;
+  if (!AppStateInvariantIdsRegistered(metadata->invariant_checks,
+                                      metadata->invariant_check_count))
+    return 0;
+
+  return 1;
+}
+
+int AppStateValidatedOwnerField(const char *field) {
+  return AppStateValidateOwnerField(field, AppStateOwnerFieldLookup(field));
+}
+
+static int
+AppStateDispatchSurfaceIdsRegistered(const char *const *surface_ids,
+                                     size_t surface_id_count) {
+  size_t index;
+
+  if (!AppStateNonEmptyStringList(surface_ids, surface_id_count))
+    return 0;
+
+  for (index = 0; index < surface_id_count; index++) {
+    if (!AppStateValidatedDispatchSurface(surface_ids[index]))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int
+AppStateValidateInvariant(const char *invariant_id,
+                          const AppStateInvariantMetadata *metadata) {
+  if (!AppStateNonEmptyString(invariant_id))
+    return 0;
+  if (metadata == NULL || !AppStateNonEmptyString(metadata->invariant_id) ||
+      strcmp(metadata->invariant_id, invariant_id))
+    return 0;
+  if (!AppStateNonEmptyString(metadata->category) ||
+      !AppStateNonEmptyString(metadata->owner_region) ||
+      !AppStateNonEmptyString(metadata->failure_mode) ||
+      !AppStateNonEmptyString(metadata->enforcement_status) ||
+      !AppStateNonEmptyString(metadata->test_strategy))
+    return 0;
+  if (!AppStateTransitionFieldsRegistered(metadata->protected_fields,
+                                          metadata->protected_field_count))
+    return 0;
+  if (!AppStateTransitionIdsRegistered(metadata->transition_ids,
+                                       metadata->transition_id_count))
+    return 0;
+  if (!AppStateDispatchSurfaceIdsRegistered(metadata->dispatch_surface_ids,
+                                            metadata->dispatch_surface_id_count))
+    return 0;
+  if (!AppStateNonEmptyStringList(metadata->migration_notes,
+                                  metadata->migration_note_count))
+    return 0;
+
+  return 1;
+}
+
+int AppStateValidatedInvariant(const char *invariant_id) {
+  return AppStateValidateInvariant(invariant_id,
+                                   AppStateInvariantLookup(invariant_id));
+}
+
+static int
+AppStateValidateGenerationDomain(
+    const char *domain_id, const AppStateGenerationDomainMetadata *metadata) {
+  if (!AppStateNonEmptyString(domain_id))
+    return 0;
+  if (metadata == NULL || !AppStateNonEmptyString(metadata->domain_id) ||
+      strcmp(metadata->domain_id, domain_id))
+    return 0;
+  if (!AppStateNonEmptyString(metadata->category) ||
+      !AppStateNonEmptyString(metadata->owner_region) ||
+      !AppStateNonEmptyString(metadata->generation_owner_field) ||
+      !AppStateNonEmptyString(metadata->stale_snapshot_policy) ||
+      !AppStateNonEmptyString(metadata->fail_closed_fallback) ||
+      !AppStateNonEmptyString(metadata->restore_boundary) ||
+      !AppStateNonEmptyString(metadata->enforcement_status))
+    return 0;
+  if (AppStateOwnerFieldLookup(metadata->generation_owner_field) == NULL)
+    return 0;
+  if (!AppStateTransitionFieldsRegistered(metadata->identity_fields,
+                                          metadata->identity_field_count))
+    return 0;
+  if (!AppStateTransitionIdsRegistered(metadata->coverage_transition_ids,
+                                       metadata->coverage_transition_id_count))
+    return 0;
+  if (!AppStateTransitionIdsRegistered(
+          metadata->advances_on_transition_ids,
+          metadata->advances_on_transition_id_count))
+    return 0;
+  if (!AppStateNonEmptyStringList(metadata->migration_notes,
+                                  metadata->migration_note_count))
+    return 0;
+
+  return 1;
+}
+
+int AppStateValidatedGenerationDomain(const char *domain_id) {
+  return AppStateValidateGenerationDomain(
+      domain_id, AppStateGenerationDomainLookup(domain_id));
+}
+
+static int
+AppStateGenerationDomainIdsRegistered(const char *const *domain_ids,
+                                      size_t domain_id_count) {
+  size_t index;
+
+  if (!AppStateNonEmptyStringList(domain_ids, domain_id_count))
+    return 0;
+
+  for (index = 0; index < domain_id_count; index++) {
+    if (!AppStateValidatedGenerationDomain(domain_ids[index]))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int
+AppStateValidateDiffHarness(const char *harness_id,
+                            const AppStateDiffHarnessMetadata *metadata) {
+  if (!AppStateNonEmptyString(harness_id))
+    return 0;
+  if (metadata == NULL || !AppStateNonEmptyString(metadata->harness_id) ||
+      strcmp(metadata->harness_id, harness_id))
+    return 0;
+  if (!AppStateNonEmptyString(metadata->check_category) ||
+      !AppStateNonEmptyString(metadata->expected_behavior) ||
+      !AppStateNonEmptyString(metadata->failure_mode) ||
+      !AppStateNonEmptyString(metadata->enforcement_status))
+    return 0;
+  if (!AppStateNonEmptyStringList(metadata->snapshot_phases,
+                                  metadata->snapshot_phase_count))
+    return 0;
+  if (!AppStateNonEmptyStringList(metadata->snapshot_regions,
+                                  metadata->snapshot_region_count))
+    return 0;
+  if (!AppStateTransitionIdsRegistered(metadata->transition_ids,
+                                       metadata->transition_id_count))
+    return 0;
+  if (!AppStateTransitionFieldsRegistered(metadata->owner_field_refs,
+                                          metadata->owner_field_ref_count))
+    return 0;
+  if (!AppStateInvariantIdsRegistered(metadata->invariant_ids,
+                                      metadata->invariant_id_count))
+    return 0;
+  if (!AppStateGenerationDomainIdsRegistered(
+          metadata->generation_domain_ids, metadata->generation_domain_id_count))
+    return 0;
+  if (!AppStateNonEmptyStringList(metadata->migration_notes,
+                                  metadata->migration_note_count))
+    return 0;
+
+  return 1;
+}
+
+int AppStateValidatedDiffHarness(const char *harness_id) {
+  return AppStateValidateDiffHarness(harness_id,
+                                     AppStateDiffHarnessLookup(harness_id));
+}
+
+static int
+AppStateTransitionSequenceStepReady(
+    const AppStateTransitionSequenceStepMetadata *step) {
+  size_t index;
+
+  if (step == NULL || !AppStateNonEmptyString(step->step_id) ||
+      !AppStateValidatedTransition(step->transition_id) ||
+      !AppStateNonEmptyString(step->expected_result))
+    return 0;
+  if (step->action_coverage_ref_count == 0 &&
+      step->event_coverage_ref_count == 0)
+    return 0;
+  if (step->action_coverage_ref_count > 0 &&
+      !AppStateNonEmptyStringList(step->action_coverage_refs,
+                                  step->action_coverage_ref_count))
+    return 0;
+  if (step->event_coverage_ref_count > 0 &&
+      !AppStateNonEmptyStringList(step->event_coverage_refs,
+                                  step->event_coverage_ref_count))
+    return 0;
+  if (!AppStateInvariantIdsRegistered(step->invariant_ids,
+                                      step->invariant_id_count))
+    return 0;
+  if (!AppStateNonEmptyStringList(step->diff_harness_ids,
+                                  step->diff_harness_id_count))
+    return 0;
+  for (index = 0; index < step->diff_harness_id_count; index++) {
+    if (!AppStateValidatedDiffHarness(step->diff_harness_ids[index]))
+      return 0;
+  }
+  if (step->generation_domain_expectations == NULL ||
+      step->generation_domain_expectation_count == 0)
+    return 0;
+  for (index = 0; index < step->generation_domain_expectation_count; index++) {
+    const AppStateTransitionSequenceGenerationExpectationMetadata *expectation =
+        &step->generation_domain_expectations[index];
+
+    if (expectation == NULL ||
+        !AppStateNonEmptyString(expectation->domain_id) ||
+        !AppStateNonEmptyString(expectation->expectation) ||
+        !AppStateValidatedGenerationDomain(expectation->domain_id))
+      return 0;
+  }
+
+  return 1;
+}
+
+static int AppStateValidateTransitionSequence(
+    const char *scenario_id, const AppStateTransitionSequenceMetadata *metadata) {
+  size_t index;
+
+  if (!AppStateNonEmptyString(scenario_id))
+    return 0;
+  if (metadata == NULL || !AppStateNonEmptyString(metadata->scenario_id) ||
+      strcmp(metadata->scenario_id, scenario_id))
+    return 0;
+  if (!AppStateNonEmptyString(metadata->category) ||
+      !AppStateNonEmptyString(metadata->flow) ||
+      !AppStateNonEmptyString(metadata->description) ||
+      metadata->steps == NULL || metadata->step_count == 0)
+    return 0;
+
+  for (index = 0; index < metadata->step_count; index++) {
+    if (!AppStateTransitionSequenceStepReady(&metadata->steps[index]))
+      return 0;
+  }
+
+  return 1;
+}
+
+int AppStateValidatedTransitionSequence(const char *scenario_id) {
+  return AppStateValidateTransitionSequence(
+      scenario_id, AppStateTransitionSequenceLookup(scenario_id));
+}
+
 static YtreeNovaAction AppStateValidateKeyActionCoverage(
     YtreeNovaAction action, const AppStateActionCoverageMetadata *coverage) {
   if (action == ACTION_NONE)
     return ACTION_NONE;
   if (coverage == NULL || coverage->action != action)
     return ACTION_NONE;
-  if (AppStateTransitionLookup(coverage->transition_id) == NULL)
+  if (!AppStateValidatedTransition(coverage->transition_id))
     return ACTION_NONE;
 
   return action;
@@ -6318,7 +6656,7 @@ AppStateValidateEventCoverage(const char *event_id,
   if (coverage == NULL || coverage->event_id == NULL ||
       strcmp(coverage->event_id, event_id))
     return 0;
-  if (AppStateTransitionLookup(coverage->transition_id) == NULL)
+  if (!AppStateValidatedTransition(coverage->transition_id))
     return 0;
 
   return 1;
@@ -6336,7 +6674,7 @@ static int AppStateValidateDispatchSurface(
   if (metadata == NULL || metadata->surface_id == NULL ||
       strcmp(metadata->surface_id, surface_id))
     return 0;
-  if (AppStateTransitionLookup(metadata->transition_id) == NULL)
+  if (!AppStateValidatedTransition(metadata->transition_id))
     return 0;
 
   return 1;
@@ -6353,7 +6691,7 @@ static int AppStateValidateCompatibilityShim(
     return 0;
   if (metadata == NULL || metadata->id == NULL || strcmp(metadata->id, shim_id))
     return 0;
-  if (AppStateTransitionLookup(metadata->target_transition) == NULL)
+  if (!AppStateValidatedTransition(metadata->target_transition))
     return 0;
   if (metadata->write_capability == NULL ||
       (strcmp(metadata->write_capability, "write_capable") &&

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4798,7 +4798,7 @@ def test_appstate_shim_lookup_fails_closed_through_runtime_metadata() -> None:
     assert validation in header
     assert "static int AppStateValidateCompatibilityShim(" in source
     assert "AppStateCompatibilityShimLookup(shim_id)" in body
-    assert "AppStateTransitionLookup(metadata->target_transition)" in body
+    assert "AppStateValidatedTransition(metadata->target_transition)" in body
     assert "metadata->write_capability" in body
     assert '"read_only_projection"' in body
     assert "strcmp(metadata->id, shim_id)" in body
@@ -5049,6 +5049,130 @@ int main(void) {
   if (AppStateValidateEventCoverage("event.terminal-resize-signal",
                                     &missing_transition))
     return 11;
+
+  return 0;
+}
+""",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            "gcc",
+            "-std=c99",
+            "-I.",
+            "-Iinclude",
+            str(probe),
+            "-o",
+            str(binary),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0, build.stdout + build.stderr
+    run = subprocess.run(
+        [str(binary)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
+def test_runtime_registry_boundary_validation_requires_registered_metadata(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "registry_boundary_validation_probe.c"
+    binary = tmp_path / "registry_boundary_validation_probe"
+    probe.write_text(
+        """
+#include "src/core/appstate_actions.c"
+
+int main(void) {
+  AppStateTransitionMetadata invalid_transition;
+  AppStateOwnerFieldMetadata invalid_owner_field;
+  AppStateInvariantMetadata invalid_invariant;
+  AppStateGenerationDomainMetadata invalid_generation_domain;
+  AppStateDiffHarnessMetadata invalid_diff_harness;
+  AppStateTransitionSequenceMetadata invalid_sequence;
+  static const char *const missing_invariant_refs[] = {
+      "invariant.__ytnova_missing__",
+  };
+
+  if (!AppStateValidatedTransition("transition.keybinding.navigate-tree"))
+    return 1;
+  if (!AppStateValidatedOwnerField("panel.tree_selection_key"))
+    return 2;
+  if (!AppStateValidatedInvariant("invariant.inactive-panel-frozen"))
+    return 3;
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return 4;
+  if (!AppStateValidatedDiffHarness("harness.transition-before-after-snapshot"))
+    return 5;
+  if (!AppStateValidatedTransitionSequence("sequence.split-toggle-f8"))
+    return 6;
+
+  if (AppStateValidatedTransition(NULL))
+    return 7;
+  if (AppStateValidatedOwnerField(""))
+    return 8;
+  if (AppStateValidatedInvariant("invariant.__ytnova_missing__"))
+    return 9;
+  if (AppStateValidatedGenerationDomain("generation.__ytnova_missing__"))
+    return 10;
+  if (AppStateValidatedDiffHarness("harness.__ytnova_missing__"))
+    return 11;
+  if (AppStateValidatedTransitionSequence("sequence.__ytnova_missing__"))
+    return 12;
+
+  invalid_transition =
+      *AppStateTransitionLookup("transition.keybinding.navigate-tree");
+  invalid_transition.owner = "";
+  if (AppStateValidateTransition("transition.keybinding.navigate-tree",
+                                 &invalid_transition))
+    return 13;
+
+  invalid_owner_field = *AppStateOwnerFieldLookup("panel.tree_selection_key");
+  invalid_owner_field.invariant_checks = missing_invariant_refs;
+  invalid_owner_field.invariant_check_count = 1;
+  if (AppStateValidateOwnerField("panel.tree_selection_key",
+                                 &invalid_owner_field))
+    return 14;
+
+  invalid_invariant =
+      *AppStateInvariantLookup("invariant.inactive-panel-frozen");
+  invalid_invariant.transition_ids = NULL;
+  invalid_invariant.transition_id_count = 0;
+  if (AppStateValidateInvariant("invariant.inactive-panel-frozen",
+                                &invalid_invariant))
+    return 15;
+
+  invalid_generation_domain =
+      *AppStateGenerationDomainLookup("generation.panel.local-authority");
+  invalid_generation_domain.generation_owner_field = "panel.__ytnova_missing__";
+  if (AppStateValidateGenerationDomain("generation.panel.local-authority",
+                                       &invalid_generation_domain))
+    return 16;
+
+  invalid_diff_harness =
+      *AppStateDiffHarnessLookup("harness.transition-before-after-snapshot");
+  invalid_diff_harness.generation_domain_ids = NULL;
+  invalid_diff_harness.generation_domain_id_count = 0;
+  if (AppStateValidateDiffHarness("harness.transition-before-after-snapshot",
+                                  &invalid_diff_harness))
+    return 17;
+
+  invalid_sequence =
+      *AppStateTransitionSequenceLookup("sequence.split-toggle-f8");
+  invalid_sequence.steps = NULL;
+  invalid_sequence.step_count = 0;
+  if (AppStateValidateTransitionSequence("sequence.split-toggle-f8",
+                                         &invalid_sequence))
+    return 18;
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- Add fail-closed runtime validators for AppState transition, owner-field, invariant, generation-domain, diff-harness, and transition-sequence metadata.
- Route existing action, event, dispatch-surface, and compatibility-shim boundary checks through validated transition metadata instead of lookup-only transition presence.
- Extend the AppState contract guard probe to pin registered and malformed metadata outcomes.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` (passes with existing warning baseline)
- `git diff --check`
