### PR TITLE
refactor(appstate): route initial panel file viewports through helper

### DIFF
--- a/src/core/init.c
+++ b/src/core/init.c
@@ -12,6 +12,7 @@
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_mode.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_appstate_window.h"
@@ -382,8 +383,13 @@ void InitView(ViewContext *ctx) {
   }
   DEBUG_LOG("InitView: setup left panel=%p", (void *)ctx->left);
   ctx->left->file_mode = MODE_1;
-  ctx->left->file_cursor_pos = 0;
   ctx->left->file_dir_entry = NULL;
+  if (!AppStateCommitPanelFileViewport(ctx->left, 0, 0)) {
+    fprintf(stderr, "InitView: failed to initialize left panel file viewport\n");
+    free(ctx->left);
+    ctx->left = NULL;
+    exit(1);
+  }
   if (!AppStateSeedPanelVisibilityFilter(ctx->left, FALSE)) {
     fprintf(stderr, "InitView: failed to initialize left panel visibility\n");
     free(ctx->left);
@@ -400,8 +406,15 @@ void InitView(ViewContext *ctx) {
   }
   DEBUG_LOG("InitView: setup right panel=%p", (void *)ctx->right);
   ctx->right->file_mode = MODE_1;
-  ctx->right->file_cursor_pos = 0;
   ctx->right->file_dir_entry = NULL;
+  if (!AppStateCommitPanelFileViewport(ctx->right, 0, 0)) {
+    fprintf(stderr, "InitView: failed to initialize right panel file viewport\n");
+    free(ctx->right);
+    free(ctx->left);
+    ctx->right = NULL;
+    ctx->left = NULL;
+    exit(1);
+  }
   if (!AppStateSeedPanelVisibilityFilter(ctx->right, FALSE)) {
     fprintf(stderr, "InitView: failed to initialize right panel visibility\n");
     free(ctx->right);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6698,6 +6698,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelFileViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in file_list
@@ -6710,6 +6711,7 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in split_transition
     assert 'include "ytnova_appstate_panel.h"' in log_source
     assert 'include "ytnova_appstate_panel.h"' in volume_source
+    assert 'include "ytnova_appstate_panel.h"' in init_source
 
     helper_start = helper.index("BOOL AppStateCommitPanelFileViewport(")
     helper_body = helper[helper_start:]
@@ -6751,6 +6753,23 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
         in restore_body
     )
     assert "AppStateCommitPanelFileViewport(panel, 0, 0)" in clear_body
+
+    init_start = init_source.index("void InitView(")
+    init_end = init_source.index("\nvoid CoreMainOps_Register(", init_start)
+    init_body = init_source[init_start:init_end]
+    initial_panel_viewport_write = re.compile(
+        r"\bctx->(?:left|right)->(?:start_file|file_cursor_pos)\s*=(?!=)"
+    )
+    assert not initial_panel_viewport_write.search(init_body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelFileViewport\(\s*ctx->(?:left|right),\s*0,\s*0\)",
+                init_body,
+            )
+        )
+        == 2
+    )
 
     refresh_start = file_nav.index("static void RefreshFileSelection(")
     move_down_start = file_nav.index("\nvoid FileNav_MoveDown(", refresh_start)


### PR DESCRIPTION
## Summary
- Route initial left/right panel file viewport seeding in `InitView` through `AppStateCommitPanelFileViewport`.
- Extend the AppState contract guard so initial panel viewport writes cannot bypass the helper.

## Validation
- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_viewport_commits_route_through_appstate_helper` failed because `src/core/init.c` did not include `ytnova_appstate_panel.h` and still wrote initial panel file viewport fields directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_viewport_commits_route_through_appstate_helper`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
