### PR TITLE
refactor(appstate): route picker tree viewport through helper

### DIFF
--- a/src/ui/f2_picker.c
+++ b/src/ui/f2_picker.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_cmd.h"
 #include "ytnova_appstate_mode.h"
+#include "ytnova_appstate_panel.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include "ytnova_ui.h"
@@ -361,18 +362,14 @@ int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
            action != ACTION_ESCAPE &&
            action != ACTION_LOG);
 
-  /* Added restoration block */
   if (ctx->active->vol != original_vol) {
-    /* 1. Restore Global Volume Context */
     ctx->active->vol = original_vol;
     if (!AppStateCommitViewMode(ctx, ctx->active->vol->vol_stats.log_mode))
       return -1;
 
-    /* 2. Restore ctx->active state from the restored volume */
     if (ctx->active)
       (void)RestorePanelTreeViewportSnapshot(ctx, ctx->active);
 
-    /* 3. Restore UI Layout */
     DisplayMenu(ctx); /* Restores Frame and Header */
 
     /* Check which view mode we were in before F2 */
@@ -399,7 +396,6 @@ int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
                        &ctx->active->vol->vol_stats);
     }
 
-    /* 4. Refresh File Content & Footer Background */
     DisplayFileWindow(ctx, ctx->active,
                       GetSelectedDirEntry(ctx, ctx->active->vol));
     RefreshWindow(ctx->ctx_file_window);
@@ -407,8 +403,9 @@ int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
     DisplayAvailBytes(ctx, &ctx->active->vol->vol_stats);
   }
 
-  panel->cursor_pos = local_cursor_pos;
-  panel->disp_begin_pos = local_disp_begin_pos;
+  if (!AppStateCommitPanelTreeViewport(panel, local_disp_begin_pos,
+                                       local_cursor_pos))
+    return -1;
 
   UnmapF2Window(ctx);
   DEBUG_LOG("EXIT HandleDirWindow: Panel=%s Cursor=%d DispBegin=%d",

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6950,6 +6950,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    f2_picker = Path("src/ui/f2_picker.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelTreeViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in dir_nav
@@ -6958,6 +6959,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in ctrl_dir
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file
     assert 'include "ytnova_appstate_panel.h"' in dir_ops
+    assert 'include "ytnova_appstate_panel.h"' in f2_picker
 
     helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
     helper_body = helper[helper_start:]
@@ -7056,6 +7058,21 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         refresh_body,
     )
     assert "AppStateCommitPanelTreeViewport(p, 0, 0)" in refresh_body
+
+    f2_exit_start = f2_picker.index(
+        "\n  if (ctx->active->vol != original_vol) {"
+    )
+    f2_exit_end = f2_picker.index("\n  UnmapF2Window(ctx);", f2_exit_start)
+    f2_exit_body = f2_picker[f2_exit_start:f2_exit_end]
+    assert not re.search(
+        r"\bpanel->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+        f2_exit_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeViewport\(\s*panel,\s*"
+        r"local_disp_begin_pos,\s*local_cursor_pos\)",
+        f2_exit_body,
+    )
 
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route the F2 directory picker exit tree viewport restore through `AppStateCommitPanelTreeViewport`.
- Extend the AppState contract guard so picker tree viewport writes cannot bypass the panel helper.
- Remove stale restoration-history comments from the touched picker exit path.

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because `src/ui/f2_picker.c` did not include the panel helper and wrote `panel->cursor_pos` / `panel->disp_begin_pos` directly.
- Focused guard after implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- AppState contract script after implementation: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Focused local build after implementation: `source .venv/bin/activate && make clean && make`
