### PR TITLE
refactor(appstate): route split layout commits through helper

### DIFF
--- a/include/ytnova_appstate_layout.h
+++ b/include/ytnova_appstate_layout.h
@@ -1,0 +1,15 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_layout.h
+ * Layout transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_LAYOUT_H
+#define YTNOVA_APPSTATE_LAYOUT_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitSplitScreenLayout(ViewContext *ctx, BOOL is_split_screen);
+
+#endif /* YTNOVA_APPSTATE_LAYOUT_H */

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file=scripts/requirements.txt scripts/requirements.in
 #
+#
 annotated-types==0.7.0
     # via pydantic
 certifi==2026.6.17

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -10,6 +10,7 @@
 
 #include "ytnova_defs.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_debug.h"
@@ -353,7 +354,10 @@ void InitView(ViewContext *ctx) {
   ctx->viewer.inhex = TRUE;
   ctx->view_mode = DISK_MODE;
   ctx->dir_mode = MODE_3;
-  ctx->is_split_screen = FALSE;
+  if (!AppStateCommitSplitScreenLayout(ctx, FALSE)) {
+    fprintf(stderr, "InitView: failed to initialize split layout\n");
+    exit(1);
+  }
 
   /* Initialize Panels */
   ctx->left = (YtreeNovaPanel *)calloc(1, sizeof(YtreeNovaPanel));
@@ -742,7 +746,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
   /* ctx already assigned in main.c */
 
   /* Initial Panel Defaults */
-  ctx->is_split_screen = FALSE;
+  if (!AppStateCommitSplitScreenLayout(ctx, FALSE))
+    return -1;
   if (!AppStateCommitActivePanel(ctx, ctx->left))
     return -1;
   /* Explicitly initialize panel file lists to zero */

--- a/src/ui/appstate_layout.c
+++ b/src/ui/appstate_layout.c
@@ -1,0 +1,19 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_layout.c
+ * Layout transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_layout.h"
+
+BOOL AppStateCommitSplitScreenLayout(ViewContext *ctx, BOOL is_split_screen) {
+  if (!AppStateValidatedOwnerField("ctx.layout"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->is_split_screen = is_split_screen ? TRUE : FALSE;
+  return TRUE;
+}

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -9,6 +9,7 @@
 
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_appstate_visibility.h"
@@ -308,7 +309,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
           !DonatePanelState(ctx, ctx->left, ctx->right))
         return FALSE;
 
-      ctx->is_split_screen = !ctx->is_split_screen;
+      if (!AppStateCommitSplitScreenLayout(ctx, !ctx->is_split_screen))
+        return FALSE;
       if (closing_split && !AppStateCommitActivePanel(ctx, ctx->left))
         return FALSE;
       ReCreateWindows(ctx);
@@ -526,7 +528,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       if (closing_active &&
           !AppStateCommitPanelFocus(ctx, closing_active, FOCUS_TREE))
         return FALSE;
-      ctx->is_split_screen = !ctx->is_split_screen;
+      if (!AppStateCommitSplitScreenLayout(ctx, !ctx->is_split_screen))
+        return FALSE;
       if (closing_split && !AppStateCommitActivePanel(ctx, ctx->left))
         return FALSE;
       ReCreateWindows(ctx);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5349,6 +5349,7 @@ int AppStateValidatedGenerationDomain(const char *domain_id) {
 }
 
 #include "src/ui/appstate_focus.c"
+#include "src/ui/appstate_layout.c"
 #include "src/ui/appstate_panel.c"
 #include "src/ui/appstate_session.c"
 #include "src/ui/appstate_volume.c"
@@ -6135,6 +6136,54 @@ def test_active_panel_session_commits_through_appstate_helper() -> None:
     assert init_body.count("AppStateCommitActivePanel(ctx, ctx->left)") >= 2
     assert "AppStateCommitActivePanel(ctx, ctx->left)" in recreate_body
     assert "AppStateCommitActivePanel(ctx, ctx->left)" in dir_body
+
+
+def test_split_layout_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_layout.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_layout.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitSplitScreenLayout(" in header
+    assert 'include "ytnova_appstate_layout.h"' in split_transition
+    assert 'include "ytnova_appstate_layout.h"' in init_source
+
+    helper_start = helper.index("BOOL AppStateCommitSplitScreenLayout(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.layout")'
+    layout_write = "ctx->is_split_screen = is_split_screen ? TRUE : FALSE;"
+
+    assert validation in helper_body
+    assert layout_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(layout_write)
+
+    for source in [split_transition, init_source]:
+        assert not re.search(r"\bctx->is_split_screen\s*=[^=]", source)
+
+    file_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleFileWindowAction("
+    )
+    dir_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleDirWindowAction("
+    )
+    file_split_body = split_transition[file_split_start:dir_split_start]
+    dir_split_body = split_transition[dir_split_start:]
+    init_view_start = init_source.index("void InitView(")
+    init_view_end = init_source.index("\nvoid CoreMainOps_Register(", init_view_start)
+    init_view_body = init_source[init_view_start:init_view_end]
+    init_start = init_source.index("int Init(")
+    init_body = init_source[init_start:]
+
+    assert "AppStateCommitSplitScreenLayout(ctx, !ctx->is_split_screen)" in (
+        file_split_body
+    )
+    assert "AppStateCommitSplitScreenLayout(ctx, !ctx->is_split_screen)" in (
+        dir_split_body
+    )
+    assert "AppStateCommitSplitScreenLayout(ctx, FALSE)" in init_view_body
+    assert "AppStateCommitSplitScreenLayout(ctx, FALSE)" in init_body
 
 
 def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:

--- a/tests/test_file_window_dispatch_regressions.py
+++ b/tests/test_file_window_dispatch_regressions.py
@@ -129,9 +129,11 @@ def test_HandleFileWindow_delegates_split_transition_hotspot():
         "Split transition owner API must validate the inactive panel after "
         f"Tab handoff.\n{split_block}"
     )
-    assert "ctx->is_split_screen = !ctx->is_split_screen;" in split_block, (
-        "Split transition owner API must commit the split toggle inside the "
-        f"transaction.\n{split_block}"
+    assert (
+        "AppStateCommitSplitScreenLayout(ctx, !ctx->is_split_screen)" in split_block
+    ), (
+        "Split transition owner API must commit the split toggle through "
+        f"AppState inside the transaction.\n{split_block}"
     )
 
 


### PR DESCRIPTION
Summary
- add a layout AppState helper for split-screen state commits guarded by the ctx layout owner field
- route initialization and split toggle writes through the helper
- extend the AppState contract guard for the split layout boundary

Validation
- make clean && make
- source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k "split_layout or active_panel_session"
- python3 scripts/check_appstate_contract.py
- git diff --check