### PR TITLE
refactor(appstate): route active panel fallbacks through helper

### DIFF
--- a/src/core/init.c
+++ b/src/core/init.c
@@ -10,6 +10,7 @@
 
 #include "ytnova_defs.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_session.h"
 #include "ytnova_debug.h"
 #include "default_profile_template.h"
 #include <fcntl.h>
@@ -378,8 +379,8 @@ void InitView(ViewContext *ctx) {
   ctx->right->file_dir_entry = NULL;
   ctx->right->hide_dot_files = FALSE;
 
-  ctx->active = ctx->left;
-  if (!AppStateCommitPanelFileShape(ctx->left, FALSE) ||
+  if (!AppStateCommitActivePanel(ctx, ctx->left) ||
+      !AppStateCommitPanelFileShape(ctx->left, FALSE) ||
       !AppStateCommitPanelFileShape(ctx->right, FALSE) ||
       !AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE) ||
       !AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_TREE)) {
@@ -443,8 +444,9 @@ void ReCreateWindows(ViewContext *ctx) {
   DEBUG_LOG("ENTER ReCreateWindows");
   if (ctx == NULL || ctx->left == NULL || ctx->right == NULL)
     return;
-  if (ctx->active == NULL)
-    ctx->active = ctx->left;
+  if (ctx->active == NULL &&
+      !AppStateCommitActivePanel(ctx, ctx->left))
+    return;
   /* 1. Recalculate Layout based on current SplitScreen state */
   Layout_Recalculate(ctx);
 
@@ -583,8 +585,9 @@ void ReCreateWindows(ViewContext *ctx) {
   }
 
   /* 6. Sync ctx->active Pointers */
-  if (ctx->active == NULL)
-    ctx->active = ctx->left;
+  if (ctx->active == NULL &&
+      !AppStateCommitActivePanel(ctx, ctx->left))
+    return;
 
   if (ctx->active == ctx->left) {
     ctx->active->pan_dir_window = ctx->left->pan_dir_window;
@@ -604,7 +607,8 @@ void ReCreateWindows(ViewContext *ctx) {
   } else {
     /* Fallback if something went wrong (e.g. RightPanel active but
      * SplitScreen/Preview disabled) */
-    ctx->active = ctx->left;
+    if (!AppStateCommitActivePanel(ctx, ctx->left))
+      return;
     ctx->active->pan_dir_window = ctx->left->pan_dir_window;
     ctx->active->pan_small_file_window = ctx->left->pan_small_file_window;
     ctx->active->pan_big_file_window = ctx->left->pan_big_file_window;
@@ -726,7 +730,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
 
   /* Initial Panel Defaults */
   ctx->is_split_screen = FALSE;
-  ctx->active = ctx->left;
+  if (!AppStateCommitActivePanel(ctx, ctx->left))
+    return -1;
   /* Explicitly initialize panel file lists to zero */
   ctx->left->file_entry_list = NULL;
   ctx->left->file_entry_list_capacity = 0;
@@ -746,7 +751,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
   /* Allocate and initialize the first volume using the dedicated module */
   struct Volume *initial_vol = Volume_Create(ctx);
   /* Assign initial volume to ActivePanel */
-  ctx->active = ctx->left; /* Default active panel */
+  if (!AppStateCommitActivePanel(ctx, ctx->left))
+    return -1;
   ctx->active->vol = initial_vol;
 
   ctx->show_stats = TRUE;

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -9,6 +9,7 @@
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_session.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -476,8 +477,9 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   de_ptr = NULL;
 
   /* Safety fallback if Init() has not set up panels */
-  if (ctx->active == NULL)
-    ctx->active = ctx->left;
+  if (ctx->active == NULL &&
+      !AppStateCommitActivePanel(ctx, ctx->left))
+    return ESC;
   if (ctx->active == NULL || ctx->active->vol == NULL)
     return ESC;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6029,10 +6029,14 @@ def test_active_panel_session_commits_through_appstate_helper() -> None:
         encoding="utf-8"
     )
     ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
 
     assert "AppStateCommitActivePanel" in header
     assert 'include "ytnova_appstate_session.h"' in split_transition
     assert 'include "ytnova_appstate_session.h"' in ctrl_file_ops
+    assert 'include "ytnova_appstate_session.h"' in init_source
+    assert 'include "ytnova_appstate_session.h"' in ctrl_dir
 
     helper_start = helper.index("BOOL AppStateCommitActivePanel(")
     helper_body = helper[helper_start:]
@@ -6046,7 +6050,7 @@ def test_active_panel_session_commits_through_appstate_helper() -> None:
     assert helper_body.index(validation) < helper_body.index(active_write)
     assert helper_body.index(membership_check) < helper_body.index(active_write)
 
-    for source in [split_transition, ctrl_file_ops]:
+    for source in [split_transition, ctrl_file_ops, init_source, ctrl_dir]:
         assert not re.search(r"\bctx->active\s*=[^=]", source)
 
     file_split_start = split_transition.index(
@@ -6076,6 +6080,22 @@ def test_active_panel_session_commits_through_appstate_helper() -> None:
     assert preview_body.index(preview_commit) < preview_body.index(
         "AppStateCommitPanelFocus(ctx, ctx->active, ctx->preview_return_focus)"
     )
+
+    init_view_start = init_source.index("void InitView(")
+    init_view_end = init_source.index("\nvoid CoreMainOps_Register(", init_view_start)
+    init_view_body = init_source[init_view_start:init_view_end]
+    init_start = init_source.index("int Init(")
+    init_body = init_source[init_start:]
+    recreate_start = init_source.index("void ReCreateWindows(")
+    recreate_end = init_source.index("\nvoid ShutdownCurses(", recreate_start)
+    recreate_body = init_source[recreate_start:recreate_end]
+    dir_start = ctrl_dir.index("HandleDirWindow(")
+    dir_body = ctrl_dir[dir_start:]
+
+    assert "AppStateCommitActivePanel(ctx, ctx->left)" in init_view_body
+    assert init_body.count("AppStateCommitActivePanel(ctx, ctx->left)") >= 2
+    assert "AppStateCommitActivePanel(ctx, ctx->left)" in recreate_body
+    assert "AppStateCommitActivePanel(ctx, ctx->left)" in dir_body
 
 
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
@@ -6250,12 +6270,16 @@ def test_initial_focus_commits_use_appstate_helper() -> None:
     assert not re.search(r"\bctx->focused_window\s*=", init_body)
     assert not re.search(r"\bctx->left->saved_focus\s*=", init_body)
     assert not re.search(r"\bctx->right->saved_focus\s*=", init_body)
-    assert "ctx->active = ctx->left;" in init_body
+    assert "AppStateCommitActivePanel(ctx, ctx->left)" in init_body
     assert "AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE)" in init_body
     assert "AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_TREE)" in init_body
-    assert init_body.index("ctx->active = ctx->left;") < init_body.index(
+    active_commit_index = init_body.index(
+        "AppStateCommitActivePanel(ctx, ctx->left)"
+    )
+    focus_commit_index = init_body.index(
         "AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE)"
     )
+    assert active_commit_index < focus_commit_index
 
 
 def test_volume_focus_mirrors_use_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route initialization and fallback active-panel commits through the AppState session helper.
- Extend AppState contract guards to reject direct active-panel writes in initialization and directory fallback paths.

## Validation
- `python3 scripts/check_appstate_contract.py`
- `pytest tests/test_appstate_contract_guard.py -q`
- `pytest tests/test_dir_window_dispatch_regressions.py tests/test_file_window_dispatch_regressions.py tests/test_panel_isolation.py -q`
- `pytest tests/test_appstate_contract_guard.py -k 'active_panel_session or initial_focus' -q`
- `make clean && make`
- `git diff --check`
