### PR TITLE
refactor(appstate): route initial visibility through helper

### DIFF
--- a/include/ytnova_appstate_visibility.h
+++ b/include/ytnova_appstate_visibility.h
@@ -12,5 +12,7 @@
 
 BOOL AppStateCommitPanelVisibilityFilter(YtreeNovaPanel *panel,
                                          BOOL hide_dot_files);
+BOOL AppStateSeedPanelVisibilityFilter(YtreeNovaPanel *panel,
+                                       BOOL hide_dot_files);
 
 #endif /* YTNOVA_APPSTATE_VISIBILITY_H */

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -11,6 +11,7 @@
 #include "ytnova_defs.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_session.h"
+#include "ytnova_appstate_visibility.h"
 #include "ytnova_debug.h"
 #include "default_profile_template.h"
 #include <fcntl.h>
@@ -364,7 +365,12 @@ void InitView(ViewContext *ctx) {
   ctx->left->file_mode = MODE_1;
   ctx->left->file_cursor_pos = 0;
   ctx->left->file_dir_entry = NULL;
-  ctx->left->hide_dot_files = FALSE;
+  if (!AppStateSeedPanelVisibilityFilter(ctx->left, FALSE)) {
+    fprintf(stderr, "InitView: failed to initialize left panel visibility\n");
+    free(ctx->left);
+    ctx->left = NULL;
+    exit(1);
+  }
 
   ctx->right = (YtreeNovaPanel *)calloc(1, sizeof(YtreeNovaPanel));
   if (ctx->right == NULL) {
@@ -377,7 +383,14 @@ void InitView(ViewContext *ctx) {
   ctx->right->file_mode = MODE_1;
   ctx->right->file_cursor_pos = 0;
   ctx->right->file_dir_entry = NULL;
-  ctx->right->hide_dot_files = FALSE;
+  if (!AppStateSeedPanelVisibilityFilter(ctx->right, FALSE)) {
+    fprintf(stderr, "InitView: failed to initialize right panel visibility\n");
+    free(ctx->right);
+    free(ctx->left);
+    ctx->right = NULL;
+    ctx->left = NULL;
+    exit(1);
+  }
 
   if (!AppStateCommitActivePanel(ctx, ctx->left) ||
       !AppStateCommitPanelFileShape(ctx->left, FALSE) ||
@@ -901,8 +914,9 @@ int Init(ViewContext *ctx, const char *configuration_file,
         (strtol(CoreInitGetProfileValue(ctx, "HIDEDOTFILES"), NULL, 0))
             ? TRUE
             : FALSE;
-    ctx->left->hide_dot_files = hide_dot_files;
-    ctx->right->hide_dot_files = hide_dot_files;
+    if (!AppStateSeedPanelVisibilityFilter(ctx->left, hide_dot_files) ||
+        !AppStateSeedPanelVisibilityFilter(ctx->right, hide_dot_files))
+      return -1;
   }
   ctx->animation_method =
       strtol(CoreInitGetProfileValue(ctx, "ANIMATION"), NULL, 0);

--- a/src/ui/appstate_visibility.c
+++ b/src/ui/appstate_visibility.c
@@ -26,3 +26,16 @@ BOOL AppStateCommitPanelVisibilityFilter(YtreeNovaPanel *panel,
   panel->vol->volume_generation++;
   return TRUE;
 }
+
+BOOL AppStateSeedPanelVisibilityFilter(YtreeNovaPanel *panel,
+                                       BOOL hide_dot_files) {
+  if (!AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume"))
+    return FALSE;
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->hide_dot_files = hide_dot_files ? TRUE : FALSE;
+  return TRUE;
+}

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5963,16 +5963,22 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
     )
     helper = Path("src/ui/appstate_visibility.c").read_text(encoding="utf-8")
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
     split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
 
+    assert 'include "ytnova_appstate_visibility.h"' in init_source
     assert 'include "ytnova_appstate_visibility.h"' in dir_ops
     assert 'include "ytnova_appstate_visibility.h"' in split_transition
     assert 'include "ytnova_appstate_visibility.h"' in panel_anchor
     assert "AppStateCommitPanelVisibilityFilter" in header
+    assert "AppStateSeedPanelVisibilityFilter" in header
 
     helper_start = helper.index("BOOL AppStateCommitPanelVisibilityFilter(")
-    helper_body = helper[helper_start:]
+    helper_end = helper.index("\nBOOL AppStateSeedPanelVisibilityFilter(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    seed_start = helper.index("BOOL AppStateSeedPanelVisibilityFilter(")
+    seed_body = helper[seed_start:]
     domain_validation = (
         'AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume")'
     )
@@ -5997,6 +6003,25 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
     assert helper_body.index(volume_owner_validation) < helper_body.index(panel_write)
     assert helper_body.index(panel_write) < helper_body.index(panel_generation)
     assert helper_body.index(panel_generation) < helper_body.index(volume_generation)
+
+    assert (
+        'AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume")'
+        in seed_body
+    )
+    assert 'AppStateValidatedOwnerField("panel.panel_generation")' in seed_body
+    assert 'AppStateValidatedOwnerField("volume.volume_generation")' not in seed_body
+    assert "panel->hide_dot_files = hide_dot_files ? TRUE : FALSE;" in seed_body
+    assert "panel->panel_generation++;" not in seed_body
+    assert "panel->vol->volume_generation++;" not in seed_body
+
+    assert "ctx->left->hide_dot_files = FALSE;" not in init_source
+    assert "ctx->right->hide_dot_files = FALSE;" not in init_source
+    assert "ctx->left->hide_dot_files = hide_dot_files;" not in init_source
+    assert "ctx->right->hide_dot_files = hide_dot_files;" not in init_source
+    assert "AppStateSeedPanelVisibilityFilter(ctx->left, FALSE)" in init_source
+    assert "AppStateSeedPanelVisibilityFilter(ctx->right, FALSE)" in init_source
+    assert "AppStateSeedPanelVisibilityFilter(ctx->left, hide_dot_files)" in init_source
+    assert "AppStateSeedPanelVisibilityFilter(ctx->right, hide_dot_files)" in init_source
 
     toggle_start = dir_ops.index("void ToggleDotFiles(")
     toggle_end = dir_ops.index("\nDirEntry *RefreshTreeSafe(", toggle_start)


### PR DESCRIPTION
## Summary
- Add an AppState visibility seed helper for startup/profile seeding before panel volume bindings are complete.
- Route initial and profile dotfile visibility seeds through the helper.
- Extend AppState contract guards to reject direct initial/profile visibility writes.

## Validation
- `python3 scripts/check_appstate_contract.py`
- `pytest tests/test_appstate_contract_guard.py -q`
- `pytest tests/test_dir_window_dispatch_regressions.py tests/test_file_window_dispatch_regressions.py tests/test_panel_isolation.py -q`
- `make clean && make`
- `git diff --check`
