### PR TITLE
refactor(appstate): route preview window handle through helper

### DIFF
--- a/include/ytnova_appstate_window.h
+++ b/include/ytnova_appstate_window.h
@@ -13,5 +13,6 @@
 BOOL AppStateSyncActiveWindowHandles(ViewContext *ctx);
 BOOL AppStateSetPanelFileWindowHandle(ViewContext *ctx, YtreeNovaPanel *panel,
                                       BOOL big_file_window);
+BOOL AppStateSetPreviewWindowHandle(ViewContext *ctx, WINDOW *preview_window);
 
 #endif /* YTNOVA_APPSTATE_WINDOW_H */

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -523,8 +523,10 @@ void ReCreateWindows(ViewContext *ctx) {
 
   /* Cleanup Preview Window */
   if (ctx->ctx_preview_window) {
-    delwin(ctx->ctx_preview_window);
-    ctx->ctx_preview_window = NULL;
+    WINDOW *preview_window = ctx->ctx_preview_window;
+    if (!AppStateSetPreviewWindowHandle(ctx, NULL))
+      return;
+    delwin(preview_window);
   }
 
   /* 3. Create Primary Panel Windows (Always Created) */
@@ -592,9 +594,14 @@ void ReCreateWindows(ViewContext *ctx) {
 
   /* 5. Create Preview Window (If Preview Mode) */
   if (ctx->preview_mode) {
-    ctx->ctx_preview_window =
+    WINDOW *preview_window =
         Newwin(ctx->layout.preview_win_height, ctx->layout.preview_win_width,
                ctx->layout.preview_win_y, ctx->layout.preview_win_x);
+    if (!AppStateSetPreviewWindowHandle(ctx, preview_window)) {
+      if (preview_window)
+        delwin(preview_window);
+      return;
+    }
     if (ctx->ctx_preview_window) {
       keypad(ctx->ctx_preview_window, TRUE);
 
@@ -780,7 +787,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
   ctx->refresh_mode =
       0; /* Will be set after ReadProfile initializes profile_data */
   ctx->preview_mode = FALSE; /* Initialize Preview Mode */
-  ctx->ctx_preview_window = NULL;
+  if (!AppStateSetPreviewWindowHandle(ctx, NULL))
+    return -1;
 
   /* Initialize global mode default */
   if (!AppStateCommitViewMode(ctx, DISK_MODE))

--- a/src/ui/appstate_window.c
+++ b/src/ui/appstate_window.c
@@ -34,3 +34,13 @@ BOOL AppStateSetPanelFileWindowHandle(ViewContext *ctx, YtreeNovaPanel *panel,
     ctx->ctx_file_window = panel->pan_file_window;
   return TRUE;
 }
+
+BOOL AppStateSetPreviewWindowHandle(ViewContext *ctx, WINDOW *preview_window) {
+  if (!AppStateValidatedOwnerField("ctx.window_handles"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->ctx_preview_window = preview_window;
+  return TRUE;
+}

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6402,6 +6402,27 @@ def test_recreate_windows_file_handle_selection_routes_through_appstate_helper()
     assert not re.search(r"\bctx->ctx_file_window\s*=[^=]", init_source)
 
 
+def test_preview_window_handle_lifecycle_routes_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_window.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_window.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateSetPreviewWindowHandle(" in header
+
+    helper_start = helper.index("BOOL AppStateSetPreviewWindowHandle(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.window_handles")'
+    assignment = "ctx->ctx_preview_window = preview_window;"
+
+    assert validation in helper_body
+    assert assignment in helper_body
+    assert helper_body.index(validation) < helper_body.index(assignment)
+
+    assert init_source.count("AppStateSetPreviewWindowHandle(ctx, NULL)") >= 2
+    assert "AppStateSetPreviewWindowHandle(ctx, preview_window)" in init_source
+    assert not re.search(r"\bctx->ctx_preview_window\s*=[^=]", init_source)
+
+
 def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an AppState helper for the preview window handle under the window-handle owner boundary
- route preview window cleanup, creation, and initialization through the helper
- add contract guard coverage for preview window handle lifecycle writes

## Validation
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'preview_window_handle_lifecycle or recreate_windows_file_handle_selection or file_window_handle_selection or active_window_handles_sync'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `git diff --check`
- `make clean && make`
