### PR TITLE
refactor(appstate): route split visibility seeding through helper

### DIFF
--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -10,6 +10,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_session.h"
+#include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include "ytnova_split_transition.h"
@@ -321,7 +322,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
           memcpy(ctx->right->tree_viewport_top_dir_path,
                  ctx->left->tree_viewport_top_dir_path,
                  sizeof(ctx->right->tree_viewport_top_dir_path));
-          ctx->right->hide_dot_files = ctx->left->hide_dot_files;
+          if (!AppStateCommitPanelVisibilityFilter(ctx->right,
+                                                   ctx->left->hide_dot_files))
+            return FALSE;
           /*
            * Split ownership boundary: a file-view split must keep the original
            * file panel active and seed the new peer from the same panel-local
@@ -540,7 +543,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
           if (!AppStateCommitPanelFileShape(
                   ctx->right, ctx->left->saved_big_file_view))
             return FALSE;
-          ctx->right->hide_dot_files = ctx->left->hide_dot_files;
+          if (!AppStateCommitPanelVisibilityFilter(ctx->right,
+                                                   ctx->left->hide_dot_files))
+            return FALSE;
           if (!AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_TREE))
             return FALSE;
           FreeFileEntryList(ctx->right);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5343,8 +5343,14 @@ int AppStateValidatedOwnerField(const char *field) {
   return fake_mode != 5;
 }
 
+int AppStateValidatedGenerationDomain(const char *domain_id) {
+  (void)domain_id;
+  return fake_mode != 6;
+}
+
 #include "src/ui/appstate_focus.c"
 #include "src/ui/appstate_session.c"
+#include "src/ui/appstate_visibility.c"
 #include "src/ui/split_transition.c"
 
 void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
@@ -5957,8 +5963,10 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
     )
     helper = Path("src/ui/appstate_visibility.c").read_text(encoding="utf-8")
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
 
     assert 'include "ytnova_appstate_visibility.h"' in dir_ops
+    assert 'include "ytnova_appstate_visibility.h"' in split_transition
     assert "AppStateCommitPanelVisibilityFilter" in header
 
     helper_start = helper.index("BOOL AppStateCommitPanelVisibilityFilter(")
@@ -6004,6 +6012,13 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
     )
     assert toggle_body.index(commit_call) < toggle_body.index(
         "BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);"
+    )
+
+    assert "ctx->right->hide_dot_files = ctx->left->hide_dot_files;" not in split_transition
+    assert re.search(
+        r"AppStateCommitPanelVisibilityFilter\(\s*ctx->right,\s*"
+        r"ctx->left->hide_dot_files\s*\)",
+        split_transition,
     )
 
 


### PR DESCRIPTION
## Summary
- Route split peer dotfile-visibility seeding through the AppState visibility commit helper.
- Extend AppState contract guards so split transitions cannot reintroduce direct peer visibility writes.

## Validation
- `python3 scripts/check_appstate_contract.py`
- `pytest tests/test_appstate_contract_guard.py -q`
- `pytest tests/test_panel_isolation.py tests/test_file_window_dispatch_regressions.py tests/test_dir_window_dispatch_regressions.py -q`
- `make clean && make`
- `git diff --check`
