### PR TITLE
chore(appstate): guard shim validation callsites

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -379,6 +379,9 @@ DISPATCH_SURFACE_CALLSITE_RE = re.compile(
     r'AppStateValidatedDispatchSurface\s*\(\s*"([^"]+)"\s*\)'
 )
 EVENT_CALLSITE_RE = re.compile(r'AppStateValidatedEvent\s*\(\s*"([^"]+)"\s*\)')
+SHIM_CALLSITE_RE = re.compile(
+    r'AppStateValidatedCompatibilityShim\s*\(\s*"([^"]+)"\s*\)'
+)
 
 
 def _load_json(path: Path) -> tuple[Any | None, list[str]]:
@@ -4696,6 +4699,12 @@ def _runtime_event_callsites_by_id(
     return _runtime_validation_callsites_by_id(source_root, EVENT_CALLSITE_RE)
 
 
+def _runtime_shim_callsites_by_id(
+    source_root: Path,
+) -> tuple[dict[str, set[str]], list[str]]:
+    return _runtime_validation_callsites_by_id(source_root, SHIM_CALLSITE_RE)
+
+
 def _validate_runtime_dispatch_surface_callsites(
     *,
     runtime_records: list[dict[str, Any]],
@@ -4752,6 +4761,36 @@ def _validate_runtime_event_callsites(
         if event_id not in callsites_by_id:
             failures.append(
                 f"{source_root}: {event_id}: missing runtime validation callsite"
+            )
+    return failures
+
+
+def _validate_runtime_shim_callsites(
+    *,
+    runtime_records: list[dict[str, Any]],
+    repository_root: Path,
+    action_runtime_path: Path,
+) -> list[str]:
+    if (
+        action_runtime_path.parent.name != "core"
+        or action_runtime_path.parent.parent.name != "src"
+    ):
+        return []
+    source_root = repository_root / "src"
+    callsites_by_id, failures = _runtime_shim_callsites_by_id(source_root)
+    runtime_shim_ids = sorted(
+        {
+            shim_id.strip()
+            for record in runtime_records
+            if isinstance(record, dict)
+            and isinstance(record.get("id"), str)
+            and (shim_id := record["id"]).strip()
+        }
+    )
+    for shim_id in runtime_shim_ids:
+        if shim_id not in callsites_by_id:
+            failures.append(
+                f"{source_root}: {shim_id}: missing runtime validation callsite"
             )
     return failures
 
@@ -7341,6 +7380,13 @@ def validate_contract(
             runtime_diff_harness_generation_domain_ids=(
                 runtime_diff_harness_generation_domain_ids_by_harness
             ),
+        )
+    )
+    failures.extend(
+        _validate_runtime_shim_callsites(
+            runtime_records=runtime_shim_records,
+            repository_root=repository_root,
+            action_runtime_path=action_runtime_path,
         )
     )
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6785,6 +6785,43 @@ def test_guard_fails_when_runtime_event_validation_callsite_is_missing(
     )
 
 
+def test_guard_fails_when_runtime_shim_validation_callsite_is_missing(
+    tmp_path: Path,
+) -> None:
+    shutil.copytree(REPO_ROOT / "src", tmp_path / "src")
+    source_path = tmp_path / "src" / "ui" / "display.c"
+    original = source_path.read_text(encoding="utf-8")
+    mutated = original.replace(
+        'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")',
+        'AppStateValidatedCompatibilityShim("shim-render-derived-row-position-missing")',
+        1,
+    )
+    assert mutated != original
+    source_path.write_text(mutated, encoding="utf-8")
+
+    failures = guard.validate_contract(
+        guard.DEFAULT_TRANSITIONS,
+        guard.DEFAULT_SHIMS,
+        guard.DEFAULT_ACTION_COVERAGE,
+        guard.DEFAULT_ACTION_HEADER,
+        guard.DEFAULT_EVENT_COVERAGE,
+        guard.DEFAULT_OWNER_FIELDS,
+        guard.DEFAULT_DISPATCH_SURFACES,
+        guard.DEFAULT_INVARIANTS,
+        guard.DEFAULT_GENERATION_DOMAINS,
+        guard.DEFAULT_DIFF_HARNESS,
+        guard.DEFAULT_TRANSITION_SEQUENCES,
+        guard.DEFAULT_ACTION_RUNTIME,
+        repository_root=tmp_path,
+    )
+
+    assert any(
+        "shim-render-derived-row-position" in failure
+        and "missing runtime validation callsite" in failure
+        for failure in failures
+    )
+
+
 def test_guard_fails_on_malformed_dispatch_surface_entry_symbol_or_path(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Summary
- Require every runtime AppState compatibility shim registry id to have an AppStateValidatedCompatibilityShim callsite under src.
- Reuse the shared runtime validation-callsite scanner for shim boundaries.
- Add a guard regression that mutates a render projection shim callsite and proves the contract fails closed.

Validation
- Red: focused pytest failed before implementation for missing shim validation callsite detection.
- source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'runtime_shim_validation_callsite_is_missing or runtime_event_validation_callsite_is_missing or runtime_dispatch_surface_validation_callsite_is_missing or current_repository_appstate_contract_passes'
- source .venv/bin/activate && python3 scripts/check_appstate_contract.py
- git diff --check
- make clean && make
