### PR TITLE
refactor(appstate): route owner directory tree viewports through helper

### DIFF
--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -896,6 +896,8 @@ static BOOL JumpToOwnerDirectory(ViewContext *ctx,
   int owner_dir_idx;
   struct Volume *owner_vol;
   int win_height;
+  int next_begin;
+  int next_cursor;
 
   if (!ctx || !ctx->active || !global_dir_entry)
     return FALSE;
@@ -929,30 +931,32 @@ static BOOL JumpToOwnerDirectory(ViewContext *ctx,
   if (win_height < 1)
     win_height = 1;
 
+  next_begin = panel->disp_begin_pos;
   if (owner_dir_idx >= panel->disp_begin_pos &&
       owner_dir_idx < panel->disp_begin_pos + win_height) {
-    panel->cursor_pos = owner_dir_idx - panel->disp_begin_pos;
+    next_cursor = owner_dir_idx - panel->disp_begin_pos;
   } else if (owner_dir_idx < win_height) {
-    panel->disp_begin_pos = 0;
-    panel->cursor_pos = owner_dir_idx;
+    next_begin = 0;
+    next_cursor = owner_dir_idx;
   } else {
-    panel->disp_begin_pos = owner_dir_idx - (win_height / 2);
-    if (panel->disp_begin_pos > panel->vol->total_dirs - win_height) {
-      panel->disp_begin_pos = panel->vol->total_dirs - win_height;
+    next_begin = owner_dir_idx - (win_height / 2);
+    if (next_begin > panel->vol->total_dirs - win_height) {
+      next_begin = panel->vol->total_dirs - win_height;
     }
-    if (panel->disp_begin_pos < 0)
-      panel->disp_begin_pos = 0;
-    panel->cursor_pos = owner_dir_idx - panel->disp_begin_pos;
+    if (next_begin < 0)
+      next_begin = 0;
+    next_cursor = owner_dir_idx - next_begin;
   }
 
-  if (panel->cursor_pos < 0)
-    panel->cursor_pos = 0;
-  if (panel->disp_begin_pos + panel->cursor_pos >= panel->vol->total_dirs) {
-    panel->cursor_pos =
-        (panel->vol->total_dirs > 0)
-            ? (panel->vol->total_dirs - 1 - panel->disp_begin_pos)
-            : 0;
+  if (next_cursor < 0)
+    next_cursor = 0;
+  if (next_begin + next_cursor >= panel->vol->total_dirs) {
+    next_cursor = (panel->vol->total_dirs > 0)
+                      ? (panel->vol->total_dirs - 1 - next_begin)
+                      : 0;
   }
+  if (!AppStateCommitPanelTreeViewport(panel, next_begin, next_cursor))
+    return FALSE;
 
   owner_dir->global_flag = FALSE;
   owner_dir->global_all_volumes = FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6948,12 +6948,14 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelTreeViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in dir_nav
     assert 'include "ytnova_appstate_panel.h"' in volume_menu
     assert 'include "ytnova_appstate_panel.h"' in log_source
     assert 'include "ytnova_appstate_panel.h"' in ctrl_dir
+    assert 'include "ytnova_appstate_panel.h"' in ctrl_file
 
     helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
     helper_body = helper[helper_start:]
@@ -7025,6 +7027,18 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         r"AppStateCommitPanelTreeViewport\(\s*ctx->active,\s*next_begin,\s*"
         r"next_cursor\)",
         jump_body,
+    )
+
+    owner_start = ctrl_file.index("static BOOL JumpToOwnerDirectory(")
+    owner_end = ctrl_file.index("\nstatic void DrawFileListJumpPrompt(", owner_start)
+    owner_body = ctrl_file[owner_start:owner_end]
+    assert not re.search(
+        r"\bpanel->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+        owner_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeViewport\(\s*panel,\s*next_begin,\s*next_cursor\)",
+        owner_body,
     )
 
 


### PR DESCRIPTION
## Summary
- Route owner-directory tree viewport positioning through `AppStateCommitPanelTreeViewport`.
- Extend the AppState tree viewport contract guard so owner-directory jumps cannot bypass the helper.

## Validation
- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because `JumpToOwnerDirectory` still wrote panel tree viewport fields directly.
- CI red fix: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- CI red fix: `python3 scripts/check_appstate_contract.py`
- CI red fix: `make qa-code-quality`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
