### PR TITLE
refactor(appstate): route file window exit viewport commits through helper

### DIFF
--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -738,8 +738,8 @@ file_window_done:
   }
   if (!volume_changed) {
     owner_panel->file_dir_entry = dir_entry;
-    owner_panel->start_file = dir_entry->start_file;
-    owner_panel->file_cursor_pos = dir_entry->cursor_pos;
+    (void)AppStateCommitPanelFileViewport(
+        owner_panel, dir_entry->start_file, dir_entry->cursor_pos);
 
     if (!switched_to_tree_panel) {
       /* Ensure all mode flags are cleared when exiting back to the tree.
@@ -752,8 +752,7 @@ file_window_done:
     }
   } else {
     owner_panel->file_dir_entry = NULL;
-    owner_panel->start_file = 0;
-    owner_panel->file_cursor_pos = 0;
+    (void)AppStateCommitPanelFileViewport(owner_panel, 0, 0);
     if (!AppStateCommitPanelFileShape(owner_panel, FALSE))
       return ESC;
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6821,6 +6821,11 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     for body in [refresh_file_body, handle_file_body]:
         assert not active_viewport_write.search(body)
         assert "AppStateCommitPanelFileViewport(ctx->active," in body
+    owner_panel_viewport_write = re.compile(
+        r"\bowner_panel->(?:start_file|file_cursor_pos)\s*=(?!=)"
+    )
+    assert not owner_panel_viewport_write.search(handle_file_body)
+    assert "AppStateCommitPanelFileViewport(owner_panel," in handle_file_body
 
     position_owner_start = ctrl_file.index(
         "static void PositionOwnerFileCursor(", handle_file_end


### PR DESCRIPTION
## Summary
- route HandleFileWindow owner-panel exit viewport commits through AppStateCommitPanelFileViewport
- keep owner-panel file viewport writes inside the AppState helper boundary
- extend the AppState contract guard for owner-panel viewport writes in HandleFileWindow

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
