### PR TITLE
refactor(appstate): route directory window tree viewports through helper

### DIFF
--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -554,8 +554,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   if (ctx->initial_directory != NULL) {
     if (!strcmp(ctx->initial_directory, ".")) /* Entry just a single "." */
     {
-      ctx->active->disp_begin_pos = 0;
-      ctx->active->cursor_pos = 0;
+      if (!AppStateCommitPanelTreeViewport(ctx->active, 0, 0))
+        return ESC;
       unput_char = CR;
     } else {
       int log_path_len = -1;
@@ -590,8 +590,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
                            ctx->active->vol->dir_entry_list[i].dir_entry->name);
           }
           if (!strcmp(new_log_path, new_name)) {
-            ctx->active->disp_begin_pos = i;
-            ctx->active->cursor_pos = 0;
+            if (!AppStateCommitPanelTreeViewport(ctx->active, i, 0))
+              return ESC;
             unput_char = CR;
             break;
           }
@@ -604,12 +604,12 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   {
     int safe_idx = ctx->active->disp_begin_pos + ctx->active->cursor_pos;
     if (ctx->active->vol->total_dirs <= 0) {
-      ctx->active->disp_begin_pos = 0;
-      ctx->active->cursor_pos = 0;
+      if (!AppStateCommitPanelTreeViewport(ctx->active, 0, 0))
+        return ESC;
       safe_idx = 0;
     } else if (safe_idx < 0 || safe_idx >= ctx->active->vol->total_dirs) {
-      ctx->active->disp_begin_pos = 0;
-      ctx->active->cursor_pos = 0;
+      if (!AppStateCommitPanelTreeViewport(ctx->active, 0, 0))
+        return ESC;
       safe_idx = 0;
     }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6144,6 +6144,7 @@ def test_view_mode_commits_through_appstate_helper() -> None:
     helper = Path("src/ui/appstate_mode.c").read_text(encoding="utf-8")
     init_source = Path("src/core/init.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitViewMode(" in header
     assert 'include "ytnova_appstate_mode.h"' in init_source
@@ -6946,11 +6947,13 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelTreeViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in dir_nav
     assert 'include "ytnova_appstate_panel.h"' in volume_menu
     assert 'include "ytnova_appstate_panel.h"' in log_source
+    assert 'include "ytnova_appstate_panel.h"' in ctrl_dir
 
     helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
     helper_body = helper[helper_start:]
@@ -6995,6 +6998,16 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         r"\bpanel->(?:disp_begin_pos|cursor_pos)\s*=(?!=)", log_disk_body
     )
     assert "AppStateCommitPanelTreeViewport(panel, 0, 0)" in log_disk_body
+
+    handle_dir_start = ctrl_dir.index("extern int HandleDirWindow(")
+    handle_dir_end = ctrl_dir.index("\nstatic void DirListJump(", handle_dir_start)
+    handle_dir_body = ctrl_dir[handle_dir_start:handle_dir_end]
+    assert not re.search(
+        r"\bctx->active->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+        handle_dir_body,
+    )
+    assert "AppStateCommitPanelTreeViewport(ctx->active, 0, 0)" in handle_dir_body
+    assert "AppStateCommitPanelTreeViewport(ctx->active, i, 0)" in handle_dir_body
 
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route `HandleDirWindow` active tree viewport initialization and safety resets through `AppStateCommitPanelTreeViewport`.
- Extend the AppState tree viewport contract guard so directory-window active panel viewport writes cannot bypass the helper.

## Validation
- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because `HandleDirWindow` still wrote active tree viewport fields directly.
- CI red fix: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_generation_restores_route_through_appstate_helper or panel_tree_viewport_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
