### PR TITLE
chore(appstate): require projection notes for generation coverage

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -3023,6 +3023,23 @@ def _validate_runtime_generation_domain_registry(
                         f"{label}: advances_on_transition_ids must be covered by "
                         f"coverage_transition_ids: {transition_id}"
                     )
+            declared_advances = {
+                transition_id
+                for transition_id in transition_refs
+                if isinstance(transition_id, str) and transition_id.strip()
+            }
+            for transition_id in coverage_transition_refs:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in declared_advances
+                    and not _has_projection_only_note(record.get("migration_notes"))
+                ):
+                    failures.append(
+                        f"{label}: coverage_transition_ids without "
+                        "advances_on_transition_ids requires a read-only/"
+                        f"projection-only migration_notes explanation: {transition_id}"
+                    )
         generation_owner_field = record.get("generation_owner_field")
         if (
             isinstance(generation_owner_field, str)
@@ -4896,6 +4913,14 @@ def _validate_generation_transition_refs(
     return failures
 
 
+def _has_projection_only_note(migration_notes: Any) -> bool:
+    return isinstance(migration_notes, list) and any(
+        isinstance(note, str)
+        and ("read-only" in note.lower() or "projection-only" in note.lower())
+        for note in migration_notes
+    )
+
+
 def _validate_generation_domains(
     *,
     generation_domains_doc: Any,
@@ -5013,6 +5038,23 @@ def _validate_generation_domains(
                     failures.append(
                         f"{label}: advances_on_transition_ids must be covered by "
                         f"coverage_transition_ids: {transition_id}"
+                    )
+            declared_advances = {
+                transition_id
+                for transition_id in advances_on_transition_ids
+                if isinstance(transition_id, str) and transition_id.strip()
+            }
+            for transition_id in coverage_transition_ids:
+                if (
+                    isinstance(transition_id, str)
+                    and transition_id.strip()
+                    and transition_id not in declared_advances
+                    and not _has_projection_only_note(record.get("migration_notes"))
+                ):
+                    failures.append(
+                        f"{label}: coverage_transition_ids without "
+                        "advances_on_transition_ids requires a read-only/"
+                        f"projection-only migration_notes explanation: {transition_id}"
                     )
 
     missing_categories = sorted(

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -977,6 +977,40 @@ static int AppStateTransitionRegistryReady(void) {
   return 1;
 }
 
+static int AppStateGenerationCoverageOnlyHasProjectionNote(
+    const AppStateGenerationDomainMetadata *metadata) {
+  size_t coverage_index;
+  int has_projection_note = 0;
+  size_t note_index;
+
+  if (metadata == NULL)
+    return 0;
+
+  for (note_index = 0; note_index < metadata->migration_note_count;
+       note_index++) {
+    const char *note = metadata->migration_notes[note_index];
+
+    if (note != NULL &&
+        (strstr(note, "read-only") != NULL ||
+         strstr(note, "projection-only") != NULL)) {
+      has_projection_note = 1;
+      break;
+    }
+  }
+
+  for (coverage_index = 0;
+       coverage_index < metadata->coverage_transition_id_count;
+       coverage_index++) {
+    if (!StringListContains(metadata->advances_on_transition_ids,
+                            metadata->advances_on_transition_id_count,
+                            metadata->coverage_transition_ids[coverage_index]) &&
+        !has_projection_note)
+      return 0;
+  }
+
+  return 1;
+}
+
 static int AppStateGenerationDomainsReady(void) {
   size_t index;
   size_t required_generation_domain_id_count =
@@ -1050,6 +1084,8 @@ static int AppStateGenerationDomainsReady(void) {
                                   [transition_index]))
         return 0;
     }
+    if (!AppStateGenerationCoverageOnlyHasProjectionNote(metadata))
+      return 0;
   }
 
   for (index = 0; index < required_generation_domain_id_count; index++) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -530,6 +530,11 @@ def _generation_domain(
         if advances_on_transition_ids is not None
         else ["transition.keybinding"]
     )
+    migration_notes = ["fixture coverage"]
+    if set(resolved_coverage_transition_ids) - set(
+        resolved_advances_on_transition_ids
+    ):
+        migration_notes = ["read-only/projection-only fixture coverage"]
     return {
         "domain_id": domain_id or f"domain.{category}",
         "category": category,
@@ -542,7 +547,7 @@ def _generation_domain(
         "fail_closed_fallback": "fixture fail-closed fallback",
         "restore_boundary": "fixture restore boundary",
         "enforcement_status": "documented_foundation_only",
-        "migration_notes": ["fixture coverage"],
+        "migration_notes": migration_notes,
     }
 
 
@@ -5986,6 +5991,38 @@ def test_guard_fails_when_runtime_generation_domain_stale_boundary_fields_drift(
     )
 
 
+def test_guard_fails_when_runtime_generation_domain_coverage_only_lacks_projection_note(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()
+    runtime_generation_domains[0]["coverage_transition_ids"] = [
+        "transition.keybinding.navigate-tree",
+        "transition.render-reflow.project-state",
+    ]
+    runtime_generation_domains[0]["advances_on_transition_ids"] = [
+        "transition.keybinding.navigate-tree"
+    ]
+    runtime_generation_domains[0]["migration_notes"] = [
+        "Coverage-only transition is not explained."
+    ]
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and "coverage_transition_ids without advances_on_transition_ids"
+        in failure
+        and "transition.render-reflow.project-state" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_when_generation_effect_names_unregistered_generation_field(
     tmp_path: Path,
 ) -> None:
@@ -11362,6 +11399,24 @@ def test_runtime_generation_domain_startup_separates_coverage_from_advances() ->
         ready_body,
         re.S,
     )
+
+
+def test_runtime_generation_domain_startup_requires_projection_note_for_coverage_only() -> None:
+    source = Path("src/core/main.c").read_text(encoding="utf-8")
+    helper_start = source.index(
+        "static int AppStateGenerationCoverageOnlyHasProjectionNote("
+    )
+    generation_start = source.index("static int AppStateGenerationDomainsReady(void)")
+    dispatch_start = source.index(
+        "static int AppStateDispatchSurfaceWriteHasInvariantCoverage("
+    )
+    helper_body = source[helper_start:generation_start]
+    ready_body = source[generation_start:dispatch_start]
+
+    assert "AppStateGenerationCoverageOnlyHasProjectionNote(metadata)" in ready_body
+    assert "metadata->migration_notes" in helper_body
+    assert '"read-only"' in helper_body
+    assert '"projection-only"' in helper_body
 
 
 def test_runtime_dispatch_surface_startup_checks_fail_closed() -> None:


### PR DESCRIPTION
Summary:
- Require coverage-only generation-domain transitions to carry a read-only/projection-only migration note in both the docs guard and runtime startup gate.
- Keep fixture generation domains aligned with the stricter projection-coverage contract.

Validation:
- Red focused pytest confirmed missing guard/runtime enforcement before implementation.
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'generation_domain'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`