### PR TITLE
refactor(appstate): route refresh tree viewports through helper

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -2096,6 +2096,7 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
 
       if (found_idx != -1) {
         int next_disp_begin = saved_disp_begin;
+        int next_cursor_pos;
 
         if (next_disp_begin < 0)
           next_disp_begin = 0;
@@ -2113,20 +2114,20 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
         if (next_disp_begin > max_begin)
           next_disp_begin = max_begin;
 
-        p->disp_begin_pos = next_disp_begin;
-        p->cursor_pos = found_idx - p->disp_begin_pos;
-        if (p->cursor_pos < 0)
-          p->cursor_pos = 0;
-        if (p->cursor_pos >= win_height)
-          p->cursor_pos = win_height - 1;
-        entry =
-            p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos].dir_entry;
+        next_cursor_pos = found_idx - next_disp_begin;
+        if (next_cursor_pos < 0)
+          next_cursor_pos = 0;
+        if (next_cursor_pos >= win_height)
+          next_cursor_pos = win_height - 1;
+        (void)AppStateCommitPanelTreeViewport(p, next_disp_begin,
+                                              next_cursor_pos);
+        entry = p->vol->dir_entry_list[p->disp_begin_pos + p->cursor_pos]
+                    .dir_entry;
       } else {
         /* Fallback to start if dir moved/deleted */
         if (p->vol->total_dirs > 0 &&
             (p->disp_begin_pos + p->cursor_pos >= p->vol->total_dirs)) {
-          p->disp_begin_pos = 0;
-          p->cursor_pos = 0;
+          (void)AppStateCommitPanelTreeViewport(p, 0, 0);
           entry = p->vol->dir_entry_list[0].dir_entry;
         }
       }
@@ -2146,8 +2147,7 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
     /* Basic bounds check */
     if (p->vol->total_dirs > 0 &&
         (p->disp_begin_pos + p->cursor_pos >= p->vol->total_dirs)) {
-      p->disp_begin_pos = 0;
-      p->cursor_pos = 0;
+      (void)AppStateCommitPanelTreeViewport(p, 0, 0);
       entry = p->vol->dir_entry_list[0].dir_entry;
     }
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6949,6 +6949,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelTreeViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in dir_nav
@@ -6956,6 +6957,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in log_source
     assert 'include "ytnova_appstate_panel.h"' in ctrl_dir
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file
+    assert 'include "ytnova_appstate_panel.h"' in dir_ops
 
     helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
     helper_body = helper[helper_start:]
@@ -7040,6 +7042,20 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         r"AppStateCommitPanelTreeViewport\(\s*panel,\s*next_begin,\s*next_cursor\)",
         owner_body,
     )
+
+    refresh_start = dir_ops.index("DirEntry *RefreshTreeSafe(")
+    scan_start = dir_ops.index("\nint ScanSubTree(", refresh_start)
+    refresh_body = dir_ops[refresh_start:scan_start]
+    assert not re.search(
+        r"\bp->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+        refresh_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeViewport\(\s*p,\s*next_disp_begin,\s*"
+        r"next_cursor_pos\)",
+        refresh_body,
+    )
+    assert "AppStateCommitPanelTreeViewport(p, 0, 0)" in refresh_body
 
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route `RefreshTreeSafe` fallback and bounds tree viewport commits through `AppStateCommitPanelTreeViewport`.
- Extend the AppState contract guard to keep `RefreshTreeSafe` from writing tree viewport fields directly.

## Validation
- RED: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed before the runtime change because `RefreshTreeSafe` still wrote `p->disp_begin_pos` and `p->cursor_pos` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && make clean && make`
