### PR TITLE
chore(appstate): validate transition sequence result metadata

### DIFF
--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6880,6 +6880,91 @@ int AppStateValidatedDiffHarness(const char *harness_id) {
                                      AppStateDiffHarnessLookup(harness_id));
 }
 
+static int AppStateExpectedResultValid(const char *expected_result) {
+  if (!AppStateNonEmptyString(expected_result))
+    return 0;
+  return strcmp(expected_result, "allowed") == 0 ||
+         strcmp(expected_result, "blocked") == 0 ||
+         strcmp(expected_result, "fallback") == 0 ||
+         strcmp(expected_result, "invalid") == 0;
+}
+
+static int AppStateFallbackPreconditionValid(const char *precondition) {
+  if (precondition == NULL)
+    return 1;
+  if (!AppStateNonEmptyString(precondition))
+    return 0;
+  return strcmp(precondition, "generation_mismatch") == 0 ||
+         strcmp(precondition, "stale_snapshot") == 0;
+}
+
+static int AppStateDiffHarnessCoversTransition(const char *harness_id,
+                                               const char *transition_id) {
+  const AppStateDiffHarnessMetadata *harness;
+
+  if (!AppStateNonEmptyString(harness_id) ||
+      !AppStateNonEmptyString(transition_id))
+    return 0;
+
+  harness = AppStateDiffHarnessLookup(harness_id);
+  if (harness == NULL ||
+      !AppStateNonEmptyStringList(harness->transition_ids,
+                                  harness->transition_id_count))
+    return 0;
+
+  return AppStateStringListContains(harness->transition_ids,
+                                    harness->transition_id_count,
+                                    transition_id);
+}
+
+static int AppStateTransitionSequenceStepRequiresNoUnrelatedMutation(
+    const AppStateTransitionSequenceStepMetadata *step) {
+  if (step == NULL || !AppStateExpectedResultValid(step->expected_result))
+    return 0;
+  return strcmp(step->expected_result, "blocked") == 0 ||
+         strcmp(step->expected_result, "fallback") == 0 ||
+         strcmp(step->expected_result, "invalid") == 0 ||
+         step->precondition != NULL;
+}
+
+static int AppStateTransitionSequenceStepNoUnrelatedMutationReady(
+    const AppStateTransitionSequenceStepMetadata *step) {
+  if (step == NULL)
+    return 0;
+  if (!AppStateTransitionSequenceStepRequiresNoUnrelatedMutation(step) &&
+      step->no_unrelated_mutation == NULL)
+    return 1;
+  if (step->no_unrelated_mutation == NULL)
+    return 0;
+  if (!AppStateNonEmptyString(step->no_unrelated_mutation->diff_harness_id) ||
+      !AppStateNonEmptyString(step->no_unrelated_mutation->expectation))
+    return 0;
+  if (!AppStateStringListContains(step->diff_harness_ids,
+                                  step->diff_harness_id_count,
+                                  step->no_unrelated_mutation->diff_harness_id))
+    return 0;
+  if (!AppStateDiffHarnessCoversTransition(
+          step->no_unrelated_mutation->diff_harness_id, step->transition_id))
+    return 0;
+
+  return 1;
+}
+
+static int AppStateTransitionSequenceStepDeterministicFallbackReady(
+    const AppStateTransitionSequenceStepMetadata *step) {
+  if (step == NULL)
+    return 0;
+  if ((step->precondition != NULL ||
+       strcmp(step->expected_result, "fallback") == 0) &&
+      step->deterministic_fallback == NULL)
+    return 0;
+  if (step->deterministic_fallback == NULL)
+    return 1;
+  return AppStateNonEmptyString(step->deterministic_fallback->outcome) &&
+         AppStateNonEmptyString(
+             step->deterministic_fallback->allowed_mutation_scope);
+}
+
 static int AppStateTransitionSequenceStepGenerationDomainOverlaps(
     const AppStateTransitionSequenceStepMetadata *step,
     const char *const *coverage_domain_refs, size_t coverage_domain_ref_count) {
@@ -7012,7 +7097,8 @@ AppStateTransitionSequenceStepReady(
 
   if (step == NULL || !AppStateNonEmptyString(step->step_id) ||
       !AppStateValidatedTransition(step->transition_id) ||
-      !AppStateNonEmptyString(step->expected_result))
+      !AppStateExpectedResultValid(step->expected_result) ||
+      !AppStateFallbackPreconditionValid(step->precondition))
     return 0;
   if (step->stimulus_action_id == NULL && step->stimulus_event_id == NULL)
     return 0;
@@ -7041,6 +7127,10 @@ AppStateTransitionSequenceStepReady(
         !AppStateValidatedGenerationDomain(expectation->domain_id))
       return 0;
   }
+  if (!AppStateTransitionSequenceStepNoUnrelatedMutationReady(step))
+    return 0;
+  if (!AppStateTransitionSequenceStepDeterministicFallbackReady(step))
+    return 0;
 
   return 1;
 }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4580,6 +4580,117 @@ int main(void) {
     assert run.returncode == 0, run.stdout + run.stderr
 
 
+def test_runtime_transition_sequence_validation_rejects_result_metadata_drift(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "transition_sequence_result_probe.c"
+    binary = tmp_path / "transition_sequence_result_probe"
+    probe.write_text(
+        """
+#include "src/core/appstate_actions.c"
+
+int main(void) {
+  AppStateTransitionSequenceStepMetadata step;
+  static const AppStateTransitionSequenceNoUnrelatedMutationMetadata
+      missing_harness = {"harness.__ytnova_missing__", "must remain unchanged"};
+  static const AppStateTransitionSequenceNoUnrelatedMutationMetadata
+      wrong_harness = {"harness.render-projection-read-only-diff",
+                       "must remain unchanged"};
+  static const AppStateTransitionSequenceNoUnrelatedMutationMetadata
+      valid_no_unrelated = {"harness.declared-write-set-diff",
+                            "must remain unchanged"};
+  static const AppStateTransitionSequenceDeterministicFallbackMetadata
+      valid_fallback = {"restore durable identity",
+                        "declared transition fields only"};
+  static const AppStateTransitionSequenceDeterministicFallbackMetadata
+      blank_fallback = {"", "declared transition fields only"};
+  const AppStateTransitionSequenceMetadata *sequence =
+      AppStateTransitionSequenceLookup("sequence.split-toggle-f8");
+
+  if (sequence == NULL || sequence->step_count < 2)
+    return 1;
+  step = sequence->steps[0];
+  if (!AppStateTransitionSequenceStepReady(&step))
+    return 2;
+
+  step.expected_result = "unknown";
+  if (AppStateTransitionSequenceStepReady(&step))
+    return 3;
+
+  step = sequence->steps[0];
+  step.expected_result = "blocked";
+  step.no_unrelated_mutation = NULL;
+  if (AppStateTransitionSequenceStepReady(&step))
+    return 4;
+
+  step.no_unrelated_mutation = &missing_harness;
+  if (AppStateTransitionSequenceStepReady(&step))
+    return 5;
+
+  step.no_unrelated_mutation = &wrong_harness;
+  if (AppStateTransitionSequenceStepReady(&step))
+    return 6;
+
+  step = sequence->steps[0];
+  step.expected_result = "fallback";
+  step.no_unrelated_mutation = &valid_no_unrelated;
+  step.deterministic_fallback = NULL;
+  if (AppStateTransitionSequenceStepReady(&step))
+    return 7;
+
+  step.deterministic_fallback = &blank_fallback;
+  if (AppStateTransitionSequenceStepReady(&step))
+    return 8;
+
+  step.deterministic_fallback = &valid_fallback;
+  if (!AppStateTransitionSequenceStepReady(&step))
+    return 12;
+
+  step = sequence->steps[1];
+  if (!AppStateTransitionSequenceStepReady(&step))
+    return 9;
+  step.no_unrelated_mutation = NULL;
+  if (AppStateTransitionSequenceStepReady(&step))
+    return 10;
+
+  step = sequence->steps[0];
+  step.precondition = "unexpected";
+  if (AppStateTransitionSequenceStepReady(&step))
+    return 11;
+
+  return 0;
+}
+""",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            "gcc",
+            "-std=c99",
+            "-I.",
+            "-Iinclude",
+            str(probe),
+            "-o",
+            str(binary),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0, build.stdout + build.stderr
+    run = subprocess.run(
+        [str(binary)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+
+
 def test_runtime_registry_status_validation_rejects_unknown_values(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- validate transition sequence expected-result, fallback, and no-unrelated-mutation metadata through runtime AppState checks
- add a focused probe that rejects drifted transition sequence result metadata

## Validation
- red focused pytest failed before implementation on unknown transition-sequence expected_result
- source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'transition_sequence_validation_rejects_result_metadata_drift'
- make clean && make
- source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'transition_sequence_validation_rejects_result_metadata_drift or transition_sequence_validation_rejects_mismatched_action_ref or current_repository_appstate_contract_passes'
- source .venv/bin/activate && python3 scripts/check_appstate_contract.py
- git diff --check
- source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py