### PR TITLE
refactor(appstate): route resize dirty state through helper

### DIFF
--- a/include/ytnova_appstate_render.h
+++ b/include/ytnova_appstate_render.h
@@ -1,0 +1,17 @@
+/***************************************************************************
+ *
+ * ytnova_appstate_render.h
+ * Render-invalidation transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#ifndef YTNOVA_APPSTATE_RENDER_H
+#define YTNOVA_APPSTATE_RENDER_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitResizeRequest(ViewContext *ctx, BOOL resize_request);
+BOOL AppStateMarkResizeRequest(ViewContext *ctx);
+BOOL AppStateClearResizeRequest(ViewContext *ctx);
+
+#endif /* YTNOVA_APPSTATE_RENDER_H */

--- a/src/ui/appstate_render.c
+++ b/src/ui/appstate_render.c
@@ -1,0 +1,27 @@
+/***************************************************************************
+ *
+ * src/ui/appstate_render.c
+ * Render-invalidation transition commits for AppState boundaries.
+ *
+ ***************************************************************************/
+
+#include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_render.h"
+
+BOOL AppStateCommitResizeRequest(ViewContext *ctx, BOOL resize_request) {
+  if (!AppStateValidatedOwnerField("ctx.render_dirty_flags"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->resize_request = resize_request ? TRUE : FALSE;
+  return TRUE;
+}
+
+BOOL AppStateMarkResizeRequest(ViewContext *ctx) {
+  return AppStateCommitResizeRequest(ctx, TRUE);
+}
+
+BOOL AppStateClearResizeRequest(ViewContext *ctx) {
+  return AppStateCommitResizeRequest(ctx, FALSE);
+}

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -8,6 +8,7 @@
 #define NO_YTNOVA_MACROS
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_session.h"
@@ -699,7 +700,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       /* SIMPLIFIED RESIZE: Just call Global Refresh */
       RefreshView(ctx, dir_entry);
       need_dsp_help = TRUE;
-      ctx->resize_request = FALSE;
+      (void)AppStateClearResizeRequest(ctx);
     }
 
     action = GetKeyAction(ctx, ch); /* Translate raw input to YtreeNovaAction */
@@ -709,7 +710,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
     switch (action) {
     case ACTION_RESIZE:
-      ctx->resize_request = TRUE;
+      (void)AppStateMarkResizeRequest(ctx);
       break;
 
     case ACTION_EDIT_CONFIG:
@@ -720,7 +721,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
     case ACTION_TOGGLE_STATS:
       ctx->show_stats = !ctx->show_stats;
-      ctx->resize_request = TRUE;
+      (void)AppStateMarkResizeRequest(ctx);
       break;
 
     case ACTION_VIEW_PREVIEW: {
@@ -1093,7 +1094,7 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
 
     case ACTION_TOGGLE_COMPACT:
       ctx->fixed_col_width = (ctx->fixed_col_width == 0) ? 32 : 0;
-      ctx->resize_request = TRUE;
+      (void)AppStateMarkResizeRequest(ctx);
       break;
 
     case ACTION_CMD_P: /* Pipe Directory */

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -14,6 +14,7 @@
 #include "../../include/sort.h"
 #include "../../include/watcher.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
 #include "../../include/ytnova_cmd.h"
 #include "../../include/ytnova_fs.h"
@@ -451,7 +452,7 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
       if (ctx->preview_mode)
         UpdatePreview(ctx, dir_entry);
       need_dsp_help = TRUE;
-      ctx->resize_request = FALSE;
+      (void)AppStateClearResizeRequest(ctx);
     }
 
     action = GetKeyAction(ctx, ch);

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -7,6 +7,7 @@
 
 #define NO_YTNOVA_MACROS
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
@@ -1100,17 +1101,17 @@ BOOL handle_file_window_misc_dispatch_action(
     break;
 
   case ACTION_RESIZE:
-    ctx->resize_request = TRUE;
+    (void)AppStateMarkResizeRequest(ctx);
     break;
 
   case ACTION_TOGGLE_STATS:
     ctx->show_stats = !ctx->show_stats;
-    ctx->resize_request = TRUE;
+    (void)AppStateMarkResizeRequest(ctx);
     break;
 
   case ACTION_TOGGLE_COMPACT:
     ctx->fixed_col_width = (ctx->fixed_col_width == 0) ? 32 : 0;
-    ctx->resize_request = TRUE;
+    (void)AppStateMarkResizeRequest(ctx);
     break;
 
   case ACTION_ESCAPE:

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -8,6 +8,7 @@
 
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_visibility.h"
@@ -1263,7 +1264,7 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
         if (!ctx->is_split_screen) {
           /* Split state changed (unsplit), and this panel no longer exists. */
           DisplayMenu(ctx);
-          ctx->resize_request = TRUE;
+          (void)AppStateMarkResizeRequest(ctx);
         }
         return;
       }

--- a/src/ui/input_line.c
+++ b/src/ui/input_line.c
@@ -8,6 +8,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_render.h"
 #include "ytnova_cmd.h"
 #include "ytnova_ui.h"
 #include <ctype.h>  /* For isalnum */
@@ -307,7 +308,7 @@ static int UI_ReadStringInternal(ViewContext *ctx, YtreeNovaPanel *panel,
     }
 
     if (ctx && ctx->resize_request) {
-      ctx->resize_request = FALSE;
+      (void)AppStateClearResizeRequest(ctx);
 
       /* Recreate window geometry */
       prompt_row = (ctx->layout.prompt_y > 0) ? 1 : 0;

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -8,6 +8,7 @@
 
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_cmd.h"
 #include "ytnova_ui.h"
 #include <ctype.h>
@@ -709,7 +710,7 @@ int WGetch(ViewContext *ctx, WINDOW *win) {
     if (!AppStateValidatedDispatchSurface("surface.resize-signal-handling"))
       return ERR;
     if (ctx)
-      ctx->resize_request = TRUE;
+      (void)AppStateMarkResizeRequest(ctx);
     c = -1;
   }
 #endif

--- a/src/ui/tagged_view.c
+++ b/src/ui/tagged_view.c
@@ -5,6 +5,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_render.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_ui.h"
@@ -209,7 +210,7 @@ static int RunTaggedViewLoop(ViewContext *ctx, char **view_paths,
     ch = NormalizeViKey(ctx, ch);
 
     if (ctx->resize_request) {
-      ctx->resize_request = FALSE;
+      (void)AppStateClearResizeRequest(ctx);
       SetupTaggedViewWindow(ctx);
       continue;
     }
@@ -219,7 +220,7 @@ static int RunTaggedViewLoop(ViewContext *ctx, char **view_paths,
     switch (ch) {
 #ifdef KEY_RESIZE
     case KEY_RESIZE:
-      ctx->resize_request = TRUE;
+      (void)AppStateMarkResizeRequest(ctx);
       break;
 #endif
     case ESC:

--- a/src/ui/view_internal.c
+++ b/src/ui/view_internal.c
@@ -5,6 +5,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_render.h"
 #include "ytnova_cmd.h"
 #include "ytnova_ui.h"
 #include <errno.h>
@@ -529,7 +530,7 @@ static void hex_edit(ViewContext *ctx, char *file_path,
     ch = NormalizeViKey(ctx, ch);
     if (ctx->resize_request) {
       DoResize(ctx, file_path, geom);
-      ctx->resize_request = FALSE;
+      (void)AppStateClearResizeRequest(ctx);
       continue;
     }
 
@@ -538,7 +539,7 @@ static void hex_edit(ViewContext *ctx, char *file_path,
 #ifdef KEY_RESIZE
 
     case KEY_RESIZE:
-      ctx->resize_request = TRUE;
+      (void)AppStateMarkResizeRequest(ctx);
       break;
 #endif
     case ESC:
@@ -747,7 +748,7 @@ int InternalView(ViewContext *ctx, char *file_path,
 
     if (ctx->resize_request) {
       DoResize(ctx, file_path, geometry);
-      ctx->resize_request = FALSE;
+      (void)AppStateClearResizeRequest(ctx);
       continue;
     }
 
@@ -755,7 +756,7 @@ int InternalView(ViewContext *ctx, char *file_path,
 
 #ifdef KEY_RESIZE
     case KEY_RESIZE:
-      ctx->resize_request = TRUE;
+      (void)AppStateMarkResizeRequest(ctx);
       break;
 #endif
 
@@ -846,7 +847,7 @@ int InternalView(ViewContext *ctx, char *file_path,
   touchwin(stdscr);
   wnoutrefresh(stdscr);
   close(fd);
-  ctx->resize_request = ctx->viewer.resize_done;
+  (void)AppStateCommitResizeRequest(ctx, ctx->viewer.resize_done);
   ctx->viewer.resize_done = FALSE;
   return result;
 }

--- a/src/ui/volume_menu.c
+++ b/src/ui/volume_menu.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_cmd.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_fs.h"
 #include "ytnova_ui.h"
 
@@ -272,7 +273,7 @@ int SelectLoadedVolume(ViewContext *ctx, int *return_key) {
       ch = WGetch(ctx, win);
 
       if (ctx && ctx->resize_request) {
-        ctx->resize_request = FALSE;
+        (void)AppStateClearResizeRequest(ctx);
         ReCreateWindows(ctx);
         DisplayMenu(ctx);
         DisplayDiskStatistic(ctx, &ctx->active->vol->vol_stats);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5589,8 +5589,9 @@ def test_wgetch_resize_signal_handling_fails_closed_before_mutation() -> None:
 
     assert validation in body
     assert "return ERR;" in body
-    assert body.index(validation) < body.index("ctx->resize_request = TRUE;")
-    assert body.index("return ERR;") < body.index("ctx->resize_request = TRUE;")
+    assert "AppStateMarkResizeRequest(ctx);" in body
+    assert body.index(validation) < body.index("AppStateMarkResizeRequest(ctx);")
+    assert body.index("return ERR;") < body.index("AppStateMarkResizeRequest(ctx);")
 
 
 def test_get_key_action_routes_decoded_actions_through_appstate_boundary() -> None:
@@ -6454,6 +6455,57 @@ def test_auxiliary_window_handle_lifecycle_routes_through_appstate_helpers() -> 
         r"history_window|matches_window|menu_window|f2_window)\s*=[^=]",
         init_source,
     )
+
+
+def test_resize_dirty_flag_writes_route_through_appstate_helpers() -> None:
+    header = Path("include/ytnova_appstate_render.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_render.c").read_text(encoding="utf-8")
+    sources = {
+        path: Path(path).read_text(encoding="utf-8")
+        for path in [
+            "src/ui/ctrl_file_ops.c",
+            "src/ui/key_engine.c",
+            "src/ui/ctrl_file.c",
+            "src/ui/input_line.c",
+            "src/ui/ctrl_dir.c",
+            "src/ui/dir_ops.c",
+            "src/ui/view_internal.c",
+            "src/ui/volume_menu.c",
+            "src/ui/tagged_view.c",
+        ]
+    }
+
+    assert "BOOL AppStateCommitResizeRequest(" in header
+    assert "BOOL AppStateMarkResizeRequest(" in header
+    assert "BOOL AppStateClearResizeRequest(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitResizeRequest(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.render_dirty_flags")'
+    assignment = "ctx->resize_request = resize_request ? TRUE : FALSE;"
+
+    assert validation in helper_body
+    assert assignment in helper_body
+    assert helper_body.index(validation) < helper_body.index(assignment)
+    assert "return AppStateCommitResizeRequest(ctx, TRUE);" in helper
+    assert "return AppStateCommitResizeRequest(ctx, FALSE);" in helper
+
+    expected_calls = {
+        "src/ui/ctrl_file_ops.c": "AppStateMarkResizeRequest(ctx)",
+        "src/ui/key_engine.c": "AppStateMarkResizeRequest(ctx)",
+        "src/ui/ctrl_file.c": "AppStateClearResizeRequest(ctx)",
+        "src/ui/input_line.c": "AppStateClearResizeRequest(ctx)",
+        "src/ui/ctrl_dir.c": "AppStateMarkResizeRequest(ctx)",
+        "src/ui/dir_ops.c": "AppStateMarkResizeRequest(ctx)",
+        "src/ui/view_internal.c": "AppStateCommitResizeRequest(ctx, ctx->viewer.resize_done)",
+        "src/ui/volume_menu.c": "AppStateClearResizeRequest(ctx)",
+        "src/ui/tagged_view.c": "AppStateClearResizeRequest(ctx)",
+    }
+
+    for path, source in sources.items():
+        assert 'include "ytnova_appstate_render.h"' in source
+        assert expected_calls[path] in source
+        assert not re.search(r"\bctx->resize_request\s*=[^=]", source)
 
 
 def test_file_selection_anchor_generation_commits_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Add AppState render dirty helper APIs for resize request commits.
- Route resize request mark/clear writes through the helper across input, directory, file, volume, and viewer loops.
- Extend contract guard coverage so direct resize dirty writes remain confined to the helper.

## Validation
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py`
- `python3 scripts/check_appstate_contract.py`