### PR TITLE
fix(appstate): restore directory dispatch selection visibly

### DIFF
--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -977,7 +977,6 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
     case ACTION_CMD_M:
       HandleDirMakeDirectory(ctx, dir_entry, s);
-      dir_entry = ResolveActiveDirEntry(ctx, s);
       need_dsp_help = TRUE;
       break;
     case ACTION_CMD_D:
@@ -986,7 +985,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       break;
 
     case ACTION_CMD_R:
-      dir_entry = HandleDirRenameDirectory(ctx, dir_entry);
+      HandleDirRenameDirectory(ctx, dir_entry);
       need_dsp_help = TRUE;
       break;
     case ACTION_REFRESH: /* Rescan */
@@ -1140,20 +1139,9 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       break;
     } /* switch */
 
-    /* Refresh dir_entry pointer in case tree was rescanned/reallocated during
-     * action */
-    if (ctx->active && ctx->active->vol && ctx->active->vol->dir_entry_list) {
-      int safe_idx = ctx->active->disp_begin_pos + ctx->active->cursor_pos;
-      if (safe_idx < 0)
-        safe_idx = 0;
-      if (safe_idx >= ctx->active->vol->total_dirs)
-        safe_idx = ctx->active->vol->total_dirs - 1;
-      if (safe_idx >= 0) {
-        dir_entry = ctx->active->vol->dir_entry_list[safe_idx].dir_entry;
-      } else {
-        dir_entry = ctx->active->vol->vol_stats.tree;
-      }
-    }
+    dir_entry = ResolveActiveDirEntry(ctx, s);
+    if (dir_entry == NULL)
+      return ESC;
     DebugLogDirLoopState("after_dispatch", ctx, dir_entry, ch, action,
                          unput_char);
 

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -493,6 +493,30 @@ def test_dir_window_hidden_toggle_uses_visible_selection_authority():
     )
 
 
+def test_dir_window_post_dispatch_refresh_uses_visible_selection_authority():
+    source = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    marker = "DebugLogDirLoopState(\"after_dispatch\""
+    log_start = source.find(marker)
+    assert log_start >= 0, "Missing after-dispatch debug marker"
+
+    switch_end = source.rfind("    } /* switch */", 0, log_start)
+    assert switch_end >= 0, "Missing HandleDirWindow switch terminator"
+    refresh_source = source[switch_end:log_start]
+
+    assert "ResolveActiveDirEntry(ctx, s)" in refresh_source, (
+        "Directory-window post-dispatch refresh must restore through the "
+        f"canonical visible active-dir resolver.\n{refresh_source}"
+    )
+    assert "disp_begin_pos + ctx->active->cursor_pos" not in refresh_source, (
+        "Directory-window post-dispatch refresh must not synthesize selection "
+        f"from raw row math.\n{refresh_source}"
+    )
+    assert "->dir_entry_list[" not in refresh_source, (
+        "Directory-window post-dispatch refresh must not index the raw "
+        f"directory row list directly.\n{refresh_source}"
+    )
+
+
 def test_dir_window_split_and_tab_keeps_file_focus(ytnova_binary, tmp_path):
     root = tmp_path / "dir_dispatch_split_tab"
     root.mkdir()


### PR DESCRIPTION
## Summary
- Replace the directory-window post-dispatch raw row refresh with the visible active-dir resolver.
- Add a static regression guard preventing the post-dispatch refresh from returning to raw directory row math.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_dir_window_post_dispatch_refresh_uses_visible_selection_authority` failed before the runtime change.
- GREEN: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_dir_window_post_dispatch_refresh_uses_visible_selection_authority`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py`
- `make clean && make`