### PR TITLE
refactor(appstate): route tree viewport commits through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -15,5 +15,7 @@ BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
                                     unsigned int panel_generation);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos);
+BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,
+                                     int cursor_pos);
 
 #endif /* YTNOVA_APPSTATE_PANEL_H */

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -42,3 +42,17 @@ BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
   panel->file_cursor_pos = file_cursor_pos;
   return TRUE;
 }
+
+BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,
+                                     int cursor_pos) {
+  if (!AppStateValidatedOwnerField("panel.tree_viewport_origin"))
+    return FALSE;
+  if (!AppStateValidatedOwnerField("panel.tree_cursor_pos"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->disp_begin_pos = disp_begin_pos;
+  panel->cursor_pos = cursor_pos;
+  return TRUE;
+}

--- a/src/ui/dir_nav.c
+++ b/src/ui/dir_nav.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_fs.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_ui.h"
 
 static void PositionPanelAtIndex(YtreeNovaPanel *p, int target_idx, int height) {
@@ -21,12 +22,10 @@ static void PositionPanelAtIndex(YtreeNovaPanel *p, int target_idx, int height) 
   begin = p->disp_begin_pos;
   cursor = p->cursor_pos;
   if (!PanelComputeViewportPosition(p, target_idx, height, &begin, &cursor)) {
-    p->disp_begin_pos = 0;
-    p->cursor_pos = 0;
+    (void)AppStateCommitPanelTreeViewport(p, 0, 0);
     return;
   }
-  p->disp_begin_pos = begin;
-  p->cursor_pos = cursor;
+  (void)AppStateCommitPanelTreeViewport(p, begin, cursor);
 }
 
 static BOOL SyncPanelToVisibleSelection(const ViewContext *ctx, YtreeNovaPanel *p,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6737,6 +6737,37 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     assert "AppStateCommitPanelFileViewport(panel, 0, 0)" in clear_body
 
 
+def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelTreeViewport(" in header
+    assert 'include "ytnova_appstate_panel.h"' in dir_nav
+
+    helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
+    helper_body = helper[helper_start:]
+    viewport_validation = 'AppStateValidatedOwnerField("panel.tree_viewport_origin")'
+    cursor_validation = 'AppStateValidatedOwnerField("panel.tree_cursor_pos")'
+    viewport_write = "panel->disp_begin_pos = disp_begin_pos;"
+    cursor_write = "panel->cursor_pos = cursor_pos;"
+    assert viewport_validation in helper_body
+    assert cursor_validation in helper_body
+    assert viewport_write in helper_body
+    assert cursor_write in helper_body
+    assert helper_body.index(viewport_validation) < helper_body.index(viewport_write)
+    assert helper_body.index(cursor_validation) < helper_body.index(cursor_write)
+
+    position_start = dir_nav.index("static void PositionPanelAtIndex(")
+    position_end = dir_nav.index(
+        "\nstatic BOOL SyncPanelToVisibleSelection(", position_start
+    )
+    position_body = dir_nav[position_start:position_end]
+    assert not re.search(r"\bp->(?:disp_begin_pos|cursor_pos)\s*=(?!=)", position_body)
+    assert "AppStateCommitPanelTreeViewport(p, 0, 0)" in position_body
+    assert "AppStateCommitPanelTreeViewport(p, begin, cursor)" in position_body
+
+
 def test_volume_generation_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Adds an AppState helper for panel tree viewport and cursor commits.
- Routes directory navigation viewport updates through the helper.
- Extends contract guard coverage to keep these tree viewport writes inside the helper boundary.

## Validation
- `make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `python3 scripts/check_appstate_contract.py`
