### PR TITLE
refactor(appstate): route directory operation viewport commits through helper

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -8,8 +8,9 @@
 
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
-#include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_appstate_window.h"
@@ -988,8 +989,11 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
                                        inactive_file_dir_path);
           if (resolved_file_dir)
             inactive->file_dir_entry = resolved_file_dir;
-          inactive->start_file = inactive_start_file;
-          inactive->file_cursor_pos = inactive_file_cursor;
+          if (!AppStateCommitPanelFileViewport(inactive, inactive_start_file,
+                                               inactive_file_cursor)) {
+            FreePathList(inactive_tagged_snapshot);
+            return;
+          }
           (void)snprintf(inactive->file_selection_dir_path,
                          sizeof(inactive->file_selection_dir_path), "%s",
                          inactive_file_dir_path);
@@ -1251,8 +1255,9 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
         return;
 
       p->file_dir_entry = dir_entry;
-      p->start_file = dir_entry->start_file;
-      p->file_cursor_pos = dir_entry->cursor_pos;
+      if (!AppStateCommitPanelFileViewport(p, dir_entry->start_file,
+                                           dir_entry->cursor_pos))
+        return;
       CapturePanelSelectionAnchor(ctx, p, dir_entry);
 
       /* Check if the panel we were handling is still valid/active.
@@ -1499,8 +1504,9 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
   }
 
   panel->file_dir_entry = dir_entry;
-  panel->start_file = dir_entry->start_file;
-  panel->file_cursor_pos = dir_entry->cursor_pos;
+  if (!AppStateCommitPanelFileViewport(panel, dir_entry->start_file,
+                                       dir_entry->cursor_pos))
+    return dir_entry;
   if (!AppStateCommitPanelFocus(ctx, panel, FOCUS_FILE))
     return dir_entry;
   if (!dir_entry->global_flag && !dir_entry->tagged_flag) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6691,6 +6691,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     file_list = Path("src/ui/file_list.c").read_text(encoding="utf-8")
     file_nav = Path("src/ui/file_nav.c").read_text(encoding="utf-8")
     ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
@@ -6702,6 +6703,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in file_list
     assert 'include "ytnova_appstate_panel.h"' in file_nav
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file_ops
+    assert 'include "ytnova_appstate_panel.h"' in dir_ops
     assert 'include "ytnova_appstate_panel.h"' in ctrl_dir
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file
     assert 'include "ytnova_appstate_panel.h"' in panel_anchor
@@ -6883,6 +6885,39 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
             )
         )
         == 2
+    )
+
+    make_dir_start = dir_ops.index("void HandleDirMakeDirectory(")
+    delete_dir_start = dir_ops.index(
+        "\nDirEntry *HandleDirDeleteDirectory(", make_dir_start
+    )
+    make_dir_body = dir_ops[make_dir_start:delete_dir_start]
+    switch_start = dir_ops.index("void HandleSwitchWindow(")
+    sync_windows_start = dir_ops.index("\nvoid SyncActivePanelWindows(", switch_start)
+    switch_body = dir_ops[switch_start:sync_windows_start]
+    restore_panel_start = dir_ops.index("DirEntry *RestorePanelFileSelection(")
+    restore_panel_end = dir_ops.index(
+        "\nDirWindowDispatchResult", restore_panel_start
+    )
+    restore_panel_body = dir_ops[restore_panel_start:restore_panel_end]
+    dir_ops_panel_viewport_write = re.compile(
+        r"\b(?:inactive|p|panel)->(?:start_file|file_cursor_pos)\s*=(?!=)"
+    )
+    for body in [make_dir_body, switch_body, restore_panel_body]:
+        assert not dir_ops_panel_viewport_write.search(body)
+    assert (
+        len(re.findall(r"AppStateCommitPanelFileViewport\(\s*inactive,", make_dir_body))
+        == 1
+    )
+    assert len(re.findall(r"AppStateCommitPanelFileViewport\(\s*p,", switch_body)) == 1
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelFileViewport\(\s*panel,",
+                restore_panel_body,
+            )
+        )
+        == 1
     )
 
 


### PR DESCRIPTION
## Summary
- route dir_ops panel file viewport commits through AppStateCommitPanelFileViewport
- keep inactive, p, and panel start_file/file_cursor_pos writes inside the AppState helper boundary
- extend the AppState contract guard for dir_ops panel viewport writes

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
- `python3 scripts/check_appstate_contract.py`
