### PR TITLE
refactor(appstate): route split directory focus commits through helper

### DIFF
--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -555,7 +555,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         flushinp();
       }
 
-      ctx->focused_window = preserved_focus;
+      if (!AppStateCommitPanelFocus(ctx, ctx->active, preserved_focus))
+        return FALSE;
       *start_vol_ptr = ctx->active->vol;
       *s_ptr = &ctx->active->vol->vol_stats;
       RefreshView(ctx, *dir_entry_ptr);
@@ -587,7 +588,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         ctx->active = ctx->left;
       }
 
-      ctx->focused_window = ctx->active->saved_focus;
+      if (!AppStateMirrorActivePanelFocus(ctx))
+        return FALSE;
       *start_vol_ptr = ctx->active->vol;
       *s_ptr = &ctx->active->vol->vol_stats;
       PanelTags_ApplyToTree(ctx, ctx->active);
@@ -633,7 +635,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         *dir_entry_ptr = (*s_ptr)->tree;
         DEBUG_LOG("DirPanelAction:switch:restore returned null; fallback tree");
       }
-      ctx->focused_window = ctx->active->saved_focus;
+      if (!AppStateMirrorActivePanelFocus(ctx))
+        return FALSE;
       if (*dir_entry_ptr) {
         DEBUG_LOG("DirPanelAction:switch:before_refresh dir='%s'",
                   (*dir_entry_ptr)->name ? (*dir_entry_ptr)->name : "<nullname>");
@@ -659,7 +662,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       ctx->active = ctx->left;
     }
 
-    ctx->focused_window = ctx->active->saved_focus;
+    if (!AppStateMirrorActivePanelFocus(ctx))
+      return FALSE;
     *start_vol_ptr = ctx->active->vol;
     *s_ptr = &ctx->active->vol->vol_stats;
     PanelTags_ApplyToTree(ctx, ctx->active);
@@ -704,7 +708,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       *dir_entry_ptr = (*s_ptr)->tree;
       DEBUG_LOG("DirPanelAction:switch:restore returned null; fallback tree");
     }
-    ctx->focused_window = ctx->active->saved_focus;
+    if (!AppStateMirrorActivePanelFocus(ctx))
+      return FALSE;
     if (*dir_entry_ptr) {
       DEBUG_LOG("DirPanelAction:switch:before_refresh dir='%s'",
                 (*dir_entry_ptr)->name ? (*dir_entry_ptr)->name : "<nullname>");

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6023,6 +6023,17 @@ def test_split_file_focus_commits_use_appstate_helper() -> None:
     assert "AppStateMirrorActivePanelFocus(ctx)" in body
 
 
+def test_split_directory_focus_commits_use_appstate_helper() -> None:
+    source = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
+    start = source.index("BOOL SplitTransition_HandleDirWindowAction(")
+    body = source[start:]
+
+    assert 'include "ytnova_appstate_focus.h"' in source
+    assert not re.search(r"\bctx->focused_window\s*=[^=]", body)
+    assert "AppStateCommitPanelFocus(ctx, ctx->active, preserved_focus)" in body
+    assert body.count("AppStateMirrorActivePanelFocus(ctx)") >= 2
+
+
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     validation = (


### PR DESCRIPTION
## Summary
- Routes split directory-window focus commits through the AppState focus helper.
- Adds guard coverage that prevents direct focused-window assignments in the split directory transition path.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py::test_split_directory_focus_commits_use_appstate_helper`
- GREEN: `make clean && make`
- GREEN: `source .venv/bin/activate && python scripts/check_appstate_contract.py`
- GREEN: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py`
- GREEN: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_dir_window_split_transition_owner_path_is_canonical tests/test_panel_isolation.py::test_split_from_dir_immediately_renders_peer_panel tests/test_panel_isolation.py::test_split_panels_keep_independent_file_focus_states`
- GREEN: `git diff --check`
