### PR TITLE
refactor(appstate): read visibility from panel state

### DIFF
--- a/src/cmd/pipe.c
+++ b/src/cmd/pipe.c
@@ -291,9 +291,18 @@ int PipeDirectory(ViewContext *ctx, DirEntry *dir_entry, char *pipe_command) {
   char path[PATH_LENGTH + 1];
   FILE *pipe_fp = NULL;
   FileEntry *fe;
+  const YtreeNovaPanel *active_panel = NULL;
+  BOOL hide_dot_files = FALSE;
   int result = -1;
   int start_dir_fd;
   pid_t child_pid = -1;
+
+  if (!ctx || !dir_entry || !pipe_command)
+    return -1;
+
+  active_panel = ctx->active;
+  hide_dot_files =
+      (active_panel != NULL && active_panel->hide_dot_files) ? TRUE : FALSE;
 
   (void)GetPath(dir_entry, path);
 
@@ -327,7 +336,7 @@ int PipeDirectory(ViewContext *ctx, DirEntry *dir_entry, char *pipe_command) {
 
   for (fe = dir_entry->file; fe; fe = fe->next) {
     if (fe->matching) {
-      if (!ctx->hide_dot_files || fe->name[0] != '.') {
+      if (!hide_dot_files || fe->name[0] != '.') {
         fprintf(pipe_fp, "%s\n", fe->name);
       }
     }

--- a/src/ui/stats.c
+++ b/src/ui/stats.c
@@ -37,7 +37,7 @@ static void PrintStatRow(ViewContext *ctx, int y, const char *label,
                          long long count, long long bytes);
 static void DrawAttributes(ViewContext *ctx, const char *name,
                            const struct stat *s, const FileEntry *fe);
-static void RecalcDir(ViewContext *ctx, DirEntry *d, Statistic *s);
+static void RecalcDir(BOOL hide_dot_files, DirEntry *d, Statistic *s);
 
 /* ************************************************************************* */
 /*                           LOGIC FUNCTIONS                                 */
@@ -71,7 +71,7 @@ static void RecalcLayout(ViewContext *ctx) {
   }
 }
 
-static void RecalcDir(ViewContext *ctx, DirEntry *d, Statistic *s) {
+static void RecalcDir(BOOL hide_dot_files, DirEntry *d, Statistic *s) {
   FileEntry *f;
   DirEntry *sub;
 
@@ -84,7 +84,7 @@ static void RecalcDir(ViewContext *ctx, DirEntry *d, Statistic *s) {
    * globally below */
 
   for (f = d->file; f; f = f->next) {
-    if (ctx->hide_dot_files && f->name[0] == '.')
+    if (hide_dot_files && f->name[0] == '.')
       continue;
 
     d->total_files++;
@@ -98,7 +98,7 @@ static void RecalcDir(ViewContext *ctx, DirEntry *d, Statistic *s) {
 
   sub = d->sub_tree;
   while (sub) {
-    RecalcDir(ctx, sub, s);
+    RecalcDir(hide_dot_files, sub, s);
     s->disk_total_directories++;
     sub = sub->next;
   }
@@ -112,6 +112,8 @@ static void RecalcDir(ViewContext *ctx, DirEntry *d, Statistic *s) {
 }
 
 void RecalculateSysStats(ViewContext *ctx, Statistic *s) {
+  BOOL hide_dot_files = (ctx && ctx->active && ctx->active->hide_dot_files);
+
   s->disk_total_files = 0;
   s->disk_total_bytes = 0;
   s->disk_matching_files = 0;
@@ -122,7 +124,7 @@ void RecalculateSysStats(ViewContext *ctx, Statistic *s) {
 
   if (s->tree) {
     s->disk_total_directories++;
-    RecalcDir(ctx, s->tree, s);
+    RecalcDir(hide_dot_files, s->tree, s);
   }
 }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5899,6 +5899,22 @@ def test_volume_tree_runtime_breadcrumb_fields_are_retired() -> None:
     assert "shim.volume-saved-tree-index" not in shims
 
 
+def test_visibility_projection_reads_panel_state_not_session_mirror() -> None:
+    stats = Path("src/ui/stats.c").read_text(encoding="utf-8")
+    pipe = Path("src/cmd/pipe.c").read_text(encoding="utf-8")
+
+    recalc_start = stats.index("void RecalculateSysStats(")
+    recalc_body = stats[recalc_start:]
+    assert "ctx->hide_dot_files" not in recalc_body
+    assert "ctx->active->hide_dot_files" in recalc_body
+
+    pipe_start = pipe.index("int PipeDirectory(")
+    pipe_end = pipe.index("\nint PipeTaggedFiles(", pipe_start)
+    pipe_body = pipe[pipe_start:pipe_end]
+    assert "ctx->hide_dot_files" not in pipe_body
+    assert "active_panel->hide_dot_files" in pipe_body
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- move stats recalculation visibility reads from the ViewContext mirror to active panel state
- move pipe directory filtering to active panel visibility
- add AppState guard coverage that blocks these consumers from reading the session mirror

## Validation
- make clean && make
- source .venv/bin/activate && python scripts/check_appstate_contract.py
- source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py
- git diff --check