### PR TITLE
refactor(appstate): route file list viewport commits through helper

### DIFF
--- a/src/ui/file_list.c
+++ b/src/ui/file_list.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "sort.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_ui.h"
@@ -235,8 +236,7 @@ void DisplayFileWindow(ViewContext *ctx, YtreeNovaPanel *panel,
     }
   }
 
-  panel->start_file = render_start;
-  panel->file_cursor_pos = render_cursor;
+  (void)AppStateCommitPanelFileViewport(panel, render_start, render_cursor);
 
   highlight_idx = -1;
   if (ctx->focused_window == FOCUS_FILE)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6688,11 +6688,13 @@ def test_panel_generation_restores_route_through_appstate_helper() -> None:
 def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    file_list = Path("src/ui/file_list.c").read_text(encoding="utf-8")
     file_nav = Path("src/ui/file_nav.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelFileViewport(" in header
+    assert 'include "ytnova_appstate_panel.h"' in file_list
     assert 'include "ytnova_appstate_panel.h"' in file_nav
     assert 'include "ytnova_appstate_panel.h"' in log_source
     assert 'include "ytnova_appstate_panel.h"' in volume_source
@@ -6755,6 +6757,15 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
             "AppStateCommitPanelFileViewport(ctx->active, dir_entry->start_file,"
             in body
         )
+
+    display_start = file_list.index("void DisplayFileWindow(")
+    build_start = file_list.index("\nvoid BuildFileEntryList(", display_start)
+    display_body = file_list[display_start:build_start]
+    assert not direct_viewport_write.search(display_body)
+    assert (
+        "AppStateCommitPanelFileViewport(panel, render_start, render_cursor)"
+        in display_body
+    )
 
 
 def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route `DisplayFileWindow` file viewport normalization through `AppStateCommitPanelFileViewport`.
- Extend the AppState contract guard so file-list viewport normalization cannot write `start_file` or `file_cursor_pos` directly.

## Validation
- Red guard proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
