### PR TITLE
chore(appstate): validate generation domain runtime advances

### DIFF
--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6704,6 +6704,8 @@ int AppStateValidatedInvariant(const char *invariant_id) {
 static int
 AppStateValidateGenerationDomain(
     const char *domain_id, const AppStateGenerationDomainMetadata *metadata) {
+  size_t index;
+
   if (!AppStateNonEmptyString(domain_id))
     return 0;
   if (metadata == NULL || !AppStateNonEmptyString(metadata->domain_id) ||
@@ -6729,6 +6731,12 @@ AppStateValidateGenerationDomain(
           metadata->advances_on_transition_ids,
           metadata->advances_on_transition_id_count))
     return 0;
+  for (index = 0; index < metadata->advances_on_transition_id_count; index++) {
+    if (!AppStateStringListContains(metadata->coverage_transition_ids,
+                                    metadata->coverage_transition_id_count,
+                                    metadata->advances_on_transition_ids[index]))
+      return 0;
+  }
   if (!AppStateNonEmptyStringList(metadata->migration_notes,
                                   metadata->migration_note_count))
     return 0;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4259,6 +4259,104 @@ int main(void) {
     assert run.returncode == 0, run.stdout + run.stderr
 
 
+def test_runtime_generation_domain_validation_requires_covered_advances(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "generation_domain_validation_probe.c"
+    binary = tmp_path / "generation_domain_validation_probe"
+    probe.write_text(
+        """
+#include "src/core/appstate_actions.c"
+
+int main(void) {
+  AppStateGenerationDomainMetadata mismatched_domain;
+  AppStateGenerationDomainMetadata missing_transition;
+  AppStateGenerationDomainMetadata uncovered_advance;
+  AppStateGenerationDomainMetadata missing_notes;
+  static const char *const missing_transition_ids[] = {
+      "transition.__ytnova_missing__",
+  };
+  static const char *const uncovered_advance_ids[] = {
+      "transition.command-completion.user-command",
+  };
+
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return 1;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
+    return 2;
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return 3;
+  if (AppStateValidatedGenerationDomain(NULL))
+    return 4;
+  if (AppStateValidatedGenerationDomain(""))
+    return 5;
+  if (AppStateValidatedGenerationDomain("generation.__ytnova_missing__"))
+    return 6;
+
+  mismatched_domain =
+      *AppStateGenerationDomainLookup("generation.panel.local-authority");
+  mismatched_domain.domain_id = "generation.__ytnova_mismatch__";
+  if (AppStateValidateGenerationDomain("generation.panel.local-authority",
+                                       &mismatched_domain))
+    return 7;
+
+  missing_transition =
+      *AppStateGenerationDomainLookup("generation.panel.local-authority");
+  missing_transition.coverage_transition_ids = missing_transition_ids;
+  missing_transition.coverage_transition_id_count = 1;
+  if (AppStateValidateGenerationDomain("generation.panel.local-authority",
+                                       &missing_transition))
+    return 8;
+
+  uncovered_advance =
+      *AppStateGenerationDomainLookup("generation.panel.local-authority");
+  uncovered_advance.advances_on_transition_ids = uncovered_advance_ids;
+  uncovered_advance.advances_on_transition_id_count = 1;
+  if (AppStateValidateGenerationDomain("generation.panel.local-authority",
+                                       &uncovered_advance))
+    return 9;
+
+  missing_notes =
+      *AppStateGenerationDomainLookup("generation.panel.local-authority");
+  missing_notes.migration_notes = 0;
+  missing_notes.migration_note_count = 0;
+  if (AppStateValidateGenerationDomain("generation.panel.local-authority",
+                                       &missing_notes))
+    return 10;
+
+  return 0;
+}
+""",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            "gcc",
+            "-std=c99",
+            "-I.",
+            "-Iinclude",
+            str(probe),
+            "-o",
+            str(binary),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0, build.stdout + build.stderr
+    run = subprocess.run(
+        [str(binary)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
 def test_runtime_action_coverage_lookup_fails_closed(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     probe = tmp_path / "action_coverage_lookup_probe.c"


### PR DESCRIPTION
Summary:
- Fail closed when runtime generation-domain metadata advances transitions outside its coverage set.
- Add a focused C probe covering valid generation domains and malformed runtime metadata.

Validation:
- Red focused probe failed before implementation on uncovered advance metadata.
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'runtime_generation_domain_validation_requires_covered_advances or runtime_generation_domain_startup or runtime_generation_write_startup'` -> PASS.
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` -> PASS.
- `make clean && make` -> PASS with existing warning baseline.
- `git diff --check` -> PASS.