### PR TITLE
fix(appstate): restore volume tree paths from panel snapshots

### DIFF
--- a/include/ytnova_defs.h
+++ b/include/ytnova_defs.h
@@ -735,8 +735,14 @@ typedef struct _panel_volume_file_state {
   int saved_file_cursor;       /* Per-panel file cursor snapshot for this volume. */
   unsigned int saved_panel_generation;
   unsigned int saved_volume_generation;
+  unsigned int saved_tree_panel_generation;
+  unsigned int saved_tree_volume_generation;
   ViewFocus saved_focus;       /* Restored panel focus shape for this volume. */
   BOOL saved_big_file_view;    /* Restored panel file-window shape for this volume. */
+  BOOL has_saved_tree_selection;
+  BOOL has_saved_tree_top;
+  char saved_tree_selected_dir_path[PATH_LENGTH + 1];
+  char saved_tree_top_dir_path[PATH_LENGTH + 1];
   char saved_file_dir_path[PATH_LENGTH + 1];
   char saved_file_selection_name[PATH_LENGTH + 1];
   char saved_file_selection_dir_path[PATH_LENGTH + 1];

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -136,22 +136,8 @@ static void PositionSavedFileSelection(ViewContext *ctx, YtreeNovaPanel *panel,
   dir_entry->cursor_pos = panel->file_cursor_pos;
 }
 
-static int FindDirIndexInVolume(const struct Volume *vol,
-                                const DirEntry *dir_entry) {
-  int i;
-
-  if (!vol || !dir_entry || !vol->dir_entry_list || vol->total_dirs <= 0)
-    return -1;
-
-  for (i = 0; i < vol->total_dirs; i++) {
-    if (vol->dir_entry_list[i].dir_entry == dir_entry)
-      return i;
-  }
-  return -1;
-}
-
 static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
-  struct Volume *vol;
+  const struct Volume *vol;
   const PanelVolumeFileState *state;
   DirEntry *resolved_file_dir = NULL;
   const char *file_dir_path = NULL;
@@ -197,12 +183,7 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
     resolved_file_dir = ResolvePanelAnchorTarget(panel, vol, file_dir_path);
     panel->file_dir_entry = resolved_file_dir;
     if (resolved_file_dir) {
-      int resolved_index;
-
       resolved_file_dir->big_window = state->saved_big_file_view;
-      resolved_index = FindDirIndexInVolume(vol, resolved_file_dir);
-      if (state->saved_focus == FOCUS_FILE && resolved_index >= 0)
-        vol->saved_tree_index = resolved_index;
       PositionSavedFileSelection(ctx, panel, resolved_file_dir,
                                  state->saved_file_selection_name);
     }
@@ -212,10 +193,33 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
 }
 
 static void SavePanelTreeSelection(YtreeNovaPanel *panel) {
+  PanelVolumeFileState *state;
+  PanelViewportSnapshot snapshot;
   int selected_index;
 
   if (!panel || !panel->vol)
     return;
+
+  state = GetPanelVolumeFileState(panel, panel->vol->id);
+  CapturePanelViewportSnapshot(panel, panel->vol, &snapshot);
+  state->saved_tree_panel_generation = panel->panel_generation;
+  state->saved_tree_volume_generation = panel->vol->volume_generation;
+  state->has_saved_tree_selection = snapshot.has_selected_dir_path;
+  state->has_saved_tree_top = snapshot.has_top_dir_path;
+  state->saved_tree_selected_dir_path[0] = '\0';
+  state->saved_tree_top_dir_path[0] = '\0';
+  if (snapshot.has_selected_dir_path) {
+    (void)snprintf(state->saved_tree_selected_dir_path,
+                   sizeof(state->saved_tree_selected_dir_path), "%s",
+                   snapshot.selected_dir_path);
+    state->saved_tree_selected_dir_path[PATH_LENGTH] = '\0';
+  }
+  if (snapshot.has_top_dir_path) {
+    (void)snprintf(state->saved_tree_top_dir_path,
+                   sizeof(state->saved_tree_top_dir_path), "%s",
+                   snapshot.top_dir_path);
+    state->saved_tree_top_dir_path[PATH_LENGTH] = '\0';
+  }
 
   /* Keep the per-volume breadcrumb aligned with the panel-local tree cursor. */
   selected_index = panel->disp_begin_pos + panel->cursor_pos;
@@ -227,6 +231,8 @@ static void SavePanelTreeSelection(YtreeNovaPanel *panel) {
 }
 
 static void RestorePanelTreeSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
+  const PanelVolumeFileState *state;
+  PanelViewportSnapshot snapshot;
   int selected_index;
   int total_dirs;
   int win_height;
@@ -242,18 +248,27 @@ static void RestorePanelTreeSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
     return;
   }
 
+  state = FindPanelVolumeFileState(panel, panel->vol->id);
   generation_valid =
-      panel->vol->saved_tree_generation == panel->panel_generation &&
-      panel->vol->saved_tree_volume_generation == panel->vol->volume_generation;
-  if (generation_valid) {
-    selected_index = panel->vol->saved_tree_index;
-    if (selected_index < 0)
-      selected_index = 0;
-    if (selected_index >= total_dirs)
-      selected_index = total_dirs - 1;
-  } else {
-    selected_index = 0;
+      state != NULL &&
+      state->saved_tree_panel_generation == panel->panel_generation &&
+      state->saved_tree_volume_generation == panel->vol->volume_generation;
+  if (generation_valid && state->has_saved_tree_selection &&
+      state->saved_tree_selected_dir_path[0]) {
+    snapshot.has_selected_dir_path = state->has_saved_tree_selection;
+    snapshot.has_top_dir_path = state->has_saved_tree_top;
+    (void)snprintf(snapshot.selected_dir_path,
+                   sizeof(snapshot.selected_dir_path), "%s",
+                   state->saved_tree_selected_dir_path);
+    (void)snprintf(snapshot.top_dir_path, sizeof(snapshot.top_dir_path), "%s",
+                   state->saved_tree_top_dir_path);
+    snapshot.selected_dir_path[PATH_LENGTH] = '\0';
+    snapshot.top_dir_path[PATH_LENGTH] = '\0';
+    if (RestorePanelViewportSnapshot(panel->vol, panel, &snapshot,
+                                     state->saved_tree_top_dir_path))
+      return;
   }
+  selected_index = 0;
 
   win_height = ctx->layout.dir_win_height;
   if (win_height <= 0 && ctx->ctx_dir_window)
@@ -263,7 +278,6 @@ static void RestorePanelTreeSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
 
   if (panel->disp_begin_pos < 0)
     panel->disp_begin_pos = 0;
-  /* Rehydrate the panel-local tree viewport from the per-volume breadcrumb. */
   if (selected_index >= panel->disp_begin_pos &&
       selected_index < panel->disp_begin_pos + win_height) {
     panel->cursor_pos = selected_index - panel->disp_begin_pos;
@@ -392,11 +406,17 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
           strcmp(found_vol->vol_stats.log_path, resolved_path) == 0) {
         reload_requested = TRUE;
       } else {
+        const PanelVolumeFileState *state;
+
         ResetPanelFileContext(panel);
         panel->vol = found_vol;
         s = &panel->vol->vol_stats;
         panel->saved_focus = panel->vol->saved_focus;
-        panel->panel_generation = panel->vol->saved_tree_generation;
+        state = FindPanelVolumeFileState(panel, panel->vol->id);
+        if (state)
+          panel->panel_generation = state->saved_tree_panel_generation;
+        else
+          panel->panel_generation = panel->vol->saved_tree_generation;
         ctx->global_search_term[0] = '\0';
         ctx->view_mode = panel->vol->vol_stats.log_mode;
 

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -249,7 +249,7 @@ def test_restore_snapshots_validate_generation_before_reuse():
     )
     assert "generation_valid =" in log_source
     assert "saved_tree_volume_generation == panel->vol->volume_generation" in log_source
-    assert "saved_tree_generation == panel->panel_generation" in log_source
+    assert "saved_tree_panel_generation == panel->panel_generation" in log_source
 
     assert "panel->panel_generation++;" in panel_anchor_source, panel_anchor_source
     assert "dst->panel_generation = src->panel_generation;" in panel_anchor_source
@@ -257,6 +257,56 @@ def test_restore_snapshots_validate_generation_before_reuse():
     assert "p->panel_generation++;" in dir_ops_source, dir_ops_source
     assert "p->vol->volume_generation++;" in dir_ops_source, dir_ops_source
     assert "ctx->active->vol->volume_generation++;" in dir_ops_source, dir_ops_source
+
+
+def test_volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb():
+    defs_source = _defs_source()
+    log_source = _log_source()
+    restore_source = _restore_panel_tree_selection_source()
+    save_start = log_source.index("static void SavePanelTreeSelection(")
+    save_end = log_source.index("\nstatic void RestorePanelTreeSelection(", save_start)
+    save_source = log_source[save_start:save_end]
+    file_restore_source = _restore_panel_file_selection_source()
+
+    for needle in (
+        "unsigned int saved_tree_panel_generation;",
+        "unsigned int saved_tree_volume_generation;",
+        "char saved_tree_selected_dir_path[PATH_LENGTH + 1];",
+        "char saved_tree_top_dir_path[PATH_LENGTH + 1];",
+    ):
+        assert needle in defs_source, (
+            "Panel volume restore state must own path-scoped tree snapshot "
+            f"metadata: {needle}\n{defs_source}"
+        )
+
+    assert "CapturePanelViewportSnapshot(panel, panel->vol, &snapshot);" in save_source
+    assert "state->saved_tree_panel_generation = panel->panel_generation;" in save_source
+    assert (
+        "state->saved_tree_volume_generation = panel->vol->volume_generation;"
+        in save_source
+    )
+    assert (
+        "snprintf(state->saved_tree_selected_dir_path,"
+        in save_source
+    ), save_source
+
+    path_restore = restore_source.find("RestorePanelViewportSnapshot(")
+    legacy_index = restore_source.find("panel->vol->saved_tree_index")
+    assert path_restore >= 0, restore_source
+    assert legacy_index < 0 or path_restore < legacy_index, (
+        "RestorePanelTreeSelection must try the panel-local path snapshot "
+        "before any legacy index breadcrumb.\n"
+        f"{restore_source}"
+    )
+    assert "state->saved_tree_panel_generation == panel->panel_generation" in (
+        restore_source
+    )
+    assert (
+        "state->saved_tree_volume_generation == panel->vol->volume_generation"
+        in restore_source
+    )
+    assert "selected_index = panel->vol->saved_tree_index;" not in restore_source
+    assert "vol->saved_tree_index = resolved_index;" not in file_restore_source
 
 
 def test_panel_anchor_restore_follows_exact_fallback_order():


### PR DESCRIPTION
## Summary
- store panel-local tree restore paths in the per-volume panel snapshot record
- restore relogged tree selections by path snapshot with generation validation before failing closed to the root row
- stop file-focus restore from rewriting the legacy volume tree index breadcrumb

## Validation
- RED: source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb
- source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb tests/test_dir_window_dispatch_regressions.py::test_restore_snapshots_validate_generation_before_reuse tests/test_dir_window_dispatch_regressions.py::test_tree_viewport_stable_restore_preserves_visible_selection tests/test_dir_window_dispatch_regressions.py::test_panel_anchor_restore_follows_exact_fallback_order tests/test_appstate_contract_guard.py::test_compatibility_shim_boundaries_fail_closed_before_legacy_writes
- python scripts/check_appstate_contract.py
- make clean && make
- git diff --check