### PR TITLE
refactor(appstate): route directory jump tree viewports through helper

### DIFF
--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -1206,8 +1206,8 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
       break;
 
     if (ch == ESC) {
-      ctx->active->disp_begin_pos = original_disp_begin_pos;
-      ctx->active->cursor_pos = original_cursor_pos;
+      (void)AppStateCommitPanelTreeViewport(
+          ctx->active, original_disp_begin_pos, original_cursor_pos);
     } else if (ch == CR || ch == LF) {
       break;
     } else if (ch == KEY_BACKSPACE || ch == 127 || ch == '\b' || ch == KEY_DC) {
@@ -1216,8 +1216,8 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
         search_buf[buf_len] = '\0';
 
         if (buf_len == 0) {
-          ctx->active->disp_begin_pos = original_disp_begin_pos;
-          ctx->active->cursor_pos = original_cursor_pos;
+          (void)AppStateCommitPanelTreeViewport(
+              ctx->active, original_disp_begin_pos, original_cursor_pos);
         } else {
           found_idx = -1;
           for (i = 0; i < ctx->active->vol->total_dirs; i++) {
@@ -1261,20 +1261,25 @@ static void DirListJump(ViewContext *ctx, DirEntry **dir_entry_ptr,
     }
 
     if (ctx->active->cursor_pos < 0)
-      ctx->active->cursor_pos = 0;
+      (void)AppStateCommitPanelTreeViewport(ctx->active,
+                                            ctx->active->disp_begin_pos, 0);
 
     if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
         ctx->active->vol->total_dirs) {
       int last_idx = ctx->active->vol->total_dirs - 1;
+      int next_begin;
+      int next_cursor;
       if (last_idx < 0)
         last_idx = 0;
       if (last_idx >= height) {
-        ctx->active->disp_begin_pos = last_idx - (height - 1);
-        ctx->active->cursor_pos = height - 1;
+        next_begin = last_idx - (height - 1);
+        next_cursor = height - 1;
       } else {
-        ctx->active->disp_begin_pos = 0;
-        ctx->active->cursor_pos = last_idx;
+        next_begin = 0;
+        next_cursor = last_idx;
       }
+      (void)AppStateCommitPanelTreeViewport(ctx->active, next_begin,
+                                            next_cursor);
     }
 
     *dir_entry_ptr = ctx->active->vol

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7009,6 +7009,24 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     assert "AppStateCommitPanelTreeViewport(ctx->active, 0, 0)" in handle_dir_body
     assert "AppStateCommitPanelTreeViewport(ctx->active, i, 0)" in handle_dir_body
 
+    jump_start = ctrl_dir.index("static void DirListJump(", handle_dir_end)
+    jump_end = ctrl_dir.index("\nstatic void DrawDirListJumpPrompt(", jump_start)
+    jump_body = ctrl_dir[jump_start:jump_end]
+    assert not re.search(
+        r"\bctx->active->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+        jump_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeViewport\(\s*ctx->active,\s*"
+        r"original_disp_begin_pos,\s*original_cursor_pos\)",
+        jump_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeViewport\(\s*ctx->active,\s*next_begin,\s*"
+        r"next_cursor\)",
+        jump_body,
+    )
+
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route `DirListJump` active tree viewport restores and bounds corrections through `AppStateCommitPanelTreeViewport`.
- Extend the AppState tree viewport contract guard so directory jump updates cannot bypass the helper.

## Validation
- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because `DirListJump` still wrote active tree viewport fields directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
