### PR TITLE
chore(appstate): align runtime registry wording

### DIFF
--- a/docs/appstate_action_coverage.json
+++ b/docs/appstate_action_coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "YtreeNovaAction AppState transition coverage",
-  "notes": "Non-runtime registry ensuring every YtreeNovaAction enum member has AppState transition metadata coverage. Runtime behavior is unchanged.",
+  "notes": "Runtime-backed registry ensuring every YtreeNovaAction enum member has AppState transition metadata coverage. Registered rows must remain aligned with the C runtime metadata.",
   "actions": [
     {
       "action": "ACTION_NONE",

--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState transition-diff harness registry",
-  "notes": "Non-runtime registry for future before/after AppState snapshot and diff checks. Runtime behavior is unchanged.",
+  "notes": "Runtime-backed registry for before/after AppState snapshot and diff checks. Registered rows must remain aligned with the C runtime metadata.",
   "diff_harness_checks": [
     {
       "harness_id": "harness.transition-before-after-snapshot",

--- a/docs/appstate_dispatch_surfaces.json
+++ b/docs/appstate_dispatch_surfaces.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState UI-affecting dispatch-surface registry",
-  "notes": "Non-runtime registry for current UI-affecting dispatch surfaces before AppState runtime migration. Runtime behavior is unchanged.",
+  "notes": "Runtime-backed registry for current UI-affecting dispatch surfaces. Registered rows must remain aligned with the C runtime metadata.",
   "dispatch_surfaces": [
     {
       "surface_id": "surface.key-decode-input-dispatch",

--- a/docs/appstate_event_coverage.json
+++ b/docs/appstate_event_coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState non-key UI-affecting event coverage",
-  "notes": "Non-runtime registry for non-key UI-affecting AppState events. Event records link required event classes to the current transition matrix during migration.",
+  "notes": "Runtime-backed registry for non-key UI-affecting AppState events. Event records link required event classes to the current transition matrix during migration.",
   "required_event_classes": [
     "terminal_resize_signal",
     "refresh_rebuild",

--- a/docs/appstate_owner_fields.json
+++ b/docs/appstate_owner_fields.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState owner/write-set field registry",
-  "notes": "Non-runtime registry for every declared_write_set field in the AppState transition, action, and event coverage registries.",
+  "notes": "Runtime-backed registry for every declared_write_set field in the AppState transition, action, and event coverage registries. Registered rows must remain aligned with the C runtime metadata.",
   "owner_fields": [
     {
       "field": "ctx.active",

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -23,6 +23,14 @@ DEFAULT_TRANSITION_SEQUENCES = REPO_ROOT / "docs" / "appstate_transition_sequenc
 DEFAULT_ACTION_HEADER = REPO_ROOT / "include" / "ytnova_defs.h"
 DEFAULT_ACTION_RUNTIME = REPO_ROOT / "src" / "core" / "appstate_actions.c"
 
+STALE_RUNTIME_REGISTRY_NOTE_PATTERNS = (
+    re.compile(r"\bnon[- ]runtime\b", re.IGNORECASE),
+    re.compile(r"\bfuture[- ]only\b", re.IGNORECASE),
+    re.compile(r"\bfor future\b", re.IGNORECASE),
+    re.compile(r"before AppState runtime migration", re.IGNORECASE),
+    re.compile(r"runtime behavior is unchanged", re.IGNORECASE),
+)
+
 REQUIRED_TRANSITION_CATEGORIES = {
     "keybinding",
     "menu_action",
@@ -467,6 +475,26 @@ def _validate_status_field(
         return []
     if value not in valid_statuses:
         return [f"{label}: unknown {field}: {value}"]
+    return []
+
+
+def _validate_runtime_backed_registry_notes(
+    *,
+    doc: Any,
+    path: Path,
+    runtime_records: list[dict[str, Any]],
+) -> list[str]:
+    if not runtime_records or not isinstance(doc, dict):
+        return []
+    notes = doc.get("notes")
+    if not isinstance(notes, str) or not notes.strip():
+        return []
+    for pattern in STALE_RUNTIME_REGISTRY_NOTE_PATTERNS:
+        if pattern.search(notes):
+            return [
+                f"{path}: runtime-backed registry notes must not describe the "
+                "registry as non-runtime, future-only, or runtime-unchanged"
+            ]
     return []
 
 
@@ -7323,6 +7351,28 @@ def validate_contract(
     failures.extend(runtime_generation_domain_failures)
     failures.extend(runtime_diff_harness_failures)
     failures.extend(runtime_transition_sequence_failures)
+    if failures:
+        return failures
+
+    for doc, path, runtime_records in (
+        (transitions_doc, transitions_path, runtime_transition_records),
+        (shims_doc, shims_path, runtime_shim_records),
+        (action_coverage_doc, action_coverage_path, runtime_action_coverage_records),
+        (event_coverage_doc, event_coverage_path, runtime_event_coverage_records),
+        (owner_fields_doc, owner_fields_path, runtime_owner_field_records),
+        (dispatch_surfaces_doc, dispatch_surfaces_path, runtime_dispatch_surface_records),
+        (invariants_doc, invariants_path, runtime_invariant_records),
+        (generation_domains_doc, generation_domains_path, runtime_generation_domain_records),
+        (diff_harness_doc, diff_harness_path, runtime_diff_harness_records),
+        (transition_sequences_doc, transition_sequences_path, runtime_transition_sequence_records),
+    ):
+        failures.extend(
+            _validate_runtime_backed_registry_notes(
+                doc=doc,
+                path=path,
+                runtime_records=runtime_records,
+            )
+        )
     if failures:
         return failures
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -2120,6 +2120,36 @@ def test_guard_passes_complete_temporary_fixtures(tmp_path: Path) -> None:
     assert failures == []
 
 
+@pytest.mark.parametrize(
+    ("path_index", "registry_name"),
+    [
+        (2, "action coverage"),
+        (4, "event coverage"),
+        (5, "owner field"),
+        (6, "dispatch surface"),
+        (9, "diff harness"),
+    ],
+)
+def test_runtime_backed_registry_notes_reject_stale_non_runtime_wording(
+    tmp_path: Path, path_index: int, registry_name: str
+) -> None:
+    paths = _write_fixture(tmp_path, transitions=_complete_transitions())
+    target = paths[path_index]
+    doc = json.loads(target.read_text(encoding="utf-8"))
+    doc["notes"] = (
+        f"Non-runtime registry for future-only {registry_name} coverage before "
+        "AppState runtime migration. Runtime behavior is unchanged."
+    )
+    target.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    failures = _validate(paths)
+
+    assert any(
+        f"{target}: runtime-backed registry notes must not describe" in failure
+        for failure in failures
+    )
+
+
 def test_current_generation_domain_docs_keep_projection_transitions_out_of_advances() -> None:
     generation_domains = json.loads(
         Path("docs/appstate_generation_domains.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- update runtime-backed AppState registry notes so they no longer describe current metadata as non-runtime or runtime-unchanged
- add contract-guard coverage rejecting stale non-runtime/future-only wording when a registry has C runtime metadata

## Validation
- python3 scripts/check_appstate_contract.py
- pytest tests/test_appstate_contract_guard.py -q
