### PR TITLE
refactor(appstate): route owner file viewport commits through helper

### DIFF
--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -840,7 +840,8 @@ static void PositionOwnerFileCursor(ViewContext *ctx, DirEntry *owner_dir,
   if (file_count <= 0) {
     owner_dir->start_file = 0;
     owner_dir->cursor_pos = 0;
-    ctx->active->start_file = owner_dir->start_file;
+    (void)AppStateCommitPanelFileViewport(ctx->active, owner_dir->start_file,
+                                          owner_dir->cursor_pos);
     return;
   }
 
@@ -854,7 +855,8 @@ static void PositionOwnerFileCursor(ViewContext *ctx, DirEntry *owner_dir,
   if (file_idx < 0) {
     owner_dir->start_file = 0;
     owner_dir->cursor_pos = 0;
-    ctx->active->start_file = owner_dir->start_file;
+    (void)AppStateCommitPanelFileViewport(ctx->active, owner_dir->start_file,
+                                          owner_dir->cursor_pos);
     return;
   }
 
@@ -882,7 +884,8 @@ static void PositionOwnerFileCursor(ViewContext *ctx, DirEntry *owner_dir,
   if (owner_dir->cursor_pos >= page_size)
     owner_dir->cursor_pos = page_size - 1;
 
-  ctx->active->start_file = owner_dir->start_file;
+  (void)AppStateCommitPanelFileViewport(ctx->active, owner_dir->start_file,
+                                        owner_dir->cursor_pos);
 }
 
 static BOOL JumpToOwnerDirectory(ViewContext *ctx,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6822,6 +6822,16 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
         assert not active_viewport_write.search(body)
         assert "AppStateCommitPanelFileViewport(ctx->active," in body
 
+    position_owner_start = ctrl_file.index(
+        "static void PositionOwnerFileCursor(", handle_file_end
+    )
+    position_owner_end = ctrl_file.index(
+        "\nstatic BOOL JumpToOwnerDirectory(", position_owner_start
+    )
+    position_owner_body = ctrl_file[position_owner_start:position_owner_end]
+    assert not active_viewport_write.search(position_owner_body)
+    assert "AppStateCommitPanelFileViewport(ctx->active," in position_owner_body
+
 
 def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route `PositionOwnerFileCursor` active viewport syncs through `AppStateCommitPanelFileViewport`.
- Extend the AppState contract guard so owner-directory positioning cannot write active file viewport fields directly.

## Validation
- Red guard proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
