### PR TITLE
refactor(appstate): route active panels through helper

### DIFF
--- a/include/ytnova_appstate_session.h
+++ b/include/ytnova_appstate_session.h
@@ -1,0 +1,15 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_session.h
+ * Session-routing transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_SESSION_H
+#define YTNOVA_APPSTATE_SESSION_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitActivePanel(ViewContext *ctx, YtreeNovaPanel *panel);
+
+#endif /* YTNOVA_APPSTATE_SESSION_H */

--- a/src/ui/appstate_session.c
+++ b/src/ui/appstate_session.c
@@ -1,0 +1,23 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_session.c
+ * Session-routing transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#define NO_YTNOVA_MACROS
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_session.h"
+
+BOOL AppStateCommitActivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
+  if (!AppStateValidatedOwnerField("ctx.active"))
+    return FALSE;
+  if (!ctx || !panel)
+    return FALSE;
+  if (panel != ctx->left && panel != ctx->right)
+    return FALSE;
+
+  ctx->active = panel;
+  return TRUE;
+}

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -8,6 +8,7 @@
 #define NO_YTNOVA_MACROS
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_session.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -276,7 +277,8 @@ BOOL handle_file_window_preview_action(
     } else {
       Statistic *stats_local;
 
-      ctx->active = ctx->preview_return_panel;
+      if (!AppStateCommitActivePanel(ctx, ctx->preview_return_panel))
+        return FALSE;
       if (!AppStateCommitPanelFocus(ctx, ctx->active, ctx->preview_return_focus))
         return FALSE;
       stats_local = &ctx->active->vol->vol_stats;

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -9,6 +9,7 @@
 
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_session.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include "ytnova_split_transition.h"
@@ -306,8 +307,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
         return FALSE;
 
       ctx->is_split_screen = !ctx->is_split_screen;
-      if (closing_split)
-        ctx->active = ctx->left;
+      if (closing_split && !AppStateCommitActivePanel(ctx, ctx->left))
+        return FALSE;
       ReCreateWindows(ctx);
       if (!ctx->is_split_screen)
         SyncActivePanelWindows(ctx);
@@ -344,12 +345,14 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
           PanelTags_Copy(ctx->right, ctx->left);
           FreeFileEntryList(ctx->right);
         }
-        ctx->active = owner_panel;
+        if (!AppStateCommitActivePanel(ctx, owner_panel))
+          return FALSE;
         if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
           return FALSE;
       } else {
         FreeFileEntryList(ctx->right);
-        ctx->active = ctx->left;
+        if (!AppStateCommitActivePanel(ctx, ctx->left))
+          return FALSE;
         if (!AppStateCommitPanelFocus(ctx, ctx->active, preserved_focus))
           return FALSE;
         BuildFileEntryList(ctx, ctx->active);
@@ -408,11 +411,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
       *switched_panel_ptr = TRUE;
       SwitchToSmallFileWindow(ctx);
 
-      if (ctx->active == ctx->left) {
-        ctx->active = ctx->right;
-      } else {
-        ctx->active = ctx->left;
-      }
+      if (!AppStateCommitActivePanel(
+              ctx, (ctx->active == ctx->left) ? ctx->right : ctx->left))
+        return FALSE;
       if (!AppStateMirrorActivePanelFocus(ctx))
         return FALSE;
       *loop_action_ptr = ACTION_NONE;
@@ -434,11 +435,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
     *switched_panel_ptr = TRUE;
     SwitchToSmallFileWindow(ctx);
 
-    if (ctx->active == ctx->left) {
-      ctx->active = ctx->right;
-    } else {
-      ctx->active = ctx->left;
-    }
+    if (!AppStateCommitActivePanel(
+            ctx, (ctx->active == ctx->left) ? ctx->right : ctx->left))
+      return FALSE;
     if (!AppStateMirrorActivePanelFocus(ctx))
       return FALSE;
     *loop_action_ptr = ACTION_NONE;
@@ -522,8 +521,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
           !AppStateCommitPanelFocus(ctx, closing_active, FOCUS_TREE))
         return FALSE;
       ctx->is_split_screen = !ctx->is_split_screen;
-      if (closing_split)
-        ctx->active = ctx->left;
+      if (closing_split && !AppStateCommitActivePanel(ctx, ctx->left))
+        return FALSE;
       ReCreateWindows(ctx);
       if (!ctx->is_split_screen)
         SyncActivePanelWindows(ctx);
@@ -548,7 +547,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         }
       } else {
         FreeFileEntryList(ctx->right);
-        ctx->active = ctx->left;
+        if (!AppStateCommitActivePanel(ctx, ctx->left))
+          return FALSE;
         *dir_entry_ptr = GetPanelDirEntry(ctx->active);
         if (preserve_left_file_state && !donate_active_state &&
             !AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
@@ -599,11 +599,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
        */
       CaptureSplitDirPanelSnapshot(previous_active, &previous_active_snapshot);
 
-      if (ctx->active == ctx->left) {
-        ctx->active = ctx->right;
-      } else {
-        ctx->active = ctx->left;
-      }
+      if (!AppStateCommitActivePanel(
+              ctx, (ctx->active == ctx->left) ? ctx->right : ctx->left))
+        return FALSE;
 
       if (!AppStateMirrorActivePanelFocus(ctx))
         return FALSE;
@@ -673,11 +671,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
                                             &previous_active_snapshot);
     }
 #else
-    if (ctx->active == ctx->left) {
-      ctx->active = ctx->right;
-    } else {
-      ctx->active = ctx->left;
-    }
+    if (!AppStateCommitActivePanel(
+            ctx, (ctx->active == ctx->left) ? ctx->right : ctx->left))
+      return FALSE;
 
     if (!AppStateMirrorActivePanelFocus(ctx))
       return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5338,7 +5338,13 @@ int AppStateValidatedCompatibilityShim(const char *shim_id) {
   return fake_mode != 4;
 }
 
+int AppStateValidatedOwnerField(const char *field) {
+  (void)field;
+  return fake_mode != 5;
+}
+
 #include "src/ui/appstate_focus.c"
+#include "src/ui/appstate_session.c"
 #include "src/ui/split_transition.c"
 
 void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
@@ -5998,6 +6004,62 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
     )
     assert toggle_body.index(commit_call) < toggle_body.index(
         "BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);"
+    )
+
+
+def test_active_panel_session_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_session.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_session.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+
+    assert "AppStateCommitActivePanel" in header
+    assert 'include "ytnova_appstate_session.h"' in split_transition
+    assert 'include "ytnova_appstate_session.h"' in ctrl_file_ops
+
+    helper_start = helper.index("BOOL AppStateCommitActivePanel(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.active")'
+    active_write = "ctx->active = panel;"
+    membership_check = "panel != ctx->left && panel != ctx->right"
+
+    assert validation in helper_body
+    assert membership_check in helper_body
+    assert active_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(active_write)
+    assert helper_body.index(membership_check) < helper_body.index(active_write)
+
+    for source in [split_transition, ctrl_file_ops]:
+        assert not re.search(r"\bctx->active\s*=[^=]", source)
+
+    file_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleFileWindowAction("
+    )
+    dir_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleDirWindowAction("
+    )
+    file_split_body = split_transition[file_split_start:dir_split_start]
+    dir_split_body = split_transition[dir_split_start:]
+
+    assert "AppStateCommitActivePanel(ctx, owner_panel)" in file_split_body
+    assert "AppStateCommitActivePanel(ctx, ctx->left)" in file_split_body
+    assert "AppStateCommitActivePanel(ctx, ctx->left)" in dir_split_body
+    assert "AppStateCommitActivePanel(" in dir_split_body
+    assert file_split_body.index("AppStateCommitActivePanel(ctx, owner_panel)") < (
+        file_split_body.index("AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)")
+    )
+    assert dir_split_body.index("AppStateCommitActivePanel(") < dir_split_body.index(
+        "AppStateMirrorActivePanelFocus(ctx)"
+    )
+
+    preview_start = ctrl_file_ops.index("BOOL handle_file_window_preview_action(")
+    preview_body = ctrl_file_ops[preview_start:]
+    preview_commit = "AppStateCommitActivePanel(ctx, ctx->preview_return_panel)"
+    assert preview_commit in preview_body
+    assert preview_body.index(preview_commit) < preview_body.index(
+        "AppStateCommitPanelFocus(ctx, ctx->active, ctx->preview_return_focus)"
     )
 
 


### PR DESCRIPTION
## Summary
- Add an AppState session-routing helper for active-panel commits.
- Route split, panel switch, and preview-return active-panel writes through the helper.
- Extend AppState contract guards to reject direct active-panel writes in those runtime boundaries.

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'active_panel_session or compatibility_shim_boundaries'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py::test_split_transition_helpers_fail_closed_on_invalid_appstate_boundary tests/test_appstate_contract_guard.py::test_active_panel_session_commits_through_appstate_helper`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py`
- `source .venv/bin/activate && pytest -q tests/test_dir_window_dispatch_regressions.py -k 'split or restore_snapshots'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` (passes; existing warning baseline remains)
- `git diff --check`
