### PR TITLE
fix(appstate): keep log tree restore on panel snapshots

### DIFF
--- a/include/ytnova_panel_anchor.h
+++ b/include/ytnova_panel_anchor.h
@@ -19,6 +19,7 @@ PanelVolumeFileState *FindPanelVolumeFileState(YtreeNovaPanel *panel,
 PanelVolumeFileState *GetPanelVolumeFileState(YtreeNovaPanel *panel,
                                               int volume_id);
 void SavePanelTreeViewportSnapshot(YtreeNovaPanel *panel);
+void ResetPanelTreeViewportSnapshot(YtreeNovaPanel *panel);
 int FindDirIndexByPath(const struct Volume *vol, const char *path);
 int FindDirIndexByPathOrAncestor(const struct Volume *vol, const char *path);
 DirEntry *ResolvePanelAnchorTarget(const YtreeNovaPanel *panel,

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -293,8 +293,6 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
         state = FindPanelVolumeFileState(panel, panel->vol->id);
         if (state)
           panel->panel_generation = state->saved_tree_panel_generation;
-        else
-          panel->panel_generation = panel->vol->saved_tree_generation;
         ctx->global_search_term[0] = '\0';
         ctx->view_mode = panel->vol->vol_stats.log_mode;
 
@@ -465,7 +463,7 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
   if (reload_requested) {
     panel->disp_begin_pos = 0;
     panel->cursor_pos = 0;
-    panel->vol->saved_tree_index = 0;
+    ResetPanelTreeViewportSnapshot(panel);
   } else {
     RestorePanelTreeSelection(ctx, panel);
   }

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -194,6 +194,21 @@ void SavePanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
   panel->vol->saved_tree_volume_generation = panel->vol->volume_generation;
 }
 
+void ResetPanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
+  PanelVolumeFileState *state;
+
+  if (!panel || !panel->vol)
+    return;
+
+  state = GetPanelVolumeFileState(panel, panel->vol->id);
+  state->saved_tree_panel_generation = panel->panel_generation;
+  state->saved_tree_volume_generation = panel->vol->volume_generation;
+  state->has_saved_tree_selection = FALSE;
+  state->has_saved_tree_top = FALSE;
+  state->saved_tree_selected_dir_path[0] = '\0';
+  state->saved_tree_top_dir_path[0] = '\0';
+}
+
 int FindDirIndexByPath(const struct Volume *vol, const char *path) {
   int i;
   char candidate_path[PATH_LENGTH + 1];

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -141,8 +141,33 @@ def _log_source():
     return Path("src/cmd/log.c").read_text(encoding="utf-8")
 
 
+def _log_disk_source():
+    source = _log_source()
+    func_start = source.find("int LogDisk(")
+    assert func_start >= 0, "Missing LogDisk in src/cmd/log.c"
+
+    next_func = source.find("\nint GetNewLogPath(", func_start + 1)
+    assert next_func > func_start, "Could not isolate LogDisk in src/cmd/log.c"
+    return source[func_start:next_func]
+
+
 def _panel_anchor_file_source():
     return Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+
+def _reset_panel_tree_viewport_snapshot_source():
+    source = _panel_anchor_file_source()
+    func_start = source.find("void ResetPanelTreeViewportSnapshot(")
+    assert func_start >= 0, (
+        "Missing ResetPanelTreeViewportSnapshot in src/ui/panel_anchor.c"
+    )
+
+    next_func = source.find("\nint FindDirIndexByPath(", func_start + 1)
+    assert next_func > func_start, (
+        "Could not isolate ResetPanelTreeViewportSnapshot in "
+        "src/ui/panel_anchor.c"
+    )
+    return source[func_start:next_func]
 
 
 def _dir_ops_source():
@@ -321,6 +346,25 @@ def test_volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb():
     )
     assert "selected_index = panel->vol->saved_tree_index;" not in restore_source
     assert "vol->saved_tree_index = resolved_index;" not in file_restore_source
+
+
+def test_log_disk_restore_does_not_use_volume_tree_breadcrumbs():
+    log_disk_source = _log_disk_source()
+    reset_snapshot_source = _reset_panel_tree_viewport_snapshot_source()
+
+    assert "panel->panel_generation = state->saved_tree_panel_generation;" in (
+        log_disk_source
+    )
+    assert "panel->vol->saved_tree_generation" not in log_disk_source
+    assert "panel->vol->saved_tree_index" not in log_disk_source
+    assert "if (reload_requested)" in log_disk_source
+    assert "panel->disp_begin_pos = 0;" in log_disk_source
+    assert "panel->cursor_pos = 0;" in log_disk_source
+    assert "ResetPanelTreeViewportSnapshot(panel);" in log_disk_source
+    assert "state->has_saved_tree_selection = FALSE;" in reset_snapshot_source
+    assert "state->has_saved_tree_top = FALSE;" in reset_snapshot_source
+    assert "saved_tree_index" not in reset_snapshot_source
+    assert "saved_tree_generation" not in reset_snapshot_source
 
 
 def test_volume_action_restore_uses_panel_tree_snapshot_not_index_breadcrumb():


### PR DESCRIPTION
## Summary
- removes log/relog restore authority from Volume saved tree breadcrumbs
- resets relog tree snapshots through panel-local state without writing Volume.saved_tree_index
- adds a focused guard for log tree restore source ownership

## Validation
- source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k 'volume_tree_restore or log_disk_restore'
- python scripts/check_appstate_contract.py
- make clean && make
- git diff --check

Note: make qa-cppcheck was not required for this small change; an attempted full run was interrupted after it proved too slow locally, and a limited-file cppcheck run reported pre-existing unused-function noise from file-local analysis.