### PR TITLE
refactor(appstate): route volume generations through helper

### DIFF
--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -1,0 +1,15 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_volume.h
+ * Volume AppState transition commits.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_VOLUME_H
+#define YTNOVA_APPSTATE_VOLUME_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitVolumeGeneration(struct Volume *volume);
+
+#endif /* YTNOVA_APPSTATE_VOLUME_H */

--- a/src/ui/appstate_visibility.c
+++ b/src/ui/appstate_visibility.c
@@ -8,6 +8,7 @@
 #define NO_YTNOVA_MACROS
 
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_visibility.h"
 
 BOOL AppStateCommitPanelVisibilityFilter(YtreeNovaPanel *panel,
@@ -23,7 +24,8 @@ BOOL AppStateCommitPanelVisibilityFilter(YtreeNovaPanel *panel,
 
   panel->hide_dot_files = hide_dot_files ? TRUE : FALSE;
   panel->panel_generation++;
-  panel->vol->volume_generation++;
+  if (!AppStateCommitVolumeGeneration(panel->vol))
+    return FALSE;
   return TRUE;
 }
 

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -1,0 +1,19 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_volume.c
+ * Volume AppState transition commit helpers.
+ *
+ ***************************************************************************/
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_volume.h"
+
+BOOL AppStateCommitVolumeGeneration(struct Volume *volume) {
+  if (!AppStateValidatedOwnerField("volume.volume_generation"))
+    return FALSE;
+  if (!volume)
+    return FALSE;
+
+  volume->volume_generation++;
+  return TRUE;
+}

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -9,6 +9,7 @@
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
@@ -163,8 +164,9 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
 
   if (!dir_entry->unlogged_flag &&
       (dir_entry->sub_tree != NULL || dir_entry->file != NULL)) {
+    if (!AppStateCommitVolumeGeneration(p->vol))
+      return;
     dir_entry->not_scanned = FALSE;
-    p->vol->volume_generation++;
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     if (inactive && inactive->vol == p->vol) {
@@ -959,7 +961,10 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
   if (!MakeDirectory(ctx, ctx->active, dir_entry, dir_name, s)) {
       DebugLogSplitState("HandleDirMakeDirectory:after_make_before_rebuild",
                          ctx);
-      ctx->active->vol->volume_generation++;
+      if (!AppStateCommitVolumeGeneration(ctx->active->vol)) {
+        FreePathList(inactive_tagged_snapshot);
+        return;
+      }
       BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
       if (active_anchor_path[0] != '\0') {
         ReanchorPanelToDir(
@@ -1028,7 +1033,8 @@ DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   CapturePanelViewportSnapshot(ctx->active, ctx->active->vol, &active_viewport);
 
   if (!DeleteDirectory(ctx, dir_entry, UI_ChoiceResolver)) {
-    ctx->active->vol->volume_generation++;
+    if (!AppStateCommitVolumeGeneration(ctx->active->vol))
+      return dir_entry;
   }
 
   BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
@@ -1081,7 +1087,8 @@ DirEntry *HandleDirRenameDirectory(ViewContext *ctx, DirEntry *dir_entry) {
   if (!GetRenameParameter(ctx, dir_entry->name, new_name)) {
     int rename_result = RenameDirectory(ctx, dir_entry, new_name);
     if (!rename_result) {
-      ctx->active->vol->volume_generation++;
+      if (!AppStateCommitVolumeGeneration(ctx->active->vol))
+        return dir_entry;
       BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
       dir_entry = ResolveActiveDirEntry(ctx, s);
     }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5351,6 +5351,7 @@ int AppStateValidatedGenerationDomain(const char *domain_id) {
 #include "src/ui/appstate_focus.c"
 #include "src/ui/appstate_panel.c"
 #include "src/ui/appstate_session.c"
+#include "src/ui/appstate_volume.c"
 #include "src/ui/appstate_visibility.c"
 #include "src/ui/split_transition.c"
 
@@ -5987,7 +5988,7 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
     volume_owner_validation = 'AppStateValidatedOwnerField("volume.volume_generation")'
     panel_write = "panel->hide_dot_files = hide_dot_files ? TRUE : FALSE;"
     panel_generation = "panel->panel_generation++;"
-    volume_generation = "panel->vol->volume_generation++;"
+    volume_generation = "AppStateCommitVolumeGeneration(panel->vol)"
 
     for required in [
         domain_validation,
@@ -6230,6 +6231,31 @@ def test_panel_generation_restores_route_through_appstate_helper() -> None:
     assert donate_body.count("AppStateRestorePanelGeneration(dst,") == 2
     assert split_body.count("AppStateRestorePanelGeneration(") == 1
     assert "source_panel_generation" in split_body
+
+
+def test_volume_generation_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    visibility = Path("src/ui/appstate_visibility.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitVolumeGeneration(" in header
+    assert 'include "ytnova_appstate_volume.h"' in visibility
+    assert 'include "ytnova_appstate_volume.h"' in dir_ops
+
+    helper_start = helper.index("BOOL AppStateCommitVolumeGeneration(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("volume.volume_generation")'
+    generation_write = "volume->volume_generation++;"
+    assert validation in helper_body
+    assert generation_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(generation_write)
+
+    assert "panel->vol->volume_generation++;" not in visibility
+    assert "AppStateCommitVolumeGeneration(panel->vol)" in visibility
+    assert "p->vol->volume_generation++;" not in dir_ops
+    assert "ctx->active->vol->volume_generation++;" not in dir_ops
+    assert dir_ops.count("AppStateCommitVolumeGeneration(") == 4
 
 
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
@@ -6527,7 +6553,7 @@ def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> 
         "ClearHelp(ctx);",
         "CaptureInactiveFallback(",
         "MakeDirectory(ctx,",
-        "volume_generation++",
+        "AppStateCommitVolumeGeneration(",
         "BuildDirEntryList(",
         "ReanchorPanelToDir(",
         "RefreshView(",
@@ -6548,7 +6574,7 @@ def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> 
         "CaptureInactiveFallbackSnapshot(",
         "CapturePanelViewportSnapshot(",
         "DeleteDirectory(ctx,",
-        "volume_generation++",
+        "AppStateCommitVolumeGeneration(",
         "BuildDirEntryList(",
         "RestorePanelViewportSnapshot(",
         "ReanchorPanelToDir(",
@@ -6568,7 +6594,7 @@ def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> 
     for call in [
         "GetRenameParameter(",
         "RenameDirectory(ctx,",
-        "volume_generation++",
+        "AppStateCommitVolumeGeneration(",
         "BuildDirEntryList(",
         "RefreshView(",
     ]:

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -292,8 +292,8 @@ def test_restore_snapshots_validate_generation_before_reuse():
 
     assert "AppStateCommitPanelVisibilityFilter(p, !p->hide_dot_files)" in dir_ops_source
     assert "panel->panel_generation++;" in visibility_source, visibility_source
-    assert "panel->vol->volume_generation++;" in visibility_source, visibility_source
-    assert "ctx->active->vol->volume_generation++;" in dir_ops_source, dir_ops_source
+    assert "AppStateCommitVolumeGeneration(panel->vol)" in visibility_source
+    assert "AppStateCommitVolumeGeneration(ctx->active->vol)" in dir_ops_source
 
 
 def test_volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb():


### PR DESCRIPTION
## Summary
- Adds a dedicated AppState volume helper for generation commits behind the volume owner-field guard.
- Routes visibility and directory mutation generation advances through that helper.
- Adds focused contract guards for the volume-generation boundary.

## Validation
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'volume_generation_commits_route_through_appstate_helper or visibility_filter_commit'`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py::test_restore_snapshots_validate_generation_before_reuse -q`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py::test_split_transition_helpers_fail_closed_on_invalid_appstate_boundary tests/test_appstate_contract_guard.py::test_volume_generation_commits_route_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_visibility_filter_commits_through_appstate_helper tests/test_dir_window_dispatch_regressions.py::test_restore_snapshots_validate_generation_before_reuse -q`
- `git diff --check`
