### PR TITLE
refactor(appstate): route file window viewport commits through helper

### DIFF
--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -16,6 +16,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
 #include "../../include/ytnova_cmd.h"
 #include "../../include/ytnova_fs.h"
 #include "../../include/ytnova_split_transition.h"
@@ -229,7 +230,8 @@ DirEntry *RefreshFileView(ViewContext *ctx, DirEntry *dir_entry) {
                dir_entry->start_file + dir_entry->cursor_pos, start_x,
                ctx->ctx_file_window);
 
-  ctx->active->start_file = dir_entry->start_file;
+  (void)AppStateCommitPanelFileViewport(ctx->active, dir_entry->start_file,
+                                        dir_entry->cursor_pos);
 
   return dir_entry;
 }
@@ -308,8 +310,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
     dir_entry->cursor_pos = 0;
     dir_entry->start_file = 0;
   }
-  ctx->active->start_file = dir_entry->start_file;
-  ctx->active->file_cursor_pos = dir_entry->cursor_pos;
+  (void)AppStateCommitPanelFileViewport(ctx->active, dir_entry->start_file,
+                                        dir_entry->cursor_pos);
   if (ctx->active->file_entry_list && ctx->active->file_count > 0) {
     int selection_idx = ctx->active->start_file + ctx->active->file_cursor_pos;
 
@@ -703,10 +705,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
 
     if (ctx->active == owner_panel) {
       owner_panel->file_dir_entry = dir_entry;
-      owner_panel->start_file = dir_entry->start_file;
-      owner_panel->file_cursor_pos = dir_entry->cursor_pos;
-      ctx->active->start_file = dir_entry->start_file;
-      ctx->active->file_cursor_pos = dir_entry->cursor_pos;
+      (void)AppStateCommitPanelFileViewport(
+          owner_panel, dir_entry->start_file, dir_entry->cursor_pos);
     }
 
     /* Centralized check: If directory became empty, we MUST pop out of file

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6692,6 +6692,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     file_nav = Path("src/ui/file_nav.c").read_text(encoding="utf-8")
     ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
 
@@ -6700,6 +6701,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in file_nav
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file_ops
     assert 'include "ytnova_appstate_panel.h"' in ctrl_dir
+    assert 'include "ytnova_appstate_panel.h"' in ctrl_file
     assert 'include "ytnova_appstate_panel.h"' in log_source
     assert 'include "ytnova_appstate_panel.h"' in volume_source
 
@@ -6803,6 +6805,20 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     )
     dir_window_body = ctrl_dir[dir_window_start:dir_window_end]
     for body in [archive_exit_body, dir_window_body]:
+        assert not active_viewport_write.search(body)
+        assert "AppStateCommitPanelFileViewport(ctx->active," in body
+
+    refresh_file_start = ctrl_file.index("DirEntry *RefreshFileView(")
+    refresh_file_end = ctrl_file.index(
+        "\nint HandleFileWindow(", refresh_file_start
+    )
+    refresh_file_body = ctrl_file[refresh_file_start:refresh_file_end]
+    handle_file_start = ctrl_file.index("int HandleFileWindow(")
+    handle_file_end = ctrl_file.index(
+        "\nstatic int FindDirIndexInVolume(", handle_file_start
+    )
+    handle_file_body = ctrl_file[handle_file_start:handle_file_end]
+    for body in [refresh_file_body, handle_file_body]:
         assert not active_viewport_write.search(body)
         assert "AppStateCommitPanelFileViewport(ctx->active," in body
 


### PR DESCRIPTION
## Summary
- Route `ctrl_file` refresh and file-window active viewport syncs through `AppStateCommitPanelFileViewport`.
- Extend the AppState contract guard so `RefreshFileView` and `HandleFileWindow` cannot write active file viewport fields directly.

## Validation
- Red guard proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
