### PR TITLE
test(appstate): require sequenced contract evaluation

### DIFF
--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -6043,6 +6043,23 @@ def _validate_step_reference_list(
     return failures
 
 
+def _validate_after_step_contract_evaluation(
+    *, step: dict[str, Any], label: str
+) -> list[str]:
+    failures: list[str] = []
+    for field, evaluation_name in (
+        ("invariant_ids", "invariant"),
+        ("diff_harness_ids", "diff harness"),
+    ):
+        value = step.get(field)
+        if isinstance(value, list) and not value:
+            failures.append(
+                f"{label}: after-step contract scenario must evaluate "
+                f"at least one {evaluation_name}"
+            )
+    return failures
+
+
 def _non_empty_string_set(value: Any) -> set[str] | None:
     if not isinstance(value, list):
         return None
@@ -6872,6 +6889,9 @@ def _validate_appstate_transition_sequences(
                 )
             )
             failures.extend(
+                _validate_after_step_contract_evaluation(step=step, label=label)
+            )
+            failures.extend(
                 _validate_step_invariant_transition_alignment(
                     invariant_refs=step.get("invariant_ids"),
                     transition_id=transition_id,
@@ -7185,6 +7205,9 @@ def _validate_runtime_transition_sequence_registry(
                         reference_label=reference_label,
                     )
                 )
+            failures.extend(
+                _validate_after_step_contract_evaluation(step=step, label=step_label)
+            )
             failures.extend(
                 _validate_step_invariant_transition_alignment(
                     invariant_refs=step.get("invariant_ids"),

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -2781,6 +2781,65 @@ def test_guard_fails_when_sequence_step_coverage_ref_transition_mismatches(
 
 
 @pytest.mark.parametrize(
+    ("registry_source", "field", "expected_label", "expected_fragment"),
+    (
+        (
+            "documented",
+            "invariant_ids",
+            "transition_sequence[0].step[0]",
+            "after-step contract scenario must evaluate at least one invariant",
+        ),
+        (
+            "documented",
+            "diff_harness_ids",
+            "transition_sequence[0].step[0]",
+            "after-step contract scenario must evaluate at least one diff harness",
+        ),
+        (
+            "runtime",
+            "invariant_ids",
+            "runtime_transition_sequence[0].step[0]",
+            "after-step contract scenario must evaluate at least one invariant",
+        ),
+        (
+            "runtime",
+            "diff_harness_ids",
+            "runtime_transition_sequence[0].step[0]",
+            "after-step contract scenario must evaluate at least one diff harness",
+        ),
+    ),
+)
+def test_guard_sequence_harness_requires_after_step_contract_evaluation(
+    tmp_path: Path,
+    registry_source: str,
+    field: str,
+    expected_label: str,
+    expected_fragment: str,
+) -> None:
+    transitions = _complete_transitions()
+    transition_sequences = _complete_transition_sequences()
+    runtime_transition_sequences = None
+    if registry_source == "runtime":
+        runtime_transition_sequences = copy.deepcopy(transition_sequences)
+        runtime_transition_sequences[0]["steps"][0][field] = []
+    else:
+        transition_sequences[0]["steps"][0][field] = []
+    paths = _write_fixture(
+        tmp_path,
+        transitions=transitions,
+        transition_sequences=transition_sequences,
+        runtime_transition_sequences=runtime_transition_sequences,
+    )
+
+    failures = _validate(paths)
+
+    assert any(
+        expected_label in failure and expected_fragment in failure
+        for failure in failures
+    )
+
+
+@pytest.mark.parametrize(
     ("coverage_field", "replacement_refs", "expected"),
     (
         (


### PR DESCRIPTION
## Summary
- Add an executable AppState sequence guard that evaluates each registered scenario entry for after-action invariant and diff-harness metadata.
- Cover both documented and runtime-backed sequence registries so empty evaluation lists fail closed.

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k sequence_harness_requires_after_step_contract_evaluation -q` (red before guard, green after)
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `source .venv/bin/activate && python scripts/check_appstate_contract.py`
- `make`