### PR TITLE
fix(appstate): restore preview return selection visibly

### DIFF
--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -283,16 +283,7 @@ BOOL handle_file_window_preview_action(
       if (start_vol_ptr)
         *start_vol_ptr = ctx->active->vol;
 
-      if (ctx->active->vol->total_dirs > 0) {
-        int idx = ctx->active->disp_begin_pos + ctx->active->cursor_pos;
-        if (idx >= ctx->active->vol->total_dirs)
-          idx = ctx->active->vol->total_dirs - 1;
-        if (idx < 0)
-          idx = 0;
-        dir_entry = ctx->active->vol->dir_entry_list[idx].dir_entry;
-      } else {
-        dir_entry = stats_local->tree;
-      }
+      dir_entry = ResolveActiveDirEntry(ctx, stats_local);
 
       ctx->ctx_dir_window = ctx->active->pan_dir_window;
       ctx->ctx_small_file_window = ctx->active->pan_small_file_window;

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -517,6 +517,29 @@ def test_dir_window_post_dispatch_refresh_uses_visible_selection_authority():
     )
 
 
+def test_file_window_preview_return_uses_visible_selection_authority():
+    source = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    preview_source = _extract_function_block(
+        source, "BOOL handle_file_window_preview_action("
+    )
+    return_source = preview_source.split("ctx->preview_mode = !ctx->preview_mode;", 1)[
+        1
+    ].split("RefreshView(ctx, dir_entry);", 1)[0]
+
+    assert "ResolveActiveDirEntry(ctx, stats_local)" in return_source, (
+        "File-window preview return must restore the active directory through "
+        f"the canonical visible active-dir resolver.\n{return_source}"
+    )
+    assert "disp_begin_pos + ctx->active->cursor_pos" not in return_source, (
+        "File-window preview return must not synthesize selection from raw row "
+        f"math.\n{return_source}"
+    )
+    assert "->dir_entry_list[" not in return_source, (
+        "File-window preview return must not index the raw directory row list "
+        f"directly.\n{return_source}"
+    )
+
+
 def test_dir_window_split_and_tab_keeps_file_focus(ytnova_binary, tmp_path):
     root = tmp_path / "dir_dispatch_split_tab"
     root.mkdir()


### PR DESCRIPTION
## Summary
- Restores file-preview exits through the canonical visible active-directory resolver.
- Adds a focused guard against preview-return raw row math or direct directory-list indexing.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_file_window_preview_return_uses_visible_selection_authority` failed before the runtime change.
- GREEN: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_file_window_preview_return_uses_visible_selection_authority`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_f7_preview.py tests/test_dir_window_dispatch_regressions.py::test_file_window_preview_return_uses_visible_selection_authority`