### PR TITLE
chore(appstate): validate registry indexed accessors

### DIFF
--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6186,6 +6186,13 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage."},
 };
 
+static int AppStateValidateActionCoverage(
+    YtreeNovaAction action, const AppStateActionCoverageMetadata *coverage);
+int AppStateValidatedEvent(const char *event_id);
+int AppStateValidatedTransition(const char *transition_id);
+int AppStateValidatedDispatchSurface(const char *surface_id);
+int AppStateValidatedCompatibilityShim(const char *shim_id);
+int AppStateValidatedInvariant(const char *invariant_id);
 int AppStateValidatedOwnerField(const char *field);
 int AppStateValidatedTransitionSequence(const char *scenario_id);
 
@@ -6283,11 +6290,18 @@ const AppStateActionCoverageMetadata *AppStateActionCoverageAt(size_t index) {
   if (index >= AppStateActionCoverageCount())
     return NULL;
 
+  if (!AppStateValidateActionCoverage(kAppStateActionCoverages[index].action,
+                                      &kAppStateActionCoverages[index]))
+    return NULL;
+
   return &kAppStateActionCoverages[index];
 }
 
 const AppStateEventCoverageMetadata *AppStateEventCoverageAt(size_t index) {
   if (index >= AppStateEventCoverageCount())
+    return NULL;
+
+  if (!AppStateValidatedEvent(kAppStateEventCoverages[index].event_id))
     return NULL;
 
   return &kAppStateEventCoverages[index];
@@ -6297,11 +6311,18 @@ const AppStateTransitionMetadata *AppStateTransitionAt(size_t index) {
   if (index >= AppStateTransitionCount())
     return NULL;
 
+  if (!AppStateValidatedTransition(kAppStateTransitions[index].id))
+    return NULL;
+
   return &kAppStateTransitions[index];
 }
 
 const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index) {
   if (index >= AppStateDispatchSurfaceCount())
+    return NULL;
+
+  if (!AppStateValidatedDispatchSurface(
+          kAppStateDispatchSurfaces[index].surface_id))
     return NULL;
 
   return &kAppStateDispatchSurfaces[index];
@@ -6312,11 +6333,17 @@ AppStateCompatibilityShimAt(size_t index) {
   if (index >= AppStateCompatibilityShimCount())
     return NULL;
 
+  if (!AppStateValidatedCompatibilityShim(kAppStateCompatibilityShims[index].id))
+    return NULL;
+
   return &kAppStateCompatibilityShims[index];
 }
 
 const AppStateInvariantMetadata *AppStateInvariantAt(size_t index) {
   if (index >= AppStateInvariantCount())
+    return NULL;
+
+  if (!AppStateValidatedInvariant(kAppStateInvariants[index].invariant_id))
     return NULL;
 
   return &kAppStateInvariants[index];
@@ -7170,35 +7197,35 @@ int AppStateValidatedTransitionSequence(const char *scenario_id) {
       scenario_id, AppStateTransitionSequenceLookup(scenario_id));
 }
 
-static YtreeNovaAction AppStateValidateKeyActionCoverage(
+static int AppStateValidateActionCoverage(
     YtreeNovaAction action, const AppStateActionCoverageMetadata *coverage) {
   const AppStateTransitionMetadata *transition;
 
-  if (action == ACTION_NONE)
-    return ACTION_NONE;
+  if ((int)action < 0 || (size_t)action >= AppStateActionCoverageCount())
+    return 0;
   if (coverage == NULL || coverage->action != action)
-    return ACTION_NONE;
+    return 0;
   transition = AppStateTransitionLookup(coverage->transition_id);
   if (!AppStateValidateTransition(coverage->transition_id, transition))
-    return ACTION_NONE;
+    return 0;
   if (!AppStateNonEmptyString(coverage->action_name) ||
       !AppStateNonEmptyString(coverage->category) ||
       !AppStateNonEmptyString(coverage->owner) ||
       !AppStateNonEmptyString(coverage->boundary_status) ||
       strcmp(coverage->category, transition->category) != 0 ||
       strcmp(coverage->owner, transition->owner) != 0)
-    return ACTION_NONE;
+    return 0;
   if (!AppStateKnownBoundaryStatus(coverage->boundary_status))
-    return ACTION_NONE;
+    return 0;
   if (!AppStateStringListEquals(coverage->declared_write_set,
                                 coverage->declared_write_set_count,
                                 transition->declared_write_set,
                                 transition->declared_write_set_count))
-    return ACTION_NONE;
+    return 0;
   if (!AppStateCoverageOwnerFieldsMatchWriteSet(
           coverage->owner_field_refs, coverage->owner_field_ref_count,
           coverage->declared_write_set, coverage->declared_write_set_count))
-    return ACTION_NONE;
+    return 0;
   if (!AppStateNonEmptyStringList(coverage->transition_sequence_refs,
                                   coverage->transition_sequence_ref_count) ||
       !AppStateNonEmptyStringList(coverage->dispatch_surface_refs,
@@ -7211,6 +7238,14 @@ static YtreeNovaAction AppStateValidateKeyActionCoverage(
                                   coverage->diff_harness_ref_count) ||
       !AppStateNonEmptyStringList(coverage->migration_notes,
                                   coverage->migration_note_count))
+    return 0;
+
+  return 1;
+}
+
+static YtreeNovaAction AppStateValidateKeyActionCoverage(
+    YtreeNovaAction action, const AppStateActionCoverageMetadata *coverage) {
+  if (!AppStateValidateActionCoverage(action, coverage))
     return ACTION_NONE;
 
   return action;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -12525,3 +12525,127 @@ def test_appstate_diff_harness_accessor_fails_closed_on_invalid_metadata() -> No
         accessor_body,
         re.S,
     )
+
+
+def test_appstate_action_coverage_accessor_fails_closed_on_invalid_metadata() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    accessor_start = source.index(
+        "const AppStateActionCoverageMetadata *AppStateActionCoverageAt(size_t index)"
+    )
+    next_accessor_start = source.index(
+        "const AppStateEventCoverageMetadata *AppStateEventCoverageAt(size_t index)"
+    )
+    accessor_body = source[accessor_start:next_accessor_start]
+
+    assert "index >= AppStateActionCoverageCount()" in accessor_body
+    assert re.search(
+        r"if \(!AppStateValidateActionCoverage\(\s*"
+        r"kAppStateActionCoverages\[index\]\.action,\s*"
+        r"&kAppStateActionCoverages\[index\]\s*"
+        r"\)\)\s*return NULL;",
+        accessor_body,
+        re.S,
+    )
+
+
+def test_appstate_event_coverage_accessor_fails_closed_on_invalid_metadata() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    accessor_start = source.index(
+        "const AppStateEventCoverageMetadata *AppStateEventCoverageAt(size_t index)"
+    )
+    next_accessor_start = source.index(
+        "const AppStateTransitionMetadata *AppStateTransitionAt(size_t index)"
+    )
+    accessor_body = source[accessor_start:next_accessor_start]
+
+    assert "index >= AppStateEventCoverageCount()" in accessor_body
+    assert re.search(
+        r"if \(!AppStateValidatedEvent\(\s*"
+        r"kAppStateEventCoverages\[index\]\.event_id\s*"
+        r"\)\)\s*return NULL;",
+        accessor_body,
+        re.S,
+    )
+
+
+def test_appstate_transition_accessor_fails_closed_on_invalid_metadata() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    accessor_start = source.index(
+        "const AppStateTransitionMetadata *AppStateTransitionAt(size_t index)"
+    )
+    next_accessor_start = source.index(
+        "const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index)"
+    )
+    accessor_body = source[accessor_start:next_accessor_start]
+
+    assert "index >= AppStateTransitionCount()" in accessor_body
+    assert re.search(
+        r"if \(!AppStateValidatedTransition\(\s*"
+        r"kAppStateTransitions\[index\]\.id\s*"
+        r"\)\)\s*return NULL;",
+        accessor_body,
+        re.S,
+    )
+
+
+def test_appstate_dispatch_surface_accessor_fails_closed_on_invalid_metadata() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    accessor_start = source.index(
+        "const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index)"
+    )
+    next_accessor_start = source.index(
+        "const AppStateCompatibilityShimMetadata *\n"
+        "AppStateCompatibilityShimAt(size_t index)"
+    )
+    accessor_body = source[accessor_start:next_accessor_start]
+
+    assert "index >= AppStateDispatchSurfaceCount()" in accessor_body
+    assert re.search(
+        r"if \(!AppStateValidatedDispatchSurface\(\s*"
+        r"kAppStateDispatchSurfaces\[index\]\.surface_id\s*"
+        r"\)\)\s*return NULL;",
+        accessor_body,
+        re.S,
+    )
+
+
+def test_appstate_shim_accessor_fails_closed_on_invalid_metadata() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    accessor_start = source.index(
+        "const AppStateCompatibilityShimMetadata *\n"
+        "AppStateCompatibilityShimAt(size_t index)"
+    )
+    next_accessor_start = source.index(
+        "const AppStateInvariantMetadata *AppStateInvariantAt(size_t index)"
+    )
+    accessor_body = source[accessor_start:next_accessor_start]
+
+    assert "index >= AppStateCompatibilityShimCount()" in accessor_body
+    assert re.search(
+        r"if \(!AppStateValidatedCompatibilityShim\(\s*"
+        r"kAppStateCompatibilityShims\[index\]\.id\s*"
+        r"\)\)\s*return NULL;",
+        accessor_body,
+        re.S,
+    )
+
+
+def test_appstate_invariant_accessor_fails_closed_on_invalid_metadata() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    accessor_start = source.index(
+        "const AppStateInvariantMetadata *AppStateInvariantAt(size_t index)"
+    )
+    next_accessor_start = source.index(
+        "const AppStateOwnerFieldMetadata *\n"
+        "AppStateOwnerFieldLookup(const char *field)"
+    )
+    accessor_body = source[accessor_start:next_accessor_start]
+
+    assert "index >= AppStateInvariantCount()" in accessor_body
+    assert re.search(
+        r"if \(!AppStateValidatedInvariant\(\s*"
+        r"kAppStateInvariants\[index\]\.invariant_id\s*"
+        r"\)\)\s*return NULL;",
+        accessor_body,
+        re.S,
+    )


### PR DESCRIPTION
## Summary
- Fail closed from indexed AppState registry accessors when backing metadata no longer passes runtime validation.
- Share action coverage validation between key-action dispatch validation and indexed action coverage access.
- Add guard tests for the remaining registry accessors.

## Local validation
- Red focused pytest failed for the new indexed accessor guard cases before implementation.
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'accessor_fails_closed_on_invalid_metadata'`
- `make clean && make`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py && source .venv/bin/activate && python3 scripts/check_appstate_contract.py && git diff --check`