### PR TITLE
refactor(appstate): route file viewport commits through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -13,5 +13,7 @@
 BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel);
 BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
                                     unsigned int panel_generation);
+BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
+                                     int file_cursor_pos);
 
 #endif /* YTNOVA_APPSTATE_PANEL_H */

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -23,9 +23,9 @@ static void ResetPanelFileContext(YtreeNovaPanel *panel) {
     return;
 
   FreeFileEntryList(panel);
+  if (!AppStateCommitPanelFileViewport(panel, 0, 0))
+    return;
   panel->file_dir_entry = NULL;
-  panel->start_file = 0;
-  panel->file_cursor_pos = 0;
   (void)AppStateCommitPanelFileShape(panel, FALSE);
 }
 
@@ -104,10 +104,10 @@ static void PositionSavedFileSelection(ViewContext *ctx, YtreeNovaPanel *panel,
   if (start < 0)
     start = 0;
 
-  panel->start_file = start;
-  panel->file_cursor_pos = selected_idx - start;
-  dir_entry->start_file = panel->start_file;
-  dir_entry->cursor_pos = panel->file_cursor_pos;
+  if (!AppStateCommitPanelFileViewport(panel, start, selected_idx - start))
+    return;
+  dir_entry->start_file = start;
+  dir_entry->cursor_pos = selected_idx - start;
 }
 
 static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
@@ -122,8 +122,8 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
   ResetPanelFileContext(panel);
   vol = panel->vol;
   state = FindPanelVolumeFileState(panel, vol->id);
-  panel->start_file = 0;
-  panel->file_cursor_pos = 0;
+  if (!AppStateCommitPanelFileViewport(panel, 0, 0))
+    return;
   panel->file_selection_name[0] = '\0';
   panel->file_selection_dir_path[0] = '\0';
   panel->file_dir_entry = NULL;
@@ -132,16 +132,20 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
   if (!state)
     return;
 
-  panel->start_file = state->saved_file_start;
-  panel->file_cursor_pos = state->saved_file_cursor;
-  if (panel->start_file < 0)
-    panel->start_file = 0;
-  if (panel->file_cursor_pos < 0)
-    panel->file_cursor_pos = 0;
-  if (state->saved_panel_generation != panel->panel_generation ||
-      state->saved_volume_generation != vol->volume_generation) {
-    panel->start_file = 0;
-    panel->file_cursor_pos = 0;
+  {
+    int start_file = state->saved_file_start;
+    int file_cursor_pos = state->saved_file_cursor;
+    if (start_file < 0)
+      start_file = 0;
+    if (file_cursor_pos < 0)
+      file_cursor_pos = 0;
+    if (state->saved_panel_generation != panel->panel_generation ||
+        state->saved_volume_generation != vol->volume_generation) {
+      start_file = 0;
+      file_cursor_pos = 0;
+    }
+    if (!AppStateCommitPanelFileViewport(panel, start_file, file_cursor_pos))
+      return;
   }
   (void)snprintf(panel->file_selection_name, sizeof(panel->file_selection_name),
                  "%s", state->saved_file_selection_name);

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_volume_registry.h"
 #include "ytnova_defs.h"
 
@@ -23,9 +24,9 @@ static void Volume_ClearPanelFileEntries(YtreeNovaPanel *panel) {
 static void Volume_ClearPanelFileAnchor(YtreeNovaPanel *panel) {
   if (!panel)
     return;
+  if (!AppStateCommitPanelFileViewport(panel, 0, 0))
+    return;
   panel->file_dir_entry = NULL;
-  panel->start_file = 0;
-  panel->file_cursor_pos = 0;
 }
 
 static void Volume_ClearPanelTags(YtreeNovaPanel *panel) {

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -30,3 +30,15 @@ BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
   panel->panel_generation = panel_generation;
   return TRUE;
 }
+
+BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
+                                     int file_cursor_pos) {
+  if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->start_file = start_file;
+  panel->file_cursor_pos = file_cursor_pos;
+  return TRUE;
+}

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6685,6 +6685,58 @@ def test_panel_generation_restores_route_through_appstate_helper() -> None:
     assert "source_panel_generation" in split_body
 
 
+def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelFileViewport(" in header
+    assert 'include "ytnova_appstate_panel.h"' in log_source
+    assert 'include "ytnova_appstate_panel.h"' in volume_source
+
+    helper_start = helper.index("BOOL AppStateCommitPanelFileViewport(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("panel.file_viewport_origin")'
+    start_write = "panel->start_file = start_file;"
+    cursor_write = "panel->file_cursor_pos = file_cursor_pos;"
+    assert validation in helper_body
+    assert start_write in helper_body
+    assert cursor_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(start_write)
+    assert helper_body.index(validation) < helper_body.index(cursor_write)
+
+    reset_start = log_source.index("static void ResetPanelFileContext(")
+    save_start = log_source.index("\nstatic void SavePanelFileSelection(", reset_start)
+    reset_body = log_source[reset_start:save_start]
+    position_start = log_source.index("static void PositionSavedFileSelection(")
+    restore_start = log_source.index("\nstatic void RestorePanelFileSelection(", position_start)
+    position_body = log_source[position_start:restore_start]
+    tree_save_start = log_source.index("\nstatic void SavePanelTreeSelection(", restore_start)
+    restore_body = log_source[restore_start:tree_save_start]
+    clear_start = volume_source.index("static void Volume_ClearPanelFileAnchor(")
+    clear_end = volume_source.index("\nstatic void Volume_ClearPanelTags(", clear_start)
+    clear_body = volume_source[clear_start:clear_end]
+    direct_viewport_write = re.compile(
+        r"\bpanel->(?:start_file|file_cursor_pos)\s*=(?!=)"
+    )
+
+    for body in [reset_body, position_body, restore_body, clear_body]:
+        assert not direct_viewport_write.search(body)
+
+    assert "AppStateCommitPanelFileViewport(panel, 0, 0)" in reset_body
+    assert (
+        "AppStateCommitPanelFileViewport(panel, start, selected_idx - start)"
+        in position_body
+    )
+    assert restore_body.count("AppStateCommitPanelFileViewport(panel, 0, 0)") == 1
+    assert (
+        "AppStateCommitPanelFileViewport(panel, start_file, file_cursor_pos)"
+        in restore_body
+    )
+    assert "AppStateCommitPanelFileViewport(panel, 0, 0)" in clear_body
+
+
 def test_volume_generation_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Adds an AppState helper for panel file viewport origin commits.
- Routes log restore and volume cleanup file viewport writes through the helper.
- Extends contract guard coverage to keep these file viewport writes inside the helper boundary.

## Validation
- `make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `python3 scripts/check_appstate_contract.py`
