### PR TITLE
refactor(appstate): route panel generation restores through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -11,5 +11,7 @@
 #include "ytnova_defs.h"
 
 BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel);
+BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
+                                    unsigned int panel_generation);
 
 #endif /* YTNOVA_APPSTATE_PANEL_H */

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -6,13 +6,13 @@
 #
 annotated-types==0.7.0
     # via pydantic
-certifi==2026.5.20
+certifi==2026.6.17
     # via requests
 cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==48.0.1
+cryptography==49.0.0
     # via google-auth
 google-ai-generativelanguage==0.6.15
     # via google-generativeai
@@ -21,9 +21,9 @@ google-api-core[grpc]==2.31.0
     #   google-ai-generativelanguage
     #   google-api-python-client
     #   google-generativeai
-google-api-python-client==2.197.0
+google-api-python-client==2.198.0
     # via google-generativeai
-google-auth==2.53.0
+google-auth==2.55.1
     # via
     #   google-ai-generativelanguage
     #   google-api-core
@@ -33,18 +33,18 @@ google-auth==2.53.0
 google-auth-httplib2==0.4.0
     # via google-api-python-client
 google-generativeai==0.8.6
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 googleapis-common-protos==1.75.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.81.0
+grpcio==1.81.1
     # via
     #   google-api-core
     #   grpcio-status
 grpcio-status==1.71.2
     # via google-api-core
-httplib2==0.31.2
+httplib2==0.32.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
@@ -57,11 +57,11 @@ nexus-rpc==1.4.0
 packaging==26.2
     # via pytest
 pexpect==4.9.0
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 pluggy==1.6.0
     # via pytest
 prompt-toolkit==3.0.52
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 proto-plus==1.28.0
     # via
     #   google-ai-generativelanguage
@@ -92,14 +92,14 @@ pygments==2.20.0
 pyparsing==3.3.2
     # via httplib2
 pyte==0.8.2
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 pytest==9.1.1
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 requests==2.34.2
     # via google-api-core
 temporalio==1.29.0
-    # via -r requirements.in
-tqdm==4.68.1
+    # via -r scripts/requirements.in
+tqdm==4.68.3
     # via google-generativeai
 types-protobuf==6.32.1.20260221
     # via temporalio
@@ -118,7 +118,7 @@ uritemplate==4.2.0
     # via google-api-python-client
 urllib3==2.7.0
     # via requests
-wcwidth==0.8.0
+wcwidth==0.8.1
     # via
     #   prompt-toolkit
     #   pyte

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_cmd.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include <assert.h>
@@ -297,8 +298,9 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
                                       (ViewFocus)panel->vol->saved_focus))
           return -1;
         state = FindPanelVolumeFileState(panel, panel->vol->id);
-        if (state)
-          panel->panel_generation = state->saved_tree_panel_generation;
+        if (state && !AppStateRestorePanelGeneration(
+                         panel, state->saved_tree_panel_generation))
+          return -1;
         ctx->global_search_term[0] = '\0';
         ctx->view_mode = panel->vol->vol_stats.log_mode;
 

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -19,3 +19,14 @@ BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel) {
   panel->panel_generation++;
   return TRUE;
 }
+
+BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
+                                    unsigned int panel_generation) {
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->panel_generation = panel_generation;
+  return TRUE;
+}

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -695,7 +695,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   dst->file_mode = src->file_mode;
   dst->max_column = src->max_column;
   dst->current_dir_entry = src->current_dir_entry;
-  dst->panel_generation = src->panel_generation;
+  if (!AppStateRestorePanelGeneration(dst, src->panel_generation))
+    return FALSE;
   if (!AppStateCommitPanelFocus(ctx, dst, src->saved_focus))
     return FALSE;
   if (!AppStateCommitPanelFileShape(dst, src->saved_big_file_view))
@@ -715,7 +716,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
     dst->cursor_pos = dst_cursor_pos;
     dst->disp_begin_pos = dst_disp_begin_pos;
     dst->current_dir_entry = dst_current_dir_entry;
-    dst->panel_generation = dst_panel_generation;
+    if (!AppStateRestorePanelGeneration(dst, dst_panel_generation))
+      return FALSE;
     if (dst_current_volume_state &&
         dst_current_volume_state->saved_file_selection_dir_path[0] != '\0') {
       if (!AppStateCommitPanelFileShape(

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -9,6 +9,7 @@
 
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
@@ -510,7 +511,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         ctx->left->cursor_pos = source_cursor_pos;
         ctx->left->disp_begin_pos = source_disp_begin_pos;
         ctx->left->current_dir_entry = source_current_dir_entry;
-        ctx->left->panel_generation = source_panel_generation;
+        if (!AppStateRestorePanelGeneration(ctx->left,
+                                            source_panel_generation))
+          return FALSE;
         if (!AppStateCommitPanelFocus(ctx, ctx->left, FOCUS_TREE))
           return FALSE;
       }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5349,6 +5349,7 @@ int AppStateValidatedGenerationDomain(const char *domain_id) {
 }
 
 #include "src/ui/appstate_focus.c"
+#include "src/ui/appstate_panel.c"
 #include "src/ui/appstate_session.c"
 #include "src/ui/appstate_visibility.c"
 #include "src/ui/split_transition.c"
@@ -6181,6 +6182,54 @@ def test_panel_anchor_viewport_generation_commits_through_appstate_helper() -> N
     assert "panel->panel_generation++;" not in restore_body
     assert position_body.count("AppStateCommitPanelGeneration(panel)") == 1
     assert restore_body.count("AppStateCommitPanelGeneration(panel)") == 1
+
+
+def test_panel_generation_restores_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
+
+    assert "BOOL AppStateRestorePanelGeneration(" in header
+    assert 'include "ytnova_appstate_panel.h"' in log_source
+    assert 'include "ytnova_appstate_panel.h"' in split_transition
+
+    helper_start = helper.index("BOOL AppStateRestorePanelGeneration(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("panel.panel_generation")'
+    generation_restore = "panel->panel_generation = panel_generation;"
+    assert validation in helper_body
+    assert generation_restore in helper_body
+    assert helper_body.index(validation) < helper_body.index(generation_restore)
+
+    log_start = log_source.index("int LogDisk(")
+    log_end = log_source.index("\nint GetNewLogPath(", log_start)
+    log_body = log_source[log_start:log_end]
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index(
+        "\nDirEntry *FindDirByPathInTree(", donate_start
+    )
+    donate_body = panel_anchor[donate_start:donate_end]
+    split_start = split_transition.index(
+        "BOOL SplitTransition_HandleDirWindowAction("
+    )
+    split_body = split_transition[split_start:]
+
+    assert (
+        "panel->panel_generation = state->saved_tree_panel_generation;"
+        not in log_body
+    )
+    assert "dst->panel_generation = src->panel_generation;" not in donate_body
+    assert "dst->panel_generation = dst_panel_generation;" not in donate_body
+    assert "ctx->left->panel_generation = source_panel_generation;" not in split_body
+    assert log_body.count("AppStateRestorePanelGeneration(") == 1
+    assert "state->saved_tree_panel_generation" in log_body
+    assert donate_body.count("AppStateRestorePanelGeneration(dst,") == 2
+    assert split_body.count("AppStateRestorePanelGeneration(") == 1
+    assert "source_panel_generation" in split_body
 
 
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -286,7 +286,9 @@ def test_restore_snapshots_validate_generation_before_reuse():
 
     assert 'include "ytnova_appstate_panel.h"' in panel_anchor_source
     assert "AppStateCommitPanelGeneration(panel)" in panel_anchor_source
-    assert "dst->panel_generation = src->panel_generation;" in panel_anchor_source
+    assert "AppStateRestorePanelGeneration(dst, src->panel_generation)" in (
+        panel_anchor_source
+    )
 
     assert "AppStateCommitPanelVisibilityFilter(p, !p->hide_dot_files)" in dir_ops_source
     assert "panel->panel_generation++;" in visibility_source, visibility_source
@@ -351,7 +353,9 @@ def test_log_disk_restore_does_not_use_volume_tree_breadcrumbs():
     log_disk_source = _log_disk_source()
     reset_snapshot_source = _reset_panel_tree_viewport_snapshot_source()
 
-    assert "panel->panel_generation = state->saved_tree_panel_generation;" in (
+    assert "AppStateRestorePanelGeneration(" in log_disk_source
+    assert "state->saved_tree_panel_generation" in log_disk_source
+    assert "panel->panel_generation = state->saved_tree_panel_generation;" not in (
         log_disk_source
     )
     assert "panel->vol->saved_tree_generation" not in log_disk_source


### PR DESCRIPTION
## Summary
- Adds an AppState helper for restoring saved panel generation values behind the panel owner-field guard.
- Routes volume-switch, panel donation, and split restoration generation writes through that helper.
- Adds a focused contract guard for these restore boundaries.

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_generation_restores_route_through_appstate_helper`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_generation or file_selection_anchor_generation or panel_anchor_viewport_generation'`
- `git diff --check`
