### PR TITLE
chore(appstate): validate dispatch surface runtime metadata

### DIFF
--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6977,14 +6977,102 @@ int AppStateValidatedEvent(const char *event_id) {
                                        AppStateEventCoverageLookup(event_id));
 }
 
+static int AppStateTransitionSequenceRefsCoverTransition(
+    const char *const *sequence_refs, size_t sequence_ref_count,
+    const char *transition_id) {
+  size_t ref_index;
+
+  if (!AppStateNonEmptyStringList(sequence_refs, sequence_ref_count) ||
+      !AppStateNonEmptyString(transition_id))
+    return 0;
+
+  for (ref_index = 0; ref_index < sequence_ref_count; ref_index++) {
+    const AppStateTransitionSequenceMetadata *sequence =
+        AppStateTransitionSequenceLookup(sequence_refs[ref_index]);
+    size_t previous_index;
+    size_t step_index;
+    int transition_seen = 0;
+
+    if (sequence == NULL || sequence->steps == NULL ||
+        sequence->step_count == 0)
+      return 0;
+    for (previous_index = 0; previous_index < ref_index; previous_index++) {
+      if (strcmp(sequence_refs[previous_index], sequence_refs[ref_index]) == 0)
+        return 0;
+    }
+    for (step_index = 0; step_index < sequence->step_count; step_index++) {
+      const AppStateTransitionSequenceStepMetadata *step =
+          &sequence->steps[step_index];
+
+      if (!AppStateNonEmptyString(step->transition_id))
+        return 0;
+      if (strcmp(step->transition_id, transition_id) == 0)
+        transition_seen = 1;
+    }
+    if (!transition_seen)
+      return 0;
+  }
+
+  return 1;
+}
+
+static int AppStateDispatchSurfaceAllowedWritesReady(
+    const AppStateDispatchSurfaceMetadata *metadata,
+    const AppStateTransitionMetadata *transition) {
+  size_t write_index;
+
+  if (metadata == NULL || transition == NULL)
+    return 0;
+  if (metadata->allowed_direct_write_count == 0)
+    return metadata->allowed_direct_writes == NULL;
+  if (metadata->allowed_direct_writes == NULL)
+    return 0;
+
+  for (write_index = 0; write_index < metadata->allowed_direct_write_count;
+       write_index++) {
+    const char *field = metadata->allowed_direct_writes[write_index];
+
+    if (!AppStateNonEmptyString(field))
+      return 0;
+    if (AppStateOwnerFieldLookup(field) == NULL)
+      return 0;
+    if (!AppStateStringListContains(transition->declared_write_set,
+                                    transition->declared_write_set_count,
+                                    field))
+      return 0;
+    if (AppStateStringListContains(metadata->allowed_direct_writes, write_index,
+                                   field))
+      return 0;
+  }
+
+  return 1;
+}
+
 static int AppStateValidateDispatchSurface(
     const char *surface_id, const AppStateDispatchSurfaceMetadata *metadata) {
+  const AppStateTransitionMetadata *transition;
+
   if (surface_id == NULL || surface_id[0] == '\0')
     return 0;
   if (metadata == NULL || metadata->surface_id == NULL ||
       strcmp(metadata->surface_id, surface_id))
     return 0;
-  if (!AppStateValidatedTransition(metadata->transition_id))
+  transition = AppStateTransitionLookup(metadata->transition_id);
+  if (!AppStateValidateTransition(metadata->transition_id, transition))
+    return 0;
+  if (!AppStateNonEmptyString(metadata->category) ||
+      !AppStateNonEmptyString(metadata->source_path) ||
+      !AppStateNonEmptyString(metadata->entry_symbol_or_path) ||
+      !AppStateNonEmptyString(metadata->boundary_status))
+    return 0;
+  if (!AppStateDispatchSurfaceAllowedWritesReady(metadata, transition))
+    return 0;
+  if (!AppStateTransitionSequenceRefsCoverTransition(
+          metadata->transition_sequence_refs,
+          metadata->transition_sequence_ref_count, metadata->transition_id))
+    return 0;
+  if (!AppStateNonEmptyStringList(metadata->migration_notes,
+                                  metadata->migration_note_count))
     return 0;
 
   return 1;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4418,6 +4418,21 @@ def test_runtime_dispatch_surface_validation_requires_registry_and_transition(
 int main(void) {
   AppStateDispatchSurfaceMetadata mismatched_surface;
   AppStateDispatchSurfaceMetadata missing_transition;
+  AppStateDispatchSurfaceMetadata blank_source_path;
+  AppStateDispatchSurfaceMetadata unknown_allowed_write;
+  AppStateDispatchSurfaceMetadata outside_allowed_write;
+  AppStateDispatchSurfaceMetadata missing_sequences;
+  AppStateDispatchSurfaceMetadata wrong_sequence;
+  AppStateDispatchSurfaceMetadata missing_notes;
+  static const char *const unknown_allowed_writes[] = {
+      "field.__ytnova_missing__",
+  };
+  static const char *const outside_allowed_writes[] = {
+      "ctx.command_state",
+  };
+  static const char *const wrong_sequence_refs[] = {
+      "sequence.volume-cycling-release",
+  };
 
   if (!AppStateValidatedDispatchSurface("surface.key-decode-input-dispatch"))
     return 1;
@@ -4463,6 +4478,53 @@ int main(void) {
   if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
                                       &missing_transition))
     return 7;
+
+  blank_source_path =
+      *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
+  blank_source_path.source_path = "";
+  if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
+                                      &blank_source_path))
+    return 17;
+
+  unknown_allowed_write =
+      *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
+  unknown_allowed_write.allowed_direct_writes = unknown_allowed_writes;
+  unknown_allowed_write.allowed_direct_write_count = 1;
+  if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
+                                      &unknown_allowed_write))
+    return 18;
+
+  outside_allowed_write =
+      *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
+  outside_allowed_write.allowed_direct_writes = outside_allowed_writes;
+  outside_allowed_write.allowed_direct_write_count = 1;
+  if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
+                                      &outside_allowed_write))
+    return 19;
+
+  missing_sequences =
+      *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
+  missing_sequences.transition_sequence_refs = 0;
+  missing_sequences.transition_sequence_ref_count = 0;
+  if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
+                                      &missing_sequences))
+    return 20;
+
+  wrong_sequence =
+      *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
+  wrong_sequence.transition_sequence_refs = wrong_sequence_refs;
+  wrong_sequence.transition_sequence_ref_count = 1;
+  if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
+                                      &wrong_sequence))
+    return 21;
+
+  missing_notes =
+      *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
+  missing_notes.migration_notes = 0;
+  missing_notes.migration_note_count = 0;
+  if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
+                                      &missing_notes))
+    return 22;
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- strengthen runtime dispatch-surface validation so malformed surface metadata fails closed at the AppState boundary
- reject blank surface fields, unknown or out-of-contract direct writes, uncovered transition-sequence refs, and missing migration notes
- extend the focused C probe for dispatch-surface validation

## Validation
- red: focused dispatch-surface probe failed before implementation on blank source-path metadata
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'runtime_dispatch_surface_validation_requires_registry_and_transition'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'dispatch_surface or appstate_contract'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` (passes with existing warning baseline)
- `git diff --check`
