### PR TITLE
refactor(appstate): route log tree viewport resets through helper

### DIFF
--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -479,8 +479,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
     ctx->hook_build_dir_entry_list(ctx, panel->vol, &(int){0});
   RestorePanelFileSelection(ctx, panel);
   if (reload_requested) {
-    panel->disp_begin_pos = 0;
-    panel->cursor_pos = 0;
+    if (!AppStateCommitPanelTreeViewport(panel, 0, 0))
+      return -1;
     ResetPanelTreeViewportSnapshot(panel);
   } else {
     RestorePanelTreeSelection(ctx, panel);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6945,10 +6945,12 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelTreeViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in dir_nav
     assert 'include "ytnova_appstate_panel.h"' in volume_menu
+    assert 'include "ytnova_appstate_panel.h"' in log_source
 
     helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
     helper_body = helper[helper_start:]
@@ -6985,6 +6987,14 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         "AppStateCommitPanelTreeViewport(panel, disp_begin_pos, cursor_pos)"
         in normalize_body
     )
+
+    log_disk_start = log_source.index("int LogDisk(")
+    log_disk_end = log_source.index("\nint GetNewLogPath(", log_disk_start)
+    log_disk_body = log_source[log_disk_start:log_disk_end]
+    assert not re.search(
+        r"\bpanel->(?:disp_begin_pos|cursor_pos)\s*=(?!=)", log_disk_body
+    )
+    assert "AppStateCommitPanelTreeViewport(panel, 0, 0)" in log_disk_body
 
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -361,8 +361,9 @@ def test_log_disk_restore_does_not_use_volume_tree_breadcrumbs():
     assert "panel->vol->saved_tree_generation" not in log_disk_source
     assert "panel->vol->saved_tree_index" not in log_disk_source
     assert "if (reload_requested)" in log_disk_source
-    assert "panel->disp_begin_pos = 0;" in log_disk_source
-    assert "panel->cursor_pos = 0;" in log_disk_source
+    assert "AppStateCommitPanelTreeViewport(panel, 0, 0)" in log_disk_source
+    assert "panel->disp_begin_pos = 0;" not in log_disk_source
+    assert "panel->cursor_pos = 0;" not in log_disk_source
     assert "ResetPanelTreeViewportSnapshot(panel);" in log_disk_source
     assert "state->has_saved_tree_selection = FALSE;" in reset_snapshot_source
     assert "state->has_saved_tree_top = FALSE;" in reset_snapshot_source


### PR DESCRIPTION
## Summary
- Route the log reload tree viewport reset through `AppStateCommitPanelTreeViewport`.
- Extend the AppState contract guard so `LogDisk` cannot write panel tree viewport fields directly.
- Update the log restore regression guard to expect the AppState helper boundary instead of direct viewport writes.

## Validation
- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because the log reload path lacked the AppState tree viewport helper call.
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k log_disk_restore_does_not_use_volume_tree_breadcrumbs`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
