### PR TITLE
refactor(appstate): route volume menu viewport commits through helper

### DIFF
--- a/src/ui/volume_menu.c
+++ b/src/ui/volume_menu.c
@@ -7,32 +7,39 @@
 
 #include "ytnova_cmd.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_fs.h"
 #include "ytnova_ui.h"
 
 static void NormalizePanelCursorForVolume(YtreeNovaPanel *panel) {
+  int disp_begin_pos;
+  int cursor_pos;
+
   if (!panel || !panel->vol) {
     return;
   }
 
   if (panel->vol->total_dirs <= 0) {
-    panel->disp_begin_pos = 0;
-    panel->cursor_pos = 0;
+    if (!AppStateCommitPanelTreeViewport(panel, 0, 0))
+      return;
     panel->file_dir_entry = NULL;
     return;
   }
 
-  if (panel->disp_begin_pos < 0)
-    panel->disp_begin_pos = 0;
-  if (panel->cursor_pos < 0)
-    panel->cursor_pos = 0;
-  if (panel->disp_begin_pos >= panel->vol->total_dirs)
-    panel->disp_begin_pos = panel->vol->total_dirs - 1;
-  if (panel->disp_begin_pos + panel->cursor_pos >= panel->vol->total_dirs)
-    panel->cursor_pos = panel->vol->total_dirs - 1 - panel->disp_begin_pos;
-  if (panel->cursor_pos < 0)
-    panel->cursor_pos = 0;
+  disp_begin_pos = panel->disp_begin_pos;
+  cursor_pos = panel->cursor_pos;
+  if (disp_begin_pos < 0)
+    disp_begin_pos = 0;
+  if (cursor_pos < 0)
+    cursor_pos = 0;
+  if (disp_begin_pos >= panel->vol->total_dirs)
+    disp_begin_pos = panel->vol->total_dirs - 1;
+  if (disp_begin_pos + cursor_pos >= panel->vol->total_dirs)
+    cursor_pos = panel->vol->total_dirs - 1 - disp_begin_pos;
+  if (cursor_pos < 0)
+    cursor_pos = 0;
+  (void)AppStateCommitPanelTreeViewport(panel, disp_begin_pos, cursor_pos);
 }
 
 static void EnsurePanelsReferenceActiveVolume(ViewContext *ctx) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6741,9 +6741,11 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
+    volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelTreeViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in dir_nav
+    assert 'include "ytnova_appstate_panel.h"' in volume_menu
 
     helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
     helper_body = helper[helper_start:]
@@ -6766,6 +6768,20 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     assert not re.search(r"\bp->(?:disp_begin_pos|cursor_pos)\s*=(?!=)", position_body)
     assert "AppStateCommitPanelTreeViewport(p, 0, 0)" in position_body
     assert "AppStateCommitPanelTreeViewport(p, begin, cursor)" in position_body
+
+    normalize_start = volume_menu.index("static void NormalizePanelCursorForVolume(")
+    normalize_end = volume_menu.index(
+        "\nstatic void EnsurePanelsReferenceActiveVolume(", normalize_start
+    )
+    normalize_body = volume_menu[normalize_start:normalize_end]
+    assert not re.search(
+        r"\bpanel->(?:disp_begin_pos|cursor_pos)\s*=(?!=)", normalize_body
+    )
+    assert "AppStateCommitPanelTreeViewport(panel, 0, 0)" in normalize_body
+    assert (
+        "AppStateCommitPanelTreeViewport(panel, disp_begin_pos, cursor_pos)"
+        in normalize_body
+    )
 
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Routes volume-menu panel cursor normalization through the AppState tree viewport helper.
- Keeps volume-menu tree viewport and cursor writes inside the helper boundary.
- Extends contract guard coverage for the volume-menu normalization path.

## Validation
- `make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `python3 scripts/check_appstate_contract.py`
