### PR TITLE
fix(appstate): require runtime diff harness coverage status

### DIFF
--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -55,7 +55,7 @@
       ],
       "expected_behavior": "A later dynamic harness snapshots every referenced AppState region before guard evaluation and after the transition result, then compares only authoritative state owned by the registered transition boundary.",
       "failure_mode": "Any unclassified region change, stale snapshot reuse, or missing before/after phase is reported as a transition contract violation.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
         "This registry entry defines the machine-readable coverage target; no runtime C runner exists in this unit."
       ]
@@ -107,7 +107,7 @@
       ],
       "expected_behavior": "The after snapshot may differ from the before snapshot only in owner fields named by the transition's declared_write_set or by an explicitly registered follow-up transition.",
       "failure_mode": "A changed owner field outside the registered write set is rejected as an undeclared AppState mutation.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
         "Runtime migration should derive concrete field comparisons from docs/appstate_transition_matrix.json declared_write_set records."
       ]
@@ -149,7 +149,7 @@
       ],
       "expected_behavior": "Render/reflow projection may consume settled AppState and stage terminal output, but it must not mutate authoritative selection, identity, focus, or generation fields.",
       "failure_mode": "Any authoritative owner or generation delta produced by render projection is rejected as render-state leakage into AppState authority.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
         "Dirty-flag clearing and window-handle staging remain named so the future harness can distinguish projection bookkeeping from selection authority."
       ]
@@ -205,7 +205,7 @@
       ],
       "expected_behavior": "Saved panel or volume snapshots whose generation markers mismatch current authority must be rejected or rebound through stable identity fallback before any restore commit.",
       "failure_mode": "Reusing stale row, pointer, or payload identity after a generation mismatch is rejected as a fail-closed violation.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
         "The future runner should seed mismatched saved/current generations to verify deterministic restore fallback."
       ]
@@ -253,7 +253,7 @@
       ],
       "expected_behavior": "A blocked transition may report only the registered user-visible failure state and must leave unrelated owner fields and all unaffected generations byte-for-byte unchanged.",
       "failure_mode": "Any unrelated owner-field or generation delta after a blocked result is rejected as nondeterministic blocked-transition mutation.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
         "Concrete blocked-result allowances should be derived from the target transition's blocked_result and declared_write_set records."
       ]

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -345,6 +345,7 @@ VALID_BOUNDARY_STATUSES = {
 }
 VALID_ENFORCEMENT_STATUSES = {
     "documented_foundation_only",
+    "covered_by_runtime_registry",
 }
 VALID_MIGRATION_STATUSES = {
     "documented_foundation_only",
@@ -506,6 +507,19 @@ def _validate_runtime_transition_boundary_status(
         return [
             f"{label}: boundary_status must use covered_by_transition_record "
             "once runtime transition is registered"
+        ]
+    return []
+
+
+def _validate_runtime_diff_harness_enforcement_status(
+    *,
+    record: dict[str, Any],
+    label: str,
+) -> list[str]:
+    if record.get("enforcement_status") == "documented_foundation_only":
+        return [
+            f"{label}: enforcement_status must use covered_by_runtime_registry "
+            "once runtime diff harness is registered"
         ]
     return []
 
@@ -3274,6 +3288,12 @@ def _validate_runtime_diff_harness_registry(
                 label=label,
                 field="enforcement_status",
                 valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
+        failures.extend(
+            _validate_runtime_diff_harness_enforcement_status(
+                record=record,
+                label=label,
             )
         )
         for field in (

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -1053,7 +1053,7 @@ static const AppStateDiffHarnessMetadata kAppStateDiffHarnesses[] = {
    sizeof(kAppStateDiffHarnessGenerationDomainIds0) / sizeof(kAppStateDiffHarnessGenerationDomainIds0[0]),
    "A later dynamic harness snapshots every referenced AppState region before guard evaluation and after the transition result, then compares only authoritative state owned by the registered transition boundary.",
    "Any unclassified region change, stale snapshot reuse, or missing before/after phase is reported as a transition contract violation.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateDiffHarnessMigrationNotes0,
    sizeof(kAppStateDiffHarnessMigrationNotes0) / sizeof(kAppStateDiffHarnessMigrationNotes0[0])},
   {"harness.declared-write-set-diff",
@@ -1072,7 +1072,7 @@ static const AppStateDiffHarnessMetadata kAppStateDiffHarnesses[] = {
    sizeof(kAppStateDiffHarnessGenerationDomainIds1) / sizeof(kAppStateDiffHarnessGenerationDomainIds1[0]),
    "The after snapshot may differ from the before snapshot only in owner fields named by the transition's declared_write_set or by an explicitly registered follow-up transition.",
    "A changed owner field outside the registered write set is rejected as an undeclared AppState mutation.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateDiffHarnessMigrationNotes1,
    sizeof(kAppStateDiffHarnessMigrationNotes1) / sizeof(kAppStateDiffHarnessMigrationNotes1[0])},
   {"harness.render-projection-read-only-diff",
@@ -1091,7 +1091,7 @@ static const AppStateDiffHarnessMetadata kAppStateDiffHarnesses[] = {
    sizeof(kAppStateDiffHarnessGenerationDomainIds2) / sizeof(kAppStateDiffHarnessGenerationDomainIds2[0]),
    "Render/reflow projection may consume settled AppState and stage terminal output, but it must not mutate authoritative selection, identity, focus, or generation fields.",
    "Any authoritative owner or generation delta produced by render projection is rejected as render-state leakage into AppState authority.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateDiffHarnessMigrationNotes2,
    sizeof(kAppStateDiffHarnessMigrationNotes2) / sizeof(kAppStateDiffHarnessMigrationNotes2[0])},
   {"harness.generation-mismatch-check",
@@ -1110,7 +1110,7 @@ static const AppStateDiffHarnessMetadata kAppStateDiffHarnesses[] = {
    sizeof(kAppStateDiffHarnessGenerationDomainIds3) / sizeof(kAppStateDiffHarnessGenerationDomainIds3[0]),
    "Saved panel or volume snapshots whose generation markers mismatch current authority must be rejected or rebound through stable identity fallback before any restore commit.",
    "Reusing stale row, pointer, or payload identity after a generation mismatch is rejected as a fail-closed violation.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateDiffHarnessMigrationNotes3,
    sizeof(kAppStateDiffHarnessMigrationNotes3) / sizeof(kAppStateDiffHarnessMigrationNotes3[0])},
   {"harness.blocked-transition-no-unrelated-mutation",
@@ -1129,7 +1129,7 @@ static const AppStateDiffHarnessMetadata kAppStateDiffHarnesses[] = {
    sizeof(kAppStateDiffHarnessGenerationDomainIds4) / sizeof(kAppStateDiffHarnessGenerationDomainIds4[0]),
    "A blocked transition may report only the registered user-visible failure state and must leave unrelated owner fields and all unaffected generations byte-for-byte unchanged.",
    "Any unrelated owner-field or generation delta after a blocked result is rejected as nondeterministic blocked-transition mutation.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateDiffHarnessMigrationNotes4,
    sizeof(kAppStateDiffHarnessMigrationNotes4) / sizeof(kAppStateDiffHarnessMigrationNotes4[0])},
 };
@@ -6771,7 +6771,8 @@ static int AppStateKnownBoundaryStatus(const char *status) {
 static int AppStateKnownFoundationStatus(const char *status) {
   if (!AppStateNonEmptyString(status))
     return 0;
-  return strcmp(status, "documented_foundation_only") == 0;
+  return strcmp(status, "documented_foundation_only") == 0 ||
+         strcmp(status, "covered_by_runtime_registry") == 0;
 }
 
 static const AppStateActionCoverageMetadata *

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -572,7 +572,7 @@ def _diff_harness(
         "generation_domain_ids": generation_domain_ids or ["domain.panel_generation"],
         "expected_behavior": "fixture expected behavior",
         "failure_mode": "fixture failure mode",
-        "enforcement_status": "documented_foundation_only",
+        "enforcement_status": "covered_by_runtime_registry",
         "migration_notes": ["fixture coverage"],
     }
 
@@ -4025,6 +4025,33 @@ def test_guard_fails_when_runtime_diff_harness_drifts_from_docs(
     assert any(
         "runtime_diff_harness[0]" in failure
         and "runtime expected_behavior does not match diff harness" in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_diff_harness_keeps_foundation_status(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    diff_harness_checks = _complete_diff_harness_checks()
+    runtime_diff_harness_checks = [dict(record) for record in diff_harness_checks]
+    diff_harness_checks[0]["enforcement_status"] = "documented_foundation_only"
+    runtime_diff_harness_checks[0]["enforcement_status"] = (
+        "documented_foundation_only"
+    )
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        diff_harness_checks=diff_harness_checks,
+        runtime_diff_harness_checks=runtime_diff_harness_checks,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_diff_harness[0]" in failure
+        and "enforcement_status must use covered_by_runtime_registry once runtime diff harness is registered"
+        in failure
         for failure in failures
     )
 


### PR DESCRIPTION
## Summary
- promote diff harness enforcement metadata to a runtime-backed coverage status
- reject runtime diff harness records that stay foundation-only once registered
- cover the runtime diff harness status contract with a focused regression

## Validation
- source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'runtime_diff_harness_keeps_foundation_status or runtime_diff_harness_drifts_from_docs or current_repository_appstate_contract_passes'\n- source .venv/bin/activate && python3 scripts/check_appstate_contract.py\n- make clean && make