### PR TITLE
refactor(appstate): route volume focus mirrors through helper

### DIFF
--- a/include/ytnova_appstate_focus.h
+++ b/include/ytnova_appstate_focus.h
@@ -12,6 +12,7 @@
 
 BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
                               ViewFocus focus);
+BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus);
 BOOL AppStateMirrorActivePanelFocus(ViewContext *ctx);
 
 #endif /* YTNOVA_APPSTATE_FOCUS_H */

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -223,7 +223,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
     ctx->hook_suspend_clock(ctx); /* Suspend clock during critical operations */
 
   if (panel->vol != NULL) {
-    panel->vol->saved_focus = panel->saved_focus;
+    if (!AppStateCommitVolumeFocusMirror(panel->vol, panel->saved_focus))
+      return -1;
   }
 
   /* Keep per-volume tree selection before switching away. */

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_defs.h"
+#include "ytnova_appstate_focus.h"
 
 extern void FreePathList(PathList *list);
 
@@ -110,7 +111,10 @@ struct Volume *Volume_Create(ViewContext *ctx) {
   /* Assign a unique ID and increment the serial counter */
   new_vol->id = ctx->volume_serial++;
   new_vol->volume_generation = 0;
-  new_vol->saved_focus = FOCUS_TREE;
+  if (!AppStateCommitVolumeFocusMirror(new_vol, FOCUS_TREE)) {
+    free(new_vol);
+    return NULL;
+  }
 
   /* Add the new volume to the global hash table (ctx->volumes_head)
    * The 'id' field of the Volume struct is used as the key. */

--- a/src/ui/appstate_focus.c
+++ b/src/ui/appstate_focus.c
@@ -25,6 +25,18 @@ BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
   return TRUE;
 }
 
+BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus) {
+  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
+    return FALSE;
+  if (!volume)
+    return FALSE;
+  if (focus != FOCUS_TREE && focus != FOCUS_FILE)
+    return FALSE;
+
+  volume->saved_focus = focus;
+  return TRUE;
+}
+
 BOOL AppStateMirrorActivePanelFocus(ViewContext *ctx) {
   if (!ctx || !ctx->active)
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6123,6 +6123,29 @@ def test_initial_focus_commits_use_appstate_helper() -> None:
     )
 
 
+def test_volume_focus_mirrors_use_appstate_helper() -> None:
+    focus_header = Path("include/ytnova_appstate_focus.h").read_text(encoding="utf-8")
+    focus_helper = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
+    volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitVolumeFocusMirror(" in focus_header
+    assert "AppStateCommitVolumeFocusMirror" in focus_helper
+
+    volume_start = volume_source.index("struct Volume *Volume_Create(")
+    volume_end = volume_source.index("\nvoid Volume_Delete(", volume_start)
+    volume_body = volume_source[volume_start:volume_end]
+    assert 'include "ytnova_appstate_focus.h"' in volume_source
+    assert "AppStateCommitVolumeFocusMirror(new_vol, FOCUS_TREE)" in volume_body
+    assert "new_vol->saved_focus = FOCUS_TREE" not in volume_body
+
+    log_start = log_source.index("int LogDisk(")
+    log_end = log_source.index("\nint GetNewLogPath(", log_start)
+    log_body = log_source[log_start:log_end]
+    assert "AppStateCommitVolumeFocusMirror(panel->vol, panel->saved_focus)" in log_body
+    assert "panel->vol->saved_focus = panel->saved_focus" not in log_body
+
+
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     validation = (


### PR DESCRIPTION
## Summary
- Routes volume focus mirror writes through the AppState focus helper boundary.
- Fails closed when a volume focus mirror commit is rejected.
- Adds guard coverage preventing direct volume focus mirror assignments.

## Validation
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `git diff --check`
