### PR TITLE
fix(appstate): require runtime generation domain status

### DIFF
--- a/docs/appstate_generation_domains.json
+++ b/docs/appstate_generation_domains.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState generation-domain registry",
-  "notes": "Non-runtime registry for identity and generation domains used by stale snapshot, restore, and rebind invariants.",
+  "notes": "Runtime-backed registry for identity and generation domains used by stale snapshot, restore, and rebind invariants.",
   "generation_domains": [
     {
       "domain_id": "generation.panel.local-authority",
@@ -43,9 +43,9 @@
       "stale_snapshot_policy": "Reject snapshots whose saved panel_generation does not match the panel-local generation marker before restore authority is applied.",
       "fail_closed_fallback": "Re-resolve by stable identity, then nearest visible ancestor, next visible sibling, previous visible sibling, and finally root visible node.",
       "restore_boundary": "Canonical panel-anchor restore helpers commit panel-local selection, viewport, focus shape, and snapshot generation together.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "Runtime panel_generation is still documented foundation; later runtime migration must wire this field to the canonical panel UI state record."
+        "Runtime panel_generation domain metadata is registered and validated against the canonical panel UI state record."
       ]
     },
     {
@@ -75,9 +75,9 @@
       "stale_snapshot_policy": "Treat any saved volume_generation mismatch as stale and require topology/payload identity re-resolution before panel snapshots are reused.",
       "fail_closed_fallback": "Keep the previous settled topology on blocked transitions; after invalidation, rebind panels through stable identities or fall back to root visible node.",
       "restore_boundary": "Refresh/rebuild and mutation-result commits advance volume generation before panel restore consumers can observe the changed volume.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "Runtime volume_generation is still documented foundation; later runtime migration must attach it to Volume topology and payload commits."
+        "Runtime volume_generation domain metadata is registered and validated against Volume topology and payload commits."
       ]
     },
     {
@@ -109,9 +109,9 @@
       "stale_snapshot_policy": "Directory snapshots must compare stable path identity against the current volume generation before row or cursor state is trusted.",
       "fail_closed_fallback": "Exact directory identity, nearest visible ancestor, next visible sibling, previous visible sibling, then root visible node.",
       "restore_boundary": "Directory rebind runs through panel-anchor helpers after the shared topology generation has settled.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "Directory identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative invalidation owner for topology changes."
+        "Directory identity runtime metadata is registered with volume.volume_generation as the authoritative invalidation owner for topology changes."
       ]
     },
     {
@@ -140,9 +140,9 @@
       "stale_snapshot_policy": "File snapshots must revalidate path/name identity and payload membership when volume generation changes.",
       "fail_closed_fallback": "Preserve the directory anchor when possible and choose a valid visible file only after exact file identity is unavailable.",
       "restore_boundary": "File identity restore is committed with the panel snapshot after topology or payload mutation has settled.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "File identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative owner for payload and namespace invalidation."
+        "File identity runtime metadata is registered with volume.volume_generation as the authoritative owner for payload and namespace invalidation."
       ]
     },
     {
@@ -171,9 +171,9 @@
       "stale_snapshot_policy": "Saved focus shape is stale when panel_generation differs and must not be restored by transient render shape.",
       "fail_closed_fallback": "Restore the recorded panel shape directly or keep the current settled shape without rendering an intermediate guess.",
       "restore_boundary": "Modal dismissal, panel reactivation, and rebind callbacks commit focus shape only through panel-local state.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "Focus-shape invalidation is represented by panel.panel_generation until a narrower runtime focus-shape generation exists."
+        "Focus-shape runtime metadata is registered with panel.panel_generation as the current invalidation owner until a narrower focus-shape generation exists."
       ]
     },
     {
@@ -200,9 +200,9 @@
       "stale_snapshot_policy": "Modal and command targets may write panel or volume state only through a declared follow-up transition boundary.",
       "fail_closed_fallback": "On blocked or failed command completion, preserve authoritative panel and volume state and write only declared message/modal fields.",
       "restore_boundary": "Modal dismissal and command completion settle session state before any panel restore or refresh follow-up observes the result.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "No dedicated ctx command/modal generation exists yet; panel.panel_generation is the closest guard for command paths that restore focus or queue panel-local follow-up work."
+        "Modal command target runtime metadata is registered with panel.panel_generation guarding command paths that restore focus or queue panel-local follow-up work."
       ]
     },
     {
@@ -232,9 +232,9 @@
       "stale_snapshot_policy": "Visibility/filter changes that alter rendered rows invalidate saved panel anchors before any snapshot can be reused.",
       "fail_closed_fallback": "Rebind visible identity through the deterministic fallback order rather than deriving from hidden or filtered row indexes.",
       "restore_boundary": "Visibility-filter commits update panel generation before rebind and render projection.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "Dedicated filter and dotfile visibility owner fields are not registered yet; panel.panel_generation is the closest panel-local invalidation owner."
+        "Visibility-filter runtime metadata is registered with panel.panel_generation as the panel-local invalidation owner for filter and dotfile visibility state."
       ]
     },
     {
@@ -262,9 +262,9 @@
       "stale_snapshot_policy": "Topology snapshots are invalid after any volume_generation advance and must be rebuilt or rebound by identity.",
       "fail_closed_fallback": "Blocked topology changes retain the previous settled tree; completed invalidation falls back panel anchors only after exact identity fails.",
       "restore_boundary": "Topology rebuild commits settle volume.dir_tree and volume.logged_state before panel rebind callbacks run.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "Topology generation is represented by volume.volume_generation until runtime Volume commit hooks are migrated."
+        "Topology runtime metadata is registered with volume.volume_generation representing Volume topology commit invalidation."
       ]
     },
     {
@@ -292,9 +292,9 @@
       "stale_snapshot_policy": "Payload cache identity must be revalidated on generation mismatch before saved file selection is restored.",
       "fail_closed_fallback": "If payload cannot be loaded safely, preserve directory selection and leave file authority unchanged or empty according to current AppState.",
       "restore_boundary": "Payload changes settle in Volume before panel file anchors are rebound.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "File payload invalidation uses volume.volume_generation until a narrower payload generation field is registered."
+        "File payload runtime metadata is registered with volume.volume_generation until a narrower payload generation field is registered."
       ]
     },
     {
@@ -323,9 +323,9 @@
       "stale_snapshot_policy": "Panel volume bindings must resolve to an existing volume identity before per-volume snapshots can be restored.",
       "fail_closed_fallback": "Do not orphan panel bindings; use deterministic volume fallback and then panel identity fallback after release or cycle invalidation.",
       "restore_boundary": "Volume lifecycle transitions update registry/binding state before panel-local restore snapshots are applied.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
-        "Volume lifecycle has no separate registry generation yet; volume.volume_generation is the closest shared invalidation owner while ctx.volumes_head remains the registry identity field."
+        "Volume lifecycle runtime metadata is registered with volume.volume_generation as the shared invalidation owner while ctx.volumes_head remains the registry identity field."
       ]
     },
     {
@@ -350,10 +350,10 @@
       "stale_snapshot_policy": "Layout reflow must project from settled AppState and may advance panel generation only for viewport bounds correction.",
       "fail_closed_fallback": "If safe projection cannot be computed, degrade or skip render without choosing new authoritative identities.",
       "restore_boundary": "Resize handling runs in the main loop and commits any viewport correction before render projection.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "migration_notes": [
         "Render projection itself is read-only/projection-only and does not advance generations; terminal resize uses panel.panel_generation only when saved viewport origins are corrected.",
-        "Render projection-only coverage is explicit here even when no generation counter advances."
+        "Render projection-only coverage is registered explicitly even when no generation counter advances."
       ]
     }
   ]

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -524,6 +524,19 @@ def _validate_runtime_diff_harness_enforcement_status(
     return []
 
 
+def _validate_runtime_generation_domain_enforcement_status(
+    *,
+    record: dict[str, Any],
+    label: str,
+) -> list[str]:
+    if record.get("enforcement_status") == "documented_foundation_only":
+        return [
+            f"{label}: enforcement_status must use covered_by_runtime_registry "
+            "once runtime generation domain is registered"
+        ]
+    return []
+
+
 def _parse_ytnova_actions(header_path: Path) -> tuple[list[str], list[str]]:
     try:
         source = header_path.read_text(encoding="utf-8")
@@ -3115,6 +3128,12 @@ def _validate_runtime_generation_domain_registry(
                 label=label,
                 field="enforcement_status",
                 valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
+        failures.extend(
+            _validate_runtime_generation_domain_enforcement_status(
+                record=record,
+                label=label,
             )
         )
         for field in (

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -568,38 +568,38 @@ static const char *const kAppStateGenerationDomainAdvancesOnTransitionIds10[] = 
   "transition.terminal-signal-resize",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes0[] = {
-  "Runtime panel_generation is still documented foundation; later runtime migration must wire this field to the canonical panel UI state record.",
+  "Runtime panel_generation domain metadata is registered and validated against the canonical panel UI state record.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes1[] = {
-  "Runtime volume_generation is still documented foundation; later runtime migration must attach it to Volume topology and payload commits.",
+  "Runtime volume_generation domain metadata is registered and validated against Volume topology and payload commits.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes2[] = {
-  "Directory identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative invalidation owner for topology changes.",
+  "Directory identity runtime metadata is registered with volume.volume_generation as the authoritative invalidation owner for topology changes.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes3[] = {
-  "File identity has no dedicated runtime generation counter yet; volume.volume_generation is the closest authoritative owner for payload and namespace invalidation.",
+  "File identity runtime metadata is registered with volume.volume_generation as the authoritative owner for payload and namespace invalidation.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes4[] = {
-  "Focus-shape invalidation is represented by panel.panel_generation until a narrower runtime focus-shape generation exists.",
+  "Focus-shape runtime metadata is registered with panel.panel_generation as the current invalidation owner until a narrower focus-shape generation exists.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes5[] = {
-  "No dedicated ctx command/modal generation exists yet; panel.panel_generation is the closest guard for command paths that restore focus or queue panel-local follow-up work.",
+  "Modal command target runtime metadata is registered with panel.panel_generation guarding command paths that restore focus or queue panel-local follow-up work.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes6[] = {
-  "Dedicated filter and dotfile visibility owner fields are not registered yet; panel.panel_generation is the closest panel-local invalidation owner.",
+  "Visibility-filter runtime metadata is registered with panel.panel_generation as the panel-local invalidation owner for filter and dotfile visibility state.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes7[] = {
-  "Topology generation is represented by volume.volume_generation until runtime Volume commit hooks are migrated.",
+  "Topology runtime metadata is registered with volume.volume_generation representing Volume topology commit invalidation.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes8[] = {
-  "File payload invalidation uses volume.volume_generation until a narrower payload generation field is registered.",
+  "File payload runtime metadata is registered with volume.volume_generation until a narrower payload generation field is registered.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes9[] = {
-  "Volume lifecycle has no separate registry generation yet; volume.volume_generation is the closest shared invalidation owner while ctx.volumes_head remains the registry identity field.",
+  "Volume lifecycle runtime metadata is registered with volume.volume_generation as the shared invalidation owner while ctx.volumes_head remains the registry identity field.",
 };
 static const char *const kAppStateGenerationDomainMigrationNotes10[] = {
   "Render projection itself is read-only/projection-only and does not advance generations; terminal resize uses panel.panel_generation only when saved viewport origins are corrected.",
-  "Render projection-only coverage is explicit here even when no generation counter advances.",
+  "Render projection-only coverage is registered explicitly even when no generation counter advances.",
 };
 
 static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
@@ -616,7 +616,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Reject snapshots whose saved panel_generation does not match the panel-local generation marker before restore authority is applied.",
    "Re-resolve by stable identity, then nearest visible ancestor, next visible sibling, previous visible sibling, and finally root visible node.",
    "Canonical panel-anchor restore helpers commit panel-local selection, viewport, focus shape, and snapshot generation together.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes0,
    sizeof(kAppStateGenerationDomainMigrationNotes0) / sizeof(kAppStateGenerationDomainMigrationNotes0[0])},
   {"generation.volume.shared-authority",
@@ -632,7 +632,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Treat any saved volume_generation mismatch as stale and require topology/payload identity re-resolution before panel snapshots are reused.",
    "Keep the previous settled topology on blocked transitions; after invalidation, rebind panels through stable identities or fall back to root visible node.",
    "Refresh/rebuild and mutation-result commits advance volume generation before panel restore consumers can observe the changed volume.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes1,
    sizeof(kAppStateGenerationDomainMigrationNotes1) / sizeof(kAppStateGenerationDomainMigrationNotes1[0])},
   {"identity.directory.stable-key",
@@ -648,7 +648,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Directory snapshots must compare stable path identity against the current volume generation before row or cursor state is trusted.",
    "Exact directory identity, nearest visible ancestor, next visible sibling, previous visible sibling, then root visible node.",
    "Directory rebind runs through panel-anchor helpers after the shared topology generation has settled.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes2,
    sizeof(kAppStateGenerationDomainMigrationNotes2) / sizeof(kAppStateGenerationDomainMigrationNotes2[0])},
   {"identity.file.stable-key",
@@ -664,7 +664,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "File snapshots must revalidate path/name identity and payload membership when volume generation changes.",
    "Preserve the directory anchor when possible and choose a valid visible file only after exact file identity is unavailable.",
    "File identity restore is committed with the panel snapshot after topology or payload mutation has settled.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes3,
    sizeof(kAppStateGenerationDomainMigrationNotes3) / sizeof(kAppStateGenerationDomainMigrationNotes3[0])},
   {"shape.panel.focus",
@@ -680,7 +680,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Saved focus shape is stale when panel_generation differs and must not be restored by transient render shape.",
    "Restore the recorded panel shape directly or keep the current settled shape without rendering an intermediate guess.",
    "Modal dismissal, panel reactivation, and rebind callbacks commit focus shape only through panel-local state.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes4,
    sizeof(kAppStateGenerationDomainMigrationNotes4) / sizeof(kAppStateGenerationDomainMigrationNotes4[0])},
   {"target.modal-command.session",
@@ -696,7 +696,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Modal and command targets may write panel or volume state only through a declared follow-up transition boundary.",
    "On blocked or failed command completion, preserve authoritative panel and volume state and write only declared message/modal fields.",
    "Modal dismissal and command completion settle session state before any panel restore or refresh follow-up observes the result.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes5,
    sizeof(kAppStateGenerationDomainMigrationNotes5) / sizeof(kAppStateGenerationDomainMigrationNotes5[0])},
   {"state.visibility-filter.panel-volume",
@@ -712,7 +712,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Visibility/filter changes that alter rendered rows invalidate saved panel anchors before any snapshot can be reused.",
    "Rebind visible identity through the deterministic fallback order rather than deriving from hidden or filtered row indexes.",
    "Visibility-filter commits update panel generation before rebind and render projection.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes6,
    sizeof(kAppStateGenerationDomainMigrationNotes6) / sizeof(kAppStateGenerationDomainMigrationNotes6[0])},
   {"state.topology.volume",
@@ -728,7 +728,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Topology snapshots are invalid after any volume_generation advance and must be rebuilt or rebound by identity.",
    "Blocked topology changes retain the previous settled tree; completed invalidation falls back panel anchors only after exact identity fails.",
    "Topology rebuild commits settle volume.dir_tree and volume.logged_state before panel rebind callbacks run.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes7,
    sizeof(kAppStateGenerationDomainMigrationNotes7) / sizeof(kAppStateGenerationDomainMigrationNotes7[0])},
   {"state.file-payload.volume",
@@ -744,7 +744,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Payload cache identity must be revalidated on generation mismatch before saved file selection is restored.",
    "If payload cannot be loaded safely, preserve directory selection and leave file authority unchanged or empty according to current AppState.",
    "Payload changes settle in Volume before panel file anchors are rebound.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes8,
    sizeof(kAppStateGenerationDomainMigrationNotes8) / sizeof(kAppStateGenerationDomainMigrationNotes8[0])},
   {"lifecycle.volume.registry",
@@ -760,7 +760,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Panel volume bindings must resolve to an existing volume identity before per-volume snapshots can be restored.",
    "Do not orphan panel bindings; use deterministic volume fallback and then panel identity fallback after release or cycle invalidation.",
    "Volume lifecycle transitions update registry/binding state before panel-local restore snapshots are applied.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes9,
    sizeof(kAppStateGenerationDomainMigrationNotes9) / sizeof(kAppStateGenerationDomainMigrationNotes9[0])},
   {"reflow.layout.projection",
@@ -776,7 +776,7 @@ static const AppStateGenerationDomainMetadata kAppStateGenerationDomains[] = {
    "Layout reflow must project from settled AppState and may advance panel generation only for viewport bounds correction.",
    "If safe projection cannot be computed, degrade or skip render without choosing new authoritative identities.",
    "Resize handling runs in the main loop and commits any viewport correction before render projection.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    kAppStateGenerationDomainMigrationNotes10,
    sizeof(kAppStateGenerationDomainMigrationNotes10) / sizeof(kAppStateGenerationDomainMigrationNotes10[0])},
 };

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -548,7 +548,7 @@ def _generation_domain(
         "stale_snapshot_policy": "fixture stale snapshot policy",
         "fail_closed_fallback": "fixture fail-closed fallback",
         "restore_boundary": "fixture restore boundary",
-        "enforcement_status": "documented_foundation_only",
+        "enforcement_status": "covered_by_runtime_registry",
         "migration_notes": migration_notes,
     }
 
@@ -6292,6 +6292,31 @@ def test_guard_fails_when_runtime_generation_domain_is_missing(
     assert any(
         "runtime generation domain registry missing domain id(s)" in failure
         and missing_domain_id in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_generation_domain_remains_foundation_only(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_generation_domains = _complete_generation_domains()
+    runtime_generation_domains[0]["enforcement_status"] = "documented_foundation_only"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_generation_domains=runtime_generation_domains,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_generation_domain[0]" in failure
+        and (
+            "enforcement_status must use covered_by_runtime_registry once "
+            "runtime generation domain is registered"
+        )
+        in failure
         for failure in failures
     )
 


### PR DESCRIPTION
## Summary
- mark generation-domain documentation and runtime metadata as runtime-backed
- reject runtime generation-domain registry rows that remain foundation-only
- cover the runtime generation-domain status guard in contract tests

## Validation
- make clean && make
- source .venv/bin/activate && python scripts/check_appstate_contract.py
- source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q