### PR TITLE
refactor(appstate): centralize focus transition commits

### DIFF
--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -30,6 +30,7 @@
         "harness.declared-write-set-diff"
       ],
       "source_boundary_refs": [
+        "src/ui/appstate_focus.c",
         "src/ui/ctrl_file.c",
         "src/ui/ctrl_dir.c"
       ]

--- a/include/ytnova_appstate_focus.h
+++ b/include/ytnova_appstate_focus.h
@@ -1,0 +1,17 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_focus.h
+ * Focus transition commits for AppState compatibility boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_FOCUS_H
+#define YTNOVA_APPSTATE_FOCUS_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
+                              ViewFocus focus);
+BOOL AppStateMirrorActivePanelFocus(ViewContext *ctx);
+
+#endif /* YTNOVA_APPSTATE_FOCUS_H */

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2792,6 +2792,7 @@ static const char *const kAppStateCompatibilityShimDiffHarnessRefs2[] = {
 };
 
 static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {
+  "src/ui/appstate_focus.c",
   "src/ui/ctrl_file.c",
   "src/ui/ctrl_dir.c",
 };

--- a/src/ui/appstate_focus.c
+++ b/src/ui/appstate_focus.c
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_focus.c
+ * Focus transition commits for AppState compatibility boundaries.
+ *
+ ***************************************************************************/
+
+#define NO_YTNOVA_MACROS
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
+
+BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
+                              ViewFocus focus) {
+  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
+    return FALSE;
+  if (!ctx || !panel)
+    return FALSE;
+  if (focus != FOCUS_TREE && focus != FOCUS_FILE)
+    return FALSE;
+
+  panel->saved_focus = focus;
+  if (ctx->active == panel)
+    ctx->focused_window = focus;
+  return TRUE;
+}
+
+BOOL AppStateMirrorActivePanelFocus(ViewContext *ctx) {
+  if (!ctx || !ctx->active)
+    return FALSE;
+  return AppStateCommitPanelFocus(ctx, ctx->active, ctx->active->saved_focus);
+}

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -8,6 +8,7 @@
 #define NO_YTNOVA_MACROS
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -378,14 +379,14 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
     if (file_cursor >= visible_rows)
       file_cursor = visible_rows - 1;
     (*dir_entry_ptr)->cursor_pos = file_cursor;
-    ctx->active->saved_focus = FOCUS_FILE;
-    ctx->focused_window = FOCUS_FILE;
+    if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
+      return FALSE;
     ctx->active->saved_big_file_view = FALSE;
     CapturePanelSelectionAnchor(ctx, ctx->active, *dir_entry_ptr);
   } else {
     (*dir_entry_ptr)->cursor_pos = -1;
-    ctx->active->saved_focus = FOCUS_TREE;
-    ctx->focused_window = FOCUS_TREE;
+    if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_TREE))
+      return FALSE;
     ctx->active->saved_big_file_view = FALSE;
   }
 
@@ -488,7 +489,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
   if (ctx->active) {
     DEBUG_LOG("HandleDirWindow: Syncing panel state");
-    ctx->focused_window = ctx->active->saved_focus;
+    if (!AppStateMirrorActivePanelFocus(ctx))
+      return ESC;
 
     /* Ensure global context windows follow the active panel. */
     SyncActivePanelWindows(ctx);

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -14,6 +14,7 @@
 #include "../../include/sort.h"
 #include "../../include/watcher.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
 #include "../../include/ytnova_cmd.h"
 #include "../../include/ytnova_fs.h"
 #include "../../include/ytnova_split_transition.h"
@@ -260,8 +261,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   Statistic *s = &ctx->active->vol->vol_stats;
   char watcher_path[PATH_LENGTH + 1];
 
-  ctx->active->saved_focus = FOCUS_FILE;
-  ctx->focused_window = FOCUS_FILE;
+  if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
+    return ESC;
   ctx->active->saved_big_file_view =
       (dir_entry->big_window || dir_entry->global_flag || dir_entry->tagged_flag);
   if (tracked_file_dir == dir_entry) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5671,8 +5671,7 @@ def test_handle_file_window_dispatch_fails_closed_before_file_work() -> None:
     early_return = "return ESC;"
     boundary_calls = [
         'DEBUG_LOG("HandleFileWindow ENTERED',
-        "ctx->focused_window = FOCUS_FILE;",
-        "ctx->active->saved_focus = FOCUS_FILE;",
+        "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)",
         "ctx->active->saved_big_file_view =",
         "BuildFileEntryList(",
         "RefreshView(",
@@ -5724,7 +5723,7 @@ def test_handle_dir_window_dispatch_fails_closed_before_directory_work() -> None
         'DEBUG_LOG("HandleDirWindow:',
         "Layout_Recalculate(",
         "DisplayMenu(",
-        "ctx->focused_window =",
+        "AppStateMirrorActivePanelFocus(ctx)",
         "SyncActivePanelWindows(",
         "ctx->preview_mode = FALSE;",
         "BuildDirEntryList(",
@@ -5940,11 +5939,14 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     display = Path("src/ui/display.c").read_text(encoding="utf-8")
+    focus_helper = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
 
     assert 'include "ytnova_appstate_actions.h"' in dir_ops
     assert 'include "ytnova_appstate_actions.h"' in ctrl_dir
     assert 'include "ytnova_appstate_actions.h"' in ctrl_file
     assert 'include "ytnova_appstate_actions.h"' in display
+    assert 'include "ytnova_appstate_focus.h"' in ctrl_dir
+    assert 'include "ytnova_appstate_focus.h"' in ctrl_file
 
     assert "shim.viewcontext-hide-dot-files" not in dir_ops
 
@@ -5954,31 +5956,30 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     dir_start = ctrl_dir.index("HandleDirWindow(")
     dir_body = ctrl_dir[dir_start:]
     assert focus_validation in dir_body
-    assert dir_body.index(focus_validation) < dir_body.index("ctx->focused_window =")
+    assert not re.search(r"\bctx->focused_window\s*=[^=]", ctrl_dir)
+    assert "AppStateMirrorActivePanelFocus(ctx)" in dir_body
 
     archive_start = ctrl_dir.index("static BOOL ExitArchiveRootToParent(")
     archive_end = ctrl_dir.index("\nstatic void HandleDirectoryCompare(", archive_start)
     archive_body = ctrl_dir[archive_start:archive_end]
-    assert archive_body.index(
-        "ctx->active->saved_focus = FOCUS_FILE;"
-    ) < archive_body.index(
-        "ctx->focused_window = FOCUS_FILE;"
-    )
-    assert archive_body.index(
-        "ctx->active->saved_focus = FOCUS_TREE;"
-    ) < archive_body.index(
-        "ctx->focused_window = FOCUS_TREE;"
-    )
+    assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)" in archive_body
+    assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_TREE)" in archive_body
 
     file_start = ctrl_file.index("int HandleFileWindow(")
     file_body = ctrl_file[file_start:]
     assert focus_validation in file_body
-    assert file_body.index(focus_validation) < file_body.index("ctx->focused_window =")
-    assert file_body.index("ctx->active->saved_focus = FOCUS_FILE;") < file_body.index(
-        "ctx->focused_window = FOCUS_FILE;"
-    )
+    assert not re.search(r"\bctx->focused_window\s*=[^=]", ctrl_file)
+    assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)" in file_body
     assert "if (ctx->active->saved_focus != FOCUS_FILE) {" in file_body
     assert "if (ctx->focused_window != FOCUS_FILE) {" not in file_body
+
+    helper_validation = (
+        'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'
+    )
+    assert helper_validation in focus_helper
+    assert focus_helper.index(helper_validation) < focus_helper.index(
+        "ctx->focused_window ="
+    )
 
     refresh_start = display.index("void RefreshView(")
     refresh_body = display[refresh_start:]


### PR DESCRIPTION
## Summary
- Adds a focused AppState helper for panel focus commits and active-panel focus mirroring.
- Routes file and directory controller focus writes through the helper instead of assigning the session mirror directly.
- Updates shim source-boundary metadata and guard coverage for the centralized focus boundary.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py::test_compatibility_shim_boundaries_fail_closed_before_legacy_writes`
- GREEN: `make clean && make`
- GREEN: `source .venv/bin/activate && python scripts/check_appstate_contract.py`
- GREEN: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py`
- GREEN: `git diff --check`
