### PR TITLE
refactor(appstate): route terminal geometry cache through helper

### DIFF
--- a/include/ytnova_appstate_layout.h
+++ b/include/ytnova_appstate_layout.h
@@ -11,5 +11,7 @@
 #include "ytnova_defs.h"
 
 BOOL AppStateCommitSplitScreenLayout(ViewContext *ctx, BOOL is_split_screen);
+BOOL AppStateCommitTerminalGeometryCache(ViewContext *ctx, int terminal_lines,
+                                         int terminal_cols);
 
 #endif /* YTNOVA_APPSTATE_LAYOUT_H */

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -886,8 +886,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
     return (1);
   }
   set_term(ctx->curses_screen);
-  ctx->cached_lines = LINES;
-  ctx->cached_cols = COLS;
+  if (!AppStateCommitTerminalGeometryCache(ctx, LINES, COLS))
+    return -1;
   Layout_Recalculate(ctx);
   if (ctx->core_init_ops.start_colors != NULL)
     ctx->core_init_ops.start_colors(ctx); /* even on b/w terminals... */

--- a/src/ui/appstate_layout.c
+++ b/src/ui/appstate_layout.c
@@ -17,3 +17,15 @@ BOOL AppStateCommitSplitScreenLayout(ViewContext *ctx, BOOL is_split_screen) {
   ctx->is_split_screen = is_split_screen ? TRUE : FALSE;
   return TRUE;
 }
+
+BOOL AppStateCommitTerminalGeometryCache(ViewContext *ctx, int terminal_lines,
+                                         int terminal_cols) {
+  if (!AppStateValidatedOwnerField("ctx.layout"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->cached_lines = terminal_lines;
+  ctx->cached_cols = terminal_cols;
+  return TRUE;
+}

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -11,6 +11,7 @@
 #include "../../include/ytnova_panel_anchor.h"
 #include "../../include/ytnova_ui.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_window.h"
 #include <assert.h>
 
@@ -695,8 +696,8 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
   /* 1. Re-evaluate Layout; only recreate windows on actual resize */
   Layout_Recalculate(ctx);
   if (ctx->cached_lines != LINES || ctx->cached_cols != COLS) {
-    ctx->cached_lines = LINES;
-    ctx->cached_cols = COLS;
+    if (!AppStateCommitTerminalGeometryCache(ctx, LINES, COLS))
+      return;
     needs_window_recreate = TRUE;
   }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6187,6 +6187,36 @@ def test_split_layout_commits_through_appstate_helper() -> None:
     assert "AppStateCommitSplitScreenLayout(ctx, FALSE)" in init_body
 
 
+def test_terminal_geometry_cache_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_layout.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_layout.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+    display = Path("src/ui/display.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitTerminalGeometryCache(" in header
+    assert 'include "ytnova_appstate_layout.h"' in init_source
+    assert 'include "ytnova_appstate_layout.h"' in display
+
+    helper_start = helper.index("BOOL AppStateCommitTerminalGeometryCache(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.layout")'
+    assignments = [
+        "ctx->cached_lines = terminal_lines;",
+        "ctx->cached_cols = terminal_cols;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    assert "AppStateCommitTerminalGeometryCache(ctx, LINES, COLS)" in init_source
+    assert "AppStateCommitTerminalGeometryCache(ctx, LINES, COLS)" in display
+    for source in [init_source, display]:
+        assert not re.search(r"\bctx->cached_lines\s*=[^=]", source)
+        assert not re.search(r"\bctx->cached_cols\s*=[^=]", source)
+
+
 def test_view_mode_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_mode.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_mode.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState layout helper for cached terminal geometry commits.
- Route startup and render reflow terminal-size cache writes through the helper.
- Extend contract guard coverage so cached geometry writes remain confined to the helper.

## Validation
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'terminal_geometry_cache or split_layout_commits'`
- `python3 scripts/check_appstate_contract.py`
