### PR TITLE
fix(appstate): anchor shim validation to source boundaries

### DIFF
--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -30,6 +30,9 @@
       "diff_harness_refs": [
         "harness.transition-before-after-snapshot",
         "harness.generation-mismatch-check"
+      ],
+      "source_boundary_refs": [
+        "src/ui/dir_ops.c"
       ]
     },
     {
@@ -63,6 +66,10 @@
       "diff_harness_refs": [
         "harness.transition-before-after-snapshot",
         "harness.generation-mismatch-check"
+      ],
+      "source_boundary_refs": [
+        "src/ui/panel_anchor.c",
+        "src/ui/dir_ops.c"
       ]
     },
     {
@@ -90,6 +97,10 @@
       ],
       "diff_harness_refs": [
         "harness.declared-write-set-diff"
+      ],
+      "source_boundary_refs": [
+        "src/ui/ctrl_file.c",
+        "src/ui/ctrl_dir.c"
       ]
     },
     {
@@ -122,6 +133,9 @@
         "harness.render-projection-read-only-diff",
         "harness.generation-mismatch-check",
         "harness.blocked-transition-no-unrelated-mutation"
+      ],
+      "source_boundary_refs": [
+        "src/ui/display.c"
       ]
     }
   ]

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -120,6 +120,8 @@ typedef struct {
   size_t generation_domain_ref_count;
   const char *const *diff_harness_refs;
   size_t diff_harness_ref_count;
+  const char *const *source_boundary_refs;
+  size_t source_boundary_ref_count;
   const char *removal_trigger;
   const char *target_transition;
   const char *follow_up_task;

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -65,6 +65,7 @@ REQUIRED_SHIM_FIELDS = {
     "owner_field_refs",
     "generation_domain_refs",
     "diff_harness_refs",
+    "source_boundary_refs",
     "removal_trigger",
     "target_transition",
     "follow_up_task",
@@ -328,6 +329,7 @@ SHIM_LIST_FIELDS = LIST_FIELDS | {
     "owner_field_refs",
     "generation_domain_refs",
     "diff_harness_refs",
+    "source_boundary_refs",
 }
 VALID_SHIM_WRITE_CAPABILITIES = {
     "write_capable",
@@ -1916,6 +1918,7 @@ def _parse_runtime_shim_registry(
     owner_ref_tables: dict[str, list[str]] = {}
     generation_domain_ref_tables: dict[str, list[str]] = {}
     diff_harness_ref_tables: dict[str, list[str]] = {}
+    source_boundary_ref_tables: dict[str, list[str]] = {}
     failures: list[str] = []
     invariant_re = re.compile(
         r"static\s+const\s+char\s+\*const\s+"
@@ -1977,6 +1980,21 @@ def _parse_runtime_shim_registry(
         diff_harness_ref_tables[table_name] = values
         failures.extend(array_failures)
 
+    source_boundary_ref_re = re.compile(
+        r"static\s+const\s+char\s+\*const\s+"
+        r"(kAppStateCompatibilityShimSourceBoundaryRefs[0-9]+)\[\]\s*=\s*\{"
+        r"(?P<body>.*?)\};",
+        re.S,
+    )
+    for source_boundary_ref_match in source_boundary_ref_re.finditer(source):
+        table_name = source_boundary_ref_match.group(1)
+        values, array_failures = _parse_string_initializer_array(
+            source_boundary_ref_match.group("body"),
+            table_name,
+        )
+        source_boundary_ref_tables[table_name] = values
+        failures.extend(array_failures)
+
     match = re.search(
         r"kAppStateCompatibilityShims\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
         source,
@@ -2004,6 +2022,9 @@ def _parse_runtime_shim_registry(
         r"\s*(?P<diff_refs>kAppStateCompatibilityShimDiffHarnessRefs[0-9]+)\s*,"
         r"\s*sizeof\((?P=diff_refs)\)\s*/"
         r"\s*sizeof\((?P=diff_refs)\[0\]\)\s*,"
+        r"\s*(?P<source_boundary_refs>kAppStateCompatibilityShimSourceBoundaryRefs[0-9]+)\s*,"
+        r"\s*sizeof\((?P=source_boundary_refs)\)\s*/"
+        r"\s*sizeof\((?P=source_boundary_refs)\[0\]\)\s*,"
         r"\s*\"(?P<removal_trigger>[^\"]*)\"\s*,"
         r"\s*\"(?P<target_transition>[^\"]*)\"\s*,"
         r"\s*\"(?P<follow_up_task>[^\"]*)\"\s*,"
@@ -2041,6 +2062,16 @@ def _parse_runtime_shim_registry(
                 f"runtime_shim[{index}]: unknown diff-harness-ref table: {diff_ref_table_name}"
             )
             diff_harness_refs = []
+        source_boundary_ref_table_name = row_match.group("source_boundary_refs")
+        source_boundary_refs = source_boundary_ref_tables.get(
+            source_boundary_ref_table_name
+        )
+        if source_boundary_refs is None:
+            failures.append(
+                f"runtime_shim[{index}]: unknown source-boundary-ref table: "
+                f"{source_boundary_ref_table_name}"
+            )
+            source_boundary_refs = []
         records.append(
             {
                 "id": row_match.group("id"),
@@ -2053,6 +2084,7 @@ def _parse_runtime_shim_registry(
                 "owner_field_refs": owner_field_refs,
                 "generation_domain_refs": generation_domain_refs,
                 "diff_harness_refs": diff_harness_refs,
+                "source_boundary_refs": source_boundary_refs,
                 "removal_trigger": row_match.group("removal_trigger"),
                 "target_transition": row_match.group("target_transition"),
                 "follow_up_task": row_match.group("follow_up_task"),
@@ -3361,6 +3393,7 @@ def _validate_runtime_shim_registry(
                 "owner_field_refs",
                 "generation_domain_refs",
                 "diff_harness_refs",
+                "source_boundary_refs",
                 "removal_trigger",
                 "target_transition",
                 "follow_up_task",
@@ -4612,6 +4645,41 @@ def _validate_source_path(
     return []
 
 
+def _validate_source_boundary_refs(
+    value: Any, *, label: str, repository_root: Path = REPO_ROOT
+) -> list[str]:
+    failures = _validate_list_field(
+        value=value,
+        label=label,
+        field="source_boundary_refs",
+    )
+    if failures:
+        return failures
+
+    assert isinstance(value, list)
+    seen: set[str] = set()
+    for index, source_path in enumerate(value):
+        if not isinstance(source_path, str) or not source_path.strip():
+            failures.append(
+                f"{label}: source_boundary_refs[{index}] must be a non-empty string"
+            )
+            continue
+        normalized = source_path.strip()
+        if normalized in seen:
+            failures.append(
+                f"{label}: duplicate source_boundary_refs[{index}]: {normalized}"
+            )
+        seen.add(normalized)
+        failures.extend(
+            _validate_source_path(
+                normalized,
+                label=f"{label}: source_boundary_refs[{index}]",
+                repository_root=repository_root,
+            )
+        )
+    return failures
+
+
 def _validate_entry_symbol_or_path(value: Any, *, label: str) -> list[str]:
     if not isinstance(value, str) or not value.strip():
         return [f"{label}: entry_symbol_or_path must be a non-empty string"]
@@ -4817,21 +4885,46 @@ def _validate_runtime_shim_callsites(
         or action_runtime_path.parent.parent.name != "src"
     ):
         return []
-    source_root = repository_root / "src"
-    callsites_by_id, failures = _runtime_shim_callsites_by_id(source_root)
-    runtime_shim_ids = sorted(
-        {
-            shim_id.strip()
-            for record in runtime_records
-            if isinstance(record, dict)
-            and isinstance(record.get("id"), str)
-            and (shim_id := record["id"]).strip()
-        }
-    )
-    for shim_id in runtime_shim_ids:
-        if shim_id not in callsites_by_id:
+    failures: list[str] = []
+    for record in runtime_records:
+        if not isinstance(record, dict):
+            continue
+        shim_id = record.get("id")
+        source_boundary_refs = record.get("source_boundary_refs")
+        if not isinstance(shim_id, str) or not shim_id.strip():
+            continue
+        if not isinstance(source_boundary_refs, list):
+            continue
+
+        source_paths: list[str] = []
+        seen_paths: set[str] = set()
+        for source_path in source_boundary_refs:
+            if (
+                not isinstance(source_path, str)
+                or not source_path.strip()
+                or source_path in seen_paths
+            ):
+                continue
+            source_paths.append(source_path)
+            seen_paths.add(source_path)
+        if not source_paths:
+            continue
+
+        shim_found = False
+        for source_path in source_paths:
+            source_file = repository_root / source_path
+            callsite_ids, read_failures = _runtime_validation_callsite_ids_in_file(
+                source_file, SHIM_CALLSITE_RE
+            )
+            failures.extend(read_failures)
+            if read_failures:
+                continue
+            if shim_id in callsite_ids:
+                shim_found = True
+                break
+        if not shim_found:
             failures.append(
-                f"{source_root}: {shim_id}: missing runtime validation callsite"
+                f"{', '.join(source_paths)}: {shim_id}: missing runtime validation callsite"
             )
     return failures
 
@@ -7390,6 +7483,13 @@ def validate_contract(
                     diff_harness_generation_domain_ids_by_harness
                 ),
                 label=label,
+            )
+        )
+        failures.extend(
+            _validate_source_boundary_refs(
+                record.get("source_boundary_refs"),
+                label=label,
+                repository_root=repository_root,
             )
         )
     failures.extend(

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2714,6 +2714,24 @@ static const char *const kAppStateCompatibilityShimDiffHarnessRefs3[] = {
   "harness.blocked-transition-no-unrelated-mutation",
 };
 
+static const char *const kAppStateCompatibilityShimSourceBoundaryRefs0[] = {
+  "src/ui/dir_ops.c",
+};
+
+static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {
+  "src/ui/panel_anchor.c",
+  "src/ui/dir_ops.c",
+};
+
+static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {
+  "src/ui/ctrl_file.c",
+  "src/ui/ctrl_dir.c",
+};
+
+static const char *const kAppStateCompatibilityShimSourceBoundaryRefs3[] = {
+  "src/ui/display.c",
+};
+
 static const char *const kAppStateInvariantProtectedFields0[] = {
   "ctx.active",
   "panel.volume_key",
@@ -6109,14 +6127,17 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    sizeof(kAppStateCompatibilityShimOwnerFieldRefs0) /
        sizeof(kAppStateCompatibilityShimOwnerFieldRefs0[0]),
    kAppStateCompatibilityShimGenerationDomainRefs0,
-   sizeof(kAppStateCompatibilityShimGenerationDomainRefs0) /
-       sizeof(kAppStateCompatibilityShimGenerationDomainRefs0[0]),
-   kAppStateCompatibilityShimDiffHarnessRefs0,
-   sizeof(kAppStateCompatibilityShimDiffHarnessRefs0) /
-       sizeof(kAppStateCompatibilityShimDiffHarnessRefs0[0]),
-   "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
-   "transition.keybinding.navigate-tree",
-   "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
+    sizeof(kAppStateCompatibilityShimGenerationDomainRefs0) /
+        sizeof(kAppStateCompatibilityShimGenerationDomainRefs0[0]),
+    kAppStateCompatibilityShimDiffHarnessRefs0,
+    sizeof(kAppStateCompatibilityShimDiffHarnessRefs0) /
+        sizeof(kAppStateCompatibilityShimDiffHarnessRefs0[0]),
+    kAppStateCompatibilityShimSourceBoundaryRefs0,
+    sizeof(kAppStateCompatibilityShimSourceBoundaryRefs0) /
+        sizeof(kAppStateCompatibilityShimSourceBoundaryRefs0[0]),
+    "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
+    "transition.keybinding.navigate-tree",
+    "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
    "check_appstate_contract.py requires this shim to declare permissions, invariants, target transition, and removal trigger."},
   {"shim.volume-saved-tree-index",
    "Volume restore breadcrumb",
@@ -6131,14 +6152,17 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    sizeof(kAppStateCompatibilityShimOwnerFieldRefs1) /
        sizeof(kAppStateCompatibilityShimOwnerFieldRefs1[0]),
    kAppStateCompatibilityShimGenerationDomainRefs1,
-   sizeof(kAppStateCompatibilityShimGenerationDomainRefs1) /
-       sizeof(kAppStateCompatibilityShimGenerationDomainRefs1[0]),
-   kAppStateCompatibilityShimDiffHarnessRefs1,
-   sizeof(kAppStateCompatibilityShimDiffHarnessRefs1) /
-       sizeof(kAppStateCompatibilityShimDiffHarnessRefs1[0]),
-   "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
-   "transition.rebuild-rebind-callback.panel-anchor",
-   "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
+    sizeof(kAppStateCompatibilityShimGenerationDomainRefs1) /
+        sizeof(kAppStateCompatibilityShimGenerationDomainRefs1[0]),
+    kAppStateCompatibilityShimDiffHarnessRefs1,
+    sizeof(kAppStateCompatibilityShimDiffHarnessRefs1) /
+        sizeof(kAppStateCompatibilityShimDiffHarnessRefs1[0]),
+    kAppStateCompatibilityShimSourceBoundaryRefs1,
+    sizeof(kAppStateCompatibilityShimSourceBoundaryRefs1) /
+        sizeof(kAppStateCompatibilityShimSourceBoundaryRefs1[0]),
+    "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
+    "transition.rebuild-rebind-callback.panel-anchor",
+    "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
    "check_appstate_contract.py keeps this debt visible until runtime migration removes the shim."},
   {"shim.focused-window-session-flag",
    "ViewContext session routing",
@@ -6153,14 +6177,17 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    sizeof(kAppStateCompatibilityShimOwnerFieldRefs2) /
        sizeof(kAppStateCompatibilityShimOwnerFieldRefs2[0]),
    kAppStateCompatibilityShimGenerationDomainRefs2,
-   sizeof(kAppStateCompatibilityShimGenerationDomainRefs2) /
-       sizeof(kAppStateCompatibilityShimGenerationDomainRefs2[0]),
-   kAppStateCompatibilityShimDiffHarnessRefs2,
-   sizeof(kAppStateCompatibilityShimDiffHarnessRefs2) /
-       sizeof(kAppStateCompatibilityShimDiffHarnessRefs2[0]),
-   "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
-   "transition.keybinding.navigate-tree",
-   "Move focus-shape authority from session mirrors into panel-local transition records.",
+    sizeof(kAppStateCompatibilityShimGenerationDomainRefs2) /
+        sizeof(kAppStateCompatibilityShimGenerationDomainRefs2[0]),
+    kAppStateCompatibilityShimDiffHarnessRefs2,
+    sizeof(kAppStateCompatibilityShimDiffHarnessRefs2) /
+        sizeof(kAppStateCompatibilityShimDiffHarnessRefs2[0]),
+    kAppStateCompatibilityShimSourceBoundaryRefs2,
+    sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2) /
+        sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2[0]),
+    "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
+    "transition.keybinding.navigate-tree",
+    "Move focus-shape authority from session mirrors into panel-local transition records.",
    "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
   {"shim-render-derived-row-position",
    "Render projection temporary",
@@ -6175,14 +6202,17 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
    sizeof(kAppStateCompatibilityShimOwnerFieldRefs3) /
        sizeof(kAppStateCompatibilityShimOwnerFieldRefs3[0]),
    kAppStateCompatibilityShimGenerationDomainRefs3,
-   sizeof(kAppStateCompatibilityShimGenerationDomainRefs3) /
-       sizeof(kAppStateCompatibilityShimGenerationDomainRefs3[0]),
-   kAppStateCompatibilityShimDiffHarnessRefs3,
-   sizeof(kAppStateCompatibilityShimDiffHarnessRefs3) /
-       sizeof(kAppStateCompatibilityShimDiffHarnessRefs3[0]),
-   "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
-   "transition.render-reflow.project-state",
-   "Audit render/reflow call sites for projection-only behavior during runtime migration.",
+    sizeof(kAppStateCompatibilityShimGenerationDomainRefs3) /
+        sizeof(kAppStateCompatibilityShimGenerationDomainRefs3[0]),
+    kAppStateCompatibilityShimDiffHarnessRefs3,
+    sizeof(kAppStateCompatibilityShimDiffHarnessRefs3) /
+        sizeof(kAppStateCompatibilityShimDiffHarnessRefs3[0]),
+    kAppStateCompatibilityShimSourceBoundaryRefs3,
+    sizeof(kAppStateCompatibilityShimSourceBoundaryRefs3) /
+        sizeof(kAppStateCompatibilityShimSourceBoundaryRefs3[0]),
+    "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
+    "transition.render-reflow.project-state",
+    "Audit render/reflow call sites for projection-only behavior during runtime migration.",
    "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage."},
 };
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1694,6 +1694,8 @@ static int AppStateCompatibilityShimsReady(void) {
                             metadata->generation_domain_ref_count) ||
         !NonEmptyStringList(metadata->diff_harness_refs,
                             metadata->diff_harness_ref_count) ||
+        !NonEmptyStringList(metadata->source_boundary_refs,
+                            metadata->source_boundary_ref_count) ||
         !NonEmptyString(metadata->removal_trigger) ||
         !NonEmptyString(metadata->target_transition) ||
         !NonEmptyString(metadata->follow_up_task) ||

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -130,6 +130,7 @@ def _shim(
     owner_field_refs: list[str] | None = None,
     generation_domain_refs: list[str] | None = None,
     diff_harness_refs: list[str] | None = None,
+    source_boundary_refs: list[str] | None = None,
 ) -> dict[str, object]:
     return {
         "id": "shim.test",
@@ -143,6 +144,7 @@ def _shim(
         "generation_domain_refs": generation_domain_refs or ["domain.panel_generation"],
         "diff_harness_refs": diff_harness_refs
         or ["harness.transition_before_after_snapshot"],
+        "source_boundary_refs": source_boundary_refs or ["src/ui/display.c"],
         "removal_trigger": "trigger",
         "target_transition": target_transition,
         "follow_up_task": "task",
@@ -1319,6 +1321,7 @@ def _runtime_source(
     shim_owner_field_refs = []
     shim_generation_domain_refs = []
     shim_diff_harness_refs = []
+    shim_source_boundary_refs = []
     shim_rows = []
     for index, record in enumerate(shims):
         invariant_checks = record.get("invariant_checks")
@@ -1365,6 +1368,18 @@ def _runtime_source(
             "static const char *const kAppStateCompatibilityShimDiffHarnessRefs"
             f"{index}[] = {{\n{diff_ref_rows}\n}};\n"
         )
+        source_boundary_refs = record.get("source_boundary_refs")
+        if not isinstance(source_boundary_refs, list):
+            source_boundary_refs = []
+        source_boundary_ref_rows = "\n".join(
+            f'  "{source_path}",'
+            for source_path in source_boundary_refs
+            if isinstance(source_path, str)
+        )
+        shim_source_boundary_refs.append(
+            "static const char *const kAppStateCompatibilityShimSourceBoundaryRefs"
+            f"{index}[] = {{\n{source_boundary_ref_rows}\n}};\n"
+        )
         shim_rows.append(
             f'  {{"{record.get("id", "")}", "{record.get("owner", "")}", '
             f'"{record.get("old_authority_path", "")}", '
@@ -1383,6 +1398,9 @@ def _runtime_source(
             f"kAppStateCompatibilityShimDiffHarnessRefs{index}, "
             f"sizeof(kAppStateCompatibilityShimDiffHarnessRefs{index}) / "
             f"sizeof(kAppStateCompatibilityShimDiffHarnessRefs{index}[0]), "
+            f"kAppStateCompatibilityShimSourceBoundaryRefs{index}, "
+            f"sizeof(kAppStateCompatibilityShimSourceBoundaryRefs{index}) / "
+            f"sizeof(kAppStateCompatibilityShimSourceBoundaryRefs{index}[0]), "
             f'"{record.get("removal_trigger", "")}", '
             f'"{record.get("target_transition", "")}", '
             f'"{record.get("follow_up_task", "")}", '
@@ -1701,6 +1719,7 @@ def _runtime_source(
         + "".join(shim_owner_field_refs)
         + "".join(shim_generation_domain_refs)
         + "".join(shim_diff_harness_refs)
+        + "".join(shim_source_boundary_refs)
         + "".join(invariant_arrays)
         + "".join(generation_domain_arrays)
         + "".join(diff_harness_arrays)
@@ -6913,6 +6932,54 @@ def test_guard_fails_when_runtime_shim_validation_callsite_is_missing(
 
     assert any(
         "shim-render-derived-row-position" in failure
+        and "missing runtime validation callsite" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_shim_validation_moves_outside_source_boundary(
+    tmp_path: Path,
+) -> None:
+    shutil.copytree(REPO_ROOT / "src", tmp_path / "src")
+    source_path = tmp_path / "src" / "ui" / "display.c"
+    original = source_path.read_text(encoding="utf-8")
+    mutated = original.replace(
+        'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")',
+        'AppStateValidatedCompatibilityShim("shim-render-derived-row-position-missing")',
+        1,
+    )
+    assert mutated != original
+    source_path.write_text(mutated, encoding="utf-8")
+
+    unrelated_source_path = tmp_path / "src" / "core" / "main.c"
+    unrelated_original = unrelated_source_path.read_text(encoding="utf-8")
+    injected = unrelated_original.replace(
+        "int main(int argc, char **argv) {",
+        'int main(int argc, char **argv) {\n  (void)AppStateValidatedCompatibilityShim("shim-render-derived-row-position");',
+        1,
+    )
+    assert injected != unrelated_original
+    unrelated_source_path.write_text(injected, encoding="utf-8")
+
+    failures = guard.validate_contract(
+        guard.DEFAULT_TRANSITIONS,
+        guard.DEFAULT_SHIMS,
+        guard.DEFAULT_ACTION_COVERAGE,
+        guard.DEFAULT_ACTION_HEADER,
+        guard.DEFAULT_EVENT_COVERAGE,
+        guard.DEFAULT_OWNER_FIELDS,
+        guard.DEFAULT_DISPATCH_SURFACES,
+        guard.DEFAULT_INVARIANTS,
+        guard.DEFAULT_GENERATION_DOMAINS,
+        guard.DEFAULT_DIFF_HARNESS,
+        guard.DEFAULT_TRANSITION_SEQUENCES,
+        guard.DEFAULT_ACTION_RUNTIME,
+        repository_root=tmp_path,
+    )
+
+    assert any(
+        "shim-render-derived-row-position" in failure
+        and "src/ui/display.c" in failure
         and "missing runtime validation callsite" in failure
         for failure in failures
     )


### PR DESCRIPTION
## Summary
- add explicit source-boundary refs for compatibility shims in the docs and runtime registries
- anchor shim runtime callsite validation to those registered source files instead of scanning anywhere under src/
- cover the moved-outside-source-boundary shim regression in the contract-guard tests

## Validation
- source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'runtime_shim_validation_moves_outside_source_boundary or runtime_shim_validation_callsite_is_missing or runtime_event_validation_moves_outside_source_boundary or runtime_event_validation_callsite_is_missing or runtime_dispatch_surface_validation_moves_outside_source_boundary or runtime_dispatch_surface_validation_callsite_is_missing or current_repository_appstate_contract_passes'
- source .venv/bin/activate && python3 scripts/check_appstate_contract.py && git diff --check