### PR TITLE
chore(appstate): guard coverage ref lookups

### DIFF
--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6588,7 +6588,8 @@ AppStateActionCoverageIdLookup(const char *action_id) {
     return NULL;
 
   for (index = 0; index < AppStateActionCoverageCount(); index++) {
-    if (!strcmp(kAppStateActionCoverages[index].action_name, action_id))
+    if (AppStateLookupIdMatches(kAppStateActionCoverages[index].action_name,
+                                action_id))
       return &kAppStateActionCoverages[index];
   }
 
@@ -6603,7 +6604,8 @@ AppStateEventCoverageIdLookup(const char *event_id) {
     return NULL;
 
   for (index = 0; index < AppStateEventCoverageCount(); index++) {
-    if (!strcmp(kAppStateEventCoverages[index].event_id, event_id))
+    if (AppStateLookupIdMatches(kAppStateEventCoverages[index].event_id,
+                                event_id))
       return &kAppStateEventCoverages[index];
   }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -12714,3 +12714,44 @@ def test_appstate_string_lookup_boundaries_fail_closed_on_invalid_registry_keys(
             re.S,
         )
         assert f"strcmp({candidate}, {requested})" not in body
+
+
+def test_appstate_coverage_ref_lookup_boundaries_fail_closed_on_invalid_ids() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    lookups = {
+        "AppStateActionCoverageIdLookup": (
+            "AppStateActionCoverageMetadata",
+            "kAppStateActionCoverages[index].action_name",
+            "action_id",
+        ),
+        "AppStateEventCoverageIdLookup": (
+            "AppStateEventCoverageMetadata",
+            "kAppStateEventCoverages[index].event_id",
+            "event_id",
+        ),
+    }
+
+    assert "static int AppStateLookupIdMatches(" in source
+    for function_name, (metadata_type, candidate, requested) in lookups.items():
+        definition = re.search(
+            r"(?m)^static const "
+            + re.escape(metadata_type)
+            + r" \*\n"
+            + function_name
+            + r"\([^)]*\) \{",
+            source,
+        )
+        assert definition is not None
+        start = definition.start()
+        end = source.index("\n}", start) + 2
+        body = source[start:end]
+        assert re.search(
+            r"AppStateLookupIdMatches\(\s*"
+            + re.escape(candidate)
+            + r"\s*,\s*"
+            + requested
+            + r"\s*\)",
+            body,
+            re.S,
+        )
+        assert f"strcmp({candidate}, {requested})" not in body


### PR DESCRIPTION
## Summary
- route AppState action and event coverage-ref lookups through the shared non-empty identifier matcher
- keep transition-sequence coverage ref resolution fail-closed when runtime coverage identifiers are malformed
- add a guard test for the coverage-ref lookup boundaries

## Validation
- red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'coverage_ref_lookup_boundaries_fail_closed_on_invalid_ids'`
- green: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'coverage_ref_lookup_boundaries_fail_closed_on_invalid_ids'`
- `make clean && make`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'coverage_ref_lookup_boundaries_fail_closed_on_invalid_ids or string_lookup_boundaries_fail_closed_on_invalid_registry_keys or runtime_transition_sequence_validation_rejects_mismatched_action_ref' && source .venv/bin/activate && python3 scripts/check_appstate_contract.py && git diff --check`