### PR TITLE
build(docs): switch generated docs to cmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
     - name: Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ccache libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc
+        sudo apt-get install -y ccache libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools cmark
 
     - name: Restore ccache
       uses: actions/cache@v6
@@ -215,7 +215,7 @@ jobs:
     - name: Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ccache clang llvm libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc lcov
+        sudo apt-get install -y ccache clang llvm libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools cmark lcov
 
     - name: Restore ccache
       uses: actions/cache@v6

--- a/.github/workflows/fedora-rawhide.yml
+++ b/.github/workflows/fedora-rawhide.yml
@@ -39,7 +39,7 @@ jobs:
             libarchive-devel \
             make \
             ncurses-devel \
-            pandoc \
+            cmark \
             python3 \
             readline-devel
 

--- a/.github/workflows/full-qa.yml
+++ b/.github/workflows/full-qa.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ccache gitleaks libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc clang-tidy cppcheck clang-tools bear valgrind
+        sudo apt-get install -y ccache gitleaks libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools cmark clang-tidy cppcheck clang-tools bear valgrind
 
     - name: Restore ccache
       uses: actions/cache@v6
@@ -152,7 +152,7 @@ jobs:
     - name: Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ccache libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc clang
+        sudo apt-get install -y ccache libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools cmark clang
 
     - name: Restore ccache
       uses: actions/cache@v6

--- a/.github/workflows/nightly-deep-valgrind.yml
+++ b/.github/workflows/nightly-deep-valgrind.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install System Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools pandoc valgrind
+        sudo apt-get install -y libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools cmark valgrind
 
     - name: Set up Python 3
       uses: actions/setup-python@v6

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ BIN_DIR     = .
 # -------------------------------------------------------------------------
 CC          ?= cc
 FUZZ_CC     ?= clang
-PANDOC      ?= pandoc
+CMARK       ?= cmark
 MAKE_CMD    ?= $(MAKE)
 
 # -------------------------------------------------------------------------
@@ -116,6 +116,7 @@ MAIN        = ytnova
 MAIN_BIN    = $(BUILD_DIR)/$(MAIN)
 MANSRC      = etc/ytnova.1.md
 MANPAGE     = $(BUILD_DIR)/ytnova.1
+MAN_TH      = .TH "YTNOVA" "1" "$(VERSIONDATE)" "ytnova $(VERSION)" "User Commands"
 
 # Automatically find all .c files in src/ and subdirectories
 SRCS        = $(wildcard $(SRC_DIR)/*.c $(SRC_DIR)/*/*.c)
@@ -182,13 +183,24 @@ $(BUILD_DIR):
 
 # Generate USAGE.md from the man page source
 docs:
-	$(PANDOC) -f markdown-tex_math_dollars -t gfm \
-		--metadata title="YtreeNova Usage" \
-		$(MANSRC) -o $(DOC_DIR)/USAGE.md
+	$(CMARK) --to commonmark $(MANSRC) > $(DOC_DIR)/USAGE.md
 
 # Generate the roff man page
 $(MANPAGE): $(MANSRC) | $(BUILD_DIR)
-	$(PANDOC) -s -t man $(MANSRC) -o $@
+	@tmp=$@.tmp; \
+	$(CMARK) --to man $(MANSRC) > "$$tmp"; \
+	first_line=$$(sed -n '1p' "$$tmp"); \
+	if [ "$$first_line" = '$(MAN_TH)' ]; then \
+		mv "$$tmp" "$@"; \
+	else \
+		{ printf '%s\n' '$(MAN_TH)'; \
+		  case $$first_line in \
+		    '.TH '*) sed '1d' "$$tmp" ;; \
+		    *) cat "$$tmp" ;; \
+		  esac; \
+		} > "$@"; \
+		rm -f "$$tmp"; \
+	fi
 
 # Install binary, man page, and documentation
 install: $(MAIN_BIN) $(MANPAGE) docs

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,14 +55,14 @@ This project uses a combination of C for the application and Python for the test
 - A C compiler (`gcc` or `clang`) and `make`.
 - `libncurses-dev`, `libtinfo-dev`, `libreadline-dev`, `libarchive-dev`.
 - `python3` and `python3-venv`.
-- `pandoc` (for generating the man page).
+- `cmark` (for generating the usage doc and man page).
 - `lcov` (for baseline CI coverage reports).
 - `llvm` tools (`llvm-symbolizer`) for sanitizer/fuzz diagnostics.
 
 On a Debian/Ubuntu-based system, you can install these with:
 ```bash
 sudo apt-get update
-sudo apt-get install build-essential clang llvm libncurses-dev libtinfo-dev libreadline-dev libarchive-dev python3-venv pandoc lcov
+sudo apt-get install build-essential clang llvm libncurses-dev libtinfo-dev libreadline-dev libarchive-dev python3-venv cmark lcov
 ```
 
 ### 2. Initial Python Environment Setup

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,399 +4,267 @@ ytnova - a file manager for Unix-like systems
 
 # SYNOPSIS
 
-`ytnova` \[`--init`\] \[`-v`\|`-V`\|`--version`\] \[`-p` *config_file*\]
-\[`-h` *history_file*\] \[`-d` *depth*\] \[`-f` *filter*\]
-\[*directory*\|*archive*\]…
+`ytnova` \[`--init`\] \[`-v`|`-V`|`--version`\] \[`-p` *config\_file*\] \[`-h` *history\_file*\] \[`-d` *depth*\] \[`-f` *filter*\] \[*directory*|*archive*\]...
 
 # DESCRIPTION
 
-**ytnova** is a file manager for UNIX-like systems (Linux, BSD, etc.).
-It is inspired by the DOS file manager **XTree™**, offering a text-based
-user interface (TUI) that is fast, lightweight, and keyboard-driven.
+**ytnova** is a file manager for UNIX-like systems (Linux, BSD, etc.). It is inspired by the DOS file manager **XTree™**, offering a text-based user interface (TUI) that is fast, lightweight, and keyboard-driven.
 
-This version is a modern refactor of the original **ytree** by Werner
-Bregulla, incorporating features from XTree™ and ZTreeWin, using modern
-C standards (C99/POSIX), and integrating robust libraries like
-`libarchive`.
+This version is a modern refactor of the original **ytree** by Werner Bregulla, incorporating features from XTree™ and ZTreeWin, using modern C standards (C99/POSIX), and integrating robust libraries like `libarchive`.
 
-If no command line arguments are provided, the current directory will be
-logged.
+If no command line arguments are provided, the current directory will be logged.
 
 # OPTIONS
 
-- **-d** *depth*: Override the default scan depth (TREEDEPTH). Supports
-  numeric values or keywords: **min**/**root** (0), **max**/**all**
-  (100).
-- **-f** *filter*: Specify an initial file filter (filespec) on startup.
-  Supports patterns (e.g., `*.c`), exclusions (`-*.o`), and combinations
-  (e.g., `*.c,*.h`). Use quotes to prevent shell expansion (e.g.,
-  `ytnova -f "*.c"`).
-- **-h** *history_file*: Use *history_file* instead of the default
-  `~/.ytnova-hst`.
-- **–init**: Create a starter profile file and exit. By default this
-  creates `~/.ytnova` only if it does not already exist. Use `-p` to
-  target a different file.
-- **-p** *config_file*: Use *config_file* instead of the default
-  `~/.ytnova`.
-- **-v**, **-V**, **–version**: Print ytnova version information and
-  exit.
-- *directory*\|*archive*: One or more directories or archive files to
-  log on startup. If multiple paths are provided, they are all loaded as
-  separate volumes. The first path specified becomes the active view.
+  - **-d** *depth*: Override the default scan depth (TREEDEPTH). Supports numeric values or keywords: **min**/**root** (0), **max**/**all** (100).
+  - **-f** *filter*: Specify an initial file filter (filespec) on startup. Supports patterns (e.g., `*.c`), exclusions (`-*.o`), and combinations (e.g., `*.c,*.h`). Use quotes to prevent shell expansion (e.g., `ytnova -f "*.c"`).
+  - **-h** *history\_file*: Use *history\_file* instead of the default `~/.ytnova-hst`.
+  - **--init**: Create a starter profile file and exit. By default this creates `~/.ytnova` only if it does not already exist. Use `-p` to target a different file.
+  - **-p** *config\_file*: Use *config\_file* instead of the default `~/.ytnova`.
+  - **-v**, **-V**, **--version**: Print ytnova version information and exit.
+  - *directory*|*archive*: One or more directories or archive files to log on startup. If multiple paths are provided, they are all loaded as separate volumes. The first path specified becomes the active view.
 
 # CONCEPTS
 
 ### The Display
 
-The screen is divided into three panes plus a footer help line: the
-**Directory Tree** (upper-left), the **File Window** (below the tree),
-and the **Statistics/Info** pane (right, spanning both left panes). The
-footer shows context-sensitive keybinding hints.
+The screen is divided into three panes plus a footer help line: the **Directory Tree** (upper-left), the **File Window** (below the tree), and the **Statistics/Info** pane (right, spanning both left panes). The footer shows context-sensitive keybinding hints.
 
 ### Logging
 
-Unlike file managers that rescan directories on demand, ytnova “logs”
-(scans) directory structures into memory. This allows instant navigation
-and searching without disk lag. Use the **l** command to log new paths
-or archives.
+Unlike file managers that rescan directories on demand, ytnova "logs" (scans) directory structures into memory. This allows instant navigation and searching without disk lag. Use the **l** command to log new paths or archives.
 
 ### Auto-Refresh
 
-ytnova monitors the **currently selected directory** for changes
-(created/deleted/modified files) and updates the file list
-automatically.
+ytnova monitors the **currently selected directory** for changes (created/deleted/modified files) and updates the file list automatically.
 
-**Note:** This monitoring is **active only for the current directory**.
-Changes occurring in parent or sibling directories while they are not
-selected will not be detected automatically. Use **^L** (Reload) or
-**F5** to refresh the view when navigating back to previously modified
-areas. Additionally, auto-refresh relies on kernel notifications. It may
-not function on network shares (NFS, SMB) or non-native mounts (e.g.,
-WSL Windows drives) where the operating system does not propagate change
-events.
+**Note:** This monitoring is **active only for the current directory**. Changes occurring in parent or sibling directories while they are not selected will not be detected automatically. Use **^L** (Reload) or **F5** to refresh the view when navigating back to previously modified areas. Additionally, auto-refresh relies on kernel notifications. It may not function on network shares (NFS, SMB) or non-native mounts (e.g., WSL Windows drives) where the operating system does not propagate change events.
 
 # MODES AND NAVIGATION
 
-**ytnova** operates in distinct modes. The active mode determines
-available commands.
+**ytnova** operates in distinct modes. The active mode determines available commands.
 
-**Directory Mode** Focus is on the directory hierarchy tree. Navigation
-keys allow moving between folders. Typing alphanumeric characters
-triggers a directory mode command (key bindings). \* **Action:** Press
-**Enter** to switch focus to the **File Mode** (file list) for the
-selected directory.
+**Directory Mode**
+Focus is on the directory hierarchy tree. Navigation keys allow moving between folders. Typing alphanumeric characters triggers a directory mode command (key bindings).
 
-**File Mode** Focus is on the file list of the selected directory.
-Operations here affect specific files. Typing alphanumeric characters
-triggers a file mode command (key bindings). \* **Action:** Press
-**Enter** to toggle the file window to full-screen. Press **Enter**
-again to restore the split view or switch back to **Directory Mode**.
+  - **Action:** Press **Enter** to switch focus to the **File Mode** (file list) for the selected directory.
 
-**Showall Mode** Toggle file-list mode for all files in the currently
-logged volume. \* **Action:** Press **Esc** to return to the previously
-selected directory. Press **\\** to jump to the owner directory of the
-selected file.
+**File Mode**
+Focus is on the file list of the selected directory. Operations here affect specific files. Typing alphanumeric characters triggers a file mode command (key bindings).
 
-**Global Mode** Toggle file-list mode for all files across all logged
-volumes. \* **Action:** Press **Esc** to return to the previously
-selected directory. Press **\\** to jump to the owner directory of the
-selected file.
+  - **Action:** Press **Enter** to toggle the file window to full-screen. Press **Enter** again to restore the split view or switch back to **Directory Mode**.
 
-**Archive Mode** When entering a supported archive (ZIP, TAR, GZ),
-ytnova treats it as a virtual filesystem with archive-aware write
-operations (copy/move/delete/rename/mkdir paths where supported). It
-behaves similarly to Directory/File modes with archive-specific
-navigation and safety semantics.
+**Showall Mode**
+Toggle file-list mode for all files in the currently logged volume.
 
-**Split Screen Mode** Activated by **F8**. The screen is divided
-vertically into two independent file manager panels. \* **Toggle:**
-Press **F8** again to return to single-panel mode. \* **Switch Focus:**
-Press **Tab** to switch active control between the Left and Right
-panels. \* **Targeting:** Operations like **Copy** and **Move**
-automatically default to the path of the inactive (passive) panel as the
-destination.
+  - **Action:** Press **Esc** to return to the previously selected directory. Press **\\** to jump to the owner directory of the selected file.
 
-**File Preview Mode** Activated by **F7**. The screen layout changes to
-show the file list on the left (or active pane) and the file contents on
-the right. \* **Toggle:** Press **F7** again to leave preview mode. \*
-**Navigate File List:** Use **Up/Down**, **Page Up/Down**, **Home/End**
-to move the selection in the file list. The preview pane updates
-immediately. \* **Scroll Preview:** Use **Shift+Up/Down** (or **^P** /
-**^N**) to scroll the content of the preview window line by line. Use
-**Shift+Page Up/Down** to scroll by pages. **Shift+Home/End** jumps to
-the beginning or end of the file.
+**Global Mode**
+Toggle file-list mode for all files across all logged volumes.
+
+  - **Action:** Press **Esc** to return to the previously selected directory. Press **\\** to jump to the owner directory of the selected file.
+
+**Archive Mode**
+When entering a supported archive (ZIP, TAR, GZ), ytnova treats it as a virtual filesystem with archive-aware write operations (copy/move/delete/rename/mkdir paths where supported). It behaves similarly to Directory/File modes with archive-specific navigation and safety semantics.
+
+**Split Screen Mode**
+Activated by **F8**. The screen is divided vertically into two independent file manager panels.
+
+  - **Toggle:** Press **F8** again to return to single-panel mode.
+  - **Switch Focus:** Press **Tab** to switch active control between the Left and Right panels.
+  - **Targeting:** Operations like **Copy** and **Move** automatically default to the path of the inactive (passive) panel as the destination.
+
+**File Preview Mode**
+Activated by **F7**. The screen layout changes to show the file list on the left (or active pane) and the file contents on the right.
+
+  - **Toggle:** Press **F7** again to leave preview mode.
+  - **Navigate File List:** Use **Up/Down**, **Page Up/Down**, **Home/End** to move the selection in the file list. The preview pane updates immediately.
+  - **Scroll Preview:** Use **Shift+Up/Down** (or **^P** / **^N**) to scroll the content of the preview window line by line. Use **Shift+Page Up/Down** to scroll by pages. **Shift+Home/End** jumps to the beginning or end of the file.
 
 # KEY BINDINGS
 
-**Note:** All keys are case insensitive unless otherwise noted. The
-symbol `^` denotes the **CTRL** key. For most commands, pressing
-**^key** (indicated in footer menus only where different) applies the
-action to all **tagged** files in the current scope.
+**Note:** All keys are case insensitive unless otherwise noted. The symbol `^` denotes the **CTRL** key. For most commands, pressing **^key** (indicated in footer menus only where different) applies the action to all **tagged** files in the current scope.
 
 ### Global Commands
 
 These commands work in most modes:
 
-- **F1**: Help (context-sensitive in prompts/dialogs).
-- **F5**: Refresh (same as **^L**).
-- **F6**: Toggle Statistics Panel (Wide Mode).
-- **F7**: Toggle File Preview Pane.
-- **F8**: Toggle Split Screen Mode.
-- **F10**: Edit `~/.ytnova` in `$EDITOR`. If the file does not exist
-  yet, the editor opens a new buffer at that path; save to create it (or
-  run `ytnova --init` to generate defaults first).
-- **/** (or **F12**): **Incremental Jump** (List Jump). Start typing to
-  jump to the first matching entry in the current list (directory names
-  in the Directory Window, filenames in the File Window). The selection
-  updates immediately as you type. Press **Enter** to accept the current
-  match, or **Esc** to cancel and restore the original selection.
-- **\\**: In **Showall**/**Global** file lists, exit that mode and jump
-  to the selected file in its owner directory. In Archive-Dir mode, `\\`
-  jumps to archive root when used below root, and exits to the parent
-  physical directory when used at archive root. In normal filesystem
-  dir/file windows and Archive-File mode, `\\` is a no-op.
-- **B**: Toggle Brief (Compact) filename view in the File Window.
-- **^L**: **Reload**. Re-read the contents of the current directory from
-  disk and refresh the view.
-- **K**: **Volume Menu**. Show a list of all currently logged volumes
-  (drives/paths). Select a volume to switch context instantly. Selecting
-  the already-active volume preserves its current in-memory state (no
-  implicit relog). Press `Delete` (or `D`) in the menu to release
-  (unlog) a volume. *(With `VI_KEYS=1`, use uppercase `K`; lowercase `k`
-  is navigation.)*
-- **\<** / **\>** (or **,** / **.**): **Cycle Volumes**. Switch to the
-  previous or next logged volume instantly.
-- **^Q**: **Quit to Directory**. If you exit ytnova with ^Q, the last
-  selected directory becomes your current working directory. See shell
-  wrapper function below.
-- **Q**: **Quit**. Exit ytnova.
+  - **F1**: Help (context-sensitive in prompts/dialogs).
+  - **F5**: Refresh (same as **^L**).
+  - **F6**: Toggle Statistics Panel (Wide Mode).
+  - **F7**: Toggle File Preview Pane.
+  - **F8**: Toggle Split Screen Mode.
+  - **F10**: Edit `~/.ytnova` in `$EDITOR`. If the file does not exist yet, the editor opens a new buffer at that path; save to create it (or run `ytnova --init` to generate defaults first).
+  - **/** (or **F12**): **Incremental Jump** (List Jump). Start typing to jump to the first matching entry in the current list (directory names in the Directory Window, filenames in the File Window). The selection updates immediately as you type. Press **Enter** to accept the current match, or **Esc** to cancel and restore the original selection.
+  - **\\**: In **Showall**/**Global** file lists, exit that mode and jump to the selected file in its owner directory. In Archive-Dir mode, `\\` jumps to archive root when used below root, and exits to the parent physical directory when used at archive root. In normal filesystem dir/file windows and Archive-File mode, `\\` is a no-op.
+  - **B**: Toggle Brief (Compact) filename view in the File Window.
+  - **^L**: **Reload**. Re-read the contents of the current directory from disk and refresh the view.
+  - **K**: **Volume Menu**. Show a list of all currently logged volumes (drives/paths). Select a volume to switch context instantly. Selecting the already-active volume preserves its current in-memory state (no implicit relog). Press `Delete` (or `D`) in the menu to release (unlog) a volume. *(With `VI_KEYS=1`, use uppercase `K`; lowercase `k` is navigation.)*
+  - **\<** / **\>** (or **,** / **.**): **Cycle Volumes**. Switch to the previous or next logged volume instantly.
+  - **^Q**: **Quit to Directory**. If you exit ytnova with ^Q, the last selected directory becomes your current working directory. See shell wrapper function below.
+  - **Q**: **Quit**. Exit ytnova.
 
 ### VI Keys Mode (Profile Option)
 
-When `VI_KEYS=1` in `[GLOBAL]`, ytnova reserves lowercase vi navigation
-keys: `h/j/k/l` and `^D/^U` (page down/up). To avoid collisions:
+When `VI_KEYS=1` in `[GLOBAL]`, ytnova reserves lowercase vi navigation keys:
+`h/j/k/l` and `^D/^U` (page down/up). To avoid collisions:
 
-- Use **H/L/K/J** for **Hex/Log/Volume Menu/Compare**.
-- In file-view contexts, use **D** for **Delete Tagged** and **U** for
-  **Untag All**.
-- Lowercase **d/u** keep the regular context action (single item /
-  current scope untag).
+  - Use **H/L/K/J** for **Hex/Log/Volume Menu/Compare**.
+  - In file-view contexts, use **D** for **Delete Tagged** and **U** for
+    **Untag All**.
+  - Lowercase **d/u** keep the regular context action (single item / current
+    scope untag).
 
 ### Directory Mode
 
 Active when browsing the directory tree window.
 
-- **A** (Attributes): Open attributes submenu for directory metadata
-  changes: mode (chmod), owner, group, date.
-- **C** (Copy): Copy the selected directory branch.
-- **D** (Delete): Delete selected directory.
-- **F** (Filter): Set file filter. Supports regex patterns (e.g.,
-  `*.c`), exclusions (`-*.o`), attributes (`:r`, `:x`), dates
-  (`>2023-01-01`), and sizes (`>1M`).
-- **G** (Global): Show all files across all logged volumes in one global
-  list.
-- **I** (Invert Tags): Toggle tag state for files in the
-  selected/current directory scope.
-- **J** (Compare): Open the compare submenu (directory, logged tree, or
-  external viewer). With `VI_KEYS=1`, use uppercase `J` for this action.
-- **L** (Log): Log a new directory or archive file. Logging an already
-  logged volume/path performs a fresh reload and reanchors selection at
-  the volume root.
-- **M** (Makedir): Create a new directory.
-- **N** (New File): Create a new empty file.
-- **O** (Only tagged): Toggle tagged-only file-list view for the current
-  directory scope.
-- **P** (Pipe, or **\|**): Pipe the selected directory to a command
-  (stdin).
-- **R** (Rename): Rename selected directory.
-- **S** (Showall): Show all files in all directories of the current
-  volume.
-- **T** (Tag): Tag all files in the selected directory.
-- **U** (Untag): Untag all files in the selected directory.
-- **V** (MoveDir): Move the selected directory branch.
-- **W** (Write): Export files in the selected directory to a command or
-  file using a formatting dialog (Raw, Framed, Page Break).
-- **X** (eXecute): Execute a shell command. The `{}` placeholder is
-  replaced by the current directory path.
-- **Z** (archive): Create an archive from the current selection. If one
-  or more files are tagged, ytnova archives the tagged files. If nothing
-  is tagged, ytnova archives the selected file or selected directory.
-  Directory sources are archived recursively. Supported destination
-  suffixes: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`,
-  `.tar.xz`/`.txz`, `.zip`.
-- **\`** (Backtick): Toggle visibility of hidden dot-files and
-  directories.
-- **^F** (Dir Mode): Cycle directory display modes (Filenames only -\>
-  Attributes -\> Inode/Owner -\> Times).
-- **Enter**: On logged directories, switch to File Mode (focus the file
-  window). On unlogged/not-yet-scanned directories, perform one-level
-  log/reveal (same behavior as `+`) and stay in Directory Mode.
-- **-**: State-based collapse/release. First press collapses an expanded
-  node. Second press on a collapsed logged node evicts the file list
-  (sets `+` status) and marks the directory as Unlogged. At root, use
-  `-` to release logged contents.
-- **Tree status marker**: Unlogged directories use `+` in the left
-  status margin column. Directory names do not carry a `+` suffix; an
-  unlogged directory may still show `/` when it has subdirectories.
-- **Left Arrow**: If the selected directory is expanded, collapse it.
-  Otherwise move selection to its parent directory. Repeated `Left`
-  keeps ascending (and collapsing where needed). At filesystem root,
-  `Left` is a no-op.
-- **Right Arrow** (Drill Down): Progressive depth navigation. If
-  collapsed: expand one level. If already expanded: move cursor to the
-  first child. It does not jump to siblings.
-- **+** (or **=**): One-level log/reveal only (no cursor movement). `=`
-  is a convenience alias (unshifted `+` on most keyboards).
-- **\*** (Asterisk): Recursively expand the current directory and all
-  its subdirectories.
+  - **A** (Attributes): Open attributes submenu for directory metadata changes:
+    mode (chmod), owner, group, date.
+  - **C** (Copy): Copy the selected directory branch.
+  - **D** (Delete): Delete selected directory.
+  - **F** (Filter): Set file filter. Supports regex patterns (e.g., `*.c`), exclusions (`-*.o`), attributes (`:r`, `:x`), dates (`>2023-01-01`), and sizes (`>1M`).
+  - **G** (Global): Show all files across all logged volumes in one global list.
+  - **I** (Invert Tags): Toggle tag state for files in the selected/current directory scope.
+  - **J** (Compare): Open the compare submenu (directory, logged tree, or external viewer). With `VI_KEYS=1`, use uppercase `J` for this action.
+  - **L** (Log): Log a new directory or archive file. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
+  - **M** (Makedir): Create a new directory.
+  - **N** (New File): Create a new empty file.
+  - **O** (Only tagged): Toggle tagged-only file-list view for the current directory scope.
+  - **P** (Pipe, or **|**): Pipe the selected directory to a command (stdin).
+  - **R** (Rename): Rename selected directory.
+  - **S** (Showall): Show all files in all directories of the current volume.
+  - **T** (Tag): Tag all files in the selected directory.
+  - **U** (Untag): Untag all files in the selected directory.
+  - **V** (MoveDir): Move the selected directory branch.
+  - **W** (Write): Export files in the selected directory to a command or file using a formatting dialog (Raw, Framed, Page Break).
+  - **X** (eXecute): Execute a shell command. The `{}` placeholder is replaced by the current directory path.
+  - **Z** (archive): Create an archive from the current selection. If one or more files are tagged, ytnova archives the tagged files. If nothing is tagged, ytnova archives the selected file or selected directory. Directory sources are archived recursively. Supported destination suffixes: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`, `.tar.xz`/`.txz`, `.zip`.
+  - **\`** (Backtick): Toggle visibility of hidden dot-files and directories.
+  - **^F** (Dir Mode): Cycle directory display modes (Filenames only -\> Attributes -\> Inode/Owner -\> Times).
+  - **Enter**: On logged directories, switch to File Mode (focus the file window). On unlogged/not-yet-scanned directories, perform one-level log/reveal (same behavior as `+`) and stay in Directory Mode.
+  - **-**: State-based collapse/release. First press collapses an expanded node. Second press on a collapsed logged node evicts the file list (sets `+` status) and marks the directory as Unlogged. At root, use `-` to release logged contents.
+  - **Tree status marker**: Unlogged directories use `+` in the left status margin column. Directory names do not carry a `+` suffix; an unlogged directory may still show `/` when it has subdirectories.
+  - **Left Arrow**: If the selected directory is expanded, collapse it. Otherwise move selection to its parent directory. Repeated `Left` keeps ascending (and collapsing where needed). At filesystem root, `Left` is a no-op.
+  - **Right Arrow** (Drill Down): Progressive depth navigation. If collapsed: expand one level. If already expanded: move cursor to the first child. It does not jump to siblings.
+  - **+** (or **=**): One-level log/reveal only (no cursor movement). `=` is a convenience alias (unshifted `+` on most keyboards).
+  - **\*** (Asterisk): Recursively expand the current directory and all its subdirectories.
 
 ### File Mode
 
 Active when the file window is focused.
 
-- **A** (Attributes): Open attributes submenu for selected file
-  metadata: mode, owner, group, date.
-- **C** (Copy): Copy the selected file.
-- **^K**: Copy all tagged files.
-- **D** (Delete): Delete selected file. *(With `VI_KEYS=1`, use
-  lowercase `d` for this action and uppercase `D` for Delete Tagged.)*
-- **E** (Edit): Edit selected file with `$EDITOR` (default: vi).
-- **F** (Filter): Set file filter.
-- **H** (Hex): View selected file in hex mode.
-- **I** (Invert Tags): Toggle the tag state of all visible files.
-- **J** (Compare): Compare the selected file with a target file.
-- **L** (Log): Log a new directory or archive file. Logging an already
-  logged volume/path performs a fresh reload and reanchors selection at
-  the volume root.
-- **M** (Move): Move the selected file.
-- **^N**: Move all tagged files.
-- **N** (New File): Create a new empty file.
-- **O** (Only tagged): Toggle tagged-only file-list view (show tagged
-  files only).
-- **P** (Pipe, or **\|**): Pipe content of file to a command (stdin).
-- **R** (Rename): Rename the selected file.
-- **S** (Sort): Sort filelist (Access time, Change time, Extension,
-  Group, Modification time, Name, Owner, Size).
-- **^S** (Search): Execute grep on tagged files. Untags files that do
-  not match the command.
-- **T** (Tag): Tag selected file.
-- **^T**: Tag all displayed files.
-- **U** (Untag): Untag selected file. *(With `VI_KEYS=1`, use lowercase
-  `u` for this action.)*
-- **^U**: Untag all displayed files. *(With `VI_KEYS=1`, `^U` is page-up
-  navigation and uppercase `U` becomes Untag All.)*
-- **V** (View): View file with the pager defined in `~/.ytnova`
-  (default: less).
-- **^V**: **View Tagged**. View all tagged files sequentially.
-- **W** (Write): Export the selected file to a command or file using a
-  formatting dialog (Raw, Framed, Page Break).
-- **X** (eXecute): Execute a shell command. `{}` is replaced by the
-  filename.
-- **Y**: (Pathcopy): Copy selected file, replicating its directory
-  structure relative to the current volume root.
-- **Z** (archive): Create an archive from tagged files, or from the
-  selected file/directory when nothing is tagged. Directory sources are
-  archived recursively.
-- **^F** (File Mode): Cycle file display modes.
-- **Enter**: Switch to Full Screen File Mode / Directory Mode.
-- **Left Arrow**: Move to the previous visible file column; in
-  one-column layouts this performs page-up navigation.
-- **Right Arrow**: Move to the next visible file column; in one-column
-  layouts this performs page-down navigation.
-- **Date Changes:** Date actions change Accessed time, Modified time, or
-  both (POSIX does not allow setting creation/birth time here).
+  - **A** (Attributes): Open attributes submenu for selected file metadata:
+    mode, owner, group, date.
+  - **C** (Copy): Copy the selected file.
+  - **^K**: Copy all tagged files.
+  - **D** (Delete): Delete selected file. *(With `VI_KEYS=1`, use lowercase `d`
+    for this action and uppercase `D` for Delete Tagged.)*
+  - **E** (Edit): Edit selected file with `$EDITOR` (default: vi).
+  - **F** (Filter): Set file filter.
+  - **H** (Hex): View selected file in hex mode.
+  - **I** (Invert Tags): Toggle the tag state of all visible files.
+  - **J** (Compare): Compare the selected file with a target file.
+  - **L** (Log): Log a new directory or archive file. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
+  - **M** (Move): Move the selected file.
+  - **^N**: Move all tagged files.
+  - **N** (New File): Create a new empty file.
+  - **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only).
+  - **P** (Pipe, or **|**): Pipe content of file to a command (stdin).
+  - **R** (Rename): Rename the selected file.
+  - **S** (Sort): Sort filelist (Access time, Change time, Extension, Group, Modification time, Name, Owner, Size).
+  - **^S** (Search): Execute grep on tagged files. Untags files that do not match the command.
+  - **T** (Tag): Tag selected file.
+  - **^T**: Tag all displayed files.
+  - **U** (Untag): Untag selected file. *(With `VI_KEYS=1`, use lowercase `u`
+    for this action.)*
+  - **^U**: Untag all displayed files. *(With `VI_KEYS=1`, `^U` is page-up
+    navigation and uppercase `U` becomes Untag All.)*
+  - **V** (View): View file with the pager defined in `~/.ytnova` (default: less).
+  - **^V**: **View Tagged**. View all tagged files sequentially.
+  - **W** (Write): Export the selected file to a command or file using a formatting dialog (Raw, Framed, Page Break).
+  - **X** (eXecute): Execute a shell command. `{}` is replaced by the filename.
+  - **Y**: (Pathcopy): Copy selected file, replicating its directory structure relative to the current volume root.
+  - **Z** (archive): Create an archive from tagged files, or from the selected file/directory when nothing is tagged. Directory sources are archived recursively.
+  - **^F** (File Mode): Cycle file display modes.
+  - **Enter**: Switch to Full Screen File Mode / Directory Mode.
+  - **Left Arrow**: Move to the previous visible file column; in one-column
+    layouts this performs page-up navigation.
+  - **Right Arrow**: Move to the next visible file column; in one-column
+    layouts this performs page-down navigation.
+  - **Date Changes:** Date actions change Accessed time, Modified time, or both (POSIX does not allow setting creation/birth time here).
 
 ### Archive Mode
 
-When browsing an archive (ZIP, TAR, ISO, etc.), ytnova behaves like a
-virtual file system with archive-aware operations and distinct
-root/non-root navigation rules.
+When browsing an archive (ZIP, TAR, ISO, etc.), ytnova behaves like a virtual file system with archive-aware operations and distinct root/non-root navigation rules.
 
 **Archive-Dir Mode**
 
-- **J** (Compare): Open compare flow. With `VI_KEYS=1`, use uppercase
-  `J` for this action.
-- **D** (Delete): Delete selected archive directory entry.
-- **F** (Filter): Set file filter.
-- **G** (Global): Show all files across all logged volumes in one global
-  list.
-- **I** (Invert Tags): Toggle tag state for files in the
-  selected/current archive directory scope.
-- **L** (Log): Log a new directory or archive. Logging an already logged
-  volume/path performs a fresh reload and reanchors selection at the
-  volume root.
-- **M** (Makedir): Create directory in archive context where supported.
-- **O** (Only tagged): Toggle tagged-only file-list view for the current
-  archive directory scope.
-- **R** (Rename): Rename selected archive directory entry.
-- **S** (Showall): Show all files in the archive.
-- **T** (Tag): Tag all files in current virtual directory.
-- **U** (Untag): Untag all files in current virtual directory.
-- **^F** (Dir Mode): Cycle display modes.
-- **Enter**: Switch to Archive-File Mode.
-- **-**: State-based collapse/release. Expanded nodes collapse;
-  collapsed logged nodes (or logged leaves) unlog/release.
-- **Left Arrow**: Collapse the current archive directory when expanded;
-  otherwise move selection to its parent directory.
-- **Right Arrow** (Drill Down): Progressive depth navigation. If
-  collapsed: expand one level. If already expanded: move cursor to the
-  first child.
-- **+** (or **=**): Expand the current archive directory by one level.
-- **\\**: At archive non-root, jump to archive root. At archive root,
-  exit to parent physical directory.
+  - **J** (Compare): Open compare flow. With `VI_KEYS=1`, use uppercase `J` for this action.
+  - **D** (Delete): Delete selected archive directory entry.
+  - **F** (Filter): Set file filter.
+  - **G** (Global): Show all files across all logged volumes in one global list.
+  - **I** (Invert Tags): Toggle tag state for files in the selected/current archive directory scope.
+  - **L** (Log): Log a new directory or archive. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
+  - **M** (Makedir): Create directory in archive context where supported.
+  - **O** (Only tagged): Toggle tagged-only file-list view for the current archive directory scope.
+  - **R** (Rename): Rename selected archive directory entry.
+  - **S** (Showall): Show all files in the archive.
+  - **T** (Tag): Tag all files in current virtual directory.
+  - **U** (Untag): Untag all files in current virtual directory.
+  - **^F** (Dir Mode): Cycle display modes.
+  - **Enter**: Switch to Archive-File Mode.
+  - **-**: State-based collapse/release. Expanded nodes collapse; collapsed logged nodes (or logged leaves) unlog/release.
+  - **Left Arrow**: Collapse the current archive directory when expanded; otherwise move selection to its parent directory.
+  - **Right Arrow** (Drill Down): Progressive depth navigation. If collapsed: expand one level. If already expanded: move cursor to the first child.
+  - **+** (or **=**): Expand the current archive directory by one level.
+  - **\\**: At archive non-root, jump to archive root. At archive root, exit to parent physical directory.
 
 **Archive-File Mode**
 
-- **C** (Copy): Copy selected file (including extract/copy paths).
-- **^K** (Copy Tagged): Copy all tagged files.
-- **D** (Delete): Delete selected archive file entry.
-- **F** (Filter): Set file filter.
-- **H** (Hex): View file in hex mode.
-- **I** (Invert Tags): Toggle the tag state of all visible files.
-- **M** (Move): Move selected file using archive-aware semantics.
-- **O** (Only tagged): Toggle tagged-only file-list view (show tagged
-  files only).
-- **P** (Pipe, or **\|**): Pipe content to command.
-- **R** (Rename): Rename selected archive file entry.
-- **S** (Sort): Sort file list.
-- **^S** (Search): Search tagged files for a string. Untags files that
-  do not match.
-- **T** (Tag): Tag selected file.
-- **^T**: Tag all files.
-- **U** (Untag): Untag selected file. *(With `VI_KEYS=1`, use lowercase
-  `u` for this action.)*
-- **^U**: Untag all files. *(With `VI_KEYS=1`, `^U` is page-up
-  navigation and uppercase `U` becomes Untag All.)*
-- **V** (View): View file.
-- **^V**: **View Tagged**. View all tagged files sequentially.
-- **W** (Write): Export file content to a command or file.
-- **Y** (Pathcopy): Copy selected file with relative path preservation.
-- **^F** (File Mode): Cycle display modes.
-- **Enter**: Switch to Archive-Dir Mode.
-- **\\**: No-op.
+  - **C** (Copy): Copy selected file (including extract/copy paths).
+  - **^K** (Copy Tagged): Copy all tagged files.
+  - **D** (Delete): Delete selected archive file entry.
+  - **F** (Filter): Set file filter.
+  - **H** (Hex): View file in hex mode.
+  - **I** (Invert Tags): Toggle the tag state of all visible files.
+  - **M** (Move): Move selected file using archive-aware semantics.
+  - **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only).
+  - **P** (Pipe, or **|**): Pipe content to command.
+  - **R** (Rename): Rename selected archive file entry.
+  - **S** (Sort): Sort file list.
+  - **^S** (Search): Search tagged files for a string. Untags files that do not match.
+  - **T** (Tag): Tag selected file.
+  - **^T**: Tag all files.
+  - **U** (Untag): Untag selected file. *(With `VI_KEYS=1`, use lowercase `u`
+    for this action.)*
+  - **^U**: Untag all files. *(With `VI_KEYS=1`, `^U` is page-up navigation and
+    uppercase `U` becomes Untag All.)*
+  - **V** (View): View file.
+  - **^V**: **View Tagged**. View all tagged files sequentially.
+  - **W** (Write): Export file content to a command or file.
+  - **Y** (Pathcopy): Copy selected file with relative path preservation.
+  - **^F** (File Mode): Cycle display modes.
+  - **Enter**: Switch to Archive-Dir Mode.
+  - **\\**: No-op.
 
 Archive file-window status text:
 
-- `Unlogged`: selected directory is unlogged.
-- `No files`: selected directory is logged and empty.
+  - `Unlogged`: selected directory is unlogged.
+  - `No files`: selected directory is logged and empty.
 
 # COMPARE
 
-- **File compare (`J` in File Mode):** Compare the selected file against
-  a target file. ytnova can use an external file-diff helper if
-  configured.
-  - `FILEDIFF` may use `%1` (source) and `%2` (target) placeholders;
-    when omitted, ytnova appends source and target paths to the helper
-    command.
-- **Directory compare (`J` in Directory Mode):**
-  - `D`: compare the current directory.
-  - `T`: compare the current logged tree.
-  - `X`: launch an external directory/tree compare viewer. *(With
-    `VI_KEYS=1`, use uppercase `J` for this action.)*
-- Internal compare tags matches on the active/source side only.
-- Logged-tree compare uses logged content only; it does not auto-log
-  unopened subdirectories.
-- There is no separate “compare tagged files” mode.
+  - **File compare (`J` in File Mode):** Compare the selected file against a target file. ytnova can use an external file-diff helper if configured.
+      - `FILEDIFF` may use `%1` (source) and `%2` (target) placeholders; when omitted, ytnova appends source and target paths to the helper command.
+  - **Directory compare (`J` in Directory Mode):**
+      - `D`: compare the current directory.
+      - `T`: compare the current logged tree.
+      - `X`: launch an external directory/tree compare viewer.
+        *(With `VI_KEYS=1`, use uppercase `J` for this action.)*
+  - Internal compare tags matches on the active/source side only.
+  - Logged-tree compare uses logged content only; it does not auto-log unopened subdirectories.
+  - There is no separate "compare tagged files" mode.
 
 # COMMAND LINE EDITING
 
@@ -404,37 +272,35 @@ Archive file-window status text:
 
 Input prompts support standard text-editing shortcuts:
 
-- **^A / Home**: Start of line.
-- **^E / End**: End of line.
-- **^K**: Delete to end of line.
-- **^U**: Delete to start of line.
-- **^W**: Delete word left.
-- **^D / Del**: Delete character.
-- **^H / Backspace**: Backspace.
+  - **^A / Home**: Start of line.
+  - **^E / End**: End of line.
+  - **^K**: Delete to end of line.
+  - **^U**: Delete to start of line.
+  - **^W**: Delete word left.
+  - **^D / Del**: Delete character.
+  - **^H / Backspace**: Backspace.
 
 ### Prompt Navigation Keys
 
-These keys apply while prompt dialogs are active (for example: Log,
-Copy, Move).
+These keys apply while prompt dialogs are active (for example: Log, Copy, Move).
 
-- **Up Arrow**: History (with `P` to Pin, `D` to Delete).
-- **F2**: Directory picker for path-entry prompts.
+  - **Up Arrow**: History (with `P` to Pin, `D` to Delete).
+  - **F2**: Directory picker for path-entry prompts.
 
 # CONFIGURATION
 
-ytnova reads configuration from `~/.ytnova` by default, or from `-p`
-*config_file* when provided.
+ytnova reads configuration from `~/.ytnova` by default, or from `-p` *config\_file*
+when provided.
 
-Use `ytnova --init` to create `~/.ytnova` when it is missing. Existing
-files are never overwritten by `--init`. Example: `ytnova --init`
+Use `ytnova --init` to create `~/.ytnova` when it is missing. Existing files are
+never overwritten by `--init`.
+Example: `ytnova --init`
 
 The file created by `--init` is a fully annotated profile template.
 
 # QUIT TO DIRECTORY
 
-To allow `^Q` to change your shell’s working directory, add this shell
-wrapper function to your `~/.bashrc`. It also gives you a short `yt`
-command:
+To allow `^Q` to change your shell's working directory, add this shell wrapper function to your `~/.bashrc`. It also gives you a short `yt` command:
 
 ``` bash
 yt() {
@@ -449,28 +315,25 @@ yt() {
 
 # FILES
 
-- `~/.ytnova`: Configuration file.
-- `~/.ytnova-hst`: Command line history.
+  - `~/.ytnova`: Configuration file.
+  - `~/.ytnova-hst`: Command line history.
 
 ### Reporting problems
 
-If you find anything amiss, you can report it using [GitHub
-Issues](https://github.com/robkam/ytreenova/issues).
+If you find anything amiss, you can report it using [GitHub Issues](https://github.com/robkam/ytreenova/issues).
 
 It will help us to address the issue if you include the following:
 
-- **OS & Configuration:** (Distro, Terminal type, etc.)
-- **YtreeNova Version:**
-- **Steps to Reproduce:**
-- **Expected Behavior:**
-- **Actual Behavior:**
+  - **OS & Configuration:** (Distro, Terminal type, etc.)
+  - **YtreeNova Version:**
+  - **Steps to Reproduce:**
+  - **Expected Behavior:**
+  - **Actual Behavior:**
 
 # AUTHORS
 
-Authors and contributors are listed in the [AUTHORS.md](AUTHORS.md)
-file.
+Authors and contributors are listed in the [AUTHORS.md](AUTHORS.md) file.
 
 # SEE ALSO
 
-**bash**(1), **glob**(7), **grep**(1), **less**(1), **regex**(7),
-**vi**(1)
+**bash**(1), **glob**(7), **grep**(1), **less**(1), **regex**(7), **vi**(1)

--- a/etc/ytnova.1.md
+++ b/etc/ytnova.1.md
@@ -1,11 +1,3 @@
----
-title: YTNOVA
-section: 1
-header: "User Commands"
-footer: "ytnova 1.0.0-alpha"
-date: "June 2026"
----
-
 # NAME
 
 ytnova - a file manager for Unix-like systems

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -30,7 +30,7 @@ if command -v apt-get &> /dev/null; then
     if ! dpkg -l | grep -q libarchive-dev; then MISSING_PACKAGES="$MISSING_PACKAGES libarchive-dev"; fi
     if ! dpkg -l | grep -q python3-pip; then MISSING_PACKAGES="$MISSING_PACKAGES python3-pip"; fi
     if ! dpkg -l | grep -q python3-venv; then MISSING_PACKAGES="$MISSING_PACKAGES python3-venv"; fi
-    if ! dpkg -l | grep -q pandoc; then MISSING_PACKAGES="$MISSING_PACKAGES pandoc"; fi
+    if ! dpkg -l | grep -q cmark; then MISSING_PACKAGES="$MISSING_PACKAGES cmark"; fi
 
     if [ -n "$MISSING_PACKAGES" ]; then
         echo "Installing missing packages: $MISSING_PACKAGES"


### PR DESCRIPTION
## What changed

- Switched the docs and manpage generation flow to `cmark`.
- Kept `etc/ytnova.1.md` as the single source for both generated outputs.
- Updated contributor setup notes to match the new docs tool.

## Validation

- `make docs`
- `make clean && make`
- Verified the built manpage has exactly one `.TH`
