### PR TITLE
refactor(appstate): route message state through helper

### DIFF
--- a/include/ytnova_appstate_message.h
+++ b/include/ytnova_appstate_message.h
@@ -1,0 +1,16 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_message.h
+ * Message-state transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_MESSAGE_H
+#define YTNOVA_APPSTATE_MESSAGE_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitStatusLineError(ViewContext *ctx, const char *message);
+BOOL AppStateClearStatusLineError(ViewContext *ctx);
+
+#endif /* YTNOVA_APPSTATE_MESSAGE_H */

--- a/src/ui/appstate_message.c
+++ b/src/ui/appstate_message.c
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_message.c
+ * Message-state transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_message.h"
+
+BOOL AppStateCommitStatusLineError(ViewContext *ctx, const char *message) {
+  if (!AppStateValidatedOwnerField("ctx.message_state"))
+    return FALSE;
+  if (!ctx || !message)
+    return FALSE;
+
+  (void)snprintf(ctx->status_line_error_text,
+                 sizeof(ctx->status_line_error_text), "%s", message);
+  ctx->status_line_error_pending = TRUE;
+  return TRUE;
+}
+
+BOOL AppStateClearStatusLineError(ViewContext *ctx) {
+  if (!AppStateValidatedOwnerField("ctx.message_state"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->status_line_error_pending = FALSE;
+  ctx->status_line_error_text[0] = '\0';
+  return TRUE;
+}

--- a/src/ui/error.c
+++ b/src/ui/error.c
@@ -5,6 +5,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_message.h"
 #include "ytnova_ui.h"
 
 #include <stdarg.h>
@@ -49,16 +50,17 @@ void UI_RenderStatusLineError(ViewContext *ctx) {
 
 void UI_ShowStatusLineError(ViewContext *ctx, const char *fmt, ...) {
   va_list ap;
+  char message[PATH_LENGTH + 1];
 
   if (!ctx || !fmt)
     return;
 
   va_start(ap, fmt);
-  (void)vsnprintf(ctx->status_line_error_text, sizeof(ctx->status_line_error_text),
-                  fmt, ap);
+  (void)vsnprintf(message, sizeof(message), fmt, ap);
   va_end(ap);
 
-  ctx->status_line_error_pending = TRUE;
+  if (!AppStateCommitStatusLineError(ctx, message))
+    return;
   UI_RenderStatusLineError(ctx);
   doupdate();
 }
@@ -69,8 +71,8 @@ void UI_ClearStatusLineError(ViewContext *ctx) {
   if (!ctx || !ctx->status_line_error_pending)
     return;
 
-  ctx->status_line_error_pending = FALSE;
-  ctx->status_line_error_text[0] = '\0';
+  if (!AppStateClearStatusLineError(ctx))
+    return;
   ClearStatusLineErrorLine(ctx);
   if (!ctx->ctx_menu_window)
     return;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6228,6 +6228,47 @@ def test_view_mode_commits_through_appstate_helper() -> None:
     )
 
 
+def test_status_line_message_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_message.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_message.c").read_text(encoding="utf-8")
+    error_source = Path("src/ui/error.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitStatusLineError(" in header
+    assert "BOOL AppStateClearStatusLineError(" in header
+    assert 'include "ytnova_appstate_message.h"' in error_source
+
+    commit_start = helper.index("BOOL AppStateCommitStatusLineError(")
+    clear_start = helper.index("BOOL AppStateClearStatusLineError(")
+    commit_body = helper[commit_start:clear_start]
+    clear_body = helper[clear_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.message_state")'
+
+    assert validation in commit_body
+    assert validation in clear_body
+    assert "ctx->status_line_error_pending = TRUE;" in commit_body
+    assert "ctx->status_line_error_pending = FALSE;" in clear_body
+    assert "ctx->status_line_error_text[0] = '\\0';" in clear_body
+    assert commit_body.index(validation) < commit_body.index(
+        "ctx->status_line_error_pending = TRUE;"
+    )
+    assert clear_body.index(validation) < clear_body.index(
+        "ctx->status_line_error_pending = FALSE;"
+    )
+
+    assert "AppStateCommitStatusLineError(ctx, message)" in error_source
+    assert "AppStateClearStatusLineError(ctx)" in error_source
+
+    show_start = error_source.index("void UI_ShowStatusLineError(")
+    clear_start = error_source.index("void UI_ClearStatusLineError(")
+    show_body = error_source[show_start:clear_start]
+    clear_body = error_source[clear_start:]
+
+    assert "ctx->status_line_error_text" not in show_body
+    assert not re.search(r"\bctx->status_line_error_pending\s*=[^=]", show_body)
+    assert "ctx->status_line_error_text[0] = '\\0';" not in clear_body
+    assert not re.search(r"\bctx->status_line_error_pending\s*=[^=]", clear_body)
+
+
 def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a message-state AppState helper for status-line error commits and clears.
- Route status-line error text and pending-flag writes through the helper after owner-field validation.
- Add contract-guard coverage that blocks direct status-line message-state writes outside the helper.

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k status_line_message` failed before implementation because the helper boundary was missing.
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'status_line_message or owner_field or runtime_registry_boundary_validation'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'status_line_message or runtime_registry_boundary_validation'`
- `make clean && make` passed with existing warning baseline.
- `git diff --check`
