### PR TITLE
chore(appstate): require runtime transition coverage statuses

### DIFF
--- a/docs/appstate_transition_matrix.json
+++ b/docs/appstate_transition_matrix.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState transition matrix",
-  "notes": "Non-runtime registry for the AppState transition contract. Runtime controllers are not migrated through this registry in this round.",
+  "notes": "Transition contract for the AppState matrix. Registered runtime transition metadata must stay aligned with these records while controller behavior continues to migrate incrementally.",
   "transitions": [
     {
       "id": "transition.keybinding.navigate-tree",
@@ -25,7 +25,7 @@
         "May request directory payload load when Enter reveals an unlogged directory."
       ],
       "render_invalidation": "tree_view,file_view,footer",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Route HandleDirWindow key dispatch through the canonical transition boundary in a later runtime migration."
     },
     {
@@ -49,7 +49,7 @@
         "May read the volume registry."
       ],
       "render_invalidation": "layout,tree_view,file_view,stats,footer",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Keep the loaded-volume preservation rule from the specification during runtime migration."
     },
     {
@@ -73,7 +73,7 @@
         "No filesystem side effects."
       ],
       "render_invalidation": "modal_overlay,footer,underlying_view_projection",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Modal migration must preserve severity versus neutral dialog routing."
     },
     {
@@ -97,7 +97,7 @@
         "No filesystem side effects."
       ],
       "render_invalidation": "modal_overlay,footer,underlying_view_projection",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Runtime migration must preserve prompt/menu/dialog completion routing while destructive confirmations stay on their dedicated command transitions."
     },
     {
@@ -122,7 +122,7 @@
         "Filesystem scan/read operations."
       ],
       "render_invalidation": "tree_view,file_view,stats,footer",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Runtime migration must keep restore ordering: rebuild, generation advance, rebind/fallback, render."
     },
     {
@@ -147,7 +147,7 @@
         "Filesystem scan/read operations after watcher debounce/settle."
       ],
       "render_invalidation": "tree_view,file_view,stats,footer",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Runtime migration must keep watcher debounce/settle routing distinct from explicit manual refresh commands while preserving rebuild ordering."
     },
     {
@@ -172,7 +172,7 @@
         "May close archive/filesystem resources."
       ],
       "render_invalidation": "layout,tree_view,file_view,stats,footer",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Ensure inactive panels sharing a released volume use deterministic fallback instead of stale pointers."
     },
     {
@@ -197,7 +197,7 @@
         "Ncurses window recreation in main loop only."
       ],
       "render_invalidation": "full_screen_projection",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Render reflow must remain projection-only and must not choose a new selection by row math."
     },
     {
@@ -223,7 +223,7 @@
         "Filesystem create/copy/move/delete/chmod-like operations already performed by command layer."
       ],
       "render_invalidation": "tree_view,file_view,stats,footer",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Runtime migration must separate command side effects from AppState commit/rollback metadata."
     },
     {
@@ -247,7 +247,7 @@
         "External command execution is outside the AppState commit boundary."
       ],
       "render_invalidation": "footer,stats_optional",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Later runtime boundary should declare whether each command completion queues refresh_rebuild."
     },
     {
@@ -273,7 +273,7 @@
         "May request payload reload for a visible but unloaded file-view anchor."
       ],
       "render_invalidation": "tree_view,file_view",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Use panel_anchor helpers as the canonical restore boundary during runtime migration."
     },
     {
@@ -295,7 +295,7 @@
         "Ncurses drawing and doupdate."
       ],
       "render_invalidation": "cleared_after_successful_projection",
-      "boundary_status": "documented_foundation_only",
+      "boundary_status": "covered_by_transition_record",
       "notes_follow_up": "Audit render paths so temporary projections cannot become restore authority."
     }
   ]

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -497,6 +497,19 @@ def _validate_runtime_action_coverage_boundary_status(
     return []
 
 
+def _validate_runtime_transition_boundary_status(
+    *,
+    record: dict[str, Any],
+    label: str,
+) -> list[str]:
+    if record.get("boundary_status") == "documented_foundation_only":
+        return [
+            f"{label}: boundary_status must use covered_by_transition_record "
+            "once runtime transition is registered"
+        ]
+    return []
+
+
 def _parse_ytnova_actions(header_path: Path) -> tuple[list[str], list[str]]:
     try:
         source = header_path.read_text(encoding="utf-8")
@@ -2495,6 +2508,9 @@ def _validate_runtime_transition_registry(
                     )
 
         failures.extend(_validate_event_boundary_status(record=record, label=label))
+        failures.extend(
+            _validate_runtime_transition_boundary_status(record=record, label=label)
+        )
         failures.extend(
             _validate_registered_write_set(
                 record=record,

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -3305,7 +3305,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects0) /
        sizeof(kAppStateTransitionSideEffects0[0]),
    "tree_view,file_view,footer",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Route HandleDirWindow key dispatch through the canonical transition boundary in a later runtime migration.",
    kAppStateTransitionWriteSet0,
    sizeof(kAppStateTransitionWriteSet0) / sizeof(kAppStateTransitionWriteSet0[0])},
@@ -3323,7 +3323,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects1) /
        sizeof(kAppStateTransitionSideEffects1[0]),
    "layout,tree_view,file_view,stats,footer",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Keep the loaded-volume preservation rule from the specification during runtime migration.",
    kAppStateTransitionWriteSet1,
    sizeof(kAppStateTransitionWriteSet1) / sizeof(kAppStateTransitionWriteSet1[0])},
@@ -3341,7 +3341,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects2) /
        sizeof(kAppStateTransitionSideEffects2[0]),
    "modal_overlay,footer,underlying_view_projection",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Modal migration must preserve severity versus neutral dialog routing.",
    kAppStateTransitionWriteSet2,
    sizeof(kAppStateTransitionWriteSet2) / sizeof(kAppStateTransitionWriteSet2[0])},
@@ -3359,7 +3359,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects2) /
        sizeof(kAppStateTransitionSideEffects2[0]),
    "modal_overlay,footer,underlying_view_projection",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Runtime migration must preserve prompt/menu/dialog completion routing while destructive confirmations stay on their dedicated command transitions.",
    kAppStateTransitionWriteSet2,
    sizeof(kAppStateTransitionWriteSet2) / sizeof(kAppStateTransitionWriteSet2[0])},
@@ -3377,7 +3377,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects3) /
        sizeof(kAppStateTransitionSideEffects3[0]),
    "tree_view,file_view,stats,footer",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Runtime migration must keep restore ordering: rebuild, generation advance, rebind/fallback, render.",
    kAppStateTransitionWriteSet3,
    sizeof(kAppStateTransitionWriteSet3) / sizeof(kAppStateTransitionWriteSet3[0])},
@@ -3395,7 +3395,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects15) /
        sizeof(kAppStateTransitionSideEffects15[0]),
    "tree_view,file_view,stats,footer",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Runtime migration must keep watcher debounce/settle routing distinct from explicit manual refresh commands while preserving rebuild ordering.",
    kAppStateTransitionWriteSet3,
    sizeof(kAppStateTransitionWriteSet3) / sizeof(kAppStateTransitionWriteSet3[0])},
@@ -3413,7 +3413,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects4) /
        sizeof(kAppStateTransitionSideEffects4[0]),
    "layout,tree_view,file_view,stats,footer",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Ensure inactive panels sharing a released volume use deterministic fallback instead of stale pointers.",
    kAppStateTransitionWriteSet4,
    sizeof(kAppStateTransitionWriteSet4) / sizeof(kAppStateTransitionWriteSet4[0])},
@@ -3431,7 +3431,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects5) /
        sizeof(kAppStateTransitionSideEffects5[0]),
    "full_screen_projection",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Render reflow must remain projection-only and must not choose a new selection by row math.",
    kAppStateTransitionWriteSet5,
    sizeof(kAppStateTransitionWriteSet5) / sizeof(kAppStateTransitionWriteSet5[0])},
@@ -3449,7 +3449,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects6) /
        sizeof(kAppStateTransitionSideEffects6[0]),
    "tree_view,file_view,stats,footer",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Runtime migration must separate command side effects from AppState commit/rollback metadata.",
    kAppStateTransitionWriteSet6,
    sizeof(kAppStateTransitionWriteSet6) / sizeof(kAppStateTransitionWriteSet6[0])},
@@ -3467,7 +3467,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects7) /
        sizeof(kAppStateTransitionSideEffects7[0]),
    "footer,stats_optional",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Later runtime boundary should declare whether each command completion queues refresh_rebuild.",
    kAppStateTransitionWriteSet7,
    sizeof(kAppStateTransitionWriteSet7) / sizeof(kAppStateTransitionWriteSet7[0])},
@@ -3485,7 +3485,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects8) /
        sizeof(kAppStateTransitionSideEffects8[0]),
    "tree_view,file_view",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Use panel_anchor helpers as the canonical restore boundary during runtime migration.",
    kAppStateTransitionWriteSet8,
    sizeof(kAppStateTransitionWriteSet8) / sizeof(kAppStateTransitionWriteSet8[0])},
@@ -3503,7 +3503,7 @@ static const AppStateTransitionMetadata kAppStateTransitions[] = {
    sizeof(kAppStateTransitionSideEffects9) /
        sizeof(kAppStateTransitionSideEffects9[0]),
    "cleared_after_successful_projection",
-   "documented_foundation_only",
+   "covered_by_transition_record",
    "Audit render paths so temporary projections cannot become restore authority.",
    kAppStateTransitionWriteSet9,
    sizeof(kAppStateTransitionWriteSet9) / sizeof(kAppStateTransitionWriteSet9[0])}

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -120,7 +120,7 @@ def _transition(category: str, transition_id: str | None = None) -> dict[str, ob
         "generation_effect": generation_effect,
         "side_effects": ["none"],
         "render_invalidation": "view",
-        "boundary_status": "documented_foundation_only",
+        "boundary_status": "covered_by_transition_record",
         "notes_follow_up": "follow-up",
     }
 
@@ -10023,6 +10023,29 @@ def test_guard_fails_when_runtime_transition_registry_has_extra_id(
         "runtime_transition" in failure
         and "id does not match a transition matrix id" in failure
         and "transition.runtime.extra" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_transition_registry_keeps_foundation_status(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_transitions = [dict(record) for record in transitions]
+    transitions[0]["boundary_status"] = "documented_foundation_only"
+    runtime_transitions[0]["boundary_status"] = "documented_foundation_only"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_transitions=runtime_transitions,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_transition[0]" in failure
+        and "boundary_status must use covered_by_transition_record once runtime transition is registered"
+        in failure
         for failure in failures
     )
 


### PR DESCRIPTION
## Summary
- promote runtime-backed transition matrix records to `covered_by_transition_record`
- keep the runtime transition registry aligned with the documented transition matrix
- reject registered runtime transition records that remain foundation-only

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'runtime_transition_registry_keeps_foundation_status or runtime_transition_registry_mismatches_matrix or current_repository_appstate_contract_passes'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`