### PR TITLE
fix(appstate): retire volume tree breadcrumb shim

### DIFF
--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -36,43 +36,6 @@
       ]
     },
     {
-      "id": "shim.volume-saved-tree-index",
-      "owner": "Volume restore breadcrumb",
-      "old_authority_path": "Volume.saved_tree_index",
-      "read_permission": "Allowed only as a fallback breadcrumb when a stable path key has already failed to resolve.",
-      "write_permission": "Do not write as primary restore authority; future writes must update stable identity keys and generation metadata first.",
-      "write_capability": "write_capable",
-      "invariant_checks": [
-        "invariant.viewport-identity-rebind",
-        "invariant.stale-snapshot-fail-closed"
-      ],
-      "removal_trigger": "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
-      "target_transition": "transition.rebuild-rebind-callback.panel-anchor",
-      "follow_up_task": "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
-      "qa_enforcement": "check_appstate_contract.py keeps this debt visible until runtime migration removes the shim.",
-      "owner_field_refs": [
-        "panel.tree_selection_key",
-        "panel.tree_cursor_pos",
-        "panel.tree_viewport_origin",
-        "panel.panel_generation"
-      ],
-      "generation_domain_refs": [
-        "generation.panel.local-authority",
-        "generation.volume.shared-authority",
-        "identity.directory.stable-key",
-        "state.topology.volume",
-        "lifecycle.volume.registry"
-      ],
-      "diff_harness_refs": [
-        "harness.transition-before-after-snapshot",
-        "harness.generation-mismatch-check"
-      ],
-      "source_boundary_refs": [
-        "src/ui/panel_anchor.c",
-        "src/ui/dir_ops.c"
-      ]
-    },
-    {
       "id": "shim.focused-window-session-flag",
       "owner": "ViewContext session routing",
       "old_authority_path": "ViewContext.focused_window",

--- a/include/ytnova_defs.h
+++ b/include/ytnova_defs.h
@@ -653,9 +653,6 @@ typedef struct {
 
 struct Volume {
   int id;
-  int saved_tree_index; /* Per-volume restore breadcrumb, not topology authority. */
-  unsigned int saved_tree_generation;
-  unsigned int saved_tree_volume_generation;
   unsigned int volume_generation;
   int saved_focus;       /* Derived restore mirror of the last focused panel mode. */
   Statistic vol_stats;

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2754,16 +2754,11 @@ static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {
 };
 
 static const char *const kAppStateCompatibilityShimInvariantChecks1[] = {
-  "invariant.viewport-identity-rebind",
-  "invariant.stale-snapshot-fail-closed",
-};
-
-static const char *const kAppStateCompatibilityShimInvariantChecks2[] = {
   "invariant.panel-local-focus-restore",
   "invariant.inactive-panel-frozen",
 };
 
-static const char *const kAppStateCompatibilityShimInvariantChecks3[] = {
+static const char *const kAppStateCompatibilityShimInvariantChecks2[] = {
   "invariant.render-projection-read-only",
   "invariant.blocked-transition-determinism",
 };
@@ -2774,18 +2769,11 @@ static const char *const kAppStateCompatibilityShimOwnerFieldRefs0[] = {
 };
 
 static const char *const kAppStateCompatibilityShimOwnerFieldRefs1[] = {
-  "panel.tree_selection_key",
-  "panel.tree_cursor_pos",
-  "panel.tree_viewport_origin",
-  "panel.panel_generation",
-};
-
-static const char *const kAppStateCompatibilityShimOwnerFieldRefs2[] = {
   "panel.focus_shape",
   "panel.panel_generation",
 };
 
-static const char *const kAppStateCompatibilityShimOwnerFieldRefs3[] = {
+static const char *const kAppStateCompatibilityShimOwnerFieldRefs2[] = {
   "panel.tree_cursor_pos",
   "panel.tree_viewport_origin",
   "panel.file_viewport_origin",
@@ -2799,18 +2787,10 @@ static const char *const kAppStateCompatibilityShimGenerationDomainRefs0[] = {
 
 static const char *const kAppStateCompatibilityShimGenerationDomainRefs1[] = {
   "generation.panel.local-authority",
-  "generation.volume.shared-authority",
-  "identity.directory.stable-key",
-  "state.topology.volume",
-  "lifecycle.volume.registry",
-};
-
-static const char *const kAppStateCompatibilityShimGenerationDomainRefs2[] = {
-  "generation.panel.local-authority",
   "shape.panel.focus",
 };
 
-static const char *const kAppStateCompatibilityShimGenerationDomainRefs3[] = {
+static const char *const kAppStateCompatibilityShimGenerationDomainRefs2[] = {
   "generation.panel.local-authority",
   "identity.directory.stable-key",
   "identity.file.stable-key",
@@ -2823,15 +2803,10 @@ static const char *const kAppStateCompatibilityShimDiffHarnessRefs0[] = {
 };
 
 static const char *const kAppStateCompatibilityShimDiffHarnessRefs1[] = {
-  "harness.transition-before-after-snapshot",
-  "harness.generation-mismatch-check",
-};
-
-static const char *const kAppStateCompatibilityShimDiffHarnessRefs2[] = {
   "harness.declared-write-set-diff",
 };
 
-static const char *const kAppStateCompatibilityShimDiffHarnessRefs3[] = {
+static const char *const kAppStateCompatibilityShimDiffHarnessRefs2[] = {
   "harness.render-projection-read-only-diff",
   "harness.generation-mismatch-check",
   "harness.blocked-transition-no-unrelated-mutation",
@@ -2842,16 +2817,11 @@ static const char *const kAppStateCompatibilityShimSourceBoundaryRefs0[] = {
 };
 
 static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {
-  "src/ui/panel_anchor.c",
-  "src/ui/dir_ops.c",
-};
-
-static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {
   "src/ui/ctrl_file.c",
   "src/ui/ctrl_dir.c",
 };
 
-static const char *const kAppStateCompatibilityShimSourceBoundaryRefs3[] = {
+static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {
   "src/ui/display.c",
 };
 
@@ -6320,11 +6290,11 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
     "transition.keybinding.navigate-tree",
     "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
    "check_appstate_contract.py requires this shim to declare permissions, invariants, target transition, and removal trigger."},
-  {"shim.volume-saved-tree-index",
-   "Volume restore breadcrumb",
-   "Volume.saved_tree_index",
-   "Allowed only as a fallback breadcrumb when a stable path key has already failed to resolve.",
-   "Do not write as primary restore authority; future writes must update stable identity keys and generation metadata first.",
+  {"shim.focused-window-session-flag",
+   "ViewContext session routing",
+   "ViewContext.focused_window",
+   "Allowed for layout routing and footer context selection while AppState focus_shape migration is incomplete.",
+   "Write only from transition commit after the active panel focus_shape has been updated.",
    "write_capable",
    kAppStateCompatibilityShimInvariantChecks1,
    sizeof(kAppStateCompatibilityShimInvariantChecks1) /
@@ -6341,16 +6311,16 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
     kAppStateCompatibilityShimSourceBoundaryRefs1,
     sizeof(kAppStateCompatibilityShimSourceBoundaryRefs1) /
         sizeof(kAppStateCompatibilityShimSourceBoundaryRefs1[0]),
-    "Volume restore breadcrumbs are path-keyed and generation-checked across rebuild/relog paths.",
-    "transition.rebuild-rebind-callback.panel-anchor",
-    "Replace index breadcrumbs with path-scoped restore snapshots in the canonical panel state record.",
-   "check_appstate_contract.py keeps this debt visible until runtime migration removes the shim."},
-  {"shim.focused-window-session-flag",
-   "ViewContext session routing",
-   "ViewContext.focused_window",
-   "Allowed for layout routing and footer context selection while AppState focus_shape migration is incomplete.",
-   "Write only from transition commit after the active panel focus_shape has been updated.",
-   "write_capable",
+    "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
+    "transition.keybinding.navigate-tree",
+    "Move focus-shape authority from session mirrors into panel-local transition records.",
+   "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
+  {"shim-render-derived-row-position",
+   "Render projection temporary",
+   "disp_begin_pos + cursor_pos render-derived lookup",
+   "Allowed only inside render projection or bounds-correction code after identity restore has run.",
+   "Never write authoritative selection from this calculation.",
+   "read_only_projection",
    kAppStateCompatibilityShimInvariantChecks2,
    sizeof(kAppStateCompatibilityShimInvariantChecks2) /
        sizeof(kAppStateCompatibilityShimInvariantChecks2[0]),
@@ -6366,31 +6336,6 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
     kAppStateCompatibilityShimSourceBoundaryRefs2,
     sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2) /
         sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2[0]),
-    "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
-    "transition.keybinding.navigate-tree",
-    "Move focus-shape authority from session mirrors into panel-local transition records.",
-   "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
-  {"shim-render-derived-row-position",
-   "Render projection temporary",
-   "disp_begin_pos + cursor_pos render-derived lookup",
-   "Allowed only inside render projection or bounds-correction code after identity restore has run.",
-   "Never write authoritative selection from this calculation.",
-   "read_only_projection",
-   kAppStateCompatibilityShimInvariantChecks3,
-   sizeof(kAppStateCompatibilityShimInvariantChecks3) /
-       sizeof(kAppStateCompatibilityShimInvariantChecks3[0]),
-   kAppStateCompatibilityShimOwnerFieldRefs3,
-   sizeof(kAppStateCompatibilityShimOwnerFieldRefs3) /
-       sizeof(kAppStateCompatibilityShimOwnerFieldRefs3[0]),
-   kAppStateCompatibilityShimGenerationDomainRefs3,
-    sizeof(kAppStateCompatibilityShimGenerationDomainRefs3) /
-        sizeof(kAppStateCompatibilityShimGenerationDomainRefs3[0]),
-    kAppStateCompatibilityShimDiffHarnessRefs3,
-    sizeof(kAppStateCompatibilityShimDiffHarnessRefs3) /
-        sizeof(kAppStateCompatibilityShimDiffHarnessRefs3[0]),
-    kAppStateCompatibilityShimSourceBoundaryRefs3,
-    sizeof(kAppStateCompatibilityShimSourceBoundaryRefs3) /
-        sizeof(kAppStateCompatibilityShimSourceBoundaryRefs3[0]),
     "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
     "transition.render-reflow.project-state",
     "Audit render/reflow call sites for projection-only behavior during runtime migration.",

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -233,7 +233,6 @@ static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
 
 static const char *const kAppStateRequiredShimIds[] = {
   "shim.viewcontext-hide-dot-files",
-  "shim.volume-saved-tree-index",
   "shim.focused-window-session-flag",
   "shim-render-derived-row-position",
 };

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -109,9 +109,6 @@ struct Volume *Volume_Create(ViewContext *ctx) {
 
   /* Assign a unique ID and increment the serial counter */
   new_vol->id = ctx->volume_serial++;
-  new_vol->saved_tree_index = 0;
-  new_vol->saved_tree_generation = 0;
-  new_vol->saved_tree_volume_generation = 0;
   new_vol->volume_generation = 0;
   new_vol->saved_focus = FOCUS_TREE;
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1749,9 +1749,6 @@ HandleDirWindowVolumeAction(ViewContext *ctx, YtreeNovaAction action,
       !*dir_entry_ptr || !s_ptr || !*s_ptr || !need_dsp_help_ptr) {
     return DIR_WINDOW_DISPATCH_HANDLED;
   }
-  if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))
-    return DIR_WINDOW_DISPATCH_HANDLED;
-
   SavePanelTreeViewportSnapshot(ctx->active);
 
   if (action == ACTION_VOL_MENU) {

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -158,13 +158,8 @@ PanelVolumeFileState *GetPanelVolumeFileState(YtreeNovaPanel *panel,
 void SavePanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
   PanelVolumeFileState *state;
   PanelViewportSnapshot snapshot;
-  int selected_index;
-
   if (!panel || !panel->vol)
     return;
-  if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))
-    return;
-
   state = GetPanelVolumeFileState(panel, panel->vol->id);
   CapturePanelViewportSnapshot(panel, panel->vol, &snapshot);
   state->saved_tree_panel_generation = panel->panel_generation;
@@ -186,12 +181,6 @@ void SavePanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
     state->saved_tree_top_dir_path[PATH_LENGTH] = '\0';
   }
 
-  selected_index = panel->disp_begin_pos + panel->cursor_pos;
-  if (selected_index < 0)
-    selected_index = 0;
-  panel->vol->saved_tree_index = selected_index;
-  panel->vol->saved_tree_generation = panel->panel_generation;
-  panel->vol->saved_tree_volume_generation = panel->vol->volume_generation;
 }
 
 void ResetPanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
@@ -446,8 +435,6 @@ BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *pane
     return FALSE;
   assert(!panel->vol || panel->vol == vol);
   if (panel->vol && panel->vol != vol)
-    return FALSE;
-  if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))
     return FALSE;
   if (!snapshot->has_selected_dir_path || !snapshot->selected_dir_path[0])
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5872,17 +5872,42 @@ def test_appstate_shim_lookup_fails_closed_through_runtime_metadata() -> None:
     assert "strcmp(metadata->id, shim_id)" in body
 
 
+def test_volume_tree_runtime_breadcrumb_fields_are_retired() -> None:
+    volume_defs = Path("include/ytnova_defs.h").read_text(encoding="utf-8")
+    volume_start = volume_defs.index("struct Volume {")
+    volume_end = volume_defs.index("\n};", volume_start)
+    volume_body = volume_defs[volume_start:volume_end]
+
+    assert "saved_tree_index" not in volume_body
+    assert "saved_tree_generation" not in volume_body
+    assert "saved_tree_volume_generation" not in volume_body
+
+    runtime_sources = [
+        Path("src/core/volume.c"),
+        Path("src/ui/dir_ops.c"),
+        Path("src/ui/panel_anchor.c"),
+        Path("src/core/appstate_actions.c"),
+    ]
+    for source_path in runtime_sources:
+        source = source_path.read_text(encoding="utf-8")
+        assert "shim.volume-saved-tree-index" not in source
+        assert "saved_tree_index" not in source
+        assert "vol->saved_tree_generation" not in source
+        assert "vol->saved_tree_volume_generation" not in source
+
+    shims = Path("docs/appstate_compat_shims.json").read_text(encoding="utf-8")
+    assert "shim.volume-saved-tree-index" not in shims
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
-    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
     display = Path("src/ui/display.c").read_text(encoding="utf-8")
 
     assert 'include "ytnova_appstate_actions.h"' in dir_ops
     assert 'include "ytnova_appstate_actions.h"' in ctrl_dir
     assert 'include "ytnova_appstate_actions.h"' in ctrl_file
-    assert 'include "ytnova_appstate_actions.h"' in panel_anchor
     assert 'include "ytnova_appstate_actions.h"' in display
 
     toggle_start = dir_ops.index("void ToggleDotFiles(")
@@ -5895,35 +5920,6 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     assert toggle_body.index(hidden_validation) < toggle_body.index("p->hide_dot_files =")
     assert toggle_body.index(hidden_validation) < toggle_body.index("ctx->hide_dot_files =")
 
-    volume_start = dir_ops.index("HandleDirWindowVolumeAction(")
-    volume_end = dir_ops.index("\nint RefreshDirWindow(", volume_start)
-    volume_body = dir_ops[volume_start:volume_end]
-    volume_validation = (
-        'if (!AppStateValidatedCompatibilityShim("shim.volume-saved-tree-index"))'
-    )
-    assert volume_validation in volume_body
-    assert volume_body.index(volume_validation) < volume_body.index(
-        "SavePanelTreeViewportSnapshot(ctx->active);"
-    )
-
-    save_start = panel_anchor.index("void SavePanelTreeViewportSnapshot(")
-    save_end = panel_anchor.index("\nint FindDirIndexByPath(", save_start)
-    save_body = panel_anchor[save_start:save_end]
-    assert volume_validation in save_body
-    assert save_body.index(volume_validation) < save_body.index(
-        "panel->vol->saved_tree_index ="
-    )
-
-    restore_start = panel_anchor.index("BOOL RestorePanelViewportSnapshot(")
-    restore_end = panel_anchor.index("\nvoid RestorePanelAnchorPath(", restore_start)
-    restore_body = panel_anchor[restore_start:restore_end]
-    assert volume_validation in restore_body
-    assert restore_body.index(volume_validation) < restore_body.index(
-        "ResolvePanelAnchorTarget("
-    )
-    assert restore_body.index(volume_validation) < restore_body.index(
-        "panel->disp_begin_pos ="
-    )
 
     focus_validation = (
         'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -257,7 +257,6 @@ def test_restore_snapshots_validate_generation_before_reuse():
     for needle in (
         "unsigned int saved_panel_generation;",
         "unsigned int saved_volume_generation;",
-        "unsigned int saved_tree_generation;",
         "unsigned int saved_tree_volume_generation;",
         "unsigned int volume_generation;",
         "unsigned int panel_generation;",
@@ -270,13 +269,6 @@ def test_restore_snapshots_validate_generation_before_reuse():
     assert "state->saved_volume_generation = panel->vol->volume_generation;" in log_source
     assert "state->saved_panel_generation != panel->panel_generation" in log_source
     assert "state->saved_volume_generation != vol->volume_generation" in log_source
-    assert "panel->vol->saved_tree_generation = panel->panel_generation;" in (
-        panel_anchor_source
-    )
-    assert (
-        "panel->vol->saved_tree_volume_generation = panel->vol->volume_generation;"
-        in panel_anchor_source
-    )
     assert "generation_valid =" in panel_anchor_source
     assert (
         "saved_tree_volume_generation == panel->vol->volume_generation"


### PR DESCRIPTION
## Summary
- retire the Volume.saved_tree_index compatibility shim from the runtime registry
- remove Volume tree breadcrumb fields, initialization, and compatibility writes
- keep panel-local tree snapshot generation validation as the restore authority

## Validation
- RED: `pytest tests/test_appstate_contract_guard.py -k volume_tree_runtime_breadcrumb_fields_are_retired -q`
- `pytest tests/test_appstate_contract_guard.py tests/test_dir_window_dispatch_regressions.py -q`
- `python scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
