### PR TITLE
chore(appstate): guard read-only projection shim writes

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -3355,6 +3355,10 @@ def _shim_write_capable(write_capability: Any) -> bool:
     return write_capability == "write_capable"
 
 
+def _shim_read_only_projection(write_capability: Any) -> bool:
+    return write_capability == "read_only_projection"
+
+
 def _validate_owner_field_ref_list(
     *,
     refs: Any,
@@ -3408,9 +3412,6 @@ def _validate_shim_owner_field_refs(
     if failures:
         return failures
 
-    if not _shim_write_capable(record.get("write_capability")):
-        return failures
-
     target_transition = record.get("target_transition")
     transition = (
         transition_ids.get(target_transition)
@@ -3430,11 +3431,21 @@ def _validate_shim_owner_field_refs(
     }
     owner_refs = record.get("owner_field_refs")
     assert isinstance(owner_refs, list)
+    write_capability = record.get("write_capability")
     for owner_ref in owner_refs:
-        if owner_ref not in declared_writes:
+        if _shim_write_capable(write_capability) and owner_ref not in declared_writes:
             failures.append(
                 f"{label}: owner_field_refs must be declared by "
                 f"target_transition write set {target_transition}: {owner_ref}"
+            )
+        if (
+            _shim_read_only_projection(write_capability)
+            and owner_ref in declared_writes
+        ):
+            failures.append(
+                f"{label}: read_only_projection owner_field_refs must stay "
+                f"outside target_transition write set {target_transition}: "
+                f"{owner_ref}"
             )
 
     return failures

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6322,6 +6322,23 @@ static int AppStateNonEmptyStringList(const char *const *values,
   return 1;
 }
 
+static int AppStateStringListContains(const char *const *values,
+                                      size_t value_count,
+                                      const char *value) {
+  size_t index;
+
+  if (!AppStateNonEmptyStringList(values, value_count) ||
+      !AppStateNonEmptyString(value))
+    return 0;
+
+  for (index = 0; index < value_count; index++) {
+    if (!strcmp(values[index], value))
+      return 1;
+  }
+
+  return 0;
+}
+
 static int AppStateTransitionFieldsRegistered(const char *const *fields,
                                               size_t field_count) {
   size_t index;
@@ -6696,17 +6713,39 @@ int AppStateValidatedDispatchSurface(const char *surface_id) {
 
 static int AppStateValidateCompatibilityShim(
     const char *shim_id, const AppStateCompatibilityShimMetadata *metadata) {
+  const AppStateTransitionMetadata *transition;
+  size_t owner_field_index;
+
   if (shim_id == NULL || shim_id[0] == '\0')
     return 0;
   if (metadata == NULL || metadata->id == NULL || strcmp(metadata->id, shim_id))
     return 0;
-  if (!AppStateValidatedTransition(metadata->target_transition))
+  transition = AppStateTransitionLookup(metadata->target_transition);
+  if (!AppStateValidateTransition(metadata->target_transition, transition))
     return 0;
   if (metadata->write_capability == NULL ||
       (strcmp(metadata->write_capability, "write_capable") &&
        strcmp(metadata->write_capability, "read_only_projection") &&
        strcmp(metadata->write_capability, "no_write")))
     return 0;
+  if (!AppStateTransitionFieldsRegistered(metadata->owner_field_refs,
+                                          metadata->owner_field_ref_count))
+    return 0;
+
+  for (owner_field_index = 0;
+       owner_field_index < metadata->owner_field_ref_count;
+       owner_field_index++) {
+    int field_in_transition = AppStateStringListContains(
+        transition->declared_write_set, transition->declared_write_set_count,
+        metadata->owner_field_refs[owner_field_index]);
+
+    if (!strcmp(metadata->write_capability, "write_capable") &&
+        !field_in_transition)
+      return 0;
+    if (!strcmp(metadata->write_capability, "read_only_projection") &&
+        field_in_transition)
+      return 0;
+  }
 
   return 1;
 }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1430,6 +1430,12 @@ static int AppStateCompatibilityShimWriteCapable(
          strcmp(metadata->write_capability, "write_capable") == 0;
 }
 
+static int AppStateCompatibilityShimReadOnlyProjection(
+    const AppStateCompatibilityShimMetadata *metadata) {
+  return metadata != NULL && metadata->write_capability != NULL &&
+         strcmp(metadata->write_capability, "read_only_projection") == 0;
+}
+
 static int AppStateCompatibilityShimWriteCapabilityKnown(
     const AppStateCompatibilityShimMetadata *metadata) {
   if (metadata == NULL || !NonEmptyString(metadata->write_capability))
@@ -1705,6 +1711,11 @@ static int AppStateCompatibilityShimsReady(void) {
           !StringListContains(transition->declared_write_set,
                               transition->declared_write_set_count,
                               metadata->owner_field_refs[ref_index]))
+        return 0;
+      if (AppStateCompatibilityShimReadOnlyProjection(metadata) &&
+          StringListContains(transition->declared_write_set,
+                             transition->declared_write_set_count,
+                             metadata->owner_field_refs[ref_index]))
         return 0;
       if (AppStateCompatibilityShimWriteCapable(metadata) &&
           AppStateGenerationOwnerFieldRegistered(

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4798,9 +4798,11 @@ def test_appstate_shim_lookup_fails_closed_through_runtime_metadata() -> None:
     assert validation in header
     assert "static int AppStateValidateCompatibilityShim(" in source
     assert "AppStateCompatibilityShimLookup(shim_id)" in body
-    assert "AppStateValidatedTransition(metadata->target_transition)" in body
+    assert "AppStateTransitionLookup(metadata->target_transition)" in body
+    assert "AppStateValidateTransition(metadata->target_transition, transition)" in body
     assert "metadata->write_capability" in body
     assert '"read_only_projection"' in body
+    assert "AppStateTransitionFieldsRegistered(metadata->owner_field_refs" in body
     assert "strcmp(metadata->id, shim_id)" in body
 
 
@@ -5099,6 +5101,7 @@ int main(void) {
   AppStateGenerationDomainMetadata invalid_generation_domain;
   AppStateDiffHarnessMetadata invalid_diff_harness;
   AppStateTransitionSequenceMetadata invalid_sequence;
+  AppStateCompatibilityShimMetadata invalid_shim;
   static const char *const missing_invariant_refs[] = {
       "invariant.__ytnova_missing__",
   };
@@ -5115,33 +5118,35 @@ int main(void) {
     return 5;
   if (!AppStateValidatedTransitionSequence("sequence.split-toggle-f8"))
     return 6;
+  if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
+    return 7;
 
   if (AppStateValidatedTransition(NULL))
-    return 7;
-  if (AppStateValidatedOwnerField(""))
     return 8;
-  if (AppStateValidatedInvariant("invariant.__ytnova_missing__"))
+  if (AppStateValidatedOwnerField(""))
     return 9;
-  if (AppStateValidatedGenerationDomain("generation.__ytnova_missing__"))
+  if (AppStateValidatedInvariant("invariant.__ytnova_missing__"))
     return 10;
-  if (AppStateValidatedDiffHarness("harness.__ytnova_missing__"))
+  if (AppStateValidatedGenerationDomain("generation.__ytnova_missing__"))
     return 11;
-  if (AppStateValidatedTransitionSequence("sequence.__ytnova_missing__"))
+  if (AppStateValidatedDiffHarness("harness.__ytnova_missing__"))
     return 12;
+  if (AppStateValidatedTransitionSequence("sequence.__ytnova_missing__"))
+    return 13;
 
   invalid_transition =
       *AppStateTransitionLookup("transition.keybinding.navigate-tree");
   invalid_transition.owner = "";
   if (AppStateValidateTransition("transition.keybinding.navigate-tree",
                                  &invalid_transition))
-    return 13;
+    return 14;
 
   invalid_owner_field = *AppStateOwnerFieldLookup("panel.tree_selection_key");
   invalid_owner_field.invariant_checks = missing_invariant_refs;
   invalid_owner_field.invariant_check_count = 1;
   if (AppStateValidateOwnerField("panel.tree_selection_key",
                                  &invalid_owner_field))
-    return 14;
+    return 15;
 
   invalid_invariant =
       *AppStateInvariantLookup("invariant.inactive-panel-frozen");
@@ -5149,14 +5154,14 @@ int main(void) {
   invalid_invariant.transition_id_count = 0;
   if (AppStateValidateInvariant("invariant.inactive-panel-frozen",
                                 &invalid_invariant))
-    return 15;
+    return 16;
 
   invalid_generation_domain =
       *AppStateGenerationDomainLookup("generation.panel.local-authority");
   invalid_generation_domain.generation_owner_field = "panel.__ytnova_missing__";
   if (AppStateValidateGenerationDomain("generation.panel.local-authority",
                                        &invalid_generation_domain))
-    return 16;
+    return 17;
 
   invalid_diff_harness =
       *AppStateDiffHarnessLookup("harness.transition-before-after-snapshot");
@@ -5164,7 +5169,7 @@ int main(void) {
   invalid_diff_harness.generation_domain_id_count = 0;
   if (AppStateValidateDiffHarness("harness.transition-before-after-snapshot",
                                   &invalid_diff_harness))
-    return 17;
+    return 18;
 
   invalid_sequence =
       *AppStateTransitionSequenceLookup("sequence.split-toggle-f8");
@@ -5172,7 +5177,14 @@ int main(void) {
   invalid_sequence.step_count = 0;
   if (AppStateValidateTransitionSequence("sequence.split-toggle-f8",
                                          &invalid_sequence))
-    return 18;
+    return 19;
+
+  invalid_shim =
+      *AppStateCompatibilityShimLookup("shim.focused-window-session-flag");
+  invalid_shim.write_capability = "read_only_projection";
+  if (AppStateValidateCompatibilityShim("shim.focused-window-session-flag",
+                                        &invalid_shim))
+    return 20;
 
   return 0;
 }
@@ -8200,6 +8212,26 @@ def test_guard_fails_when_runtime_shim_owner_field_ref_is_unknown(
     )
 
 
+def test_guard_fails_when_read_only_projection_shim_owner_field_is_in_write_set(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    shim = _shim()
+    shim["write_permission"] = "Read-only projection for render calculations."
+    shim["write_capability"] = "read_only_projection"
+    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
+
+    failures = _validate(paths)
+
+    assert any(
+        "shim[0]" in failure
+        and "read_only_projection owner_field_refs must stay outside "
+        "target_transition write set" in failure
+        and "field" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_runtime_shim_write_capability_is_missing(
     tmp_path: Path,
 ) -> None:
@@ -8294,6 +8326,32 @@ def test_guard_fails_when_runtime_write_capable_shim_owner_field_is_outside_writ
         and "owner_field_refs must be declared by target_transition write set"
         in failure
         and "panel.tree_selection_key" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_read_only_projection_owner_field_is_in_write_set(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_shims = [_shim()]
+    runtime_shims[0]["write_permission"] = (
+        "Read-only projection for render calculations."
+    )
+    runtime_shims[0]["write_capability"] = "read_only_projection"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_shims=runtime_shims,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_shim[0]" in failure
+        and "read_only_projection owner_field_refs must stay outside "
+        "target_transition write set" in failure
+        and "field" in failure
         for failure in failures
     )
 


### PR DESCRIPTION
Summary:
- Reject read-only projection shims when their owner fields are also in the target transition write set.
- Apply the same guard in the Python contract checker and runtime C metadata validators.
- Cover malformed document/runtime shim metadata and runtime startup validation.

Validation:
- `make clean && make` -> PASS with existing warning baseline.
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py` -> PASS.
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` -> PASS.
- `git diff --check` -> PASS.