### PR TITLE
refactor(appstate): route donated visibility through helper

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include "ytnova_ui.h"
@@ -700,7 +701,6 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   dst->max_visual_linkname_len = src->max_visual_linkname_len;
   dst->max_visual_userview_len = src->max_visual_userview_len;
   dst->reverse_sort = src->reverse_sort;
-  dst->hide_dot_files = src->hide_dot_files;
   (void)snprintf(dst->file_selection_name, sizeof(dst->file_selection_name),
                  "%s", src->file_selection_name);
   (void)snprintf(dst->file_selection_dir_path,
@@ -747,6 +747,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
     FreePanelVolumeFileState(dst->volume_file_state);
     dst->volume_file_state = volume_file_state;
   }
+  if (!AppStateCommitPanelVisibilityFilter(dst, src->hide_dot_files))
+    return FALSE;
   RestorePanelAnchorPath(dst->vol, dst, file_dir_path);
   return TRUE;
 }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5964,9 +5964,11 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
     helper = Path("src/ui/appstate_visibility.c").read_text(encoding="utf-8")
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
 
     assert 'include "ytnova_appstate_visibility.h"' in dir_ops
     assert 'include "ytnova_appstate_visibility.h"' in split_transition
+    assert 'include "ytnova_appstate_visibility.h"' in panel_anchor
     assert "AppStateCommitPanelVisibilityFilter" in header
 
     helper_start = helper.index("BOOL AppStateCommitPanelVisibilityFilter(")
@@ -6019,6 +6021,16 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
         r"AppStateCommitPanelVisibilityFilter\(\s*ctx->right,\s*"
         r"ctx->left->hide_dot_files\s*\)",
         split_transition,
+    )
+
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+    assert "dst->hide_dot_files = src->hide_dot_files;" not in donate_body
+    assert re.search(
+        r"AppStateCommitPanelVisibilityFilter\(\s*dst,\s*"
+        r"src->hide_dot_files\s*\)",
+        donate_body,
     )
 
 


### PR DESCRIPTION
## Summary
- Route donated panel visibility copies through the AppState visibility helper after donation restore branches settle.
- Extend AppState contract guards to reject direct donated visibility writes.

## Validation
- `python3 scripts/check_appstate_contract.py`
- `pytest tests/test_appstate_contract_guard.py -q`
- `pytest tests/test_panel_isolation.py tests/test_file_window_dispatch_regressions.py tests/test_dir_window_dispatch_regressions.py -q`
- `make clean && make`
- `git diff --check`
