### PR TITLE
fix(appstate): restore directory mutations through visible selection

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1011,12 +1011,17 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
 DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   InactiveFallbackSnapshot inactive_snapshot;
   PanelViewportSnapshot active_viewport;
+  const Statistic *s;
 
+  if (!ctx || !ctx->active || !ctx->active->vol || !dir_entry)
+    return dir_entry;
   if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))
     return dir_entry;
   if (!AppStateValidatedEvent("event.filesystem-mutation-result"))
     return dir_entry;
 
+  s = (ctx && ctx->active && ctx->active->vol) ? &ctx->active->vol->vol_stats
+                                               : NULL;
   CaptureInactiveFallbackSnapshot(ctx, ctx->active, &inactive_snapshot);
   CapturePanelViewportSnapshot(ctx->active, ctx->active->vol, &active_viewport);
 
@@ -1041,9 +1046,7 @@ DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   }
   if (!ctx->active || !ctx->active->vol || !ctx->active->vol->dir_entry_list ||
       ctx->active->vol->total_dirs <= 0) {
-    dir_entry =
-        (ctx->active && ctx->active->vol) ? ctx->active->vol->vol_stats.tree
-                                          : NULL;
+    dir_entry = ResolveActiveDirEntry(ctx, s);
     if (dir_entry) {
       dir_entry->start_file = 0;
       dir_entry->cursor_pos = -1;
@@ -1051,35 +1054,37 @@ DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
     }
     return dir_entry;
   }
-  dir_entry = ctx->active->vol
-                  ->dir_entry_list[ctx->active->disp_begin_pos +
-                                   ctx->active->cursor_pos]
-                  .dir_entry;
-  dir_entry->start_file = 0;
-  dir_entry->cursor_pos = -1;
-  RefreshView(ctx, dir_entry);
+  dir_entry = ResolveActiveDirEntry(ctx, s);
+  if (dir_entry) {
+    dir_entry->start_file = 0;
+    dir_entry->cursor_pos = -1;
+    RefreshView(ctx, dir_entry);
+  }
   return dir_entry;
 }
 
 DirEntry *HandleDirRenameDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   char new_name[PATH_LENGTH + 1];
+  const Statistic *s;
 
+  if (!ctx || !ctx->active || !ctx->active->vol || !dir_entry)
+    return dir_entry;
   if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))
     return dir_entry;
   if (!AppStateValidatedEvent("event.filesystem-mutation-result"))
     return dir_entry;
 
+  s = (ctx && ctx->active && ctx->active->vol) ? &ctx->active->vol->vol_stats
+                                               : NULL;
   if (!GetRenameParameter(ctx, dir_entry->name, new_name)) {
     int rename_result = RenameDirectory(ctx, dir_entry, new_name);
     if (!rename_result) {
       ctx->active->vol->volume_generation++;
       BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
-      dir_entry = ctx->active->vol
-                      ->dir_entry_list[ctx->active->disp_begin_pos +
-                                       ctx->active->cursor_pos]
-                      .dir_entry;
+      dir_entry = ResolveActiveDirEntry(ctx, s);
     }
-    RefreshView(ctx, dir_entry);
+    if (dir_entry)
+      RefreshView(ctx, dir_entry);
   }
 
   return dir_entry;

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -540,6 +540,42 @@ def test_file_window_preview_return_uses_visible_selection_authority():
     )
 
 
+def test_dir_mutation_results_use_visible_selection_authority():
+    source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    delete_source = _extract_function_block(
+        source, "DirEntry *HandleDirDeleteDirectory("
+    )
+    delete_rebuild = delete_source.split(
+        "BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);",
+        1,
+    )[1]
+    rename_source = _extract_function_block(
+        source, "DirEntry *HandleDirRenameDirectory("
+    )
+    rename_rebuild = rename_source.split(
+        "BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);",
+        1,
+    )[1]
+
+    for label, post_rebuild in (
+        ("directory delete", delete_rebuild),
+        ("directory rename", rename_rebuild),
+    ):
+        assert "ResolveActiveDirEntry(ctx," in post_rebuild, (
+            f"{label} rebuild result must restore through the canonical visible "
+            f"active-dir resolver.\n{post_rebuild}"
+        )
+        assert "disp_begin_pos +\n" not in post_rebuild, (
+            f"{label} rebuild result must not synthesize selection from raw "
+            f"row math.\n{post_rebuild}"
+        )
+        assert "->dir_entry_list[" not in post_rebuild, (
+            f"{label} rebuild result must not index the raw directory row list "
+            f"directly.\n{post_rebuild}"
+        )
+
+
 def test_dir_window_split_and_tab_keeps_file_focus(ytnova_binary, tmp_path):
     root = tmp_path / "dir_dispatch_split_tab"
     root.mkdir()


### PR DESCRIPTION
## Summary
- Directory delete and rename rebuild paths now resolve the post-mutation directory through the canonical visible active-dir resolver instead of raw row-index selection.
- Added a focused static regression guard for delete and rename post-rebuild authority.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -k mutation_results_use_visible_selection_authority` failed before the runtime change.
- GREEN: same targeted pytest command passed after the runtime change.
- `make clean && make` passed.