### PR TITLE
refactor(appstate): route volume registry through helper

### DIFF
--- a/.cppcheck-suppressions.txt
+++ b/.cppcheck-suppressions.txt
@@ -5,10 +5,10 @@ checkLevelNormal
 checkersReport
 
 # UTHash macro-expansion false-positive at HASH_ADD_INT callsite.
-unreachableCode:src/core/volume.c
+unreachableCode:src/core/appstate_volume_registry.c
 
 # UTHash internals trigger this in macro-expanded temporary variables.
-constVariablePointer:src/core/volume.c
+constVariablePointer:src/core/appstate_volume_registry.c
 
 # Tag-walk callback signature is shared and non-const by design.
 constParameterPointer:src/cmd/pipe.c

--- a/include/ytnova_appstate_volume_registry.h
+++ b/include/ytnova_appstate_volume_registry.h
@@ -1,0 +1,17 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_volume_registry.h
+ * Volume-registry transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_VOLUME_REGISTRY_H
+#define YTNOVA_APPSTATE_VOLUME_REGISTRY_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateRegisterVolume(ViewContext *ctx, struct Volume *volume);
+BOOL AppStateUnregisterVolume(ViewContext *ctx, struct Volume *volume);
+BOOL AppStateClearVolumeRegistry(ViewContext *ctx);
+
+#endif /* YTNOVA_APPSTATE_VOLUME_REGISTRY_H */

--- a/src/core/appstate_volume_registry.c
+++ b/src/core/appstate_volume_registry.c
@@ -1,0 +1,39 @@
+/***************************************************************************
+ *
+ * src/core/appstate_volume_registry.c
+ * Volume-registry transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_volume_registry.h"
+
+BOOL AppStateRegisterVolume(ViewContext *ctx, struct Volume *volume) {
+  if (!AppStateValidatedOwnerField("ctx.volumes_head"))
+    return FALSE;
+  if (!ctx || !volume)
+    return FALSE;
+
+  HASH_ADD_INT(ctx->volumes_head, id, volume);
+  return TRUE;
+}
+
+BOOL AppStateUnregisterVolume(ViewContext *ctx, struct Volume *volume) {
+  if (!AppStateValidatedOwnerField("ctx.volumes_head"))
+    return FALSE;
+  if (!ctx || !volume)
+    return FALSE;
+
+  HASH_DEL(ctx->volumes_head, volume);
+  return TRUE;
+}
+
+BOOL AppStateClearVolumeRegistry(ViewContext *ctx) {
+  if (!AppStateValidatedOwnerField("ctx.volumes_head"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->volumes_head = NULL;
+  return TRUE;
+}

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -5,8 +5,9 @@
  *
  ***************************************************************************/
 
-#include "ytnova_defs.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_volume_registry.h"
+#include "ytnova_defs.h"
 
 extern void FreePathList(PathList *list);
 
@@ -116,9 +117,10 @@ struct Volume *Volume_Create(ViewContext *ctx) {
     return NULL;
   }
 
-  /* Add the new volume to the global hash table (ctx->volumes_head)
-   * The 'id' field of the Volume struct is used as the key. */
-  HASH_ADD_INT(ctx->volumes_head, id, new_vol);
+  if (!AppStateRegisterVolume(ctx, new_vol)) {
+    free(new_vol);
+    return NULL;
+  }
 
   return new_vol;
 }
@@ -137,6 +139,8 @@ void Volume_Delete(ViewContext *ctx, struct Volume *vol) {
   if (vol == NULL) {
     return;
   }
+  if (!AppStateUnregisterVolume(ctx, vol))
+    return;
 
   if (vol->dir_entry_list) {
     free(vol->dir_entry_list);
@@ -155,9 +159,6 @@ void Volume_Delete(ViewContext *ctx, struct Volume *vol) {
     Volume_ClearPanelTags(ctx->right);
     ctx->right->vol = NULL;
   }
-
-  /* Remove the volume from the global hash table */
-  HASH_DEL(ctx->volumes_head, vol);
 
   /* Free the associated directory tree if it exists */
   if (vol->vol_stats.tree != NULL) {
@@ -187,7 +188,7 @@ void Volume_FreeAll(ViewContext *ctx) {
     ctx->left->vol = NULL;
   if (ctx->right)
     ctx->right->vol = NULL;
-  ctx->volumes_head = NULL;
+  (void)AppStateClearVolumeRegistry(ctx);
 }
 
 /*

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6269,6 +6269,48 @@ def test_status_line_message_commits_through_appstate_helper() -> None:
     assert not re.search(r"\bctx->status_line_error_pending\s*=[^=]", clear_body)
 
 
+def test_volume_registry_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume_registry.h").read_text(
+        encoding="utf-8"
+    )
+    helper = Path("src/core/appstate_volume_registry.c").read_text(
+        encoding="utf-8"
+    )
+    volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateRegisterVolume(" in header
+    assert "BOOL AppStateUnregisterVolume(" in header
+    assert "BOOL AppStateClearVolumeRegistry(" in header
+    assert 'include "ytnova_appstate_volume_registry.h"' in volume_source
+
+    register_start = helper.index("BOOL AppStateRegisterVolume(")
+    unregister_start = helper.index("BOOL AppStateUnregisterVolume(")
+    clear_start = helper.index("BOOL AppStateClearVolumeRegistry(")
+    register_body = helper[register_start:unregister_start]
+    unregister_body = helper[unregister_start:clear_start]
+    clear_body = helper[clear_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.volumes_head")'
+
+    assert validation in register_body
+    assert validation in unregister_body
+    assert validation in clear_body
+    assert "HASH_ADD_INT(ctx->volumes_head, id, volume);" in register_body
+    assert "HASH_DEL(ctx->volumes_head, volume);" in unregister_body
+    assert "ctx->volumes_head = NULL;" in clear_body
+    assert register_body.index(validation) < register_body.index("HASH_ADD_INT(")
+    assert unregister_body.index(validation) < unregister_body.index("HASH_DEL(")
+    assert clear_body.index(validation) < clear_body.index(
+        "ctx->volumes_head = NULL;"
+    )
+
+    assert "AppStateRegisterVolume(ctx, new_vol)" in volume_source
+    assert "AppStateUnregisterVolume(ctx, vol)" in volume_source
+    assert "AppStateClearVolumeRegistry(ctx)" in volume_source
+    assert "HASH_ADD_INT(ctx->volumes_head" not in volume_source
+    assert "HASH_DEL(ctx->volumes_head" not in volume_source
+    assert "ctx->volumes_head = NULL;" not in volume_source
+
+
 def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState volume-registry helper for registering, unregistering, and clearing loaded volumes.
- Route writes to the shared volume registry through owner-field validation.
- Add contract-guard coverage that blocks direct registry writes outside the helper.

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k volume_registry_commits` failed before implementation because the helper boundary was missing.
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_registry_commits or status_line_message or runtime_registry_boundary_validation'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_registry_commits or runtime_registry_boundary_validation'`
- `make clean && make` passed with existing warning baseline.
- `git diff --check`
