### PR TITLE
refactor(appstate): route focus restore commits through helper

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -344,7 +344,29 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Keep footer help text unchanged during `/` incremental jump and apply immediate selection movement as characters are typed (for example `/y` jumps to the first matching entry) without footer prompt takeover.
 *   **Status**: Confirmed.
 
-### **BUG-25: Recursive Scan Interrupt Responsiveness**
+### **BUG-25: Color Configuration Roles Are Misrouted Across Unrelated UI Surfaces**
+*   **Description**: Current color-pair names and rendering usage do not map cleanly to visible UI roles. Changing one color key can affect unrelated surfaces, while some documented keys appear unused or hard to observe.
+*   **Manual findings (2026-06-25)**:
+    *   Stats panel dynamic values are rendered with the same color as nearby static labels in several places, so values such as paths, filesystem names, counts, sizes, attributes, owners, and timestamps cannot be made white independently of labels.
+    *   Stats section titles (`FILTER`, `VOLUME`, `VOLUME STATS`, `CURRENT DIR`/`CURRENT FILE`, `ATTRIBUTES`) are inconsistently treated as border text versus ordinary text.
+    *   `WINDIR_COLOR` appears to affect the current filter value, static+dynamic text in volume stats, and current-dir totals/matches/tags text.
+    *   `WINFILE_COLOR` appears to affect autoview text.
+    *   `WINSTATS_COLOR` has no obvious observed effect in the checked flows.
+    *   `BORDERS_COLOR` affects line art, but also appears to affect the dynamic path part of the header, stats box titles, static+dynamic text in volume sections, current-dir/attributes path text, and all text in the attributes box.
+    *   `MENU_COLOR` affects footer menu text and also the clock color.
+    *   Neutral interaction surfaces are inconsistent: footer prompts can turn grey wholesale, history can remain cyan-on-blue when it should be neutral dialog styling, and F2 option/help text mixes prompt, menu, and content roles.
+*   **Expected**: Color keys should map to coherent semantic roles. Borders/box lines, static labels, dynamic values, keybinding text, neutral dialog/history surfaces, prompt input fields, preview text, and footer/help text must be independently predictable enough that changing one role does not unexpectedly recolor unrelated UI surfaces.
+*   **Impact**: Makes theme tuning unreliable and confusing; users cannot produce a restrained, readable theme because color controls behave like cross-wired chimeras rather than intentional UI roles.
+*   **Remediation**:
+    *   Audit all uses of `CPAIR_*`, `WbkgdSet`, `wattr*`, and `COLOR_PAIR` in the header, stats panel, footer/prompt, F2/history, autoview/preview, and dialog paths.
+    *   Split static stats labels from dynamic stats values at render call sites.
+    *   Separate border/box-line roles from title text and content text.
+    *   Ensure color configuration comments describe actual behavior until the role-based theme system replaces the legacy keys.
+    *   Align with `ROADMAP` Task 60 by introducing semantic roles instead of preserving misleading legacy pair names as the long-term model.
+*   **Related**: `ROADMAP` Task 60 (role-based theme system and restrained default palette).
+*   **Status**: Confirmed.
+
+### **BUG-26: Recursive Scan Interrupt Responsiveness**
 *   **Description**: Interrupting a recursive expansion (`*`) via `ESC` is supported but requires multiple keypresses (Prompt Y/N).
 *   **Impact**: Users cannot instantly halt accidental large-branch scans.
 *   **Remediation**: Evaluate if `ESC` during `ReadTree` should immediately halt the scan once instead of prompting, given that partial results are preserved.
@@ -352,7 +374,7 @@ Ordering policy (for all editors, including AI editors):
 
 ## **Correctness, Consistency, and Naming Defects (Priority Ordered)**
 
-### **BUG-26: Configuration Template Drift (`VI_KEYS`)**
+### **BUG-27: Configuration Template Drift (`VI_KEYS`)**
 *   **Description**: Discrepancy in default visibility and documentation for `VI_KEYS`.
 *   **Findings**:
     *   `default_profile_template.h` uses `VI_KEYS=0`.
@@ -362,7 +384,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Ensure the `ytnova --init` generation path strictly matches the `etc/ytnova.conf` provided in the distribution.
 *   **Status**: Confirmed.
 
-### **BUG-27: VI Mode Key Ambiguity and Collisions**
+### **BUG-28: VI Mode Key Ambiguity and Collisions**
 *   **Description**: When `VI_KEYS=1` is enabled, lowercase navigation keys (`h/j/k/l`) collide with primary command keys without clear UI signaling.
 *   **Findings**:
     *   `j` maps to both `ACTION_MOVE_DOWN` (via `VI_KEY_DOWN`) and historically to `ACTION_LOG_VOLUME` (though currently `l/L` is the log volume key, older documentation/muscle memory remains confused).
@@ -371,14 +393,14 @@ Ordering policy (for all editors, including AI editors):
 *   **Remediation**: Audit all `VI_KEY` remappings in `key_engine.c` and ensure the footer help lines (`display.c`) dynamically update to show the uppercase variants when `VI_KEYS=1`.
 *   **Status**: Confirmed.
 
-### **BUG-28: Incremental Search Legacy Mapping (`F12`)**
+### **BUG-29: Incremental Search Legacy Mapping (`F12`)**
 *   **Description**: `F12` is used as an alias for `/` (Incremental Search/Jump), but its presence is inconsistent in help strings and documentation.
 *   **Impact**: Confuses users about "hidden" keys.
 *   **Remediation**: Explicitly document `F12` as a legacy alias or deprecate it in favor of standard `/`.
 *   **Parity Principle:** Treat this as a documentation-parity defect class: no active keybinding may exist in runtime without consistent footer, `F1`, and manpage/USAGE coverage.
 *   **Status**: Confirmed.
 
-### **BUG-29: Misleading Tree Expansion Action Names**
+### **BUG-30: Misleading Tree Expansion Action Names**
 *   **Description**: The internal `YtreeNovaAction` names for tree expansion are swapped relative to their behavior and documentation.
 *   **Findings**:
     *   `+` key maps to `ACTION_TREE_EXPAND_ALL`, but only expands **one level**.
@@ -389,7 +411,7 @@ Ordering policy (for all editors, including AI editors):
     *   Rename `ACTION_ASTERISK` -> `ACTION_TREE_EXPAND_RECURSIVE`.
 *   **Status**: Confirmed.
 
-### **BUG-30: Intermittent Split-Brain Redraw Between Stats Box and Main Panes**
+### **BUG-31: Intermittent Split-Brain Redraw Between Stats Box and Main Panes**
 *   **Description**: Intermittently, the stats box redraw state can diverge from the main UI surfaces (`path`, `dir`, and `file` windows), leaving one surface fresh while the other appears stale/corrupted.
 *   **Impact**: Creates a visibly broken UI state and undermines trust in navigation context during active workflows.
 *   **Remediation**: Unify frame redraw ownership so stats and main panes are rendered from one layout snapshot in one update cycle, and force full-surface invalidation/redraw on resize/recovery/error paths.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -955,9 +955,135 @@ Ordering policy (for all editors, including AI editors):
 ---
 
 ## **Phase 7: Internationalization and Configurability**
-*   **Goal:** Refactor the application to support localization and user-defined keybindings, moving away from hardcoded English-centric values.
+*   **Goal:** Refactor the application to support role-based themes, localization, and user-defined keybindings, moving away from hardcoded English-centric values and colors.
 
-### **Task 60: Externalize UI Strings with GNU gettext (i18n Foundation)**
+### **Task 60: Establish Role-Based Theme System and Restrained Default Palette**
+*   **Goal:** Define and implement a role-based color/theme system with a restrained classic-blue default theme, a bash-black alternate theme, plain-text user-editable theme storage, and safe foreground/background handling that prevents color bleed between themes.
+*   **Priority:** High. The default visual identity will strongly affect first impressions, screenshots, user trust, and whether users perceive ytnova as focused or noisy.
+*   **Design Direction:**
+    *   There is one canonical default look: blue background, bright readable content, restrained structure, grey selection/dialog surfaces, and road-sign alert colors.
+    *   Use color for structure, state, and exceptional meaning, not decoration.
+    *   Default public theme should be a restrained classic blue TUI:
+        *   blue main background;
+        *   bright white for filenames, paths, dynamic values, keybindings, changing text, and tree guide lines;
+        *   white for static labels, fixed captions, and stats titles;
+        *   cyan on blue for panel borders, separators, dialog boxes, and window frames;
+        *   black on light grey for selections, bars, and neutral dialogs;
+        *   bright white on blue for informational text;
+        *   black on yellow for warnings;
+        *   bright white on red for errors;
+        *   black on yellow for search hits or rare standout emphasis.
+    *   Avoid frequent yellow, green, or bright/cyan-heavy text in the default theme. Loud colors must be rare.
+    *   Keep UI chrome quieter than file/content text.
+    *   Global/branch/showall mode should be indicated through panel titles, status labels, frame accents, or subtle markers rather than making ordinary filenames loud.
+    *   The default theme should preserve the xtree/ztree-derived feel while avoiding rainbow-style orthodox file-manager visual noise.
+*   **Role Granularity Direction:**
+    *   Provide enough semantic roles to control important visual categories without requiring users to configure every widget separately.
+    *   Prefer broad reusable roles over per-window/per-line duplication.
+    *   Minimum roles:
+        *   `background`: default application background.
+        *   `box_lines`: panel borders, separators, dialog boxes, and window frames.
+        *   `tree_lines`: tree guide glyphs; default follows dynamic/content text rather than border chrome.
+        *   `static_text`: fixed labels/captions and text that rarely changes.
+        *   `dynamic_text`: filenames, paths, counts, sizes, timestamps, current mode values, tree names, and file names.
+        *   `keybind`: footer/menu keybinding characters.
+        *   `selection`: active highlighted row/bar.
+        *   `dialog`: neutral prompt/dialog surface.
+        *   `info`: informational road-sign color.
+        *   `warning`: warning road-sign color.
+        *   `error`: error road-sign color.
+        *   `search_hit`: standout search/current-hit highlight.
+        *   `disabled`: inactive or unavailable commands/options.
+    *   Do not add a separate `critical` role; fatal failures are generally outside useful interactive rendering scope.
+    *   Allow advanced themes to override narrower roles later, but default theme files should stay short and readable.
+*   **Theme vs File-Type Coloring:**
+    *   Themes and file-type coloring are separate concerns.
+    *   A theme defines semantic UI roles.
+    *   File-type coloring is an optional content-decoration layer defined by the active theme.
+    *   Any theme may define its own file-type coloring palette.
+    *   If the active theme defines no file-type palette rules, all filenames use the theme `dynamic_text`/filename role.
+    *   File-type colors must never assume a specific theme background or reduce readability on the active theme.
+*   **File-Type Palette Format Direction:**
+    *   File-type palettes belong to themes, so different themes can define different extension colors.
+    *   If the active theme defines no file-type palette rules, all filenames use the theme `dynamic_text`/filename role.
+    *   If an extension is not listed in the active theme palette, it uses the default filename color.
+    *   Prefer compact grouped rules over one line per extension, for example:
+        *   `red: tar,tgz,arj,taz,lzh,zip,z,Z,gz,bz2,deb,rpm,jar,rar,7z,iso,img`
+        *   `+cyan: sh,bash,zsh,py,pl,rb`
+    *   The left side should accept the same color syntax as theme roles, including optional background:
+        *   `red`
+        *   `+red`
+        *   `red on blue`
+        *   `+cyan on black`
+    *   When a file-type rule omits a background, inherit the active theme filename background but still resolve to a complete foreground/background pair internally.
+    *   Legacy numeric color pairs may remain supported for compatibility, but new examples should use named colors.
+*   **Configuration Direction:**
+    *   Preserve compatibility with existing color settings where practical.
+    *   Add `grey` / `gray` support for dark grey.
+    *   Add `+grey` / `+gray` support for light grey.
+    *   Add a bright-prefix syntax such as `+red`, `+yellow`, `+white`, and `+grey`.
+    *   Prefer canonical plain-text style syntax such as:
+        *   `+white on blue`
+        *   `white on blue`
+        *   `cyan on blue`
+        *   `black on +grey`
+        *   `black on yellow`
+        *   `+white on red`
+    *   Move larger theme definitions out of the main `~/.ytnova` config into a plain-text theme file `~/.ythemes`, while keeping `~/.ytnova` for selecting the active theme.
+    *   `~/.ythemes` may contain an unlimited number of named themes.
+    *   Used theme definitions are uncommented.
+    *   Unused bundled or user themes can be prefixed with `#` to comment them out.
+    *   The format should remain friendly to user edits and future contributed themes, such as light variants, beige themes, or alternate black-background themes.
+*   **Default Palette Direction:**
+    *   `background = blue`
+    *   `box_lines = cyan on blue`
+    *   `tree_lines = +white on blue`
+    *   `static_text = white on blue`
+    *   `dynamic_text = +white on blue`
+    *   `keybind = +white on blue`
+    *   `selection = black on +grey`
+    *   `dialog = black on +grey`
+    *   `info = +white on blue`
+    *   `warning = black on yellow`
+    *   `error = +white on red`
+    *   `search_hit = black on yellow`
+    *   `disabled = grey on blue`
+*   **Implementation Direction:**
+    *   Audit existing color options, including whether `WINERR_COLOR` and `ERR_COLOR` are duplicates or whether one is unused.
+    *   Audit `src/ui/color.c` and all window background/border drawing paths for reversed color-pair use, unintended `A_REVERSE`, foreground-only styling, and stale background attributes.
+    *   Replace ad-hoc foreground-only coloring with complete role resolution where each rendered style resolves to a foreground and background.
+    *   Ensure `cyan,blue` renders cyan glyphs on blue background, never blue glyphs on cyan background.
+    *   Ensure panel borders and stats borders draw cyan line glyphs on blue background; they must not set the whole panel fill to cyan.
+    *   Ensure stats titles render as white on blue and stats dynamic values render as bright white on blue.
+    *   Ensure tree and file names render as bright white on blue in the classic-blue theme.
+    *   Ensure switching from black-theme coloring to blue-theme coloring cannot leave black-background or incompatible file-color attributes behind.
+    *   Set window background once per refresh path and clear/redraw safely; avoid background changes inside per-row rendering loops.
+    *   Keep file-type color application as a distinct optional layer after base theme role resolution.
+*   **Theme Set:**
+    *   Provide at least two built-in themes:
+        *   `classic-blue`: restrained public/default theme.
+        *   `bash-black`: power-user black-background theme with optional richer file coloring.
+    *   Future in-app theme editing should operate on semantic roles and the separate file-type coloring layer rather than exposing unrelated one-off color knobs.
+*   **Out of Scope / Follow-On:**
+    *   Modal-dialog placement may deserve separate UX work. XTree/ZTree-style footer prompts can be preferable because they appear where the user is already looking, but that should be handled as a separate interaction-design task rather than bundled into the theme system.
+*   **Acceptance Criteria:**
+    *   The default theme is readable, restrained, and suitable for screenshots.
+    *   Normal filenames, tree names, tree lines, paths, keybindings, and dynamic values are bright white or otherwise high-contrast in the classic-blue theme.
+    *   Static labels and stats titles are white or otherwise clearly readable in the classic-blue theme.
+    *   Error text uses bright white on red.
+    *   Warning and search-hit styling uses black on yellow.
+    *   Yellow is reserved for warnings/search/rare emphasis and is not used for frequent ordinary states.
+    *   File-type coloring can be omitted from a theme, leaving filenames on the default filename/`dynamic_text` role.
+    *   Any theme can define its own file-type coloring palette.
+    *   File-type colors do not bleed assumptions from one theme into another theme.
+    *   `grey`/`gray`, `+grey`/`+gray`, and `+color` bright-prefix parsing are documented and tested.
+    *   Theme implementation proves foreground/background pair correctness.
+    *   `docs/SPECIFICATION.md` documents the user-visible theme/color contract.
+    *   `docs/ARCHITECTURE.md` documents the rendering/config invariants.
+    *   Existing user color configuration remains compatible where practical, with documented migration behavior for any renamed/deprecated options.
+*   - [ ] **Status:** Not Started.
+
+### **Task 61: Externalize UI Strings with GNU gettext (i18n Foundation)**
 *   **Description:** Replace hardcoded user-facing strings with gettext-backed message lookups (`gettext`/`_()`), initialize locale/domain at startup, and add a standard catalog workflow (`.pot` -> `.po` -> compiled catalogs). Keep default locale as English while enabling translation packs.
 *   **Documentation i18n split:** Use `po4a` for manpage/doc translation workflow (source: `etc/ytnova.1.md`; generated docs stay derived artifacts). Use gettext for runtime UI surfaces (`F1`, footer labels/help, prompts, status/error/info text).
 *   **Translation path policy:** Define default translation discovery paths for system and user installs (for example system locale catalogs under `/usr/share/locale/.../LC_MESSAGES/ytnova.mo` with a user-level override path), and document contributor workflow for adding a language.
@@ -965,7 +1091,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** For C/POSIX terminal software, GNU gettext is the most conventional and broadly understood approach. It has mature tooling, standard translator workflow, and broad ecosystem familiarity; a custom loadable language-file system would add avoidable maintenance and onboarding cost.
 *   - [ ] **Status:** Not Started.
 
-### **Task 61: Implement Configurable Keymap**
+### **Task 62: Implement Configurable Keymap**
 *   **Description:** Abstract all hardcoded key commands (e.g., 'm', '^N') into a configurable keymap loaded from a separate keymap profile file. The core application logic will respond to command identifiers (e.g., `CMD_MOVE`), not raw characters. This will allow users to customize their workflow and resolve keybinding conflicts.
 *   **Sequencing dependency:** Implement after Task 45 (Ctrl-held footer signaling + footer wording cleanup). Prefer completing Task 46 parity gate first so keymap work lands on a stable footer/F1 contract.
 *   **Config contract:** Select profile via `ytnova.conf` (opt-in), keeping a stable default keymap for existing users.

--- a/etc/ytnova.conf
+++ b/etc/ytnova.conf
@@ -99,57 +99,57 @@ TAGGEDVIEWER=internal
 # UI Color Customization
 # Colors can be specified as:
 # Each color pair is written as: foreground,background
-# 1. Standard colors: black(0), red(1), green(2), yellow(3), blue(4), magenta(5), cyan(6), white(7)
-#    Bright colors: black(8), red(9), green(10), yellow(11), blue(12), magenta(13), cyan(14), white(15)
+# 1. Standard colors: black(0), red(1), green(2), yellow(3), blue(4), magenta(5), cyan(6), white(7), grey(8)
+#    Bright colors: red(9), green(10), yellow(11), blue(12), magenta(13), cyan(14), white(15)
 # 2. Numeric codes (0-255) for 256-color terminals (e.g., TERM=xterm-256color)
 #
 [COLORS]
-# Default "Terminal Classic" (Bash-like 256-color Theme)
-# Dull white on black, bright white hotkeys, dull yellow highlights.
-# DIR_COLOR=7,0       # Dull White on Black
-# HIDIR_COLOR=0,3     # Black on Dull Yellow (Selection)
-# WINDIR_COLOR=7,0    # Window text/borders
-# FILE_COLOR=7,0      # File list text
-# HIFILE_COLOR=0,3    # Black on Dull Yellow (Selection)
-# WINFILE_COLOR=7,0   # File window text/borders
-# STATS_COLOR=7,0     # Directory/File stats panel text
-# WINSTATS_COLOR=7,0  # Stats window text/borders
-# BORDERS_COLOR=8,0   # Bright Black (Gray) borders
-# MENU_COLOR=7,0      # Footer Menu Text
-# DIALOG_COLOR=7,0    # Neutral dialog/picker text/background
-# HIMENUS_COLOR=15,0  # Footer Key Bindings (Bright White)
-# WINERR_COLOR=15,1   # Bright White on Red
-# HST_COLOR=7,0       # Text background for F2 History
-# HIHST_COLOR=0,3     # Selected entry in F2 History
-# WINHST_COLOR=7,0    # Window background for F2 History
-# GLOBAL_COLOR=3,0    # Search-hit text (non-selected)
-# HIGLOBAL_COLOR=15,3 # Search-hit highlight (selected)
+# Classic Blue
+# DIR_COLOR=15,blue           # Directory text
+# HIDIR_COLOR=black,white     # Selected directory entry
+# WINDIR_COLOR=cyan,blue      # Directory window text/borders
+# FILE_COLOR=15,blue          # File list text
+# HIFILE_COLOR=black,white    # Selected file entry
+# WINFILE_COLOR=cyan,blue     # File window text/borders
+# STATS_COLOR=15,blue         # Directory/File stats panel text
+# WINSTATS_COLOR=cyan,blue    # Stats window text/borders
+# BORDERS_COLOR=cyan,blue     # Window borders
+# MENU_COLOR=cyan,blue        # Footer menu text
+# DIALOG_COLOR=black,white    # Neutral dialog/picker text/background
+# HIMENUS_COLOR=15,blue       # Footer key bindings
+# WINERR_COLOR=white,magenta  # Error dialog text/background
+# HST_COLOR=15,blue           # F2 History text
+# HIHST_COLOR=black,white     # Selected F2 History entry
+# WINHST_COLOR=cyan,blue      # F2 History window text/borders
+# GLOBAL_COLOR=15,blue        # Search-hit text (non-selected)
+# HIGLOBAL_COLOR=black,yellow # Search-hit highlight (selected)
 # INFO_COLOR=15,4     # Bright White on Blue (non-bright: 7,4)
 # WARN_COLOR=11,0     # Bright Yellow on Black (non-bright: 3,0)
 # ERR_COLOR=15,1      # Bright White on Red (non-bright: 7,1)
 
-# Example "Classic Blue" color scheme
-# DIR_COLOR=white,blue        # Directory text
-# HIDIR_COLOR=black,white     # Selected directory entry
-# WINDIR_COLOR=cyan,blue      # Directory window text/borders
-# FILE_COLOR=white,blue       # File list text
-# HIFILE_COLOR=black,white    # Selected file entry
-# WINFILE_COLOR=cyan,blue     # File window text/borders
-# STATS_COLOR=blue,cyan       # Directory/File stats panel text
-# WINSTATS_COLOR=blue,cyan    # Stats window text/borders
-# BORDERS_COLOR=blue,cyan     # Window borders
-# MENU_COLOR=cyan,blue        # Footer menu text
-# DIALOG_COLOR=cyan,blue      # Neutral dialog/picker text/background
-# HIMENUS_COLOR=white,blue    # Footer key bindings
-# WINERR_COLOR=blue,white     # Error dialog text/background
-# HST_COLOR=yellow,cyan       # F2 History text
-# HIHST_COLOR=white,white     # Selected F2 History entry
-# WINHST_COLOR=yellow,cyan    # F2 History window text/borders
-# GLOBAL_COLOR=yellow,cyan    # Search-hit text (non-selected)
-# HIGLOBAL_COLOR=white,yellow # Search-hit highlight (selected)
-# INFO_COLOR=white,blue       # Info dialog text/background
-# WARN_COLOR=yellow,black     # Warning text/background
-# ERR_COLOR=red,white         # Error text/background
+# Terminal (Bash-like 256-color Theme)
+Dull white on black, bright white hotkeys, dull yellow highlights.
+DIR_COLOR=7,0       # Dull White on Black
+HIDIR_COLOR=0,3     # Black on Dull Yellow (Selection)
+WINDIR_COLOR=7,0    # Window text/borders
+FILE_COLOR=7,0      # File list text
+HIFILE_COLOR=0,3    # Black on Dull Yellow (Selection)
+WINFILE_COLOR=7,0   # File window text/borders
+STATS_COLOR=7,0     # Directory/File stats panel text
+WINSTATS_COLOR=7,0  # Stats window text/borders
+BORDERS_COLOR=8,0   # Bright Black (Gray) borders
+MENU_COLOR=7,0      # Footer Menu Text
+DIALOG_COLOR=7,0    # Neutral dialog/picker text/background
+HIMENUS_COLOR=15,0  # Footer Key Bindings (Bright White)
+WINERR_COLOR=15,1   # Bright White on Red
+HST_COLOR=7,0       # Text background for F2 History
+HIHST_COLOR=0,3     # Selected entry in F2 History
+WINHST_COLOR=7,0    # Window background for F2 History
+GLOBAL_COLOR=3,0    # Search-hit text (non-selected)
+HIGLOBAL_COLOR=15,3 # Search-hit highlight (selected)
+INFO_COLOR=15,4     # Bright White on Blue (non-bright: 7,4)
+WARN_COLOR=11,0     # Bright Yellow on Black (non-bright: 3,0)
+ERR_COLOR=15,1      # Bright White on Red (non-bright: 7,1)
 
 #
 # File Type Colorization

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_cmd.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include <assert.h>
@@ -159,7 +160,8 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
                                  state->saved_file_selection_name);
     }
   }
-  panel->saved_focus = state->saved_focus;
+  if (!AppStateCommitPanelFocus(ctx, panel, state->saved_focus))
+    return;
   panel->saved_big_file_view = state->saved_big_file_view;
 }
 
@@ -289,7 +291,9 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
         ResetPanelFileContext(panel);
         panel->vol = found_vol;
         s = &panel->vol->vol_stats;
-        panel->saved_focus = panel->vol->saved_focus;
+        if (!AppStateCommitPanelFocus(ctx, panel,
+                                      (ViewFocus)panel->vol->saved_focus))
+          return -1;
         state = FindPanelVolumeFileState(panel, panel->vol->id);
         if (state)
           panel->panel_generation = state->saved_tree_panel_generation;
@@ -439,7 +443,9 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
   ResetPanelFileContext(panel);
   panel->vol = loaded_vol;
   s = &panel->vol->vol_stats;
-  panel->saved_focus = panel->vol->saved_focus;
+  if (!AppStateCommitPanelFocus(ctx, panel,
+                                (ViewFocus)panel->vol->saved_focus))
+    return -1;
   ctx->global_search_term[0] = '\0';
   ctx->view_mode = s->log_mode;
 

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -727,7 +727,8 @@ file_window_done:
      * handoff to a tree-focused peer is different: the previous file panel is
      * now inactive and must keep its file-window shape frozen.
      */
-    owner_panel->saved_focus = FOCUS_TREE;
+    if (!AppStateCommitPanelFocus(ctx, owner_panel, FOCUS_TREE))
+      return ESC;
     owner_panel->saved_big_file_view = FALSE;
   }
   if (!volume_changed) {

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1497,7 +1497,8 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
   panel->file_dir_entry = dir_entry;
   panel->start_file = dir_entry->start_file;
   panel->file_cursor_pos = dir_entry->cursor_pos;
-  panel->saved_focus = FOCUS_FILE;
+  if (!AppStateCommitPanelFocus(ctx, panel, FOCUS_FILE))
+    return dir_entry;
   if (!dir_entry->global_flag && !dir_entry->tagged_flag) {
     dir_entry->big_window = panel->saved_big_file_view;
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6034,6 +6034,45 @@ def test_split_directory_focus_commits_use_appstate_helper() -> None:
     assert body.count("AppStateMirrorActivePanelFocus(ctx)") >= 2
 
 
+def test_focus_restore_commits_use_appstate_helper() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+
+    dir_start = dir_ops.index("DirEntry *RestorePanelFileSelection(")
+    dir_end = dir_ops.index("\nDirWindowDispatchResult", dir_start)
+    dir_body = dir_ops[dir_start:dir_end]
+    assert "AppStateCommitPanelFocus(ctx, panel, FOCUS_FILE)" in dir_body
+    assert "panel->saved_focus = FOCUS_FILE" not in dir_body
+
+    file_start = ctrl_file.index("int HandleFileWindow(")
+    file_body = ctrl_file[file_start:]
+    assert "AppStateCommitPanelFocus(ctx, owner_panel, FOCUS_TREE)" in file_body
+    assert "owner_panel->saved_focus = FOCUS_TREE" not in file_body
+
+    restore_start = log_source.index("static void RestorePanelFileSelection(")
+    restore_end = log_source.index("\nstatic void SavePanelTreeSelection(", restore_start)
+    restore_body = log_source[restore_start:restore_end]
+    assert 'include "ytnova_appstate_focus.h"' in log_source
+    assert "AppStateCommitPanelFocus(ctx, panel, state->saved_focus)" in restore_body
+    assert "panel->saved_focus = state->saved_focus" not in restore_body
+
+    log_start = log_source.index("int LogDisk(")
+    log_end = log_source.index("\nint GetNewLogPath(", log_start)
+    log_body = log_source[log_start:log_end]
+    assert "panel->saved_focus = panel->vol->saved_focus" not in log_body
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelFocus\(\s*ctx,\s*panel,\s*"
+                r"\(ViewFocus\)panel->vol->saved_focus\s*\)",
+                log_body,
+            )
+        )
+        >= 2
+    )
+
+
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     validation = (


### PR DESCRIPTION
## Summary
- Routes focus-restore writes through the AppState focus helper for panel restore, file-window exit, and loaded-volume restore paths.
- Adds guard coverage that fails on direct focus restore assignments in those paths.

## Validation
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py tests/test_panel_isolation.py tests/test_archive_exit_ui.py -q`
- `git diff --check`
