### PR TITLE
refactor(appstate): retire visibility session mirror

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,7 +143,7 @@ Split-transfer/switch code must classify each field before copying or restoring:
 | State Class | Owned By | Examples | Forbidden Cross-Panel Behavior |
 |---|---|---|---|
 | **Panel-Local** | `YtreeNovaPanel` | `cursor_pos`, `disp_begin_pos`, `start_file`, `file_cursor_pos`, `file_dir_entry`, `saved_focus`, `saved_big_file_view`, `file_selection_name`, `file_selection_dir_path`, `tagged_paths`, `hide_dot_files` | Active-only commands must not mutate the inactive panel's values. |
-| **Derived / Restore-Mirror** | `ViewContext` mirrors and `Volume` restore breadcrumbs | `ctx->hide_dot_files`, `saved_tree_index`, `saved_focus` | May shadow panel-local state for compatibility or restore, but must never become the authoritative source of truth when a panel-local copy exists. |
+| **Derived / Restore-Mirror** | `ViewContext` mirrors and `Volume` restore breadcrumbs | `saved_tree_index`, `saved_focus` | May shadow panel-local state for compatibility or restore, but must never become the authoritative source of truth when a panel-local copy exists. |
 | **Shared-Topology** | `Volume` (possibly referenced by both panels) | `vol_stats.tree`, `dir_entry_list`, directory expansion/logging topology | Panel code may mirror topology visibility updates, but must re-anchor each panel by identity/path and must not infer panel-local selection by shared index. |
 | **Session-Only** | `ViewContext` session scope | `is_split_screen`, `focused_window`, layout windows, session options other than panel-local visibility state | Session toggles must not be treated as panel-local transfer state; split hand-off code must not use them to overwrite inactive panel-local snapshots. |
 

--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -4,38 +4,6 @@
   "notes": "Compatibility shims document legacy authority paths that may remain during migration. They must be read/write classified and removed when the target transition boundary is live.",
   "shims": [
     {
-      "id": "shim.viewcontext-hide-dot-files",
-      "owner": "ViewContext derived mirror",
-      "old_authority_path": "ViewContext.hide_dot_files",
-      "read_permission": "Allowed only as a derived compatibility mirror for helpers that have not yet accepted YtreeNovaPanel dotfile visibility.",
-      "write_permission": "Write only when synchronizing from the active panel's authoritative dotfile_visibility during transition commit.",
-      "write_capability": "write_capable",
-      "invariant_checks": [
-        "invariant.hidden-entry-visible-navigation",
-        "invariant.inactive-panel-frozen"
-      ],
-      "removal_trigger": "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
-      "target_transition": "transition.keybinding.navigate-tree",
-      "follow_up_task": "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
-      "qa_enforcement": "check_appstate_contract.py requires this shim to declare permissions, invariants, target transition, and removal trigger.",
-      "owner_field_refs": [
-        "panel.tree_viewport_origin",
-        "panel.panel_generation"
-      ],
-      "generation_domain_refs": [
-        "generation.panel.local-authority",
-        "identity.directory.stable-key",
-        "state.visibility-filter.panel-volume"
-      ],
-      "diff_harness_refs": [
-        "harness.transition-before-after-snapshot",
-        "harness.generation-mismatch-check"
-      ],
-      "source_boundary_refs": [
-        "src/ui/dir_ops.c"
-      ]
-    },
-    {
       "id": "shim.focused-window-session-flag",
       "owner": "ViewContext session routing",
       "old_authority_path": "ViewContext.focused_window",

--- a/include/ytnova_defs.h
+++ b/include/ytnova_defs.h
@@ -796,7 +796,7 @@ typedef struct {
   unsigned int max_visual_linkname_len;
   unsigned int max_visual_userview_len;
   BOOL reverse_sort;
-  BOOL hide_dot_files; /* Panel-local visibility; ViewContext keeps the active mirror. */
+  BOOL hide_dot_files; /* Panel-local visibility. */
 } YtreeNovaPanel;
 
 typedef struct _history {
@@ -998,7 +998,6 @@ typedef struct _ViewContext {
   int cached_cols;  /* Last known COLS for resize detection */
   BOOL bypass_small_window;
   BOOL highlight_full_line;
-  BOOL hide_dot_files; /* Active-panel mirror of panel-local dotfile visibility. */
   BOOL status_line_error_pending;
   char status_line_error_text[PATH_LENGTH + 1];
   char *initial_directory;

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2748,11 +2748,6 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceMigrationNotes12,
    sizeof(kAppStateDispatchSurfaceMigrationNotes12) / sizeof(kAppStateDispatchSurfaceMigrationNotes12[0])},
 };
-static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {
-  "invariant.hidden-entry-visible-navigation",
-  "invariant.inactive-panel-frozen",
-};
-
 static const char *const kAppStateCompatibilityShimInvariantChecks1[] = {
   "invariant.panel-local-focus-restore",
   "invariant.inactive-panel-frozen",
@@ -2761,11 +2756,6 @@ static const char *const kAppStateCompatibilityShimInvariantChecks1[] = {
 static const char *const kAppStateCompatibilityShimInvariantChecks2[] = {
   "invariant.render-projection-read-only",
   "invariant.blocked-transition-determinism",
-};
-
-static const char *const kAppStateCompatibilityShimOwnerFieldRefs0[] = {
-  "panel.tree_viewport_origin",
-  "panel.panel_generation",
 };
 
 static const char *const kAppStateCompatibilityShimOwnerFieldRefs1[] = {
@@ -2777,12 +2767,6 @@ static const char *const kAppStateCompatibilityShimOwnerFieldRefs2[] = {
   "panel.tree_cursor_pos",
   "panel.tree_viewport_origin",
   "panel.file_viewport_origin",
-};
-
-static const char *const kAppStateCompatibilityShimGenerationDomainRefs0[] = {
-  "generation.panel.local-authority",
-  "identity.directory.stable-key",
-  "state.visibility-filter.panel-volume",
 };
 
 static const char *const kAppStateCompatibilityShimGenerationDomainRefs1[] = {
@@ -2797,11 +2781,6 @@ static const char *const kAppStateCompatibilityShimGenerationDomainRefs2[] = {
   "reflow.layout.projection",
 };
 
-static const char *const kAppStateCompatibilityShimDiffHarnessRefs0[] = {
-  "harness.transition-before-after-snapshot",
-  "harness.generation-mismatch-check",
-};
-
 static const char *const kAppStateCompatibilityShimDiffHarnessRefs1[] = {
   "harness.declared-write-set-diff",
 };
@@ -2810,10 +2789,6 @@ static const char *const kAppStateCompatibilityShimDiffHarnessRefs2[] = {
   "harness.render-projection-read-only-diff",
   "harness.generation-mismatch-check",
   "harness.blocked-transition-no-unrelated-mutation",
-};
-
-static const char *const kAppStateCompatibilityShimSourceBoundaryRefs0[] = {
-  "src/ui/dir_ops.c",
 };
 
 static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {
@@ -6265,31 +6240,6 @@ static const AppStateActionCoverageMetadata
 };
 
 static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
-  {"shim.viewcontext-hide-dot-files",
-   "ViewContext derived mirror",
-   "ViewContext.hide_dot_files",
-   "Allowed only as a derived compatibility mirror for helpers that have not yet accepted YtreeNovaPanel dotfile visibility.",
-   "Write only when synchronizing from the active panel's authoritative dotfile_visibility during transition commit.",
-   "write_capable",
-   kAppStateCompatibilityShimInvariantChecks0,
-   sizeof(kAppStateCompatibilityShimInvariantChecks0) /
-       sizeof(kAppStateCompatibilityShimInvariantChecks0[0]),
-   kAppStateCompatibilityShimOwnerFieldRefs0,
-   sizeof(kAppStateCompatibilityShimOwnerFieldRefs0) /
-       sizeof(kAppStateCompatibilityShimOwnerFieldRefs0[0]),
-   kAppStateCompatibilityShimGenerationDomainRefs0,
-    sizeof(kAppStateCompatibilityShimGenerationDomainRefs0) /
-        sizeof(kAppStateCompatibilityShimGenerationDomainRefs0[0]),
-    kAppStateCompatibilityShimDiffHarnessRefs0,
-    sizeof(kAppStateCompatibilityShimDiffHarnessRefs0) /
-        sizeof(kAppStateCompatibilityShimDiffHarnessRefs0[0]),
-    kAppStateCompatibilityShimSourceBoundaryRefs0,
-    sizeof(kAppStateCompatibilityShimSourceBoundaryRefs0) /
-        sizeof(kAppStateCompatibilityShimSourceBoundaryRefs0[0]),
-    "All visibility and restore helpers consume panel-local dotfile_visibility directly.",
-    "transition.keybinding.navigate-tree",
-    "Runtime migration of visibility toggles and restore helpers to AppState panel records.",
-   "check_appstate_contract.py requires this shim to declare permissions, invariants, target transition, and removal trigger."},
   {"shim.focused-window-session-flag",
    "ViewContext session routing",
    "ViewContext.focused_window",

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -883,12 +883,14 @@ int Init(ViewContext *ctx, const char *configuration_file,
       (strtol(CoreInitGetProfileValue(ctx, "HIGHLIGHT_FULL_LINE"), NULL, 0))
           ? TRUE
           : FALSE;
-  ctx->hide_dot_files =
-      (strtol(CoreInitGetProfileValue(ctx, "HIDEDOTFILES"), NULL, 0)) ? TRUE
-                                                                       : FALSE;
-  /* Seed both panel-local copies; ctx->hide_dot_files remains the active mirror. */
-  ctx->left->hide_dot_files = ctx->hide_dot_files;
-  ctx->right->hide_dot_files = ctx->hide_dot_files;
+  {
+    BOOL hide_dot_files =
+        (strtol(CoreInitGetProfileValue(ctx, "HIDEDOTFILES"), NULL, 0))
+            ? TRUE
+            : FALSE;
+    ctx->left->hide_dot_files = hide_dot_files;
+    ctx->right->hide_dot_files = hide_dot_files;
+  }
   ctx->animation_method =
       strtol(CoreInitGetProfileValue(ctx, "ANIMATION"), NULL, 0);
   ctx->initial_directory = (char *)CoreInitGetProfileValue(ctx, "INITIALDIR");

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -232,7 +232,6 @@ static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
 };
 
 static const char *const kAppStateRequiredShimIds[] = {
-  "shim.viewcontext-hide-dot-files",
   "shim.focused-window-session-flag",
   "shim-render-derived-row-position",
 };

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1286,8 +1286,6 @@ void SyncActivePanelWindows(ViewContext *ctx) {
   ctx->ctx_small_file_window = ctx->active->pan_small_file_window;
   ctx->ctx_big_file_window = ctx->active->pan_big_file_window;
   ctx->ctx_file_window = ctx->active->pan_file_window;
-  /* Keep the session mirror aligned with the active panel's local visibility. */
-  ctx->hide_dot_files = ctx->active->hide_dot_files;
 }
 
 DirEntry *ResolveActiveDirEntry(ViewContext *ctx, const Statistic *s) {
@@ -1883,9 +1881,6 @@ void ToggleDotFiles(ViewContext *ctx, YtreeNovaPanel *p) {
 
   if (!ctx || !p || !p->vol)
     return;
-  if (!AppStateValidatedCompatibilityShim("shim.viewcontext-hide-dot-files"))
-    return;
-
   s = &p->vol->vol_stats;
   inactive_anchor_path[0] = '\0';
   CapturePanelViewportSnapshot(p, p->vol, &active_viewport);
@@ -1926,9 +1921,7 @@ void ToggleDotFiles(ViewContext *ctx, YtreeNovaPanel *p) {
    * rebuild */
   SuspendClock(ctx);
 
-  /* Toggle active-panel state and synchronize context view filter. */
   p->hide_dot_files = !p->hide_dot_files;
-  ctx->hide_dot_files = p->hide_dot_files;
   p->panel_generation++;
   p->vol->volume_generation++;
   RecalculateSysStats(ctx, s);

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -344,8 +344,6 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
         ctx->active = ctx->left;
         ctx->active->saved_focus = preserved_focus;
         ctx->focused_window = preserved_focus;
-        /* Restore the session mirror from the newly active panel. */
-        ctx->hide_dot_files = ctx->active->hide_dot_files;
         BuildFileEntryList(ctx, ctx->active);
         if (donate_active_state)
           *switched_panel_ptr = TRUE;
@@ -367,7 +365,6 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
        */
       *loop_action_ptr = ACTION_NONE;
       *return_esc_ptr = FALSE;
-      ctx->hide_dot_files = ctx->active->hide_dot_files;
       SplitTransitionDebugLogFileState("FileAction:split:after", ctx);
 #ifndef NDEBUG
       if (stable_panel)
@@ -406,7 +403,6 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
         ctx->active = ctx->left;
       }
       /* Restore the session mirror from the newly active panel. */
-      ctx->hide_dot_files = ctx->active->hide_dot_files;
       ctx->focused_window = ctx->active->saved_focus;
       *loop_action_ptr = ACTION_NONE;
       AssertSplitFilePanelSnapshotUnchanged(target_panel,
@@ -429,8 +425,6 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
     } else {
       ctx->active = ctx->left;
     }
-    /* Restore the session mirror from the newly active panel. */
-    ctx->hide_dot_files = ctx->active->hide_dot_files;
     ctx->focused_window = ctx->active->saved_focus;
     *loop_action_ptr = ACTION_NONE;
 #endif
@@ -557,7 +551,6 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       }
 
       ctx->focused_window = preserved_focus;
-      ctx->hide_dot_files = ctx->active->hide_dot_files;
       *start_vol_ptr = ctx->active->vol;
       *s_ptr = &ctx->active->vol->vol_stats;
       RefreshView(ctx, *dir_entry_ptr);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5899,6 +5899,26 @@ def test_volume_tree_runtime_breadcrumb_fields_are_retired() -> None:
     assert "shim.volume-saved-tree-index" not in shims
 
 
+def test_visibility_session_mirror_is_retired() -> None:
+    runtime_paths = [
+        Path("include/ytnova_defs.h"),
+        Path("src/core/init.c"),
+        Path("src/ui/dir_ops.c"),
+        Path("src/ui/split_transition.c"),
+    ]
+    for runtime_path in runtime_paths:
+        assert "ctx->hide_dot_files" not in runtime_path.read_text(encoding="utf-8")
+
+    shims = Path("docs/appstate_compat_shims.json").read_text(encoding="utf-8")
+    runtime_registry = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    architecture = Path("docs/ARCHITECTURE.md").read_text(encoding="utf-8")
+
+    assert "shim.viewcontext-hide-dot-files" not in shims
+    assert "shim.viewcontext-hide-dot-files" not in runtime_registry
+    assert "ViewContext.hide_dot_files" not in shims
+    assert "ctx->hide_dot_files" not in architecture
+
+
 def test_visibility_projection_reads_panel_state_not_session_mirror() -> None:
     stats = Path("src/ui/stats.c").read_text(encoding="utf-8")
     pipe = Path("src/cmd/pipe.c").read_text(encoding="utf-8")
@@ -5926,16 +5946,7 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     assert 'include "ytnova_appstate_actions.h"' in ctrl_file
     assert 'include "ytnova_appstate_actions.h"' in display
 
-    toggle_start = dir_ops.index("void ToggleDotFiles(")
-    toggle_end = dir_ops.index("\nDirEntry *RefreshTreeSafe(", toggle_start)
-    toggle_body = dir_ops[toggle_start:toggle_end]
-    hidden_validation = (
-        'if (!AppStateValidatedCompatibilityShim("shim.viewcontext-hide-dot-files"))'
-    )
-    assert hidden_validation in toggle_body
-    assert toggle_body.index(hidden_validation) < toggle_body.index("p->hide_dot_files =")
-    assert toggle_body.index(hidden_validation) < toggle_body.index("ctx->hide_dot_files =")
-
+    assert "shim.viewcontext-hide-dot-files" not in dir_ops
 
     focus_validation = (
         'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'


### PR DESCRIPTION
## Summary
- remove the ViewContext hidden-file visibility mirror from runtime state
- retire the hidden-file AppState compatibility shim from docs and runtime registry
- add source guard coverage so hidden-file visibility stays panel-local

## Validation
- make clean && make
- source .venv/bin/activate && python scripts/check_appstate_contract.py
- source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py::test_visibility_session_mirror_is_retired tests/test_appstate_contract_guard.py::test_visibility_projection_reads_panel_state_not_session_mirror tests/test_appstate_contract_guard.py::test_compatibility_shim_boundaries_fail_closed_before_legacy_writes
- git diff --check