### PR TITLE
refactor(appstate): route panel anchor viewport commits through helper

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -689,8 +689,9 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   dst->disp_begin_pos = src->disp_begin_pos;
   memcpy(dst->tree_viewport_top_dir_path, src->tree_viewport_top_dir_path,
          sizeof(dst->tree_viewport_top_dir_path));
-  dst->start_file = src->start_file;
-  dst->file_cursor_pos = src->file_cursor_pos;
+  if (!AppStateCommitPanelFileViewport(dst, src->start_file,
+                                       src->file_cursor_pos))
+    return FALSE;
   dst->file_dir_entry = src->file_dir_entry;
   dst->file_mode = src->file_mode;
   dst->max_column = src->max_column;
@@ -723,8 +724,10 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
       if (!AppStateCommitPanelFileShape(
               dst, dst_current_volume_state->saved_big_file_view))
         return FALSE;
-      dst->start_file = dst_current_volume_state->saved_file_start;
-      dst->file_cursor_pos = dst_current_volume_state->saved_file_cursor;
+      if (!AppStateCommitPanelFileViewport(
+              dst, dst_current_volume_state->saved_file_start,
+              dst_current_volume_state->saved_file_cursor))
+        return FALSE;
       (void)snprintf(dst->file_selection_name,
                      sizeof(dst->file_selection_name), "%s",
                      dst_current_volume_state->saved_file_selection_name);
@@ -736,8 +739,9 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
         return FALSE;
       if (!AppStateCommitPanelFileShape(dst, dst_saved_big_file_view))
         return FALSE;
-      dst->start_file = dst_start_file;
-      dst->file_cursor_pos = dst_file_cursor_pos;
+      if (!AppStateCommitPanelFileViewport(dst, dst_start_file,
+                                           dst_file_cursor_pos))
+        return FALSE;
       dst->file_dir_entry = (DirEntry *)dst_file_dir_entry;
       (void)snprintf(dst->file_selection_name,
                      sizeof(dst->file_selection_name), "%s",

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6693,6 +6693,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
 
@@ -6702,6 +6703,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file_ops
     assert 'include "ytnova_appstate_panel.h"' in ctrl_dir
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file
+    assert 'include "ytnova_appstate_panel.h"' in panel_anchor
     assert 'include "ytnova_appstate_panel.h"' in log_source
     assert 'include "ytnova_appstate_panel.h"' in volume_source
 
@@ -6836,6 +6838,18 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     position_owner_body = ctrl_file[position_owner_start:position_owner_end]
     assert not active_viewport_write.search(position_owner_body)
     assert "AppStateCommitPanelFileViewport(ctx->active," in position_owner_body
+
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+    dst_viewport_write = re.compile(
+        r"\bdst->(?:start_file|file_cursor_pos)\s*=(?!=)"
+    )
+    assert not dst_viewport_write.search(donate_body)
+    assert (
+        len(re.findall(r"AppStateCommitPanelFileViewport\(\s*dst,", donate_body))
+        == 3
+    )
 
 
 def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- route DonatePanelState panel file viewport copies and restores through AppStateCommitPanelFileViewport
- keep donated panel start_file and file_cursor_pos writes inside the AppState helper boundary
- extend the AppState contract guard for DonatePanelState dst viewport writes

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
