### PR TITLE
refactor(appstate): route active window handles through helper

### DIFF
--- a/include/ytnova_appstate_window.h
+++ b/include/ytnova_appstate_window.h
@@ -1,0 +1,15 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_window.h
+ * Window-handle transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_WINDOW_H
+#define YTNOVA_APPSTATE_WINDOW_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateSyncActiveWindowHandles(ViewContext *ctx);
+
+#endif /* YTNOVA_APPSTATE_WINDOW_H */

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -14,6 +14,7 @@
 #include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_appstate_visibility.h"
+#include "ytnova_appstate_window.h"
 #include "ytnova_debug.h"
 #include "default_profile_template.h"
 #include <fcntl.h>
@@ -636,11 +637,8 @@ void ReCreateWindows(ViewContext *ctx) {
     ctx->active->pan_file_window = ctx->left->pan_file_window;
   }
 
-  /* 7. Sync Global View Context */
-  ctx->ctx_dir_window = ctx->active->pan_dir_window;
-  ctx->ctx_small_file_window = ctx->active->pan_small_file_window;
-  ctx->ctx_big_file_window = ctx->active->pan_big_file_window;
-  ctx->ctx_file_window = ctx->active->pan_file_window;
+  if (!AppStateSyncActiveWindowHandles(ctx))
+    return;
 
   /* 8. Utility Windows */
   if (ctx->ctx_border_window)

--- a/src/ui/appstate_window.c
+++ b/src/ui/appstate_window.c
@@ -1,0 +1,22 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_window.c
+ * Window-handle transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_window.h"
+
+BOOL AppStateSyncActiveWindowHandles(ViewContext *ctx) {
+  if (!AppStateValidatedOwnerField("ctx.window_handles"))
+    return FALSE;
+  if (!ctx || !ctx->active)
+    return FALSE;
+
+  ctx->ctx_dir_window = ctx->active->pan_dir_window;
+  ctx->ctx_small_file_window = ctx->active->pan_small_file_window;
+  ctx->ctx_big_file_window = ctx->active->pan_big_file_window;
+  ctx->ctx_file_window = ctx->active->pan_file_window;
+  return TRUE;
+}

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -10,6 +10,7 @@
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
+#include "ytnova_appstate_window.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -292,10 +293,8 @@ BOOL handle_file_window_preview_action(
 
       dir_entry = ResolveActiveDirEntry(ctx, stats_local);
 
-      ctx->ctx_dir_window = ctx->active->pan_dir_window;
-      ctx->ctx_small_file_window = ctx->active->pan_small_file_window;
-      ctx->ctx_big_file_window = ctx->active->pan_big_file_window;
-      ctx->ctx_file_window = ctx->active->pan_file_window;
+      if (!AppStateSyncActiveWindowHandles(ctx))
+        return FALSE;
 
       ctx->fixed_col_width = *saved_fixed_width_ptr;
       ReCreateWindows(ctx);

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -11,6 +11,7 @@
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_visibility.h"
+#include "ytnova_appstate_window.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -1290,13 +1291,7 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
 }
 
 void SyncActivePanelWindows(ViewContext *ctx) {
-  if (!ctx || !ctx->active)
-    return;
-
-  ctx->ctx_dir_window = ctx->active->pan_dir_window;
-  ctx->ctx_small_file_window = ctx->active->pan_small_file_window;
-  ctx->ctx_big_file_window = ctx->active->pan_big_file_window;
-  ctx->ctx_file_window = ctx->active->pan_file_window;
+  (void)AppStateSyncActiveWindowHandles(ctx);
 }
 
 DirEntry *ResolveActiveDirEntry(ViewContext *ctx, const Statistic *s) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6311,6 +6311,47 @@ def test_volume_registry_commits_through_appstate_helper() -> None:
     assert "ctx->volumes_head = NULL;" not in volume_source
 
 
+def test_active_window_handles_sync_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_window.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_window.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateSyncActiveWindowHandles(" in header
+    for source in [init_source, ctrl_file_ops, dir_ops]:
+        assert 'include "ytnova_appstate_window.h"' in source
+
+    helper_start = helper.index("BOOL AppStateSyncActiveWindowHandles(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.window_handles")'
+    assignments = [
+        "ctx->ctx_dir_window = ctx->active->pan_dir_window;",
+        "ctx->ctx_small_file_window = ctx->active->pan_small_file_window;",
+        "ctx->ctx_big_file_window = ctx->active->pan_big_file_window;",
+        "ctx->ctx_file_window = ctx->active->pan_file_window;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    assert "AppStateSyncActiveWindowHandles(ctx)" in init_source
+    assert "AppStateSyncActiveWindowHandles(ctx)" in ctrl_file_ops
+    assert "AppStateSyncActiveWindowHandles(ctx)" in dir_ops
+    for source in [init_source, ctrl_file_ops, dir_ops]:
+        assert "ctx->ctx_dir_window = ctx->active->pan_dir_window;" not in source
+        assert (
+            "ctx->ctx_small_file_window = ctx->active->pan_small_file_window;"
+            not in source
+        )
+        assert (
+            "ctx->ctx_big_file_window = ctx->active->pan_big_file_window;"
+            not in source
+        )
+
+
 def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState window-handle helper for active panel handle synchronization.
- Route active panel global window-handle sync through owner-field validation.
- Add contract-guard coverage that blocks direct active-window sync writes outside the helper.

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k active_window_handles_sync` failed before implementation because the helper boundary was missing.
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'active_window_handles_sync or runtime_registry_boundary_validation'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passed with existing warning baseline.
- `git diff --check`
