### PR TITLE
refactor(appstate): route initial focus commits through helper

### DIFF
--- a/src/core/init.c
+++ b/src/core/init.c
@@ -9,6 +9,7 @@
  ***************************************************************************/
 
 #include "ytnova_defs.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_debug.h"
 #include "default_profile_template.h"
 #include <fcntl.h>
@@ -351,7 +352,6 @@ void InitView(ViewContext *ctx) {
   ctx->view_mode = DISK_MODE;
   ctx->dir_mode = MODE_3;
   ctx->is_split_screen = FALSE;
-  ctx->focused_window = FOCUS_TREE;
 
   /* Initialize Panels */
   ctx->left = (YtreeNovaPanel *)calloc(1, sizeof(YtreeNovaPanel));
@@ -361,7 +361,6 @@ void InitView(ViewContext *ctx) {
   }
   DEBUG_LOG("InitView: setup left panel=%p", (void *)ctx->left);
   ctx->left->file_mode = MODE_1;
-  ctx->left->saved_focus = FOCUS_TREE;
   ctx->left->file_cursor_pos = 0;
   ctx->left->file_dir_entry = NULL;
   ctx->left->saved_big_file_view = FALSE;
@@ -376,13 +375,21 @@ void InitView(ViewContext *ctx) {
   }
   DEBUG_LOG("InitView: setup right panel=%p", (void *)ctx->right);
   ctx->right->file_mode = MODE_1;
-  ctx->right->saved_focus = FOCUS_TREE;
   ctx->right->file_cursor_pos = 0;
   ctx->right->file_dir_entry = NULL;
   ctx->right->saved_big_file_view = FALSE;
   ctx->right->hide_dot_files = FALSE;
 
   ctx->active = ctx->left;
+  if (!AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE) ||
+      !AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_TREE)) {
+    fprintf(stderr, "InitView: failed to initialize panel focus\n");
+    free(ctx->right);
+    free(ctx->left);
+    ctx->right = NULL;
+    ctx->left = NULL;
+    exit(1);
+  }
 
   DEBUG_LOG("EXIT InitView");
 }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6105,6 +6105,24 @@ def test_split_seeded_focus_commits_use_appstate_helper() -> None:
     assert not re.search(r"\bctx->active->saved_focus\s*=(?!=)", dir_body)
 
 
+def test_initial_focus_commits_use_appstate_helper() -> None:
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+    init_start = init_source.index("void InitView(")
+    init_end = init_source.index("\nvoid CoreMainOps_Register(", init_start)
+    init_body = init_source[init_start:init_end]
+
+    assert 'include "ytnova_appstate_focus.h"' in init_source
+    assert not re.search(r"\bctx->focused_window\s*=", init_body)
+    assert not re.search(r"\bctx->left->saved_focus\s*=", init_body)
+    assert not re.search(r"\bctx->right->saved_focus\s*=", init_body)
+    assert "ctx->active = ctx->left;" in init_body
+    assert "AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE)" in init_body
+    assert "AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_TREE)" in init_body
+    assert init_body.index("ctx->active = ctx->left;") < init_body.index(
+        "AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE)"
+    )
+
+
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     validation = (


### PR DESCRIPTION
## Summary
- Routes initial session and panel focus setup through the AppState focus helper.
- Fails closed during initialization if focus commits are rejected.
- Adds guard coverage preventing direct initial focus assignments.

## Validation
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `git diff --check`
