### PR TITLE
fix(appstate): restore focus transitions from panel state

### DIFF
--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -378,14 +378,14 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
     if (file_cursor >= visible_rows)
       file_cursor = visible_rows - 1;
     (*dir_entry_ptr)->cursor_pos = file_cursor;
-    ctx->focused_window = FOCUS_FILE;
     ctx->active->saved_focus = FOCUS_FILE;
+    ctx->focused_window = FOCUS_FILE;
     ctx->active->saved_big_file_view = FALSE;
     CapturePanelSelectionAnchor(ctx, ctx->active, *dir_entry_ptr);
   } else {
     (*dir_entry_ptr)->cursor_pos = -1;
-    ctx->focused_window = FOCUS_TREE;
     ctx->active->saved_focus = FOCUS_TREE;
+    ctx->focused_window = FOCUS_TREE;
     ctx->active->saved_big_file_view = FALSE;
   }
 

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -260,9 +260,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   Statistic *s = &ctx->active->vol->vol_stats;
   char watcher_path[PATH_LENGTH + 1];
 
-  /* ADDED INSTRUCTION: Focus Unification */
-  ctx->focused_window = FOCUS_FILE;
   ctx->active->saved_focus = FOCUS_FILE;
+  ctx->focused_window = FOCUS_FILE;
   ctx->active->saved_big_file_view =
       (dir_entry->big_window || dir_entry->global_flag || dir_entry->tagged_flag);
   if (tracked_file_dir == dir_entry) {
@@ -681,7 +680,7 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
     }
 
     if (switched_panel && ctx->active != owner_panel) {
-      if (ctx->focused_window != FOCUS_FILE) {
+      if (ctx->active->saved_focus != FOCUS_FILE) {
         switched_to_tree_panel = TRUE;
         action = ACTION_ESCAPE;
         goto file_window_done;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5929,10 +5929,29 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     assert focus_validation in dir_body
     assert dir_body.index(focus_validation) < dir_body.index("ctx->focused_window =")
 
+    archive_start = ctrl_dir.index("static BOOL ExitArchiveRootToParent(")
+    archive_end = ctrl_dir.index("\nstatic void HandleDirectoryCompare(", archive_start)
+    archive_body = ctrl_dir[archive_start:archive_end]
+    assert archive_body.index(
+        "ctx->active->saved_focus = FOCUS_FILE;"
+    ) < archive_body.index(
+        "ctx->focused_window = FOCUS_FILE;"
+    )
+    assert archive_body.index(
+        "ctx->active->saved_focus = FOCUS_TREE;"
+    ) < archive_body.index(
+        "ctx->focused_window = FOCUS_TREE;"
+    )
+
     file_start = ctrl_file.index("int HandleFileWindow(")
     file_body = ctrl_file[file_start:]
     assert focus_validation in file_body
     assert file_body.index(focus_validation) < file_body.index("ctx->focused_window =")
+    assert file_body.index("ctx->active->saved_focus = FOCUS_FILE;") < file_body.index(
+        "ctx->focused_window = FOCUS_FILE;"
+    )
+    assert "if (ctx->active->saved_focus != FOCUS_FILE) {" in file_body
+    assert "if (ctx->focused_window != FOCUS_FILE) {" not in file_body
 
     refresh_start = display.index("void RefreshView(")
     refresh_body = display[refresh_start:]


### PR DESCRIPTION
## Summary
- restore archive and file-entry focus transitions by committing panel-local `saved_focus` before mirroring `ViewContext.focused_window`
- use the active panel focus shape, not the session mirror, when deciding split file handoff behavior
- add a source guard that blocks direct session-focus authority on the targeted paths

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py::test_compatibility_shim_boundaries_fail_closed_before_legacy_writes` failed before implementation on session mirror ordering
- GREEN: same targeted pytest passed after implementation
- `make clean && make` passed with existing warnings
- `source .venv/bin/activate && python scripts/check_appstate_contract.py` passed
- `git diff --check` passed
