### PR TITLE
fix(appstate): restore volume switches from panel snapshots

### DIFF
--- a/include/ytnova_panel_anchor.h
+++ b/include/ytnova_panel_anchor.h
@@ -14,6 +14,11 @@ BOOL CapturePanelAnchorPath(const YtreeNovaPanel *panel, const struct Volume *vo
                             char *out_path, size_t out_path_size);
 void CapturePanelViewportSnapshot(YtreeNovaPanel *panel, const struct Volume *vol,
                                   PanelViewportSnapshot *snapshot);
+PanelVolumeFileState *FindPanelVolumeFileState(YtreeNovaPanel *panel,
+                                               int volume_id);
+PanelVolumeFileState *GetPanelVolumeFileState(YtreeNovaPanel *panel,
+                                              int volume_id);
+void SavePanelTreeViewportSnapshot(YtreeNovaPanel *panel);
 int FindDirIndexByPath(const struct Volume *vol, const char *path);
 int FindDirIndexByPathOrAncestor(const struct Volume *vol, const char *path);
 DirEntry *ResolvePanelAnchorTarget(const YtreeNovaPanel *panel,
@@ -23,6 +28,7 @@ void PositionPanelAtIndex(YtreeNovaPanel *panel, int idx);
 BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *panel,
                                   const PanelViewportSnapshot *snapshot,
                                   const char *preferred_top_path);
+BOOL RestorePanelTreeViewportSnapshot(ViewContext *ctx, YtreeNovaPanel *panel);
 void RememberPanelViewportTop(YtreeNovaPanel *panel);
 void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,
                             const char *anchor_path);

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -15,35 +15,6 @@ extern void FreeFileEntryList(YtreeNovaPanel *panel);
 extern void BuildFileEntryList(ViewContext *ctx, YtreeNovaPanel *panel);
 extern int FileNav_GetMaxDispFiles(const ViewContext *ctx);
 
-static PanelVolumeFileState *FindPanelVolumeFileState(YtreeNovaPanel *panel,
-                                                      int volume_id) {
-  PanelVolumeFileState *state;
-
-  if (!panel)
-    return NULL;
-
-  for (state = panel->volume_file_state; state; state = state->next) {
-    if (state->volume_id == volume_id)
-      return state;
-  }
-  return NULL;
-}
-
-static PanelVolumeFileState *GetPanelVolumeFileState(YtreeNovaPanel *panel,
-                                                     int volume_id) {
-  PanelVolumeFileState *state;
-
-  state = FindPanelVolumeFileState(panel, volume_id);
-  if (state)
-    return state;
-
-  state = (PanelVolumeFileState *)xcalloc(1, sizeof(PanelVolumeFileState));
-  state->volume_id = volume_id;
-  state->next = panel->volume_file_state;
-  panel->volume_file_state = state;
-  return state;
-}
-
 static void ResetPanelFileContext(YtreeNovaPanel *panel) {
   if (!panel)
     return;
@@ -193,104 +164,11 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
 }
 
 static void SavePanelTreeSelection(YtreeNovaPanel *panel) {
-  PanelVolumeFileState *state;
-  PanelViewportSnapshot snapshot;
-  int selected_index;
-
-  if (!panel || !panel->vol)
-    return;
-
-  state = GetPanelVolumeFileState(panel, panel->vol->id);
-  CapturePanelViewportSnapshot(panel, panel->vol, &snapshot);
-  state->saved_tree_panel_generation = panel->panel_generation;
-  state->saved_tree_volume_generation = panel->vol->volume_generation;
-  state->has_saved_tree_selection = snapshot.has_selected_dir_path;
-  state->has_saved_tree_top = snapshot.has_top_dir_path;
-  state->saved_tree_selected_dir_path[0] = '\0';
-  state->saved_tree_top_dir_path[0] = '\0';
-  if (snapshot.has_selected_dir_path) {
-    (void)snprintf(state->saved_tree_selected_dir_path,
-                   sizeof(state->saved_tree_selected_dir_path), "%s",
-                   snapshot.selected_dir_path);
-    state->saved_tree_selected_dir_path[PATH_LENGTH] = '\0';
-  }
-  if (snapshot.has_top_dir_path) {
-    (void)snprintf(state->saved_tree_top_dir_path,
-                   sizeof(state->saved_tree_top_dir_path), "%s",
-                   snapshot.top_dir_path);
-    state->saved_tree_top_dir_path[PATH_LENGTH] = '\0';
-  }
-
-  /* Keep the per-volume breadcrumb aligned with the panel-local tree cursor. */
-  selected_index = panel->disp_begin_pos + panel->cursor_pos;
-  if (selected_index < 0)
-    selected_index = 0;
-  panel->vol->saved_tree_index = selected_index;
-  panel->vol->saved_tree_generation = panel->panel_generation;
-  panel->vol->saved_tree_volume_generation = panel->vol->volume_generation;
+  SavePanelTreeViewportSnapshot(panel);
 }
 
 static void RestorePanelTreeSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
-  const PanelVolumeFileState *state;
-  PanelViewportSnapshot snapshot;
-  int selected_index;
-  int total_dirs;
-  int win_height;
-  BOOL generation_valid;
-
-  if (!ctx || !panel || !panel->vol)
-    return;
-
-  total_dirs = panel->vol->total_dirs;
-  if (total_dirs <= 0) {
-    panel->disp_begin_pos = 0;
-    panel->cursor_pos = 0;
-    return;
-  }
-
-  state = FindPanelVolumeFileState(panel, panel->vol->id);
-  generation_valid =
-      state != NULL &&
-      state->saved_tree_panel_generation == panel->panel_generation &&
-      state->saved_tree_volume_generation == panel->vol->volume_generation;
-  if (generation_valid && state->has_saved_tree_selection &&
-      state->saved_tree_selected_dir_path[0]) {
-    snapshot.has_selected_dir_path = state->has_saved_tree_selection;
-    snapshot.has_top_dir_path = state->has_saved_tree_top;
-    (void)snprintf(snapshot.selected_dir_path,
-                   sizeof(snapshot.selected_dir_path), "%s",
-                   state->saved_tree_selected_dir_path);
-    (void)snprintf(snapshot.top_dir_path, sizeof(snapshot.top_dir_path), "%s",
-                   state->saved_tree_top_dir_path);
-    snapshot.selected_dir_path[PATH_LENGTH] = '\0';
-    snapshot.top_dir_path[PATH_LENGTH] = '\0';
-    if (RestorePanelViewportSnapshot(panel->vol, panel, &snapshot,
-                                     state->saved_tree_top_dir_path))
-      return;
-  }
-  selected_index = 0;
-
-  win_height = ctx->layout.dir_win_height;
-  if (win_height <= 0 && ctx->ctx_dir_window)
-    win_height = getmaxy(ctx->ctx_dir_window);
-  if (win_height <= 0)
-    win_height = 1;
-
-  if (panel->disp_begin_pos < 0)
-    panel->disp_begin_pos = 0;
-  if (selected_index >= panel->disp_begin_pos &&
-      selected_index < panel->disp_begin_pos + win_height) {
-    panel->cursor_pos = selected_index - panel->disp_begin_pos;
-    return;
-  }
-
-  if (selected_index >= win_height) {
-    panel->disp_begin_pos = selected_index - (win_height - 1);
-    panel->cursor_pos = win_height - 1;
-  } else {
-    panel->disp_begin_pos = 0;
-    panel->cursor_pos = selected_index;
-  }
+  (void)RestorePanelTreeViewportSnapshot(ctx, panel);
 }
 
 /* Helper function to handle scan progress updates */

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1752,8 +1752,7 @@ HandleDirWindowVolumeAction(ViewContext *ctx, YtreeNovaAction action,
   if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))
     return DIR_WINDOW_DISPATCH_HANDLED;
 
-  ctx->active->vol->saved_tree_index =
-      ctx->active->disp_begin_pos + ctx->active->cursor_pos;
+  SavePanelTreeViewportSnapshot(ctx->active);
 
   if (action == ACTION_VOL_MENU) {
     res = SelectLoadedVolume(ctx, NULL);
@@ -1778,7 +1777,7 @@ HandleDirWindowVolumeAction(ViewContext *ctx, YtreeNovaAction action,
     return DIR_WINDOW_DISPATCH_RETURN_ESC;
 
   *s_ptr = &ctx->active->vol->vol_stats;
-  ctx->active->disp_begin_pos = ctx->active->vol->saved_tree_index;
+  (void)RestorePanelTreeViewportSnapshot(ctx, ctx->active);
 
   if (ctx->active->vol->total_dirs > 0) {
     if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=

--- a/src/ui/f2_picker.c
+++ b/src/ui/f2_picker.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
+#include "ytnova_panel_anchor.h"
 #include "ytnova_ui.h"
 
 int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
@@ -26,6 +27,7 @@ int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
   char new_log_path[PATH_LENGTH + 1];
 
   original_vol = ctx->active->vol;
+  SavePanelTreeViewportSnapshot(ctx->active);
   DEBUG_LOG("ENTER HandleDirWindow: Panel=%s Vol=%s Cursor=%d",
             (panel == ctx->left ? "LEFT" : "RIGHT"),
             (panel->vol ? panel->vol->vol_stats.log_path : "NULL"),
@@ -365,11 +367,8 @@ int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
     ctx->view_mode = ctx->active->vol->vol_stats.log_mode;
 
     /* 2. Restore ctx->active state from the restored volume */
-    if (ctx->active) {
-      /* Panel isolation: No vol_stats sync */
-      ctx->active->disp_begin_pos =
-          ctx->active->vol->saved_tree_index /* legacy removed */;
-    }
+    if (ctx->active)
+      (void)RestorePanelTreeViewportSnapshot(ctx, ctx->active);
 
     /* 3. Restore UI Layout */
     DisplayMenu(ctx); /* Restores Frame and Header */

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -126,6 +126,74 @@ void CapturePanelViewportSnapshot(YtreeNovaPanel *panel, const struct Volume *vo
   }
 }
 
+PanelVolumeFileState *FindPanelVolumeFileState(YtreeNovaPanel *panel,
+                                               int volume_id) {
+  PanelVolumeFileState *state;
+
+  if (!panel)
+    return NULL;
+
+  for (state = panel->volume_file_state; state; state = state->next) {
+    if (state->volume_id == volume_id)
+      return state;
+  }
+  return NULL;
+}
+
+PanelVolumeFileState *GetPanelVolumeFileState(YtreeNovaPanel *panel,
+                                              int volume_id) {
+  PanelVolumeFileState *state;
+
+  state = FindPanelVolumeFileState(panel, volume_id);
+  if (state)
+    return state;
+
+  state = (PanelVolumeFileState *)xcalloc(1, sizeof(PanelVolumeFileState));
+  state->volume_id = volume_id;
+  state->next = panel->volume_file_state;
+  panel->volume_file_state = state;
+  return state;
+}
+
+void SavePanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
+  PanelVolumeFileState *state;
+  PanelViewportSnapshot snapshot;
+  int selected_index;
+
+  if (!panel || !panel->vol)
+    return;
+  if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))
+    return;
+
+  state = GetPanelVolumeFileState(panel, panel->vol->id);
+  CapturePanelViewportSnapshot(panel, panel->vol, &snapshot);
+  state->saved_tree_panel_generation = panel->panel_generation;
+  state->saved_tree_volume_generation = panel->vol->volume_generation;
+  state->has_saved_tree_selection = snapshot.has_selected_dir_path;
+  state->has_saved_tree_top = snapshot.has_top_dir_path;
+  state->saved_tree_selected_dir_path[0] = '\0';
+  state->saved_tree_top_dir_path[0] = '\0';
+  if (snapshot.has_selected_dir_path) {
+    (void)snprintf(state->saved_tree_selected_dir_path,
+                   sizeof(state->saved_tree_selected_dir_path), "%s",
+                   snapshot.selected_dir_path);
+    state->saved_tree_selected_dir_path[PATH_LENGTH] = '\0';
+  }
+  if (snapshot.has_top_dir_path) {
+    (void)snprintf(state->saved_tree_top_dir_path,
+                   sizeof(state->saved_tree_top_dir_path), "%s",
+                   snapshot.top_dir_path);
+    state->saved_tree_top_dir_path[PATH_LENGTH] = '\0';
+  }
+
+  selected_index = panel->disp_begin_pos + panel->cursor_pos;
+  if (selected_index < 0)
+    selected_index = 0;
+  panel->vol->saved_tree_index = selected_index;
+  panel->vol->saved_tree_generation = panel->panel_generation;
+  panel->vol->saved_tree_volume_generation = panel->vol->volume_generation;
+}
+
 int FindDirIndexByPath(const struct Volume *vol, const char *path) {
   int i;
   char candidate_path[PATH_LENGTH + 1];
@@ -408,6 +476,70 @@ BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *pane
   RememberPanelViewportTop(panel);
   panel->panel_generation++;
   return TRUE;
+}
+
+BOOL RestorePanelTreeViewportSnapshot(ViewContext *ctx, YtreeNovaPanel *panel) {
+  const PanelVolumeFileState *state;
+  PanelViewportSnapshot snapshot;
+  int selected_index;
+  int total_dirs;
+  int win_height;
+  BOOL generation_valid;
+
+  if (!ctx || !panel || !panel->vol)
+    return FALSE;
+
+  total_dirs = panel->vol->total_dirs;
+  if (total_dirs <= 0) {
+    panel->disp_begin_pos = 0;
+    panel->cursor_pos = 0;
+    return FALSE;
+  }
+
+  state = FindPanelVolumeFileState(panel, panel->vol->id);
+  generation_valid =
+      state != NULL &&
+      state->saved_tree_panel_generation == panel->panel_generation &&
+      state->saved_tree_volume_generation == panel->vol->volume_generation;
+  if (generation_valid && state->has_saved_tree_selection &&
+      state->saved_tree_selected_dir_path[0]) {
+    snapshot.has_selected_dir_path = state->has_saved_tree_selection;
+    snapshot.has_top_dir_path = state->has_saved_tree_top;
+    (void)snprintf(snapshot.selected_dir_path,
+                   sizeof(snapshot.selected_dir_path), "%s",
+                   state->saved_tree_selected_dir_path);
+    (void)snprintf(snapshot.top_dir_path, sizeof(snapshot.top_dir_path), "%s",
+                   state->saved_tree_top_dir_path);
+    snapshot.selected_dir_path[PATH_LENGTH] = '\0';
+    snapshot.top_dir_path[PATH_LENGTH] = '\0';
+    if (RestorePanelViewportSnapshot(panel->vol, panel, &snapshot,
+                                     state->saved_tree_top_dir_path))
+      return TRUE;
+  }
+  selected_index = 0;
+
+  win_height = ctx->layout.dir_win_height;
+  if (win_height <= 0 && ctx->ctx_dir_window)
+    win_height = getmaxy(ctx->ctx_dir_window);
+  if (win_height <= 0)
+    win_height = 1;
+
+  if (panel->disp_begin_pos < 0)
+    panel->disp_begin_pos = 0;
+  if (selected_index >= panel->disp_begin_pos &&
+      selected_index < panel->disp_begin_pos + win_height) {
+    panel->cursor_pos = selected_index - panel->disp_begin_pos;
+    return FALSE;
+  }
+
+  if (selected_index >= win_height) {
+    panel->disp_begin_pos = selected_index - (win_height - 1);
+    panel->cursor_pos = win_height - 1;
+  } else {
+    panel->disp_begin_pos = 0;
+    panel->cursor_pos = selected_index;
+  }
+  return FALSE;
 }
 
 void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5903,7 +5903,15 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     )
     assert volume_validation in volume_body
     assert volume_body.index(volume_validation) < volume_body.index(
-        "ctx->active->vol->saved_tree_index ="
+        "SavePanelTreeViewportSnapshot(ctx->active);"
+    )
+
+    save_start = panel_anchor.index("void SavePanelTreeViewportSnapshot(")
+    save_end = panel_anchor.index("\nint FindDirIndexByPath(", save_start)
+    save_body = panel_anchor[save_start:save_end]
+    assert volume_validation in save_body
+    assert save_body.index(volume_validation) < save_body.index(
+        "panel->vol->saved_tree_index ="
     )
 
     restore_start = panel_anchor.index("BOOL RestorePanelViewportSnapshot(")

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -150,12 +150,15 @@ def _dir_ops_source():
 
 
 def test_tree_viewport_stable_restore_preserves_visible_selection():
-    restore_source = _restore_panel_tree_selection_source()
+    panel_anchor_source = _panel_anchor_file_source()
+    restore_start = panel_anchor_source.index("BOOL RestorePanelTreeViewportSnapshot(")
+    restore_end = panel_anchor_source.index("\nvoid RestorePanelAnchorPath(", restore_start)
+    restore_source = panel_anchor_source[restore_start:restore_end]
     visible_guard = (
         r"selected_index\s*>=\s*panel->disp_begin_pos"
         r"[\s\S]*selected_index\s*<\s*panel->disp_begin_pos\s*\+\s*win_height"
         r"[\s\S]*panel->cursor_pos\s*=\s*selected_index\s*-\s*panel->disp_begin_pos"
-        r"[\s\S]*return\s*;"
+        r"[\s\S]*return\s+(?:TRUE|FALSE);"
     )
 
     assert re.search(visible_guard, restore_source), (
@@ -242,14 +245,22 @@ def test_restore_snapshots_validate_generation_before_reuse():
     assert "state->saved_volume_generation = panel->vol->volume_generation;" in log_source
     assert "state->saved_panel_generation != panel->panel_generation" in log_source
     assert "state->saved_volume_generation != vol->volume_generation" in log_source
-    assert "panel->vol->saved_tree_generation = panel->panel_generation;" in log_source
+    assert "panel->vol->saved_tree_generation = panel->panel_generation;" in (
+        panel_anchor_source
+    )
     assert (
         "panel->vol->saved_tree_volume_generation = panel->vol->volume_generation;"
-        in log_source
+        in panel_anchor_source
     )
-    assert "generation_valid =" in log_source
-    assert "saved_tree_volume_generation == panel->vol->volume_generation" in log_source
-    assert "saved_tree_panel_generation == panel->panel_generation" in log_source
+    assert "generation_valid =" in panel_anchor_source
+    assert (
+        "saved_tree_volume_generation == panel->vol->volume_generation"
+        in panel_anchor_source
+    )
+    assert (
+        "saved_tree_panel_generation == panel->panel_generation"
+        in panel_anchor_source
+    )
 
     assert "panel->panel_generation++;" in panel_anchor_source, panel_anchor_source
     assert "dst->panel_generation = src->panel_generation;" in panel_anchor_source
@@ -262,10 +273,13 @@ def test_restore_snapshots_validate_generation_before_reuse():
 def test_volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb():
     defs_source = _defs_source()
     log_source = _log_source()
-    restore_source = _restore_panel_tree_selection_source()
-    save_start = log_source.index("static void SavePanelTreeSelection(")
-    save_end = log_source.index("\nstatic void RestorePanelTreeSelection(", save_start)
-    save_source = log_source[save_start:save_end]
+    panel_anchor_source = _panel_anchor_file_source()
+    save_start = panel_anchor_source.index("void SavePanelTreeViewportSnapshot(")
+    save_end = panel_anchor_source.index("\nint FindDirIndexByPath(", save_start)
+    save_source = panel_anchor_source[save_start:save_end]
+    restore_start = panel_anchor_source.index("BOOL RestorePanelTreeViewportSnapshot(")
+    restore_end = panel_anchor_source.index("\nvoid RestorePanelAnchorPath(", restore_start)
+    restore_source = panel_anchor_source[restore_start:restore_end]
     file_restore_source = _restore_panel_file_selection_source()
 
     for needle in (
@@ -307,6 +321,47 @@ def test_volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb():
     )
     assert "selected_index = panel->vol->saved_tree_index;" not in restore_source
     assert "vol->saved_tree_index = resolved_index;" not in file_restore_source
+
+
+def test_volume_action_restore_uses_panel_tree_snapshot_not_index_breadcrumb():
+    dir_ops_source = _dir_ops_source()
+    volume_start = dir_ops_source.index("HandleDirWindowVolumeAction(")
+    volume_end = dir_ops_source.index("\nint RefreshDirWindow(", volume_start)
+    volume_source = dir_ops_source[volume_start:volume_end]
+
+    save_snapshot = volume_source.find("SavePanelTreeViewportSnapshot(ctx->active);")
+    select_loaded = volume_source.find("SelectLoadedVolume(ctx, NULL)")
+    cycle_loaded = volume_source.find("CycleLoadedVolume(ctx, ctx->active,")
+    restore_snapshot = volume_source.find(
+        "RestorePanelTreeViewportSnapshot(ctx, ctx->active)"
+    )
+
+    assert save_snapshot >= 0, volume_source
+    assert select_loaded > save_snapshot, volume_source
+    assert cycle_loaded > save_snapshot, volume_source
+    assert restore_snapshot > save_snapshot, volume_source
+    assert "ctx->active->vol->saved_tree_index =" not in volume_source
+    assert (
+        "ctx->active->disp_begin_pos = ctx->active->vol->saved_tree_index"
+        not in volume_source
+    )
+
+
+def test_f2_picker_return_uses_panel_tree_snapshot_not_index_breadcrumb():
+    f2_source = Path("src/ui/f2_picker.c").read_text(encoding="utf-8")
+    original_vol = f2_source.index("original_vol = ctx->active->vol;")
+    restore_block = f2_source.index("if (ctx->active->vol != original_vol)")
+
+    save_snapshot = f2_source.find("SavePanelTreeViewportSnapshot(ctx->active);")
+    restore_snapshot = f2_source.find(
+        "RestorePanelTreeViewportSnapshot(ctx, ctx->active)", restore_block
+    )
+
+    assert 'include "ytnova_panel_anchor.h"' in f2_source
+    assert save_snapshot > original_vol, f2_source
+    assert save_snapshot < restore_block, f2_source
+    assert restore_snapshot > restore_block, f2_source
+    assert "ctx->active->vol->saved_tree_index" not in f2_source
 
 
 def test_panel_anchor_restore_follows_exact_fallback_order():


### PR DESCRIPTION
## Summary
- centralize panel-local tree viewport snapshot save and restore for volume transitions
- migrate volume action and F2 picker return paths away from direct Volume.saved_tree_index restore authority
- keep the compatibility breadcrumb aligned only after path snapshot capture

## Validation
- RED: source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_volume_action_restore_uses_panel_tree_snapshot_not_index_breadcrumb tests/test_dir_window_dispatch_regressions.py::test_f2_picker_return_uses_panel_tree_snapshot_not_index_breadcrumb
- source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py tests/test_appstate_contract_guard.py
- python scripts/check_appstate_contract.py
- make clean && make
- make qa-cppcheck
- git diff --check