### PR TITLE
refactor(appstate): route directory focus commits through helper

### DIFF
--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -31,8 +31,10 @@
       ],
       "source_boundary_refs": [
         "src/ui/appstate_focus.c",
+        "src/ui/ctrl_file_ops.c",
         "src/ui/ctrl_file.c",
-        "src/ui/ctrl_dir.c"
+        "src/ui/ctrl_dir.c",
+        "src/ui/dir_ops.c"
       ]
     },
     {

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2793,8 +2793,10 @@ static const char *const kAppStateCompatibilityShimDiffHarnessRefs2[] = {
 
 static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {
   "src/ui/appstate_focus.c",
+  "src/ui/ctrl_file_ops.c",
   "src/ui/ctrl_file.c",
   "src/ui/ctrl_dir.c",
+  "src/ui/dir_ops.c",
 };
 
 static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -7,6 +7,7 @@
 
 #define NO_YTNOVA_MACROS
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -276,7 +277,8 @@ BOOL handle_file_window_preview_action(
       Statistic *stats_local;
 
       ctx->active = ctx->preview_return_panel;
-      ctx->focused_window = ctx->preview_return_focus;
+      if (!AppStateCommitPanelFocus(ctx, ctx->active, ctx->preview_return_focus))
+        return FALSE;
       stats_local = &ctx->active->vol->vol_stats;
       if (stats_ptr)
         *stats_ptr = stats_local;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -8,6 +8,7 @@
 
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -1128,7 +1129,9 @@ void HandleShowAll(ViewContext *ctx, BOOL tagged_only, BOOL all_volumes,
      */
     flushinp();
     result = HandleFileWindow(ctx, dir_entry);
-    ctx->focused_window = (result == '\\') ? FOCUS_FILE : FOCUS_TREE;
+    if (!AppStateCommitPanelFocus(
+            ctx, ctx->active, (result == '\\') ? FOCUS_FILE : FOCUS_TREE))
+      return;
 
     if (result != LOG_ESC) {
       /* Restore normal mode and refresh the entire view */
@@ -1538,7 +1541,8 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeNovaAction action,
                        ctx->active);
 
     ctx->preview_mode = FALSE;
-    ctx->focused_window = FOCUS_TREE;
+    if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_TREE))
+      return DIR_WINDOW_DISPATCH_RETURN_ESC;
 
     if (ctx->active != saved_panel) {
       if (ctx->active->vol == NULL)
@@ -1686,7 +1690,8 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
       RefreshView(ctx, *dir_entry_ptr);
     }
 
-    ctx->focused_window = FOCUS_TREE;
+    if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_TREE))
+      return DIR_WINDOW_DISPATCH_RETURN_ESC;
     *action_ptr = ACTION_NONE;
     return DIR_WINDOW_DISPATCH_HANDLED;
   }
@@ -1700,7 +1705,8 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
   saved_panel = ctx->active;
   HandleSwitchWindow(ctx, *dir_entry_ptr, need_dsp_help_ptr, ch_ptr, ctx->active);
   *ch_ptr = 0;
-  ctx->focused_window = ctx->active->saved_focus;
+  if (!AppStateMirrorActivePanelFocus(ctx))
+    return DIR_WINDOW_DISPATCH_RETURN_ESC;
 
   if (ctx->active != saved_panel) {
     if (ctx->active->vol == NULL)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5938,6 +5938,7 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
     display = Path("src/ui/display.c").read_text(encoding="utf-8")
     focus_helper = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
 
@@ -5945,8 +5946,10 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     assert 'include "ytnova_appstate_actions.h"' in ctrl_dir
     assert 'include "ytnova_appstate_actions.h"' in ctrl_file
     assert 'include "ytnova_appstate_actions.h"' in display
+    assert 'include "ytnova_appstate_focus.h"' in dir_ops
     assert 'include "ytnova_appstate_focus.h"' in ctrl_dir
     assert 'include "ytnova_appstate_focus.h"' in ctrl_file
+    assert 'include "ytnova_appstate_focus.h"' in ctrl_file_ops
 
     assert "shim.viewcontext-hide-dot-files" not in dir_ops
 
@@ -5972,6 +5975,16 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)" in file_body
     assert "if (ctx->active->saved_focus != FOCUS_FILE) {" in file_body
     assert "if (ctx->focused_window != FOCUS_FILE) {" not in file_body
+
+    assert not re.search(r"\bctx->focused_window\s*=[^=]", dir_ops)
+    assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_TREE)" in dir_ops
+    assert "AppStateMirrorActivePanelFocus(ctx)" in dir_ops
+
+    assert not re.search(r"\bctx->focused_window\s*=[^=]", ctrl_file_ops)
+    assert (
+        "AppStateCommitPanelFocus(ctx, ctx->active, ctx->preview_return_focus)"
+        in ctrl_file_ops
+    )
 
     helper_validation = (
         'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'


### PR DESCRIPTION
## Summary
- Routes directory-operation and preview-return focused-window commits through the AppState focus helper.
- Extends focused-window shim source-boundary metadata to the migrated helper call sites.
- Updates AppState guard coverage so these files no longer assign the focus session mirror directly.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py::test_compatibility_shim_boundaries_fail_closed_before_legacy_writes`
- GREEN: `make clean && make`
- GREEN: `source .venv/bin/activate && python scripts/check_appstate_contract.py`
- GREEN: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py`
- GREEN: `git diff --check`
