### PR TITLE
chore(appstate): validate generation and harness accessors

### DIFF
--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6250,11 +6250,18 @@ AppStateGenerationDomainAt(size_t index) {
   if (index >= AppStateGenerationDomainCount())
     return NULL;
 
+  if (!AppStateValidatedGenerationDomain(
+          kAppStateGenerationDomains[index].domain_id))
+    return NULL;
+
   return &kAppStateGenerationDomains[index];
 }
 
 const AppStateDiffHarnessMetadata *AppStateDiffHarnessAt(size_t index) {
   if (index >= AppStateDiffHarnessCount())
+    return NULL;
+
+  if (!AppStateValidatedDiffHarness(kAppStateDiffHarnesses[index].harness_id))
     return NULL;
 
   return &kAppStateDiffHarnesses[index];

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -12486,3 +12486,42 @@ def test_runtime_diff_harness_startup_requires_documented_harness_ids() -> None:
         source,
         re.S,
     )
+
+
+def test_appstate_generation_domain_accessor_fails_closed_on_invalid_metadata() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    accessor_start = source.index("AppStateGenerationDomainAt(size_t index)")
+    next_accessor_start = source.index(
+        "const AppStateDiffHarnessMetadata *AppStateDiffHarnessAt(size_t index)"
+    )
+    accessor_body = source[accessor_start:next_accessor_start]
+
+    assert "index >= AppStateGenerationDomainCount()" in accessor_body
+    assert re.search(
+        r"if \(!AppStateValidatedGenerationDomain\(\s*"
+        r"kAppStateGenerationDomains\[index\]\.domain_id\s*"
+        r"\)\)\s*return NULL;",
+        accessor_body,
+        re.S,
+    )
+
+
+def test_appstate_diff_harness_accessor_fails_closed_on_invalid_metadata() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    accessor_start = source.index(
+        "const AppStateDiffHarnessMetadata *AppStateDiffHarnessAt(size_t index)"
+    )
+    next_accessor_start = source.index(
+        "const AppStateTransitionSequenceMetadata *\n"
+        "AppStateTransitionSequenceAt(size_t index)"
+    )
+    accessor_body = source[accessor_start:next_accessor_start]
+
+    assert "index >= AppStateDiffHarnessCount()" in accessor_body
+    assert re.search(
+        r"if \(!AppStateValidatedDiffHarness\(\s*"
+        r"kAppStateDiffHarnesses\[index\]\.harness_id\s*"
+        r"\)\)\s*return NULL;",
+        accessor_body,
+        re.S,
+    )


### PR DESCRIPTION
## Summary
- make generation-domain metadata accessors fail closed through existing runtime validation
- make diff-harness metadata accessors fail closed through existing runtime validation
- add guard tests that pin those accessor boundaries

## Validation
- red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'appstate_generation_domain_accessor_fails_closed_on_invalid_metadata or appstate_diff_harness_accessor_fails_closed_on_invalid_metadata'`
- green: same focused pytest selector
- `make clean && make`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'appstate_generation_domain_accessor_fails_closed_on_invalid_metadata or appstate_diff_harness_accessor_fails_closed_on_invalid_metadata or current_repository_appstate_contract_passes' && source .venv/bin/activate && python3 scripts/check_appstate_contract.py && git diff --check`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
