### PR TITLE
refactor(appstate): route viewport generations through helper

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -378,7 +379,8 @@ void PositionPanelAtIndex(YtreeNovaPanel *panel, int idx) {
   panel->disp_begin_pos = begin;
   panel->cursor_pos = cursor;
   RememberPanelViewportTop(panel);
-  panel->panel_generation++;
+  if (!AppStateCommitPanelGeneration(panel))
+    return;
 }
 
 static BOOL VisibleIndexWithinTopPath(const struct Volume *vol,
@@ -478,7 +480,8 @@ BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *pane
   }
 
   RememberPanelViewportTop(panel);
-  panel->panel_generation++;
+  if (!AppStateCommitPanelGeneration(panel))
+    return FALSE;
   return TRUE;
 }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6161,6 +6161,28 @@ def test_file_selection_anchor_generation_commits_through_appstate_helper() -> N
     assert capture_body.count("AppStateCommitPanelGeneration(panel)") == 2
 
 
+def test_panel_anchor_viewport_generation_commits_through_appstate_helper() -> None:
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    assert 'include "ytnova_appstate_panel.h"' in panel_anchor
+
+    position_start = panel_anchor.index("void PositionPanelAtIndex(")
+    position_end = panel_anchor.index(
+        "\nstatic BOOL VisibleIndexWithinTopPath(", position_start
+    )
+    position_body = panel_anchor[position_start:position_end]
+    restore_start = panel_anchor.index("BOOL RestorePanelViewportSnapshot(")
+    restore_end = panel_anchor.index(
+        "\nBOOL RestorePanelTreeViewportSnapshot(", restore_start
+    )
+    restore_body = panel_anchor[restore_start:restore_end]
+
+    assert "panel->panel_generation++;" not in position_body
+    assert "panel->panel_generation++;" not in restore_body
+    assert position_body.count("AppStateCommitPanelGeneration(panel)") == 1
+    assert restore_body.count("AppStateCommitPanelGeneration(panel)") == 1
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -284,7 +284,8 @@ def test_restore_snapshots_validate_generation_before_reuse():
         in panel_anchor_source
     )
 
-    assert "panel->panel_generation++;" in panel_anchor_source, panel_anchor_source
+    assert 'include "ytnova_appstate_panel.h"' in panel_anchor_source
+    assert "AppStateCommitPanelGeneration(panel)" in panel_anchor_source
     assert "dst->panel_generation = src->panel_generation;" in panel_anchor_source
 
     assert "AppStateCommitPanelVisibilityFilter(p, !p->hide_dot_files)" in dir_ops_source


### PR DESCRIPTION
## Summary
- Route panel-anchor viewport generation commits through the AppState panel helper.
- Add contract coverage for viewport generation helper boundaries.
- Align snapshot regression guard with the AppState helper boundary.

## Validation
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_restore_snapshots_validate_generation_before_reuse -q`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py && pytest tests/test_appstate_contract_guard.py -q && pytest tests/test_panel_isolation.py tests/test_dir_window_dispatch_regressions.py -q`
- `make clean && make`
- `git diff --check`
