### PR TITLE
chore(appstate): validate registry status metadata

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -334,6 +334,17 @@ VALID_SHIM_WRITE_CAPABILITIES = {
     "read_only_projection",
     "no_write",
 }
+VALID_BOUNDARY_STATUSES = {
+    "covered_by_transition_record",
+    "documented_foundation_only",
+    "mapped_to_existing_broad_transition",
+}
+VALID_ENFORCEMENT_STATUSES = {
+    "documented_foundation_only",
+}
+VALID_MIGRATION_STATUSES = {
+    "documented_foundation_only",
+}
 DISPATCH_LIST_FIELDS = {"migration_notes", "transition_sequence_refs"}
 INVARIANT_LIST_FIELDS = {
     "protected_fields",
@@ -423,6 +434,21 @@ def _validate_required_fields(
             failures.append(f"{label}: {field} must be non-empty")
 
     return failures
+
+
+def _validate_status_field(
+    *,
+    record: dict[str, Any],
+    label: str,
+    field: str,
+    valid_statuses: set[str],
+) -> list[str]:
+    value = record.get(field)
+    if not isinstance(value, str) or not value.strip():
+        return []
+    if value not in valid_statuses:
+        return [f"{label}: unknown {field}: {value}"]
+    return []
 
 
 def _parse_ytnova_actions(header_path: Path) -> tuple[list[str], list[str]]:
@@ -2156,6 +2182,14 @@ def _validate_runtime_action_coverage_registry(
         action_name = record.get("action_name")
         if not isinstance(action_name, str) or not action_name.strip():
             failures.append(f"{label}: action_name must be non-empty")
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="boundary_status",
+                valid_statuses=VALID_BOUNDARY_STATUSES,
+            )
+        )
 
         action = record.get("action")
         if isinstance(action, str) and action.strip():
@@ -2386,6 +2420,14 @@ def _validate_runtime_transition_registry(
                         f"{runtime_id}: {record.get(field)}"
                     )
 
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="boundary_status",
+                valid_statuses=VALID_BOUNDARY_STATUSES,
+            )
+        )
         failures.extend(
             _validate_registered_write_set(
                 record=record,
@@ -2626,6 +2668,14 @@ def _validate_runtime_owner_field_registry(
                         f"{runtime_field}: {record.get(field)}"
                     )
 
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="migration_status",
+                valid_statuses=VALID_MIGRATION_STATUSES,
+            )
+        )
         for field in sorted(REQUIRED_OWNER_FIELDS - {"invariant_checks"}):
             value = record.get(field)
             if not isinstance(value, str) or not value.strip():
@@ -2719,6 +2769,14 @@ def _validate_runtime_dispatch_surface_registry(
                         f"surface {runtime_id}: {record.get(field)}"
                     )
 
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="boundary_status",
+                valid_statuses=VALID_BOUNDARY_STATUSES,
+            )
+        )
         writes = record.get("allowed_direct_writes")
         if not isinstance(writes, list):
             failures.append(f"{label}: allowed_direct_writes must be a list")
@@ -2829,6 +2887,14 @@ def _validate_runtime_invariant_registry(
                         f"{runtime_id}: {record.get(field)}"
                     )
 
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="enforcement_status",
+                valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
         for field in (
             "protected_fields",
             "transition_ids",
@@ -2953,6 +3019,14 @@ def _validate_runtime_generation_domain_registry(
                         f"domain {runtime_id}: {record.get(field)}"
                     )
 
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="enforcement_status",
+                valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
         for field in (
             "domain_id",
             "category",
@@ -3118,6 +3192,14 @@ def _validate_runtime_diff_harness_registry(
                         f"{runtime_id}: {record.get(field)}"
                     )
 
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="enforcement_status",
+                valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
         for field in (
             "harness_id",
             "check_category",
@@ -3800,6 +3882,14 @@ def _validate_owner_fields(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="migration_status",
+                valid_statuses=VALID_MIGRATION_STATUSES,
+            )
+        )
 
         field = record.get("field")
         if isinstance(field, str) and field.strip():
@@ -4385,6 +4475,14 @@ def _validate_appstate_diff_harness(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="enforcement_status",
+                valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
 
         harness_id = record.get("harness_id")
         harness_label = label
@@ -4652,6 +4750,14 @@ def _validate_dispatch_surfaces(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="boundary_status",
+                valid_statuses=VALID_BOUNDARY_STATUSES,
+            )
+        )
         if "allowed_direct_writes" not in record:
             failures.append(f"{label}: missing required field(s): allowed_direct_writes")
         else:
@@ -4775,6 +4881,14 @@ def _validate_invariants(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="enforcement_status",
+                valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
         if "dispatch_surface_ids" not in record:
             failures.append(f"{label}: missing required field(s): dispatch_surface_ids")
         else:
@@ -4956,6 +5070,14 @@ def _validate_generation_domains(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="enforcement_status",
+                valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
 
         if "advances_on_transition_ids" not in record:
             failures.append(
@@ -5134,6 +5256,16 @@ def _validate_runtime_event_coverage_registry(
                 label=label,
             )
         )
+        if not isinstance(record, dict):
+            continue
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="boundary_status",
+                valid_statuses=VALID_BOUNDARY_STATUSES,
+            )
+        )
         failures.extend(
             _validate_owner_field_coverage_refs(
                 record=record,
@@ -5299,6 +5431,14 @@ def _validate_event_coverage(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="boundary_status",
+                valid_statuses=VALID_BOUNDARY_STATUSES,
+            )
+        )
         failures.extend(
             _validate_registered_write_set(
                 record=record,
@@ -6862,6 +7002,14 @@ def validate_contract(
         if not isinstance(record, dict):
             continue
         failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="boundary_status",
+                valid_statuses=VALID_BOUNDARY_STATUSES,
+            )
+        )
+        failures.extend(
             _validate_registered_write_set(
                 record=record,
                 registered_fields=registered_owner_fields,
@@ -7181,6 +7329,14 @@ def validate_contract(
         )
         if not isinstance(record, dict):
             continue
+        failures.extend(
+            _validate_status_field(
+                record=record,
+                label=label,
+                field="boundary_status",
+                valid_statuses=VALID_BOUNDARY_STATUSES,
+            )
+        )
         failures.extend(
             _validate_registered_write_set(
                 record=record,

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6517,6 +6517,20 @@ static int AppStateStringListsOverlap(const char *const *left,
   return 0;
 }
 
+static int AppStateKnownBoundaryStatus(const char *status) {
+  if (!AppStateNonEmptyString(status))
+    return 0;
+  return strcmp(status, "covered_by_transition_record") == 0 ||
+         strcmp(status, "documented_foundation_only") == 0 ||
+         strcmp(status, "mapped_to_existing_broad_transition") == 0;
+}
+
+static int AppStateKnownFoundationStatus(const char *status) {
+  if (!AppStateNonEmptyString(status))
+    return 0;
+  return strcmp(status, "documented_foundation_only") == 0;
+}
+
 static const AppStateActionCoverageMetadata *
 AppStateActionCoverageIdLookup(const char *action_id) {
   size_t index;
@@ -6646,6 +6660,8 @@ AppStateValidateTransition(const char *transition_id,
       !AppStateNonEmptyString(metadata->boundary_status) ||
       !AppStateNonEmptyString(metadata->notes_follow_up))
     return 0;
+  if (!AppStateKnownBoundaryStatus(metadata->boundary_status))
+    return 0;
   if (!AppStateTransitionFieldsRegistered(metadata->declared_write_set,
                                           metadata->declared_write_set_count))
     return 0;
@@ -6686,6 +6702,8 @@ AppStateValidateOwnerField(const char *field,
       !AppStateNonEmptyString(metadata->runtime_carrier) ||
       !AppStateNonEmptyString(metadata->mutation_rule) ||
       !AppStateNonEmptyString(metadata->migration_status))
+    return 0;
+  if (!AppStateKnownFoundationStatus(metadata->migration_status))
     return 0;
   if (!AppStateInvariantIdsRegistered(metadata->invariant_checks,
                                       metadata->invariant_check_count))
@@ -6728,6 +6746,8 @@ AppStateValidateInvariant(const char *invariant_id,
       !AppStateNonEmptyString(metadata->enforcement_status) ||
       !AppStateNonEmptyString(metadata->test_strategy))
     return 0;
+  if (!AppStateKnownFoundationStatus(metadata->enforcement_status))
+    return 0;
   if (!AppStateTransitionFieldsRegistered(metadata->protected_fields,
                                           metadata->protected_field_count))
     return 0;
@@ -6766,6 +6786,8 @@ AppStateValidateGenerationDomain(
       !AppStateNonEmptyString(metadata->fail_closed_fallback) ||
       !AppStateNonEmptyString(metadata->restore_boundary) ||
       !AppStateNonEmptyString(metadata->enforcement_status))
+    return 0;
+  if (!AppStateKnownFoundationStatus(metadata->enforcement_status))
     return 0;
   if (AppStateOwnerFieldLookup(metadata->generation_owner_field) == NULL)
     return 0;
@@ -6825,6 +6847,8 @@ AppStateValidateDiffHarness(const char *harness_id,
       !AppStateNonEmptyString(metadata->expected_behavior) ||
       !AppStateNonEmptyString(metadata->failure_mode) ||
       !AppStateNonEmptyString(metadata->enforcement_status))
+    return 0;
+  if (!AppStateKnownFoundationStatus(metadata->enforcement_status))
     return 0;
   if (!AppStateNonEmptyStringList(metadata->snapshot_phases,
                                   metadata->snapshot_phase_count))
@@ -7067,6 +7091,8 @@ static YtreeNovaAction AppStateValidateKeyActionCoverage(
       strcmp(coverage->category, transition->category) != 0 ||
       strcmp(coverage->owner, transition->owner) != 0)
     return ACTION_NONE;
+  if (!AppStateKnownBoundaryStatus(coverage->boundary_status))
+    return ACTION_NONE;
   if (!AppStateStringListEquals(coverage->declared_write_set,
                                 coverage->declared_write_set_count,
                                 transition->declared_write_set,
@@ -7118,6 +7144,8 @@ AppStateValidateEventCoverage(const char *event_id,
       !AppStateNonEmptyString(coverage->boundary_status) ||
       strcmp(coverage->category, transition->category) != 0 ||
       strcmp(coverage->owner, transition->owner) != 0)
+    return 0;
+  if (!AppStateKnownBoundaryStatus(coverage->boundary_status))
     return 0;
   if (!AppStateStringListEquals(coverage->declared_write_set,
                                 coverage->declared_write_set_count,
@@ -7239,6 +7267,8 @@ static int AppStateValidateDispatchSurface(
       !AppStateNonEmptyString(metadata->source_path) ||
       !AppStateNonEmptyString(metadata->entry_symbol_or_path) ||
       !AppStateNonEmptyString(metadata->boundary_status))
+    return 0;
+  if (!AppStateKnownBoundaryStatus(metadata->boundary_status))
     return 0;
   if (!AppStateDispatchSurfaceAllowedWritesReady(metadata, transition))
     return 0;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -120,7 +120,7 @@ def _transition(category: str, transition_id: str | None = None) -> dict[str, ob
         "generation_effect": generation_effect,
         "side_effects": ["none"],
         "render_invalidation": "view",
-        "boundary_status": "test",
+        "boundary_status": "documented_foundation_only",
         "notes_follow_up": "follow-up",
     }
 
@@ -174,7 +174,7 @@ def _action(
         ),
         "diff_harness_refs": _diff_harness_refs_for_transition(transition_id),
         "invariant_refs": _invariant_refs_for_transition(transition_id),
-        "boundary_status": "test",
+        "boundary_status": "documented_foundation_only",
         "migration_notes": ["fixture action coverage"],
     }
 
@@ -225,7 +225,7 @@ def _event(
         "invariant_refs": _invariant_refs_for_transition(
             resolved_transition_id
         ),
-        "boundary_status": "test",
+        "boundary_status": "documented_foundation_only",
         "trigger_paths": ["fixture trigger"],
         "migration_notes": ["fixture event coverage"],
     }
@@ -485,7 +485,7 @@ def _dispatch_surface(
         "source_path": "src/ui/key_engine.c",
         "entry_symbol_or_path": "GetEventOrKey",
         "transition_id": resolved_transition_id,
-        "boundary_status": "test",
+        "boundary_status": "documented_foundation_only",
         "allowed_direct_writes": allowed_direct_writes,
         "transition_sequence_refs": [sequence_by_surface_category[category]],
         "migration_notes": ["fixture coverage"],
@@ -744,7 +744,7 @@ def _owner_field(field: str = "field") -> dict[str, object]:
         "canonical_owner": "YtreeNovaPanel(fixture)",
         "runtime_carrier": "YtreeNovaPanel fixture carrier",
         "mutation_rule": "Fixture transitions may mutate only declared fields.",
-        "migration_status": "test",
+        "migration_status": "documented_foundation_only",
         "invariant_checks": ["invariant.inactive_panel_frozen"],
     }
 
@@ -4580,6 +4580,108 @@ int main(void) {
     assert run.returncode == 0, run.stdout + run.stderr
 
 
+def test_runtime_registry_status_validation_rejects_unknown_values(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "appstate_status_validation_probe.c"
+    binary = tmp_path / "appstate_status_validation_probe"
+    probe.write_text(
+        """
+#include "src/core/appstate_actions.c"
+
+int main(void) {
+  AppStateActionCoverageMetadata action_coverage;
+  AppStateDiffHarnessMetadata diff_harness;
+  AppStateDispatchSurfaceMetadata dispatch_surface;
+  AppStateEventCoverageMetadata event_coverage;
+  AppStateGenerationDomainMetadata generation_domain;
+  AppStateInvariantMetadata invariant;
+  AppStateOwnerFieldMetadata owner_field;
+  AppStateTransitionMetadata transition;
+
+  transition = *AppStateTransitionLookup("transition.keybinding.navigate-tree");
+  transition.boundary_status = "boundary.__ytnova_unknown__";
+  if (AppStateValidateTransition("transition.keybinding.navigate-tree",
+                                 &transition))
+    return 1;
+
+  action_coverage = *AppStateActionCoverageLookup(ACTION_ENTER);
+  action_coverage.boundary_status = "boundary.__ytnova_unknown__";
+  if (AppStateValidateKeyActionCoverage(ACTION_ENTER, &action_coverage) !=
+      ACTION_NONE)
+    return 2;
+
+  event_coverage =
+      *AppStateEventCoverageLookup("event.terminal-resize-signal");
+  event_coverage.boundary_status = "boundary.__ytnova_unknown__";
+  if (AppStateValidateEventCoverage("event.terminal-resize-signal",
+                                    &event_coverage))
+    return 3;
+
+  dispatch_surface =
+      *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
+  dispatch_surface.boundary_status = "boundary.__ytnova_unknown__";
+  if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
+                                      &dispatch_surface))
+    return 4;
+
+  owner_field = *AppStateOwnerFieldLookup("ctx.active");
+  owner_field.migration_status = "boundary.__ytnova_unknown__";
+  if (AppStateValidateOwnerField("ctx.active", &owner_field))
+    return 5;
+
+  invariant = *AppStateInvariantLookup("invariant.inactive-panel-frozen");
+  invariant.enforcement_status = "boundary.__ytnova_unknown__";
+  if (AppStateValidateInvariant("invariant.inactive-panel-frozen", &invariant))
+    return 6;
+
+  generation_domain =
+      *AppStateGenerationDomainLookup("generation.panel.local-authority");
+  generation_domain.enforcement_status = "boundary.__ytnova_unknown__";
+  if (AppStateValidateGenerationDomain("generation.panel.local-authority",
+                                       &generation_domain))
+    return 7;
+
+  diff_harness =
+      *AppStateDiffHarnessLookup("harness.transition-before-after-snapshot");
+  diff_harness.enforcement_status = "boundary.__ytnova_unknown__";
+  if (AppStateValidateDiffHarness("harness.transition-before-after-snapshot",
+                                  &diff_harness))
+    return 8;
+
+  return 0;
+}
+""",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            "gcc",
+            "-std=c99",
+            "-I.",
+            "-Iinclude",
+            str(probe),
+            "-o",
+            str(binary),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0, build.stdout + build.stderr
+    run = subprocess.run(
+        [str(binary)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
 def test_runtime_dispatch_surface_validation_requires_registry_and_transition(
     tmp_path: Path,
 ) -> None:
@@ -7503,6 +7605,87 @@ def test_guard_fails_when_required_transition_field_is_missing(tmp_path: Path) -
     failures = _validate(paths)
 
     assert any("missing required field" in failure and "owner" in failure for failure in failures)
+
+
+def test_guard_fails_when_registry_status_is_unknown(tmp_path: Path) -> None:
+    transitions = _complete_transitions()
+    actions = _complete_actions()
+    events = _complete_events()
+    owner_fields = _complete_owner_fields()
+    dispatch_surfaces = _complete_dispatch_surfaces()
+    invariants = _complete_invariants()
+    generation_domains = _complete_generation_domains()
+    diff_harness_checks = _complete_diff_harness_checks()
+    transitions[0]["boundary_status"] = "boundary.__ytnova_unknown__"
+    actions[0]["boundary_status"] = "boundary.__ytnova_unknown__"
+    events[0]["boundary_status"] = "boundary.__ytnova_unknown__"
+    owner_fields[0]["migration_status"] = "boundary.__ytnova_unknown__"
+    dispatch_surfaces[0]["boundary_status"] = "boundary.__ytnova_unknown__"
+    invariants[0]["enforcement_status"] = "boundary.__ytnova_unknown__"
+    generation_domains[0]["enforcement_status"] = "boundary.__ytnova_unknown__"
+    diff_harness_checks[0]["enforcement_status"] = "boundary.__ytnova_unknown__"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        actions=actions,
+        events=events,
+        owner_fields=owner_fields,
+        dispatch_surfaces=dispatch_surfaces,
+        invariants=invariants,
+        generation_domains=generation_domains,
+        diff_harness_checks=diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "transition[0]" in failure
+        and "unknown boundary_status" in failure
+        and "boundary.__ytnova_unknown__" in failure
+        for failure in failures
+    )
+    assert any(
+        "action[0]" in failure
+        and "unknown boundary_status" in failure
+        and "boundary.__ytnova_unknown__" in failure
+        for failure in failures
+    )
+    assert any(
+        "event[0]" in failure
+        and "unknown boundary_status" in failure
+        and "boundary.__ytnova_unknown__" in failure
+        for failure in failures
+    )
+    assert any(
+        "owner_field[0]" in failure
+        and "unknown migration_status" in failure
+        and "boundary.__ytnova_unknown__" in failure
+        for failure in failures
+    )
+    assert any(
+        "dispatch_surface[0]" in failure
+        and "unknown boundary_status" in failure
+        and "boundary.__ytnova_unknown__" in failure
+        for failure in failures
+    )
+    assert any(
+        "invariant[0]" in failure
+        and "unknown enforcement_status" in failure
+        and "boundary.__ytnova_unknown__" in failure
+        for failure in failures
+    )
+    assert any(
+        "generation_domain[0]" in failure
+        and "unknown enforcement_status" in failure
+        and "boundary.__ytnova_unknown__" in failure
+        for failure in failures
+    )
+    assert any(
+        "diff_harness_check[0]" in failure
+        and "unknown enforcement_status" in failure
+        and "boundary.__ytnova_unknown__" in failure
+        for failure in failures
+    )
 
 
 def test_guard_fails_when_required_shim_field_is_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary:
- Fail closed when AppState registry boundary, enforcement, or migration status metadata uses an unknown value.
- Apply the status allowlist consistently in the docs guard and runtime metadata validators.
- Add focused guard and C probes for unknown status values.

Validation:
- Red focused pytest failed before implementation on unknown registry status values.
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'registry_status_validation_rejects_unknown_values or registry_status_is_unknown'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make`
- `git diff --check`