### PR TITLE
refactor(appstate): route file window handles through helper

### DIFF
--- a/include/ytnova_appstate_window.h
+++ b/include/ytnova_appstate_window.h
@@ -11,5 +11,7 @@
 #include "ytnova_defs.h"
 
 BOOL AppStateSyncActiveWindowHandles(ViewContext *ctx);
+BOOL AppStateSetPanelFileWindowHandle(ViewContext *ctx, YtreeNovaPanel *panel,
+                                      BOOL big_file_window);
 
 #endif /* YTNOVA_APPSTATE_WINDOW_H */

--- a/src/ui/appstate_window.c
+++ b/src/ui/appstate_window.c
@@ -20,3 +20,17 @@ BOOL AppStateSyncActiveWindowHandles(ViewContext *ctx) {
   ctx->ctx_file_window = ctx->active->pan_file_window;
   return TRUE;
 }
+
+BOOL AppStateSetPanelFileWindowHandle(ViewContext *ctx, YtreeNovaPanel *panel,
+                                      BOOL big_file_window) {
+  if (!AppStateValidatedOwnerField("ctx.window_handles"))
+    return FALSE;
+  if (!ctx || !panel)
+    return FALSE;
+
+  panel->pan_file_window = big_file_window ? panel->pan_big_file_window
+                                           : panel->pan_small_file_window;
+  if (panel == ctx->active)
+    ctx->ctx_file_window = panel->pan_file_window;
+  return TRUE;
+}

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -11,6 +11,7 @@
 #include "../../include/ytnova_panel_anchor.h"
 #include "../../include/ytnova_ui.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_window.h"
 #include <assert.h>
 
 /* PrintMenuLine is removed as its functionality for drawing the static stats
@@ -361,10 +362,7 @@ void SwitchToSmallFileWindow(ViewContext *ctx) {
   wattroff(ctx->ctx_border_window, A_ALTCHARSET);
   wattrset(ctx->ctx_border_window, A_NORMAL);
 
-  ctx->ctx_file_window = ctx->ctx_small_file_window;
-  if (ctx->active) {
-    ctx->active->pan_file_window = ctx->active->pan_small_file_window;
-  }
+  AppStateSetPanelFileWindowHandle(ctx, ctx->active, FALSE);
 }
 
 void SwitchToBigFileWindow(ViewContext *ctx) {
@@ -387,10 +385,7 @@ void SwitchToBigFileWindow(ViewContext *ctx) {
   wattroff(ctx->ctx_border_window, A_ALTCHARSET);
   wattrset(ctx->ctx_border_window, A_NORMAL);
 
-  ctx->ctx_file_window = ctx->ctx_big_file_window;
-  if (ctx->active) {
-    ctx->active->pan_file_window = ctx->active->pan_big_file_window;
-  }
+  AppStateSetPanelFileWindowHandle(ctx, ctx->active, TRUE);
 }
 
 void MapF2Window(ViewContext *ctx) {
@@ -762,10 +757,7 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
      * surgery assumes standard tree/file geometry and corrupts preview
      * borders.
      */
-    if (ctx->active && ctx->active->pan_big_file_window) {
-      ctx->active->pan_file_window = ctx->active->pan_big_file_window;
-      ctx->ctx_file_window = ctx->active->pan_big_file_window;
-    }
+    AppStateSetPanelFileWindowHandle(ctx, ctx->active, TRUE);
     DisplayFileWindow(ctx, ctx->active, dir_entry);
     if (ctx->ctx_preview_window)
       wnoutrefresh(ctx->ctx_preview_window);
@@ -784,16 +776,9 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
                            ? active_big_mode
                            : IsPanelSavedBigFileMode(ctx->right);
 
-      ctx->left->pan_file_window =
-          left_big_mode ? ctx->left->pan_big_file_window
-                        : ctx->left->pan_small_file_window;
-      ctx->right->pan_file_window =
-          right_big_mode ? ctx->right->pan_big_file_window
-                         : ctx->right->pan_small_file_window;
-      ctx->active->pan_file_window =
-          active_big_mode ? ctx->active->pan_big_file_window
-                          : ctx->active->pan_small_file_window;
-      ctx->ctx_file_window = ctx->active->pan_file_window;
+      AppStateSetPanelFileWindowHandle(ctx, ctx->left, left_big_mode);
+      AppStateSetPanelFileWindowHandle(ctx, ctx->right, right_big_mode);
+      AppStateSetPanelFileWindowHandle(ctx, ctx->active, active_big_mode);
 
       DrawSplitSeparatorRow(ctx, left_big_mode, right_big_mode);
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6352,6 +6352,38 @@ def test_active_window_handles_sync_through_appstate_helper() -> None:
         )
 
 
+def test_file_window_handle_selection_routes_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_window.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_window.c").read_text(encoding="utf-8")
+    display = Path("src/ui/display.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateSetPanelFileWindowHandle(" in header
+    assert 'include "ytnova_appstate_window.h"' in display
+
+    helper_start = helper.index("BOOL AppStateSetPanelFileWindowHandle(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.window_handles")'
+    assignments = [
+        "panel->pan_file_window = big_file_window ? panel->pan_big_file_window",
+        "ctx->ctx_file_window = panel->pan_file_window;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    assert "AppStateSetPanelFileWindowHandle(ctx, ctx->active, FALSE)" in display
+    assert "AppStateSetPanelFileWindowHandle(ctx, ctx->active, TRUE)" in display
+    assert "AppStateSetPanelFileWindowHandle(ctx, ctx->left, left_big_mode)" in display
+    assert (
+        "AppStateSetPanelFileWindowHandle(ctx, ctx->right, right_big_mode)"
+        in display
+    )
+    assert not re.search(r"\bctx->ctx_file_window\s*=[^=]", display)
+    assert not re.search(r"\b(?:ctx->active|ctx->left|ctx->right)->pan_file_window\s*=", display)
+
+
 def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an AppState helper for panel file-window handle selection under the window-handle owner boundary
- route display, preview, and split-screen file-window handle selection through the helper
- extend the AppState contract guard for the display-side boundary

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'file_window_handle_selection or active_window_handles_sync or runtime_registry_boundary_validation'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
