### PR TITLE
refactor(appstate): route file shape commits through helper

### DIFF
--- a/include/ytnova_appstate_focus.h
+++ b/include/ytnova_appstate_focus.h
@@ -12,6 +12,7 @@
 
 BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
                               ViewFocus focus);
+BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view);
 BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus);
 BOOL AppStateMirrorActivePanelFocus(ViewContext *ctx);
 

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -24,7 +24,7 @@ static void ResetPanelFileContext(YtreeNovaPanel *panel) {
   panel->file_dir_entry = NULL;
   panel->start_file = 0;
   panel->file_cursor_pos = 0;
-  panel->saved_big_file_view = FALSE;
+  (void)AppStateCommitPanelFileShape(panel, FALSE);
 }
 
 static void SavePanelFileSelection(YtreeNovaPanel *panel) {
@@ -55,7 +55,7 @@ static void SavePanelFileSelection(YtreeNovaPanel *panel) {
   }
   if (panel->file_dir_entry != NULL)
     state->saved_big_file_view = panel->file_dir_entry->big_window;
-  panel->saved_big_file_view = state->saved_big_file_view;
+  (void)AppStateCommitPanelFileShape(panel, state->saved_big_file_view);
 
   (void)snprintf(state->saved_file_selection_name,
                  sizeof(state->saved_file_selection_name), "%s",
@@ -125,7 +125,8 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
   panel->file_selection_name[0] = '\0';
   panel->file_selection_dir_path[0] = '\0';
   panel->file_dir_entry = NULL;
-  panel->saved_big_file_view = FALSE;
+  if (!AppStateCommitPanelFileShape(panel, FALSE))
+    return;
   if (!state)
     return;
 
@@ -162,7 +163,7 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
   }
   if (!AppStateCommitPanelFocus(ctx, panel, state->saved_focus))
     return;
-  panel->saved_big_file_view = state->saved_big_file_view;
+  (void)AppStateCommitPanelFileShape(panel, state->saved_big_file_view);
 }
 
 static void SavePanelTreeSelection(YtreeNovaPanel *panel) {

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -363,7 +363,6 @@ void InitView(ViewContext *ctx) {
   ctx->left->file_mode = MODE_1;
   ctx->left->file_cursor_pos = 0;
   ctx->left->file_dir_entry = NULL;
-  ctx->left->saved_big_file_view = FALSE;
   ctx->left->hide_dot_files = FALSE;
 
   ctx->right = (YtreeNovaPanel *)calloc(1, sizeof(YtreeNovaPanel));
@@ -377,11 +376,12 @@ void InitView(ViewContext *ctx) {
   ctx->right->file_mode = MODE_1;
   ctx->right->file_cursor_pos = 0;
   ctx->right->file_dir_entry = NULL;
-  ctx->right->saved_big_file_view = FALSE;
   ctx->right->hide_dot_files = FALSE;
 
   ctx->active = ctx->left;
-  if (!AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE) ||
+  if (!AppStateCommitPanelFileShape(ctx->left, FALSE) ||
+      !AppStateCommitPanelFileShape(ctx->right, FALSE) ||
+      !AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE) ||
       !AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_TREE)) {
     fprintf(stderr, "InitView: failed to initialize panel focus\n");
     free(ctx->right);

--- a/src/ui/appstate_focus.c
+++ b/src/ui/appstate_focus.c
@@ -25,6 +25,16 @@ BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view) {
+  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->saved_big_file_view = big_file_view ? TRUE : FALSE;
+  return TRUE;
+}
+
 BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus) {
   if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
     return FALSE;

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -381,13 +381,15 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
     (*dir_entry_ptr)->cursor_pos = file_cursor;
     if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
       return FALSE;
-    ctx->active->saved_big_file_view = FALSE;
+    if (!AppStateCommitPanelFileShape(ctx->active, FALSE))
+      return FALSE;
     CapturePanelSelectionAnchor(ctx, ctx->active, *dir_entry_ptr);
   } else {
     (*dir_entry_ptr)->cursor_pos = -1;
     if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_TREE))
       return FALSE;
-    ctx->active->saved_big_file_view = FALSE;
+    if (!AppStateCommitPanelFileShape(ctx->active, FALSE))
+      return FALSE;
   }
 
   ctx->active->file_dir_entry = *dir_entry_ptr;

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -254,6 +254,9 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   BOOL switched_panel = FALSE;
   BOOL switched_to_tree_panel = FALSE;
   BOOL return_esc = FALSE;
+  BOOL big_file_shape =
+      (dir_entry->big_window || dir_entry->global_flag ||
+       dir_entry->tagged_flag);
   YtreeNovaPanel *owner_panel = ctx->active;
   DirEntry *tracked_file_dir = ctx->active->file_dir_entry;
   const DirEntry *last_stats_dir = NULL; /* Track context changes */
@@ -263,8 +266,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
 
   if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
     return ESC;
-  ctx->active->saved_big_file_view =
-      (dir_entry->big_window || dir_entry->global_flag || dir_entry->tagged_flag);
+  if (!AppStateCommitPanelFileShape(ctx->active, big_file_shape))
+    return ESC;
   if (tracked_file_dir == dir_entry) {
     dir_entry->start_file = ctx->active->start_file;
     dir_entry->cursor_pos = ctx->active->file_cursor_pos;
@@ -729,7 +732,8 @@ file_window_done:
      */
     if (!AppStateCommitPanelFocus(ctx, owner_panel, FOCUS_TREE))
       return ESC;
-    owner_panel->saved_big_file_view = FALSE;
+    if (!AppStateCommitPanelFileShape(owner_panel, FALSE))
+      return ESC;
   }
   if (!volume_changed) {
     owner_panel->file_dir_entry = dir_entry;
@@ -749,7 +753,8 @@ file_window_done:
     owner_panel->file_dir_entry = NULL;
     owner_panel->start_file = 0;
     owner_panel->file_cursor_pos = 0;
-    owner_panel->saved_big_file_view = FALSE;
+    if (!AppStateCommitPanelFileShape(owner_panel, FALSE))
+      return ESC;
   }
 
   DEBUG_LOG("DEBUG: HandleFileWindow EXITING with %s",

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -1061,8 +1061,9 @@ BOOL handle_file_window_misc_dispatch_action(
     }
     if (dir_entry->big_window)
       break;
+    if (!AppStateCommitPanelFileShape(ctx->active, TRUE))
+      return FALSE;
     dir_entry->big_window = TRUE;
-    ctx->active->saved_big_file_view = TRUE;
     RefreshView(ctx, dir_entry);
     FileNav_RereadWindowSize(ctx, dir_entry);
     loop_action = ACTION_NONE;

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -694,7 +694,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   dst->panel_generation = src->panel_generation;
   if (!AppStateCommitPanelFocus(ctx, dst, src->saved_focus))
     return FALSE;
-  dst->saved_big_file_view = src->saved_big_file_view;
+  if (!AppStateCommitPanelFileShape(dst, src->saved_big_file_view))
+    return FALSE;
   dst->max_visual_filename_len = src->max_visual_filename_len;
   dst->max_visual_linkname_len = src->max_visual_linkname_len;
   dst->max_visual_userview_len = src->max_visual_userview_len;
@@ -714,7 +715,9 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
     dst->panel_generation = dst_panel_generation;
     if (dst_current_volume_state &&
         dst_current_volume_state->saved_file_selection_dir_path[0] != '\0') {
-      dst->saved_big_file_view = dst_current_volume_state->saved_big_file_view;
+      if (!AppStateCommitPanelFileShape(
+              dst, dst_current_volume_state->saved_big_file_view))
+        return FALSE;
       dst->start_file = dst_current_volume_state->saved_file_start;
       dst->file_cursor_pos = dst_current_volume_state->saved_file_cursor;
       (void)snprintf(dst->file_selection_name,
@@ -726,7 +729,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
     } else {
       if (!AppStateCommitPanelFocus(ctx, dst, FOCUS_FILE))
         return FALSE;
-      dst->saved_big_file_view = dst_saved_big_file_view;
+      if (!AppStateCommitPanelFileShape(dst, dst_saved_big_file_view))
+        return FALSE;
       dst->start_file = dst_start_file;
       dst->file_cursor_pos = dst_file_cursor_pos;
       dst->file_dir_entry = (DirEntry *)dst_file_dir_entry;

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -257,9 +257,11 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
   switch (action) {
   case ACTION_SPLIT_SCREEN:
     SplitTransitionDebugLogFileState("FileAction:split:before", ctx);
-    owner_panel->saved_big_file_view =
-        (dir_entry->big_window || dir_entry->global_flag ||
-         dir_entry->tagged_flag);
+    if (!AppStateCommitPanelFileShape(owner_panel,
+                                      dir_entry->big_window ||
+                                          dir_entry->global_flag ||
+                                          dir_entry->tagged_flag))
+      return FALSE;
 
     if (!ctx->is_split_screen) {
       owner_panel->file_dir_entry = dir_entry;
@@ -336,7 +338,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
           (void)snprintf(ctx->right->file_selection_dir_path,
                          sizeof(ctx->right->file_selection_dir_path), "%s",
                          ctx->left->file_selection_dir_path);
-          ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
+          if (!AppStateCommitPanelFileShape(
+                  ctx->right, ctx->left->saved_big_file_view))
+            return FALSE;
           PanelTags_Copy(ctx->right, ctx->left);
           FreeFileEntryList(ctx->right);
         }
@@ -396,9 +400,11 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
       CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
       if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
         return FALSE;
-      ctx->active->saved_big_file_view =
-          (dir_entry->big_window || dir_entry->global_flag ||
-           dir_entry->tagged_flag);
+      if (!AppStateCommitPanelFileShape(ctx->active,
+                                        dir_entry->big_window ||
+                                            dir_entry->global_flag ||
+                                            dir_entry->tagged_flag))
+        return FALSE;
       *switched_panel_ptr = TRUE;
       SwitchToSmallFileWindow(ctx);
 
@@ -420,9 +426,11 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
     CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
     if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
       return FALSE;
-    ctx->active->saved_big_file_view =
-        (dir_entry->big_window || dir_entry->global_flag ||
-         dir_entry->tagged_flag);
+    if (!AppStateCommitPanelFileShape(ctx->active,
+                                      dir_entry->big_window ||
+                                          dir_entry->global_flag ||
+                                          dir_entry->tagged_flag))
+      return FALSE;
     *switched_panel_ptr = TRUE;
     SwitchToSmallFileWindow(ctx);
 
@@ -530,7 +538,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
                  sizeof(ctx->right->tree_viewport_top_dir_path));
           ctx->right->start_file = ctx->left->start_file;
           ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
-          ctx->right->saved_big_file_view = ctx->left->saved_big_file_view;
+          if (!AppStateCommitPanelFileShape(
+                  ctx->right, ctx->left->saved_big_file_view))
+            return FALSE;
           ctx->right->hide_dot_files = ctx->left->hide_dot_files;
           if (!AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_TREE))
             return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5681,7 +5681,7 @@ def test_handle_file_window_dispatch_fails_closed_before_file_work() -> None:
     boundary_calls = [
         'DEBUG_LOG("HandleFileWindow ENTERED',
         "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)",
-        "ctx->active->saved_big_file_view =",
+        "AppStateCommitPanelFileShape(ctx->active, big_file_shape)",
         "BuildFileEntryList(",
         "RefreshView(",
         "GetEventOrKey(",
@@ -6144,6 +6144,55 @@ def test_volume_focus_mirrors_use_appstate_helper() -> None:
     log_body = log_source[log_start:log_end]
     assert "AppStateCommitVolumeFocusMirror(panel->vol, panel->saved_focus)" in log_body
     assert "panel->vol->saved_focus = panel->saved_focus" not in log_body
+
+
+def test_panel_file_shape_commits_use_appstate_helper() -> None:
+    focus_header = Path("include/ytnova_appstate_focus.h").read_text(encoding="utf-8")
+    focus_helper = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
+    sources = {
+        path: Path(path).read_text(encoding="utf-8")
+        for path in [
+            "src/core/init.c",
+            "src/cmd/log.c",
+            "src/ui/ctrl_dir.c",
+            "src/ui/ctrl_file.c",
+            "src/ui/ctrl_file_ops.c",
+            "src/ui/panel_anchor.c",
+            "src/ui/split_transition.c",
+        ]
+    }
+    direct_panel_shape_write = re.compile(
+        r"\b(?:ctx->left|ctx->right|ctx->active|owner_panel|panel|dst)"
+        r"->saved_big_file_view\s*="
+    )
+
+    assert "BOOL AppStateCommitPanelFileShape(" in focus_header
+    assert "AppStateCommitPanelFileShape" in focus_helper
+    for source in sources.values():
+        assert 'include "ytnova_appstate_focus.h"' in source
+        assert not direct_panel_shape_write.search(source)
+
+    assert "AppStateCommitPanelFileShape(ctx->left, FALSE)" in sources["src/core/init.c"]
+    assert "AppStateCommitPanelFileShape(panel, state->saved_big_file_view)" in sources[
+        "src/cmd/log.c"
+    ]
+    assert "AppStateCommitPanelFileShape(ctx->active, FALSE)" in sources[
+        "src/ui/ctrl_dir.c"
+    ]
+    assert "AppStateCommitPanelFileShape(owner_panel, FALSE)" in sources[
+        "src/ui/ctrl_file.c"
+    ]
+    assert "AppStateCommitPanelFileShape(ctx->active, TRUE)" in sources[
+        "src/ui/ctrl_file_ops.c"
+    ]
+    assert "AppStateCommitPanelFileShape(dst, src->saved_big_file_view)" in sources[
+        "src/ui/panel_anchor.c"
+    ]
+    assert re.search(
+        r"AppStateCommitPanelFileShape\(\s*ctx->right,\s*"
+        r"ctx->left->saved_big_file_view\s*\)",
+        sources["src/ui/split_transition.c"],
+    )
 
 
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:


### PR DESCRIPTION
## Summary
- Add an AppState helper for panel file-window shape commits.
- Route panel saved file-window shape writes through the validated helper across init, restore, split, and file-window paths.
- Add a guard that blocks direct panel file-shape writes outside the helper.

## Validation
- make clean && make
- make
- make qa-appstate-contract
- source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'compatibility_shim_boundaries or focus_restore or split_seeded or initial_focus or volume_focus_mirrors or panel_file_shape_commits'