### PR TITLE
fix(appstate): require runtime invariant status

### DIFF
--- a/docs/appstate_invariants.json
+++ b/docs/appstate_invariants.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState transition invariant registry",
-  "notes": "Non-runtime registry for invariants that future state-sequence tests must enforce at AppState transition boundaries. Runtime behavior is unchanged.",
+  "notes": "Runtime-backed invariant registry for AppState transition boundaries. Registered rows must remain aligned with the C runtime metadata and future state-sequence enforcement.",
   "invariants": [
     {
       "invariant_id": "invariant.inactive-panel-frozen",
@@ -40,7 +40,7 @@
         "surface.resize-signal-handling"
       ],
       "failure_mode": "Fail if an active-only transition mutates inactive panel-local identity, viewport, focus, restore, or generation fields outside an explicitly targeted transition.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "test_strategy": "State-sequence harness snapshots both panels before each active-panel transition and compares inactive panel fields after allowed and blocked outcomes.",
       "migration_notes": [
         "Future dynamic tests should distinguish shared topology mirroring from inactive panel-local mutation."
@@ -71,7 +71,7 @@
         "surface.resize-signal-handling"
       ],
       "failure_mode": "Fail if render or reflow chooses new authoritative selection, focus, viewport, panel generation, or volume generation from projected rows or window geometry.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "test_strategy": "Transition-diff harness runs render/reflow passes after settled transitions and verifies only declared render projection fields change.",
       "migration_notes": [
         "Runtime migration must keep ncurses drawing and temporary row calculations from becoming restore authority."
@@ -104,7 +104,7 @@
         "surface.watcher-live-refresh"
       ],
       "failure_mode": "Fail if visible navigation lands on a hidden entry or resurrects a concealed identity after visibility/topology changes.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "test_strategy": "Generated navigation sequences toggle visibility, rebuild, and move through visible rows while asserting the selected identity remains visible or falls back deterministically.",
       "migration_notes": [
         "Hidden-entry checks must use stable identity and visibility metadata rather than stale row positions."
@@ -139,7 +139,7 @@
         "surface.volume-operation"
       ],
       "failure_mode": "Fail if focus restoration imports another panel's shape, briefly renders a different shape, or restores focus from session mirrors instead of panel-local records.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "test_strategy": "Sequence tests alternate modal dismissal, Tab/F8-style routing, and file/tree transitions while asserting each panel restores its own recorded focus shape.",
       "migration_notes": [
         "Compatibility session mirrors may shadow focus only after the panel-local owner has committed the transition."
@@ -174,7 +174,7 @@
         "surface.watcher-live-refresh"
       ],
       "failure_mode": "Fail if rebuild, mutation, or resize restores viewport from raw rows when the stable identity is still visible or before deterministic fallback order is exhausted.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "test_strategy": "Snapshot/diff tests rebuild or resize around stable directory and file identities, then assert exact rebind when visible and deterministic fallback otherwise.",
       "migration_notes": [
         "Canonical restore helpers must remain the only authority for rebind after topology or layout invalidation."
@@ -213,7 +213,7 @@
         "surface.watcher-live-refresh"
       ],
       "failure_mode": "Fail if shared volume topology or registry changes overwrite panel-local selection, focus, tags, viewport, or restore snapshots by shared index or pointer aliasing.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "test_strategy": "Split-panel sequences share a volume, mutate shared topology, and verify each panel rebinds through its own identity without cross-panel field drift.",
       "migration_notes": [
         "Shared topology mirroring must be followed by panel-local rebind rather than copying active panel state into inactive panels."
@@ -248,7 +248,7 @@
         "surface.watcher-live-refresh"
       ],
       "failure_mode": "Fail if a generation mismatch reuses stale DirEntry/FileEntry pointers, stale flat-list rows, or stale snapshot payloads instead of exact rebind or deterministic fallback.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "test_strategy": "Harness corrupts or invalidates saved generations around rebuild/mutation transitions and asserts stale snapshots fail closed without unrelated mutation.",
       "migration_notes": [
         "Generation validation must happen before any restore snapshot is applied to a panel record."
@@ -299,7 +299,7 @@
         "surface.render-reflow-projection"
       ],
       "failure_mode": "Fail if a blocked or invalid transition partially mutates authoritative panel/volume state, advances generations, performs hidden side effects, or chooses a non-deterministic fallback.",
-      "enforcement_status": "documented_foundation_only",
+      "enforcement_status": "covered_by_runtime_registry",
       "test_strategy": "Negative state-sequence tests force guard failures and unavailable targets, then assert no unrelated owner fields differ and any message/modal output is declared.",
       "migration_notes": [
         "Blocked outcomes are cross-cutting across all registered transition and dispatch surfaces but are listed explicitly here for guard traceability."

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -537,6 +537,19 @@ def _validate_runtime_generation_domain_enforcement_status(
     return []
 
 
+def _validate_runtime_invariant_enforcement_status(
+    *,
+    record: dict[str, Any],
+    label: str,
+) -> list[str]:
+    if record.get("enforcement_status") == "documented_foundation_only":
+        return [
+            f"{label}: enforcement_status must use covered_by_runtime_registry "
+            "once runtime invariant is registered"
+        ]
+    return []
+
+
 def _parse_ytnova_actions(header_path: Path) -> tuple[list[str], list[str]]:
     try:
         source = header_path.read_text(encoding="utf-8")
@@ -2996,6 +3009,12 @@ def _validate_runtime_invariant_registry(
                 label=label,
                 field="enforcement_status",
                 valid_statuses=VALID_ENFORCEMENT_STATUSES,
+            )
+        )
+        failures.extend(
+            _validate_runtime_invariant_enforcement_status(
+                record=record,
+                label=label,
             )
         )
         for field in (

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -3122,7 +3122,7 @@ static const AppStateInvariantMetadata kAppStateInvariants[] = {
    sizeof(kAppStateInvariantDispatchSurfaceIds0) /
        sizeof(kAppStateInvariantDispatchSurfaceIds0[0]),
    "Fail if an active-only transition mutates inactive panel-local identity, viewport, focus, restore, or generation fields outside an explicitly targeted transition.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    "State-sequence harness snapshots both panels before each active-panel transition and compares inactive panel fields after allowed and blocked outcomes.",
    kAppStateInvariantMigrationNotes0,
    sizeof(kAppStateInvariantMigrationNotes0) /
@@ -3140,7 +3140,7 @@ static const AppStateInvariantMetadata kAppStateInvariants[] = {
    sizeof(kAppStateInvariantDispatchSurfaceIds1) /
        sizeof(kAppStateInvariantDispatchSurfaceIds1[0]),
    "Fail if render or reflow chooses new authoritative selection, focus, viewport, panel generation, or volume generation from projected rows or window geometry.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    "Transition-diff harness runs render/reflow passes after settled transitions and verifies only declared render projection fields change.",
    kAppStateInvariantMigrationNotes1,
    sizeof(kAppStateInvariantMigrationNotes1) /
@@ -3158,7 +3158,7 @@ static const AppStateInvariantMetadata kAppStateInvariants[] = {
    sizeof(kAppStateInvariantDispatchSurfaceIds2) /
        sizeof(kAppStateInvariantDispatchSurfaceIds2[0]),
    "Fail if visible navigation lands on a hidden entry or resurrects a concealed identity after visibility/topology changes.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    "Generated navigation sequences toggle visibility, rebuild, and move through visible rows while asserting the selected identity remains visible or falls back deterministically.",
    kAppStateInvariantMigrationNotes2,
    sizeof(kAppStateInvariantMigrationNotes2) /
@@ -3176,7 +3176,7 @@ static const AppStateInvariantMetadata kAppStateInvariants[] = {
    sizeof(kAppStateInvariantDispatchSurfaceIds3) /
        sizeof(kAppStateInvariantDispatchSurfaceIds3[0]),
    "Fail if focus restoration imports another panel's shape, briefly renders a different shape, or restores focus from session mirrors instead of panel-local records.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    "Sequence tests alternate modal dismissal, Tab/F8-style routing, and file/tree transitions while asserting each panel restores its own recorded focus shape.",
    kAppStateInvariantMigrationNotes3,
    sizeof(kAppStateInvariantMigrationNotes3) /
@@ -3194,7 +3194,7 @@ static const AppStateInvariantMetadata kAppStateInvariants[] = {
    sizeof(kAppStateInvariantDispatchSurfaceIds4) /
        sizeof(kAppStateInvariantDispatchSurfaceIds4[0]),
    "Fail if rebuild, mutation, or resize restores viewport from raw rows when the stable identity is still visible or before deterministic fallback order is exhausted.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    "Snapshot/diff tests rebuild or resize around stable directory and file identities, then assert exact rebind when visible and deterministic fallback otherwise.",
    kAppStateInvariantMigrationNotes4,
    sizeof(kAppStateInvariantMigrationNotes4) /
@@ -3212,7 +3212,7 @@ static const AppStateInvariantMetadata kAppStateInvariants[] = {
    sizeof(kAppStateInvariantDispatchSurfaceIds5) /
        sizeof(kAppStateInvariantDispatchSurfaceIds5[0]),
    "Fail if shared volume topology or registry changes overwrite panel-local selection, focus, tags, viewport, or restore snapshots by shared index or pointer aliasing.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    "Split-panel sequences share a volume, mutate shared topology, and verify each panel rebinds through its own identity without cross-panel field drift.",
    kAppStateInvariantMigrationNotes5,
    sizeof(kAppStateInvariantMigrationNotes5) /
@@ -3230,7 +3230,7 @@ static const AppStateInvariantMetadata kAppStateInvariants[] = {
    sizeof(kAppStateInvariantDispatchSurfaceIds6) /
        sizeof(kAppStateInvariantDispatchSurfaceIds6[0]),
    "Fail if a generation mismatch reuses stale DirEntry/FileEntry pointers, stale flat-list rows, or stale snapshot payloads instead of exact rebind or deterministic fallback.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    "Harness corrupts or invalidates saved generations around rebuild/mutation transitions and asserts stale snapshots fail closed without unrelated mutation.",
    kAppStateInvariantMigrationNotes6,
    sizeof(kAppStateInvariantMigrationNotes6) /
@@ -3248,7 +3248,7 @@ static const AppStateInvariantMetadata kAppStateInvariants[] = {
    sizeof(kAppStateInvariantDispatchSurfaceIds7) /
        sizeof(kAppStateInvariantDispatchSurfaceIds7[0]),
    "Fail if a blocked or invalid transition partially mutates authoritative panel/volume state, advances generations, performs hidden side effects, or chooses a non-deterministic fallback.",
-   "documented_foundation_only",
+   "covered_by_runtime_registry",
    "Negative state-sequence tests force guard failures and unavailable targets, then assert no unrelated owner fields differ and any message/modal output is declared.",
    kAppStateInvariantMigrationNotes7,
    sizeof(kAppStateInvariantMigrationNotes7) /
@@ -6993,6 +6993,8 @@ AppStateValidateInvariant(const char *invariant_id,
       !AppStateNonEmptyString(metadata->test_strategy))
     return 0;
   if (!AppStateKnownFoundationStatus(metadata->enforcement_status))
+    return 0;
+  if (strcmp(metadata->enforcement_status, "documented_foundation_only") == 0)
     return 0;
   if (!AppStateTransitionFieldsRegistered(metadata->protected_fields,
                                           metadata->protected_field_count))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -510,7 +510,7 @@ def _invariant(
             dispatch_surface_ids or ["surface.key_decode_input_dispatch"]
         ),
         "failure_mode": "fixture failure mode",
-        "enforcement_status": "documented_foundation_only",
+        "enforcement_status": "covered_by_runtime_registry",
         "test_strategy": "fixture state-sequence coverage",
         "migration_notes": ["fixture coverage"],
     }
@@ -4839,7 +4839,7 @@ int main(void) {
     assert run.returncode == 0, run.stdout + run.stderr
 
 
-def test_runtime_registry_boundary_validation_accepts_foundation_status(
+def test_runtime_registry_boundary_validation_scopes_foundation_status(
     tmp_path: Path,
 ) -> None:
     repo_root = Path(__file__).resolve().parents[1]
@@ -4853,6 +4853,7 @@ int main(void) {
   AppStateActionCoverageMetadata action_coverage;
   AppStateDispatchSurfaceMetadata dispatch_surface;
   AppStateEventCoverageMetadata event_coverage;
+  AppStateInvariantMetadata invariant;
   AppStateTransitionMetadata transition;
 
   transition = *AppStateTransitionLookup("transition.keybinding.navigate-tree");
@@ -4880,6 +4881,11 @@ int main(void) {
   if (!AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
                                        &dispatch_surface))
     return 4;
+
+  invariant = *AppStateInvariantLookup("invariant.inactive-panel-frozen");
+  invariant.enforcement_status = "documented_foundation_only";
+  if (AppStateValidateInvariant("invariant.inactive-panel-frozen", &invariant))
+    return 5;
 
   return 0;
 }
@@ -6315,6 +6321,31 @@ def test_guard_fails_when_runtime_generation_domain_remains_foundation_only(
         and (
             "enforcement_status must use covered_by_runtime_registry once "
             "runtime generation domain is registered"
+        )
+        in failure
+        for failure in failures
+    )
+
+
+def test_guard_fails_when_runtime_invariant_remains_foundation_only(
+    tmp_path: Path,
+) -> None:
+    transitions = _complete_transitions()
+    runtime_invariants = _complete_invariants()
+    runtime_invariants[0]["enforcement_status"] = "documented_foundation_only"
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        runtime_invariants=runtime_invariants,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        "runtime_invariant[0]" in failure
+        and (
+            "enforcement_status must use covered_by_runtime_registry once "
+            "runtime invariant is registered"
         )
         in failure
         for failure in failures


### PR DESCRIPTION
## Summary
- Promote AppState invariant metadata to runtime-backed coverage status in docs and the C registry.
- Reject runtime invariant rows that still claim foundation-only coverage.
- Add guard coverage for invariant status drift.

## Validation
- `make clean && make`
- `source .venv/bin/activate && python scripts/check_appstate_contract.py && pytest tests/test_appstate_contract_guard.py -q`