### PR TITLE
refactor(appstate): route visibility toggles through helper

### DIFF
--- a/include/ytnova_appstate_visibility.h
+++ b/include/ytnova_appstate_visibility.h
@@ -1,0 +1,16 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_visibility.h
+ * Visibility-filter transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_VISIBILITY_H
+#define YTNOVA_APPSTATE_VISIBILITY_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitPanelVisibilityFilter(YtreeNovaPanel *panel,
+                                         BOOL hide_dot_files);
+
+#endif /* YTNOVA_APPSTATE_VISIBILITY_H */

--- a/src/ui/appstate_visibility.c
+++ b/src/ui/appstate_visibility.c
@@ -1,0 +1,28 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_visibility.c
+ * Visibility-filter transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#define NO_YTNOVA_MACROS
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_visibility.h"
+
+BOOL AppStateCommitPanelVisibilityFilter(YtreeNovaPanel *panel,
+                                         BOOL hide_dot_files) {
+  if (!AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume"))
+    return FALSE;
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
+  if (!AppStateValidatedOwnerField("volume.volume_generation"))
+    return FALSE;
+  if (!panel || !panel->vol)
+    return FALSE;
+
+  panel->hide_dot_files = hide_dot_files ? TRUE : FALSE;
+  panel->panel_generation++;
+  panel->vol->volume_generation++;
+  return TRUE;
+}

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -9,6 +9,7 @@
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_visibility.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -1928,9 +1929,10 @@ void ToggleDotFiles(ViewContext *ctx, YtreeNovaPanel *p) {
    * rebuild */
   SuspendClock(ctx);
 
-  p->hide_dot_files = !p->hide_dot_files;
-  p->panel_generation++;
-  p->vol->volume_generation++;
+  if (!AppStateCommitPanelVisibilityFilter(p, !p->hide_dot_files)) {
+    InitClock(ctx);
+    return;
+  }
   RecalculateSysStats(ctx, s);
 
   /* Rebuild the linear list of visible directories. */

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -4473,19 +4473,21 @@ int main(void) {
     return 2;
   if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
     return 3;
-  if (AppStateValidatedGenerationDomain(NULL))
+  if (!AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume"))
     return 4;
-  if (AppStateValidatedGenerationDomain(""))
+  if (AppStateValidatedGenerationDomain(NULL))
     return 5;
-  if (AppStateValidatedGenerationDomain("generation.__ytnova_missing__"))
+  if (AppStateValidatedGenerationDomain(""))
     return 6;
+  if (AppStateValidatedGenerationDomain("generation.__ytnova_missing__"))
+    return 7;
 
   mismatched_domain =
       *AppStateGenerationDomainLookup("generation.panel.local-authority");
   mismatched_domain.domain_id = "generation.__ytnova_mismatch__";
   if (AppStateValidateGenerationDomain("generation.panel.local-authority",
                                        &mismatched_domain))
-    return 7;
+    return 8;
 
   missing_transition =
       *AppStateGenerationDomainLookup("generation.panel.local-authority");
@@ -4493,7 +4495,7 @@ int main(void) {
   missing_transition.coverage_transition_id_count = 1;
   if (AppStateValidateGenerationDomain("generation.panel.local-authority",
                                        &missing_transition))
-    return 8;
+    return 9;
 
   uncovered_advance =
       *AppStateGenerationDomainLookup("generation.panel.local-authority");
@@ -4501,15 +4503,15 @@ int main(void) {
   uncovered_advance.advances_on_transition_id_count = 1;
   if (AppStateValidateGenerationDomain("generation.panel.local-authority",
                                        &uncovered_advance))
-    return 9;
+    return 10;
 
   missing_notes =
       *AppStateGenerationDomainLookup("generation.panel.local-authority");
-  missing_notes.migration_notes = 0;
+  missing_notes.migration_notes = NULL;
   missing_notes.migration_note_count = 0;
   if (AppStateValidateGenerationDomain("generation.panel.local-authority",
                                        &missing_notes))
-    return 10;
+    return 11;
 
   return 0;
 }
@@ -5941,6 +5943,62 @@ def test_visibility_projection_reads_panel_state_not_session_mirror() -> None:
     pipe_body = pipe[pipe_start:pipe_end]
     assert "ctx->hide_dot_files" not in pipe_body
     assert "active_panel->hide_dot_files" in pipe_body
+
+
+def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_visibility.h").read_text(
+        encoding="utf-8"
+    )
+    helper = Path("src/ui/appstate_visibility.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    assert 'include "ytnova_appstate_visibility.h"' in dir_ops
+    assert "AppStateCommitPanelVisibilityFilter" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelVisibilityFilter(")
+    helper_body = helper[helper_start:]
+    domain_validation = (
+        'AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume")'
+    )
+    panel_owner_validation = 'AppStateValidatedOwnerField("panel.panel_generation")'
+    volume_owner_validation = 'AppStateValidatedOwnerField("volume.volume_generation")'
+    panel_write = "panel->hide_dot_files = hide_dot_files ? TRUE : FALSE;"
+    panel_generation = "panel->panel_generation++;"
+    volume_generation = "panel->vol->volume_generation++;"
+
+    for required in [
+        domain_validation,
+        panel_owner_validation,
+        volume_owner_validation,
+        panel_write,
+        panel_generation,
+        volume_generation,
+    ]:
+        assert required in helper_body
+
+    assert helper_body.index(domain_validation) < helper_body.index(panel_write)
+    assert helper_body.index(panel_owner_validation) < helper_body.index(panel_write)
+    assert helper_body.index(volume_owner_validation) < helper_body.index(panel_write)
+    assert helper_body.index(panel_write) < helper_body.index(panel_generation)
+    assert helper_body.index(panel_generation) < helper_body.index(volume_generation)
+
+    toggle_start = dir_ops.index("void ToggleDotFiles(")
+    toggle_end = dir_ops.index("\nDirEntry *RefreshTreeSafe(", toggle_start)
+    toggle_body = dir_ops[toggle_start:toggle_end]
+    commit_call = "AppStateCommitPanelVisibilityFilter(p, !p->hide_dot_files)"
+
+    assert "p->hide_dot_files = !p->hide_dot_files;" not in toggle_body
+    assert "p->panel_generation++;" not in toggle_body
+    assert "p->vol->volume_generation++;" not in toggle_body
+    assert commit_call in toggle_body
+    assert "InitClock(ctx);\n    return;" in toggle_body
+    assert toggle_body.index("SuspendClock(ctx);") < toggle_body.index(commit_call)
+    assert toggle_body.index(commit_call) < toggle_body.index(
+        "RecalculateSysStats(ctx, s);"
+    )
+    assert toggle_body.index(commit_call) < toggle_body.index(
+        "BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);"
+    )
 
 
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -174,6 +174,10 @@ def _dir_ops_source():
     return Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
 
 
+def _appstate_visibility_source():
+    return Path("src/ui/appstate_visibility.c").read_text(encoding="utf-8")
+
+
 def test_tree_viewport_stable_restore_preserves_visible_selection():
     panel_anchor_source = _panel_anchor_file_source()
     restore_start = panel_anchor_source.index("BOOL RestorePanelTreeViewportSnapshot(")
@@ -253,6 +257,7 @@ def test_restore_snapshots_validate_generation_before_reuse():
     log_source = _log_source()
     panel_anchor_source = _panel_anchor_file_source()
     dir_ops_source = _dir_ops_source()
+    visibility_source = _appstate_visibility_source()
 
     for needle in (
         "unsigned int saved_panel_generation;",
@@ -282,8 +287,9 @@ def test_restore_snapshots_validate_generation_before_reuse():
     assert "panel->panel_generation++;" in panel_anchor_source, panel_anchor_source
     assert "dst->panel_generation = src->panel_generation;" in panel_anchor_source
 
-    assert "p->panel_generation++;" in dir_ops_source, dir_ops_source
-    assert "p->vol->volume_generation++;" in dir_ops_source, dir_ops_source
+    assert "AppStateCommitPanelVisibilityFilter(p, !p->hide_dot_files)" in dir_ops_source
+    assert "panel->panel_generation++;" in visibility_source, visibility_source
+    assert "panel->vol->volume_generation++;" in visibility_source, visibility_source
     assert "ctx->active->vol->volume_generation++;" in dir_ops_source, dir_ops_source
 
 


### PR DESCRIPTION
## Summary
- Add a visibility-filter AppState helper for panel dotfile visibility commits.
- Route dotfile toggle owner writes and generation bumps through the helper.
- Extend AppState contract guards for the helper and visibility generation-domain runtime coverage.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'visibility_filter or generation_domain'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `make clean && make` (passes; existing warning baseline remains)
- `git diff --check`
