### PR TITLE
fix(appstate): restore dotfile toggle selection visibly

### DIFF
--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -886,16 +886,9 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     case ACTION_TOGGLE_HIDDEN: {
       ToggleDotFiles(ctx, ctx->active);
 
-      /* Update current dir pointer using the new accessor function
-      because ToggleDotFiles might have changed the list layout */
-      if (ctx->active->vol->total_dirs > 0) {
-        dir_entry = ctx->active->vol
-                        ->dir_entry_list[ctx->active->disp_begin_pos +
-                                         ctx->active->cursor_pos]
-                        .dir_entry;
-      } else {
-        dir_entry = s->tree;
-      }
+      dir_entry = ResolveActiveDirEntry(ctx, s);
+      if (dir_entry == NULL)
+        return ESC;
 
       need_dsp_help = TRUE;
     } break;

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -479,6 +479,20 @@ def test_dir_window_split_transition_owner_path_is_canonical():
     )
 
 
+def test_dir_window_hidden_toggle_uses_visible_selection_authority():
+    toggle_case = _dir_navigation_action_case_source("ACTION_TOGGLE_HIDDEN")
+    post_toggle = toggle_case.split("ToggleDotFiles(ctx, ctx->active);", 1)[1]
+
+    assert "ResolveActiveDirEntry(ctx, s)" in post_toggle, (
+        "Hidden-file visibility toggles must restore selection through the "
+        f"canonical visible active-dir resolver.\n{toggle_case}"
+    )
+    assert "->dir_entry_list[" not in post_toggle, (
+        "Hidden-file visibility toggles must not synthesize restore authority "
+        f"from raw directory row indexes after changing visibility.\n{toggle_case}"
+    )
+
+
 def test_dir_window_split_and_tab_keeps_file_focus(ytnova_binary, tmp_path):
     root = tmp_path / "dir_dispatch_split_tab"
     root.mkdir()


### PR DESCRIPTION
## Summary
- Route directory-window dotfile-toggle restore through the canonical visible active-dir resolver.
- Fail closed if the resolver cannot produce an active directory after the visibility rebuild.
- Add a focused regression guard against raw post-toggle row-index restore authority.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_dir_window_hidden_toggle_uses_visible_selection_authority` failed before the runtime change.
- GREEN: `make clean && make`
- GREEN: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_dir_window_hidden_toggle_uses_visible_selection_authority tests/test_dir_window_dispatch_regressions.py::test_dir_window_split_transition_owner_path_is_canonical`