### PR TITLE
refactor(appstate): route split file focus commits through helper

### DIFF
--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -34,7 +34,8 @@
         "src/ui/ctrl_file_ops.c",
         "src/ui/ctrl_file.c",
         "src/ui/ctrl_dir.c",
-        "src/ui/dir_ops.c"
+        "src/ui/dir_ops.c",
+        "src/ui/split_transition.c"
       ]
     },
     {

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2797,6 +2797,7 @@ static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {
   "src/ui/ctrl_file.c",
   "src/ui/ctrl_dir.c",
   "src/ui/dir_ops.c",
+  "src/ui/split_transition.c",
 };
 
 static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -8,6 +8,7 @@
 #define NO_YTNOVA_MACROS
 
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include "ytnova_split_transition.h"
@@ -338,12 +339,13 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
           FreeFileEntryList(ctx->right);
         }
         ctx->active = owner_panel;
-        ctx->focused_window = FOCUS_FILE;
+        if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
+          return FALSE;
       } else {
         FreeFileEntryList(ctx->right);
         ctx->active = ctx->left;
-        ctx->active->saved_focus = preserved_focus;
-        ctx->focused_window = preserved_focus;
+        if (!AppStateCommitPanelFocus(ctx, ctx->active, preserved_focus))
+          return FALSE;
         BuildFileEntryList(ctx, ctx->active);
         if (donate_active_state)
           *switched_panel_ptr = TRUE;
@@ -390,7 +392,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
       owner_panel->start_file = dir_entry->start_file;
       owner_panel->file_cursor_pos = dir_entry->cursor_pos;
       CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
-      ctx->active->saved_focus = FOCUS_FILE;
+      if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
+        return FALSE;
       ctx->active->saved_big_file_view =
           (dir_entry->big_window || dir_entry->global_flag ||
            dir_entry->tagged_flag);
@@ -402,8 +405,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
       } else {
         ctx->active = ctx->left;
       }
-      /* Restore the session mirror from the newly active panel. */
-      ctx->focused_window = ctx->active->saved_focus;
+      if (!AppStateMirrorActivePanelFocus(ctx))
+        return FALSE;
       *loop_action_ptr = ACTION_NONE;
       AssertSplitFilePanelSnapshotUnchanged(target_panel,
                                             &target_panel_snapshot);
@@ -413,7 +416,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
     owner_panel->start_file = dir_entry->start_file;
     owner_panel->file_cursor_pos = dir_entry->cursor_pos;
     CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
-    ctx->active->saved_focus = FOCUS_FILE;
+    if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
+      return FALSE;
     ctx->active->saved_big_file_view =
         (dir_entry->big_window || dir_entry->global_flag ||
          dir_entry->tagged_flag);
@@ -425,7 +429,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
     } else {
       ctx->active = ctx->left;
     }
-    ctx->focused_window = ctx->active->saved_focus;
+    if (!AppStateMirrorActivePanelFocus(ctx))
+      return FALSE;
     *loop_action_ptr = ACTION_NONE;
 #endif
     SplitTransitionDebugLogFileState("FileAction:switch:after", ctx);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5331,6 +5331,12 @@ int AppStateValidatedTransition(const char *transition_id) {
   return fake_mode != 3;
 }
 
+int AppStateValidatedCompatibilityShim(const char *shim_id) {
+  (void)shim_id;
+  return fake_mode != 4;
+}
+
+#include "src/ui/appstate_focus.c"
 #include "src/ui/split_transition.c"
 
 void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
@@ -6002,6 +6008,19 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     assert render_validation in refresh_body
     assert refresh_body.index(render_validation) < refresh_body.index("Layout_Recalculate(")
     assert refresh_body.index(render_validation) < refresh_body.index("DisplayTree(")
+
+
+def test_split_file_focus_commits_use_appstate_helper() -> None:
+    source = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
+    start = source.index("BOOL SplitTransition_HandleFileWindowAction(")
+    end = source.index("\nBOOL SplitTransition_HandleDirWindowAction(", start)
+    body = source[start:end]
+
+    assert 'include "ytnova_appstate_focus.h"' in source
+    assert not re.search(r"\bctx->focused_window\s*=[^=]", body)
+    assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)" in body
+    assert "AppStateCommitPanelFocus(ctx, ctx->active, preserved_focus)" in body
+    assert "AppStateMirrorActivePanelFocus(ctx)" in body
 
 
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:


### PR DESCRIPTION
## Summary
- Routes split file-window focus commits through the AppState focus helper.
- Extends focused-window shim source-boundary metadata to split transition helper call sites.
- Adds guard coverage that prevents direct focused-window assignments in the split file transition path.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py::test_split_file_focus_commits_use_appstate_helper`
- GREEN: `make clean && make`
- GREEN: `source .venv/bin/activate && python scripts/check_appstate_contract.py`
- GREEN: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py`
- GREEN: `source .venv/bin/activate && pytest tests/test_file_window_dispatch_regressions.py::test_HandleFileWindow_delegates_split_transition_hotspot tests/test_panel_isolation.py::test_split_from_file_preserves_inactive_panel_file_state tests/test_panel_isolation.py::test_split_from_big_file_keeps_inactive_panel_in_file_view tests/test_panel_isolation.py::test_split_tab_from_small_file_does_not_expand_inactive_panel tests/test_panel_isolation.py::test_split_tab_enter_tab_keeps_tree_panel_focus_local`
- GREEN: `git diff --check`
