### PR TITLE
refactor(appstate): route split seeded focus commits through helper

### DIFF
--- a/include/ytnova_panel_anchor.h
+++ b/include/ytnova_panel_anchor.h
@@ -33,7 +33,8 @@ BOOL RestorePanelTreeViewportSnapshot(ViewContext *ctx, YtreeNovaPanel *panel);
 void RememberPanelViewportTop(YtreeNovaPanel *panel);
 void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,
                             const char *anchor_path);
-void DonatePanelState(YtreeNovaPanel *dst, const YtreeNovaPanel *src);
+BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
+                      const YtreeNovaPanel *src);
 DirEntry *FindDirByPathInTree(DirEntry *entry, const char *path);
 void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
                               YtreeNovaPanel *panel, const char *label);

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include "ytnova_ui.h"
@@ -618,7 +619,8 @@ CopyPanelVolumeFileState(const PanelVolumeFileState *src) {
   return head;
 }
 
-void DonatePanelState(YtreeNovaPanel *dst, const YtreeNovaPanel *src) {
+BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
+                      const YtreeNovaPanel *src) {
   char file_dir_path[PATH_LENGTH + 1];
   BOOL dst_saved_big_file_view;
   int dst_cursor_pos;
@@ -635,8 +637,8 @@ void DonatePanelState(YtreeNovaPanel *dst, const YtreeNovaPanel *src) {
   PanelVolumeFileState *volume_file_state;
   BOOL source_is_file;
 
-  if (!dst || !src || dst == src)
-    return;
+  if (!ctx || !dst || !src || dst == src)
+    return FALSE;
   assert(!dst->vol || !src->vol || dst->vol == src->vol);
   assert(src->saved_focus != FOCUS_FILE ||
          src->file_selection_dir_path[0] != '\0');
@@ -690,7 +692,8 @@ void DonatePanelState(YtreeNovaPanel *dst, const YtreeNovaPanel *src) {
   dst->max_column = src->max_column;
   dst->current_dir_entry = src->current_dir_entry;
   dst->panel_generation = src->panel_generation;
-  dst->saved_focus = src->saved_focus;
+  if (!AppStateCommitPanelFocus(ctx, dst, src->saved_focus))
+    return FALSE;
   dst->saved_big_file_view = src->saved_big_file_view;
   dst->max_visual_filename_len = src->max_visual_filename_len;
   dst->max_visual_linkname_len = src->max_visual_linkname_len;
@@ -721,7 +724,8 @@ void DonatePanelState(YtreeNovaPanel *dst, const YtreeNovaPanel *src) {
                      sizeof(dst->file_selection_dir_path), "%s",
                      dst_current_volume_state->saved_file_selection_dir_path);
     } else {
-      dst->saved_focus = FOCUS_FILE;
+      if (!AppStateCommitPanelFocus(ctx, dst, FOCUS_FILE))
+        return FALSE;
       dst->saved_big_file_view = dst_saved_big_file_view;
       dst->start_file = dst_start_file;
       dst->file_cursor_pos = dst_file_cursor_pos;
@@ -733,12 +737,14 @@ void DonatePanelState(YtreeNovaPanel *dst, const YtreeNovaPanel *src) {
                      sizeof(dst->file_selection_dir_path), "%s",
                      dst_file_selection_dir_path);
     }
-    dst->saved_focus = FOCUS_TREE;
+    if (!AppStateCommitPanelFocus(ctx, dst, FOCUS_TREE))
+      return FALSE;
   } else {
     FreePanelVolumeFileState(dst->volume_file_state);
     dst->volume_file_state = volume_file_state;
   }
   RestorePanelAnchorPath(dst->vol, dst, file_dir_path);
+  return TRUE;
 }
 
 DirEntry *FindDirByPathInTree(DirEntry *entry, const char *path) {

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -299,8 +299,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
       }
       CaptureSplitFilePanelSnapshot(stable_panel, &stable_panel_snapshot);
 #endif
-      if (donate_active_state && ctx->left && ctx->right)
-        DonatePanelState(ctx->left, ctx->right);
+      if (donate_active_state && ctx->left && ctx->right &&
+          !DonatePanelState(ctx, ctx->left, ctx->right))
+        return FALSE;
 
       ctx->is_split_screen = !ctx->is_split_screen;
       if (closing_split)
@@ -325,7 +326,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
            * focus or it will redraw as a tree panel and break per-panel file
            * state on the first Tab.
            */
-          ctx->right->saved_focus = FOCUS_FILE;
+          if (!AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_FILE))
+            return FALSE;
           ctx->right->start_file = ctx->left->start_file;
           ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
           (void)snprintf(ctx->right->file_selection_name,
@@ -493,12 +495,14 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         donate_active_state = TRUE;
 
       if (donate_active_state && ctx->left && ctx->right) {
-        DonatePanelState(ctx->left, ctx->right);
+        if (!DonatePanelState(ctx, ctx->left, ctx->right))
+          return FALSE;
         ctx->left->cursor_pos = source_cursor_pos;
         ctx->left->disp_begin_pos = source_disp_begin_pos;
         ctx->left->current_dir_entry = source_current_dir_entry;
         ctx->left->panel_generation = source_panel_generation;
-        ctx->left->saved_focus = FOCUS_TREE;
+        if (!AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE))
+          return FALSE;
       }
       if (preserve_left_file_state && !donate_active_state && ctx->left &&
           ctx->left->vol) {
@@ -506,8 +510,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         if (left_dir_entry)
           CapturePanelSelectionAnchor(ctx, ctx->left, left_dir_entry);
       }
-      if (closing_active)
-        closing_active->saved_focus = FOCUS_TREE;
+      if (closing_active &&
+          !AppStateCommitPanelFocus(ctx, closing_active, FOCUS_TREE))
+        return FALSE;
       ctx->is_split_screen = !ctx->is_split_screen;
       if (closing_split)
         ctx->active = ctx->left;
@@ -527,15 +532,17 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
           ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
           ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
           ctx->right->hide_dot_files = ctx->left->hide_dot_files;
-          ctx->right->saved_focus = FOCUS_TREE;
+          if (!AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_TREE))
+            return FALSE;
           FreeFileEntryList(ctx->right);
         }
       } else {
         FreeFileEntryList(ctx->right);
         ctx->active = ctx->left;
         *dir_entry_ptr = GetPanelDirEntry(ctx->active);
-        if (preserve_left_file_state && !donate_active_state)
-          ctx->active->saved_focus = FOCUS_FILE;
+        if (preserve_left_file_state && !donate_active_state &&
+            !AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
+          return FALSE;
         if (ctx->active->saved_focus == FOCUS_FILE) {
           if (ctx->active->file_selection_dir_path[0] != '\0') {
             /*

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5345,9 +5345,12 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
   (void)panel;
   (void)dir_entry;
 }
-void DonatePanelState(YtreeNovaPanel *dst, const YtreeNovaPanel *src) {
+BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
+                      const YtreeNovaPanel *src) {
+  (void)ctx;
   (void)dst;
   (void)src;
+  return TRUE;
 }
 void ReCreateWindows(ViewContext *ctx) { (void)ctx; }
 void SyncActivePanelWindows(ViewContext *ctx) { (void)ctx; }
@@ -6071,6 +6074,35 @@ def test_focus_restore_commits_use_appstate_helper() -> None:
         )
         >= 2
     )
+
+
+def test_split_seeded_focus_commits_use_appstate_helper() -> None:
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
+    panel_header = Path("include/ytnova_panel_anchor.h").read_text(encoding="utf-8")
+
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+    assert 'include "ytnova_appstate_focus.h"' in panel_anchor
+    assert "BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst" in panel_header
+    assert "AppStateCommitPanelFocus(ctx, dst, src->saved_focus)" in donate_body
+    assert "AppStateCommitPanelFocus(ctx, dst, FOCUS_FILE)" in donate_body
+    assert "AppStateCommitPanelFocus(ctx, dst, FOCUS_TREE)" in donate_body
+    assert not re.search(r"\bdst->saved_focus\s*=", donate_body)
+
+    file_start = split_transition.index("BOOL SplitTransition_HandleFileWindowAction(")
+    dir_start = split_transition.index("\nBOOL SplitTransition_HandleDirWindowAction(", file_start)
+    file_body = split_transition[file_start:dir_start]
+    dir_body = split_transition[dir_start:]
+
+    assert "DonatePanelState(ctx, ctx->left, ctx->right)" in split_transition
+    assert not re.search(r"\bctx->right->saved_focus\s*=", file_body)
+    assert "AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_FILE)" in file_body
+    assert not re.search(r"\bctx->left->saved_focus\s*=", dir_body)
+    assert not re.search(r"\bclosing_active->saved_focus\s*=", dir_body)
+    assert not re.search(r"\bctx->right->saved_focus\s*=", dir_body)
+    assert not re.search(r"\bctx->active->saved_focus\s*=(?!=)", dir_body)
 
 
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:


### PR DESCRIPTION
## Summary
- Routes split panel seed/donation focus writes through the AppState focus helper.
- Makes panel state donation fail closed when the focus helper rejects a commit.
- Adds guard coverage for split seeded focus paths.

## Validation
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py tests/test_panel_isolation.py -q`
- `git diff --check`
