### PR TITLE
refactor(appstate): route view mode commits through helper

### DIFF
--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -82,6 +82,7 @@
       "owner_field_refs": [
         "ctx.active",
         "ctx.command_state",
+        "ctx.view_mode",
         "ctx.message_state",
         "ctx.modal_state",
         "ctx.pending_transition",

--- a/docs/appstate_invariants.json
+++ b/docs/appstate_invariants.json
@@ -260,6 +260,7 @@
       "owner_region": "ctx/session state",
       "protected_fields": [
         "ctx.command_state",
+        "ctx.view_mode",
         "ctx.message_state",
         "ctx.modal_state",
         "ctx.pending_transition",

--- a/docs/appstate_owner_fields.json
+++ b/docs/appstate_owner_fields.json
@@ -28,6 +28,18 @@
       ]
     },
     {
+      "field": "ctx.view_mode",
+      "owner_region": "ctx/session state",
+      "canonical_owner": "ViewContext.view_mode",
+      "runtime_carrier": "ViewContext.view_mode",
+      "mutation_rule": "May change only through allowed volume restore, log, or mode transition commits.",
+      "migration_status": "runtime_backed",
+      "invariant_checks": [
+        "invariant.blocked-transition-determinism",
+        "invariant.shared-state-panel-local-isolation"
+      ]
+    },
+    {
       "field": "ctx.message_state",
       "owner_region": "ctx/session state",
       "canonical_owner": "ViewContext.message_region",

--- a/include/ytnova_appstate_mode.h
+++ b/include/ytnova_appstate_mode.h
@@ -1,0 +1,15 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_mode.h
+ * View-mode transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_MODE_H
+#define YTNOVA_APPSTATE_MODE_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitViewMode(ViewContext *ctx, int view_mode);
+
+#endif /* YTNOVA_APPSTATE_MODE_H */

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file=scripts/requirements.txt scripts/requirements.in
 #
 #
+#
 annotated-types==0.7.0
     # via pydantic
 certifi==2026.6.17

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_cmd.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -302,7 +303,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
                          panel, state->saved_tree_panel_generation))
           return -1;
         ctx->global_search_term[0] = '\0';
-        ctx->view_mode = panel->vol->vol_stats.log_mode;
+        if (!AppStateCommitViewMode(ctx, panel->vol->vol_stats.log_mode))
+          return -1;
 
         /* Re-apply the volume's own filter */
         (void)SetFilter(s->file_spec, s);
@@ -415,7 +417,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
       /* We tried to create a NEW volume and failed. */
       /* panel->vol is still old_vol (valid). Restore its display. */
       panel->vol = old_vol;
-      ctx->view_mode = panel->vol->vol_stats.log_mode;
+      if (!AppStateCommitViewMode(ctx, panel->vol->vol_stats.log_mode))
+        return -1;
       s = &panel->vol->vol_stats;
 
       if (ctx->hook_display_menu)
@@ -451,7 +454,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
                                 (ViewFocus)panel->vol->saved_focus))
     return -1;
   ctx->global_search_term[0] = '\0';
-  ctx->view_mode = s->log_mode;
+  if (!AppStateCommitViewMode(ctx, s->log_mode))
+    return -1;
 
   /* If this is a new volume (not the startup one), apply saved filter from
    * previous context */

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -196,6 +196,14 @@ static const AppStateOwnerFieldMetadata kAppStateOwnerFields[] = {
    "runtime_backed",
    kAppStateOwnerFieldInvariantChecks1,
    sizeof(kAppStateOwnerFieldInvariantChecks1) / sizeof(kAppStateOwnerFieldInvariantChecks1[0])},
+  {"ctx.view_mode",
+   "ctx/session state",
+   "ViewContext.view_mode",
+   "ViewContext.view_mode",
+   "May change only through allowed volume restore, log, or mode transition commits.",
+   "runtime_backed",
+   kAppStateOwnerFieldInvariantChecks1,
+   sizeof(kAppStateOwnerFieldInvariantChecks1) / sizeof(kAppStateOwnerFieldInvariantChecks1[0])},
   {"ctx.message_state",
    "ctx/session state",
    "ViewContext.message_region",
@@ -860,6 +868,7 @@ static const char *const kAppStateDiffHarnessTransitionIds1[] = {
 static const char *const kAppStateDiffHarnessOwnerFieldRefs1[] = {
   "ctx.active",
   "ctx.command_state",
+  "ctx.view_mode",
   "ctx.message_state",
   "ctx.modal_state",
   "ctx.pending_transition",
@@ -3029,6 +3038,7 @@ static const char *const kAppStateInvariantMigrationNotes6[] = {
 
 static const char *const kAppStateInvariantProtectedFields7[] = {
   "ctx.command_state",
+  "ctx.view_mode",
   "ctx.message_state",
   "ctx.modal_state",
   "ctx.pending_transition",

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -11,6 +11,7 @@
 #include "ytnova_defs.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_layout.h"
+#include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_debug.h"
@@ -352,7 +353,10 @@ void InitView(ViewContext *ctx) {
   memset(ctx, 0, sizeof(ViewContext));
   CoreMainOps_Register(ctx);
   ctx->viewer.inhex = TRUE;
-  ctx->view_mode = DISK_MODE;
+  if (!AppStateCommitViewMode(ctx, DISK_MODE)) {
+    fprintf(stderr, "InitView: failed to initialize view mode\n");
+    exit(1);
+  }
   ctx->dir_mode = MODE_3;
   if (!AppStateCommitSplitScreenLayout(ctx, FALSE)) {
     fprintf(stderr, "InitView: failed to initialize split layout\n");
@@ -781,7 +785,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
   ctx->ctx_preview_window = NULL;
 
   /* Initialize global mode default */
-  ctx->view_mode = DISK_MODE;
+  if (!AppStateCommitViewMode(ctx, DISK_MODE))
+    return -1;
 
   /* Use setlocale to correctly initialize for WITH_UTF8 or system locale */
   setlocale(LC_ALL, "");

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -178,6 +178,7 @@ static const char *const kAppStateRequiredTransitionIds[] = {
 static const char *const kAppStateRequiredOwnerFieldIds[] = {
   "ctx.active",
   "ctx.command_state",
+  "ctx.view_mode",
   "ctx.message_state",
   "ctx.modal_state",
   "ctx.pending_transition",

--- a/src/ui/appstate_mode.c
+++ b/src/ui/appstate_mode.c
@@ -1,0 +1,21 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_mode.c
+ * View-mode transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_mode.h"
+
+BOOL AppStateCommitViewMode(ViewContext *ctx, int view_mode) {
+  if (!AppStateValidatedOwnerField("ctx.view_mode"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+  if (view_mode < DISK_MODE || view_mode >= MAX_MODES)
+    return FALSE;
+
+  ctx->view_mode = view_mode;
+  return TRUE;
+}

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -9,6 +9,7 @@
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
@@ -397,7 +398,8 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
   ctx->active->start_file = (*dir_entry_ptr)->start_file;
   ctx->active->file_cursor_pos = (*dir_entry_ptr)->cursor_pos;
 
-  ctx->view_mode = ctx->active->vol->vol_stats.log_mode;
+  if (!AppStateCommitViewMode(ctx, ctx->active->vol->vol_stats.log_mode))
+    return FALSE;
   RefreshView(ctx, *dir_entry_ptr);
   return TRUE;
 }

--- a/src/ui/f2_picker.c
+++ b/src/ui/f2_picker.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_cmd.h"
+#include "ytnova_appstate_mode.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include "ytnova_ui.h"
@@ -364,7 +365,8 @@ int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
   if (ctx->active->vol != original_vol) {
     /* 1. Restore Global Volume Context */
     ctx->active->vol = original_vol;
-    ctx->view_mode = ctx->active->vol->vol_stats.log_mode;
+    if (!AppStateCommitViewMode(ctx, ctx->active->vol->vol_stats.log_mode))
+      return -1;
 
     /* 2. Restore ctx->active state from the restored volume */
     if (ctx->active)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6186,6 +6186,48 @@ def test_split_layout_commits_through_appstate_helper() -> None:
     assert "AppStateCommitSplitScreenLayout(ctx, FALSE)" in init_body
 
 
+def test_view_mode_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_mode.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_mode.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    f2_picker = Path("src/ui/f2_picker.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitViewMode(" in header
+    for source in [init_source, log_source, f2_picker, ctrl_dir]:
+        assert 'include "ytnova_appstate_mode.h"' in source
+
+    helper_start = helper.index("BOOL AppStateCommitViewMode(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.view_mode")'
+    bounds_check = "view_mode < DISK_MODE || view_mode >= MAX_MODES"
+    view_mode_write = "ctx->view_mode = view_mode;"
+
+    assert validation in helper_body
+    assert bounds_check in helper_body
+    assert view_mode_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(view_mode_write)
+    assert helper_body.index(bounds_check) < helper_body.index(view_mode_write)
+
+    for source in [init_source, log_source, f2_picker, ctrl_dir]:
+        assert not re.search(r"\bctx->view_mode\s*=[^=]", source)
+
+    assert init_source.count("AppStateCommitViewMode(ctx, DISK_MODE)") >= 2
+    assert "AppStateCommitViewMode(ctx, panel->vol->vol_stats.log_mode)" in (
+        log_source
+    )
+    assert "AppStateCommitViewMode(ctx, s->log_mode)" in log_source
+    assert (
+        "AppStateCommitViewMode(ctx, ctx->active->vol->vol_stats.log_mode)"
+        in f2_picker
+    )
+    assert (
+        "AppStateCommitViewMode(ctx, ctx->active->vol->vol_stats.log_mode)"
+        in ctrl_dir
+    )
+
+
 def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
Summary
- add a view-mode AppState helper guarded by the ctx view-mode owner field
- register view-mode authority with invariant and diff-harness coverage
- route initialization, log restore, picker restore, and directory restore writes through the helper

Validation
- make clean && make
- make
- source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k "view_mode or split_transition_helpers_fail_closed"
- python3 scripts/check_appstate_contract.py
- git diff --check