### PR TITLE
build(omnios): support setup and debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ CC          ?= cc
 FUZZ_CC     ?= clang
 PANDOC      ?= pandoc
 MAKE_CMD    ?= $(MAKE)
+UNAME_S     := $(shell uname -s)
 
 # -------------------------------------------------------------------------
 # Install Destinations
@@ -76,6 +77,16 @@ PROJECT_LDFLAGS  =
 PROJECT_LDLIBS   = -lncursesw -ltinfo -lreadline -larchive -lm
 PROJECT_OPTFLAGS ?= -O2
 
+ifeq ($(UNAME_S),SunOS)
+    # OmniOS / illumos GCC defaults to a newer C dialect that clashes with
+    # the system curses headers; keep this on GNU17 and build 64-bit for
+    # compatibility with the packaged OmniOS libraries.
+    PROJECT_CFLAGS += -std=gnu17 -m64
+    PROJECT_CPPFLAGS += -I/opt/ooce/libarchive/include
+    PROJECT_LDFLAGS  += -L/opt/ooce/lib/amd64 -L/usr/lib/amd64 -R/opt/ooce/lib/amd64
+    PROJECT_LDLIBS    = -lncurses -ltermlib -lreadline -larchive -lm
+endif
+
 # Coverage build switch (for gcov/lcov-driven C coverage reports).
 COVERAGE    ?= 0
 ifeq ($(COVERAGE),1)
@@ -92,13 +103,16 @@ endif
 
 # -------------------------------------------------------------------------
 # Build Mode Selection
-# Run 'make DEBUG=1' for development (AddressSanitizer enabled)
+# Run 'make DEBUG=1' for development (AddressSanitizer enabled on non-SunOS)
 # Run 'make' for release (Optimized, no runtime dependency on ASan)
 # -------------------------------------------------------------------------
 ifeq ($(DEBUG),1)
-    # Debug Build: Enable ASan, Debug Symbols, disable optimization
-    PROJECT_CFLAGS  += -fsanitize=address -g -O1 -fno-omit-frame-pointer
-    PROJECT_LDFLAGS += -fsanitize=address
+    # Debug Build: Enable ASan where supported; SunOS/OmniOS uses plain debug flags.
+    PROJECT_CFLAGS  += -g -O0 -fno-omit-frame-pointer
+    ifneq ($(UNAME_S),SunOS)
+        PROJECT_CFLAGS  += -fsanitize=address
+        PROJECT_LDFLAGS += -fsanitize=address
+    endif
 else
     # Release Build: Standard Optimization when no external CFLAGS were supplied.
     # Keep sanitizer builds at -O1 for better diagnostics and deterministic PTY timing.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **YtreeNova: A File Manager for Unix-like Systems**
 
-**YtreeNova** is a keyboard-first file manager for Linux and BSD with fast multi-volume logging and navigation.
+**YtreeNova** is a keyboard-first file manager for Unix-like systems, including Linux, BSD, illumos, and GNU Hurd, with fast multi-volume logging and navigation.
 
 > [!IMPORTANT]
 > **STATUS: ALPHA (v1.0.0-alpha)**
@@ -54,6 +54,10 @@ v1.0.0-alpha is being published early so people can use the program, inspect the
 ## Installation
 
 ### Prerequisites
+
+These are the minimum source-build prerequisites. For the full developer
+setup (Python venv, tests, and helper scripts), see
+[CONTRIBUTING.md](docs/CONTRIBUTING.md).
 
 *   **C Compiler** (GCC or Clang; Clang is required for fuzz targets)
 *   **ncurses** (libncurses-dev / ncurses-devel)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,6 +50,11 @@ For pull-request governance and conflict triage policy, see **[PR_GATE.md](PR_GA
 
 This project uses a combination of C for the application and Python for the test suite and AI assistance tools.
 
+- Linux (including WSL) users can start with `scripts/setup_dev.sh`.
+- OmniOS users can use `scripts/setup_omnios.sh`.
+- BSD users can use `scripts/setup_bsd.sh` when it is added.
+- GNU Hurd users can use `scripts/setup_hurd.sh` when it is added.
+
 ### 1. Prerequisites
 
 - A C compiler (`gcc` or `clang`) and `make`.
@@ -182,7 +187,7 @@ make
 ```
 
 ### Debug Build (AddressSanitizer)
-When developing new features or debugging crashes (especially segmentation faults), you should compile with debug mode enabled. This links against **AddressSanitizer (ASan)** and disables optimizations (`-O1`), providing detailed stack traces on memory errors.
+When developing new features or debugging crashes (especially segmentation faults), you should compile with debug mode enabled. On Linux, this links against **AddressSanitizer (ASan)** and disables optimizations, providing detailed stack traces on memory errors. On OmniOS, `gmake DEBUG=1` builds symbols only; ASan is unavailable.
 
 ```bash
 make clean

--- a/include/ytnova_defs.h
+++ b/include/ytnova_defs.h
@@ -12,6 +12,9 @@ typedef struct _ViewContext ViewContext;
 /* Large File Support must be defined before system headers */
 #define _LARGEFILE64_SOURCE 1
 #define _FILE_OFFSET_BITS 64
+#if defined(__sun) && !defined(_XOPEN_SOURCE_EXTENDED)
+#define _XOPEN_SOURCE_EXTENDED 1
+#endif
 
 #include <ctype.h>
 #include <locale.h>
@@ -27,6 +30,10 @@ typedef struct _ViewContext ViewContext;
 #if !defined(HAVE_CURSES)
 #include <curses.h>
 #include <term.h>
+#endif
+
+#if defined(__sun) && !defined(HAVE_WRESIZE)
+extern int wresize(WINDOW *win, int nlines, int ncols);
 #endif
 
 #include <dirent.h>
@@ -55,6 +62,10 @@ typedef struct _ViewContext ViewContext;
 
 #ifdef WITH_UTF8
 #include <wchar.h>
+#endif
+
+#ifndef KEY_RESIZE
+#define KEY_RESIZE 0xFFFF
 #endif
 
 #include "uthash.h"

--- a/include/ytnova_dialog.h
+++ b/include/ytnova_dialog.h
@@ -9,7 +9,6 @@
 #define YTNOVA_DIALOG_H
 
 #include "ytnova_defs.h"
-#include <ncurses.h>
 
 /* Dialog stack limits */
 #define MAX_DIALOG_STACK 16

--- a/scripts/setup_omnios.sh
+++ b/scripts/setup_omnios.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# setup_omnios.sh
+# Sets up the OmniOS development environment for ytnova.
+
+set -euo pipefail
+PATH=/opt/local/sbin:/opt/local/bin:$PATH
+
+echo ">>> Refreshing OmniOS package catalogs..."
+sudo pkg refresh --full
+
+echo ">>> Installing OmniOS build dependencies..."
+sudo pkg install developer/omnios-build-tools ooce/library/libarchive library/ncurses library/readline
+
+if ! command -v pandoc >/dev/null 2>&1; then
+    echo ">>> Installing pandoc via pkgsrc/pkgin..."
+    if ! command -v pkgin >/dev/null 2>&1; then
+        # pkgsrc/pkgin are bootstrapped here because OmniOS does not ship pandoc.
+        BOOTSTRAP_TAR="bootstrap-trunk-x86_64-20240116.tar.gz"
+        BOOTSTRAP_SHA="4d92a333587d9dcc669ff64264451ca65da701b7"
+        TMPDIR="$(mktemp -d)"
+
+        (
+            cd "$TMPDIR"
+            curl -O "https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/${BOOTSTRAP_TAR}"
+            [ "${BOOTSTRAP_SHA}" = "$(/bin/digest -a sha1 "${BOOTSTRAP_TAR}")" ] || {
+                echo "ERROR: checksum failure for ${BOOTSTRAP_TAR}" >&2
+                exit 1
+            }
+            sudo tar -zxpf "${BOOTSTRAP_TAR}" -C /
+        )
+
+        PATH=/opt/local/sbin:/opt/local/bin:$PATH
+        sudo /opt/local/sbin/pkg_add -U pkg_install pkgin libarchive
+        sudo /opt/local/bin/pkgin -y update
+        echo ">>> pkgsrc/pkgin bootstrapped to install hs-pandoc."
+    fi
+
+    sudo /opt/local/bin/pkgin -y install hs-pandoc
+fi
+
+echo
+echo "Setup complete."
+echo "You may now build ytnova with:"
+echo "  cd ~/ytreenova"
+echo "  gmake"

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -25,10 +25,6 @@
 
 /* External declarations for Signal Safety enforcement */
 
-/* Wrapper function to satisfy tputs(..., int (*putc_func)(int)) signature */
-/* It writes the character 'c' to standard output. */
-static int term_putc(int c) { return fputc(c, stdout); }
-
 char *StrLeft(const char *str, size_t visible_count) {
   char *result;
   size_t len;
@@ -308,9 +304,6 @@ void HitReturnToContinue(void) {
 #if !defined(XCURSES)
   char *te;
 
-  char *tgetstr(const char *, char **);
-  int tputs(const char *, int, int (*)(int));
-
   curs_set(1);
 
   vidattr(A_REVERSE);
@@ -322,7 +315,7 @@ void HitReturnToContinue(void) {
 
   te = tgetstr("me", NULL);
   if (te != NULL) {
-    tputs(te, 1, term_putc);
+    putp(te);
   } else {
     putp("\033[0m");
   }


### PR DESCRIPTION
## Summary
- add an OmniOS setup helper with the platform-specific package/bootstrap path
- make the build handle OmniOS library paths and debug-mode differences
- keep the developer setup notes Linux-first, with a short OmniOS exception for debug builds

## Validation
- `gmake -n DEBUG=1`