### PR TITLE
refactor(appstate): route split tree viewports through helper

### DIFF
--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -321,8 +321,10 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
       if (ctx->is_split_screen) {
         if (ctx->right && ctx->left) {
           ctx->right->vol = ctx->left->vol;
-          ctx->right->cursor_pos = ctx->left->cursor_pos;
-          ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
+          if (!AppStateCommitPanelTreeViewport(ctx->right,
+                                               ctx->left->disp_begin_pos,
+                                               ctx->left->cursor_pos))
+            return FALSE;
           memcpy(ctx->right->tree_viewport_top_dir_path,
                  ctx->left->tree_viewport_top_dir_path,
                  sizeof(ctx->right->tree_viewport_top_dir_path));
@@ -515,8 +517,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       if (donate_active_state && ctx->left && ctx->right) {
         if (!DonatePanelState(ctx, ctx->left, ctx->right))
           return FALSE;
-        ctx->left->cursor_pos = source_cursor_pos;
-        ctx->left->disp_begin_pos = source_disp_begin_pos;
+        if (!AppStateCommitPanelTreeViewport(ctx->left, source_disp_begin_pos,
+                                             source_cursor_pos))
+          return FALSE;
         ctx->left->current_dir_entry = source_current_dir_entry;
         if (!AppStateRestorePanelGeneration(ctx->left,
                                             source_panel_generation))
@@ -544,8 +547,10 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       if (ctx->is_split_screen) {
         if (ctx->right && ctx->left) {
           ctx->right->vol = ctx->left->vol;
-          ctx->right->cursor_pos = ctx->left->cursor_pos;
-          ctx->right->disp_begin_pos = ctx->left->disp_begin_pos;
+          if (!AppStateCommitPanelTreeViewport(ctx->right,
+                                               ctx->left->disp_begin_pos,
+                                               ctx->left->cursor_pos))
+            return FALSE;
           memcpy(ctx->right->tree_viewport_top_dir_path,
                  ctx->left->tree_viewport_top_dir_path,
                  sizeof(ctx->right->tree_viewport_top_dir_path));
@@ -632,8 +637,11 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       if (ctx->active->vol->total_dirs > 0) {
         if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
             ctx->active->vol->total_dirs) {
-          ctx->active->cursor_pos =
+          int next_cursor_pos =
               ctx->active->vol->total_dirs - 1 - ctx->active->disp_begin_pos;
+          if (!AppStateCommitPanelTreeViewport(
+                  ctx->active, ctx->active->disp_begin_pos, next_cursor_pos))
+            return FALSE;
         }
         *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
       } else {
@@ -704,8 +712,11 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
     if (ctx->active->vol->total_dirs > 0) {
       if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
           ctx->active->vol->total_dirs) {
-        ctx->active->cursor_pos =
+        int next_cursor_pos =
             ctx->active->vol->total_dirs - 1 - ctx->active->disp_begin_pos;
+        if (!AppStateCommitPanelTreeViewport(
+                ctx->active, ctx->active->disp_begin_pos, next_cursor_pos))
+          return FALSE;
       }
       *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
     } else {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6951,6 +6951,9 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     f2_picker = Path("src/ui/f2_picker.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
 
     assert "BOOL AppStateCommitPanelTreeViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in dir_nav
@@ -6960,6 +6963,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in ctrl_file
     assert 'include "ytnova_appstate_panel.h"' in dir_ops
     assert 'include "ytnova_appstate_panel.h"' in f2_picker
+    assert 'include "ytnova_appstate_panel.h"' in split_transition
 
     helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
     helper_body = helper[helper_start:]
@@ -7072,6 +7076,46 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         r"AppStateCommitPanelTreeViewport\(\s*panel,\s*"
         r"local_disp_begin_pos,\s*local_cursor_pos\)",
         f2_exit_body,
+    )
+
+    file_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleFileWindowAction("
+    )
+    dir_split_start = split_transition.index(
+        "\nBOOL SplitTransition_HandleDirWindowAction(", file_split_start
+    )
+    file_split_body = split_transition[file_split_start:dir_split_start]
+    dir_split_body = split_transition[dir_split_start:]
+    split_tree_viewport_write = re.compile(
+        r"\b(?:ctx->right|ctx->left|ctx->active)->"
+        r"(?:disp_begin_pos|cursor_pos)\s*=(?!=)"
+    )
+    for body in [file_split_body, dir_split_body]:
+        assert not split_tree_viewport_write.search(body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelTreeViewport\(\s*ctx->right,\s*"
+                r"ctx->left->disp_begin_pos,\s*ctx->left->cursor_pos\s*\)",
+                split_transition,
+            )
+        )
+        == 2
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeViewport\(\s*ctx->left,\s*"
+        r"source_disp_begin_pos,\s*source_cursor_pos\s*\)",
+        dir_split_body,
+    )
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelTreeViewport\(\s*ctx->active,\s*"
+                r"ctx->active->disp_begin_pos,\s*next_cursor_pos\s*\)",
+                split_transition,
+            )
+        )
+        == 2
     )
 
 


### PR DESCRIPTION
## Summary
- Route split transition tree viewport seeding, donation restore, and active-panel bounds correction through `AppStateCommitPanelTreeViewport`.
- Extend the AppState contract guard so split transition tree viewport writes cannot bypass the panel helper.

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because `src/ui/split_transition.c` still wrote split panel tree viewport fields directly.
- Focused guard after implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- AppState contract script after implementation: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Focused local build after implementation: `source .venv/bin/activate && make clean && make`
