### PR TITLE
refactor(appstate): route split transition viewport commits through helper

### DIFF
--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -269,8 +269,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
 
     if (!ctx->is_split_screen) {
       owner_panel->file_dir_entry = dir_entry;
-      owner_panel->start_file = dir_entry->start_file;
-      owner_panel->file_cursor_pos = dir_entry->cursor_pos;
+      if (!AppStateCommitPanelFileViewport(owner_panel, dir_entry->start_file,
+                                           dir_entry->cursor_pos))
+        return FALSE;
     }
     CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
 
@@ -337,8 +338,10 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
            */
           if (!AppStateCommitPanelFocus(ctx, ctx->right, FOCUS_FILE))
             return FALSE;
-          ctx->right->start_file = ctx->left->start_file;
-          ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
+          if (!AppStateCommitPanelFileViewport(ctx->right,
+                                               ctx->left->start_file,
+                                               ctx->left->file_cursor_pos))
+            return FALSE;
           (void)snprintf(ctx->right->file_selection_name,
                          sizeof(ctx->right->file_selection_name), "%s",
                          ctx->left->file_selection_name);
@@ -404,8 +407,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
       CaptureSplitFilePanelSnapshot(target_panel, &target_panel_snapshot);
 
       owner_panel->file_dir_entry = dir_entry;
-      owner_panel->start_file = dir_entry->start_file;
-      owner_panel->file_cursor_pos = dir_entry->cursor_pos;
+      if (!AppStateCommitPanelFileViewport(owner_panel, dir_entry->start_file,
+                                           dir_entry->cursor_pos))
+        return FALSE;
       CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
       if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
         return FALSE;
@@ -428,8 +432,9 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
     }
 #else
     owner_panel->file_dir_entry = dir_entry;
-    owner_panel->start_file = dir_entry->start_file;
-    owner_panel->file_cursor_pos = dir_entry->cursor_pos;
+    if (!AppStateCommitPanelFileViewport(owner_panel, dir_entry->start_file,
+                                         dir_entry->cursor_pos))
+      return FALSE;
     CapturePanelSelectionAnchor(ctx, owner_panel, dir_entry);
     if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
       return FALSE;
@@ -544,8 +549,10 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
           memcpy(ctx->right->tree_viewport_top_dir_path,
                  ctx->left->tree_viewport_top_dir_path,
                  sizeof(ctx->right->tree_viewport_top_dir_path));
-          ctx->right->start_file = ctx->left->start_file;
-          ctx->right->file_cursor_pos = ctx->left->file_cursor_pos;
+          if (!AppStateCommitPanelFileViewport(ctx->right,
+                                               ctx->left->start_file,
+                                               ctx->left->file_cursor_pos))
+            return FALSE;
           if (!AppStateCommitPanelFileShape(
                   ctx->right, ctx->left->saved_big_file_view))
             return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6694,6 +6694,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
 
@@ -6704,6 +6705,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in ctrl_dir
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file
     assert 'include "ytnova_appstate_panel.h"' in panel_anchor
+    assert 'include "ytnova_appstate_panel.h"' in split_transition
     assert 'include "ytnova_appstate_panel.h"' in log_source
     assert 'include "ytnova_appstate_panel.h"' in volume_source
 
@@ -6849,6 +6851,38 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     assert (
         len(re.findall(r"AppStateCommitPanelFileViewport\(\s*dst,", donate_body))
         == 3
+    )
+
+    file_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleFileWindowAction("
+    )
+    dir_split_start = split_transition.index(
+        "\nBOOL SplitTransition_HandleDirWindowAction(", file_split_start
+    )
+    file_split_body = split_transition[file_split_start:dir_split_start]
+    dir_split_body = split_transition[dir_split_start:]
+    split_panel_viewport_write = re.compile(
+        r"\b(?:owner_panel|ctx->right)->(?:start_file|file_cursor_pos)\s*=(?!=)"
+    )
+    for body in [file_split_body, dir_split_body]:
+        assert not split_panel_viewport_write.search(body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelFileViewport\(\s*owner_panel,",
+                file_split_body,
+            )
+        )
+        == 3
+    )
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelFileViewport\(\s*ctx->right,",
+                split_transition,
+            )
+        )
+        == 2
     )
 
 


### PR DESCRIPTION
## Summary
- route split-transition owner-panel and peer-panel file viewport copies through AppStateCommitPanelFileViewport
- keep split transition start_file and file_cursor_pos writes inside the AppState helper boundary
- extend the AppState contract guard for split-transition panel viewport writes

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
