### PR TITLE
refactor(appstate): route file selection generations through helper

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1543,7 +1543,7 @@ Ordering policy (for all editors, including AI editors):
 
 ### **Idea FE-41: Port to other platforms**
 *   **Validation:** Currently practical via WSL and QEMU
-*   **Possible:** OmniOS (illumos), GNU Hurd
-*   **Possible but impractical for maintainers right now:**  macOS, AIX, OpenVMS, Solaris
+*   **Possible:** OmniOS (illumos), GNU Hurd, FreeBSD
+*   **Possible but impractical for maintainers right now:**  macOS, AIX, OpenVMS, Solaris, Redox OS
 *   **Out of scope:** Windows (ZTreeWin exists), legacy UNIXes including HP-UX
 *   - [ ] **Status:** Not Started.

--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -1,0 +1,15 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_panel.h
+ * Panel-local AppState transition commits.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_PANEL_H
+#define YTNOVA_APPSTATE_PANEL_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel);
+
+#endif /* YTNOVA_APPSTATE_PANEL_H */

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -1,0 +1,21 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_panel.c
+ * Panel-local transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#define NO_YTNOVA_MACROS
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_panel.h"
+
+BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel) {
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->panel_generation++;
+  return TRUE;
+}

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -8,6 +8,7 @@
 #define NO_YTNOVA_MACROS
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
@@ -68,7 +69,8 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
 
   if (!panel->file_entry_list || panel->file_count == 0) {
     panel->file_selection_name[0] = '\0';
-    panel->panel_generation++;
+    if (!AppStateCommitPanelGeneration(panel))
+      return;
     return;
   }
 
@@ -87,7 +89,8 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
                    sizeof(panel->file_selection_name), "%s",
                    selected_file->name);
   }
-  panel->panel_generation++;
+  if (!AppStateCommitPanelGeneration(panel))
+    return;
 }
 
 static void DebugLogFilePanelState(const char *label, const YtreeNovaPanel *panel);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6135,6 +6135,32 @@ def test_active_panel_session_commits_through_appstate_helper() -> None:
     assert "AppStateCommitActivePanel(ctx, ctx->left)" in dir_body
 
 
+def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelGeneration(" in header
+    assert 'include "ytnova_appstate_panel.h"' in ctrl_file_ops
+
+    helper_start = helper.index("BOOL AppStateCommitPanelGeneration(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("panel.panel_generation")'
+    generation_write = "panel->panel_generation++;"
+    assert validation in helper_body
+    assert generation_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(generation_write)
+
+    capture_start = ctrl_file_ops.index("void CapturePanelSelectionAnchor(")
+    capture_end = ctrl_file_ops.index(
+        "\nstatic void DebugLogFilePanelState(", capture_start
+    )
+    capture_body = ctrl_file_ops[capture_start:capture_end]
+
+    assert "panel->panel_generation++;" not in capture_body
+    assert capture_body.count("AppStateCommitPanelGeneration(panel)") == 2
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState panel-generation commit helper.
- Route file-selection anchor generation bumps through the helper.
- Extend AppState contract guards to reject direct file-selection anchor generation increments.

## Validation
- `python3 scripts/check_appstate_contract.py`
- `pytest tests/test_appstate_contract_guard.py -q`
- `pytest tests/test_file_window_dispatch_regressions.py tests/test_panel_isolation.py -q`
- `make clean && make`
- `git diff --check`
