### PR TITLE
refactor(appstate): route anchor tree viewports through helper

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -376,8 +376,8 @@ void PositionPanelAtIndex(YtreeNovaPanel *panel, int idx) {
     cursor = 0;
   }
 
-  panel->disp_begin_pos = begin;
-  panel->cursor_pos = cursor;
+  if (!AppStateCommitPanelTreeViewport(panel, begin, cursor))
+    return;
   RememberPanelViewportTop(panel);
   if (!AppStateCommitPanelGeneration(panel))
     return;
@@ -465,8 +465,8 @@ BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *pane
   if (top_path &&
       VisibleIndexWithinTopPath(vol, panel, top_path, target_idx, height,
                                 &top_idx)) {
-    panel->disp_begin_pos = top_idx;
-    panel->cursor_pos = target_idx - top_idx;
+    begin = top_idx;
+    cursor = target_idx - top_idx;
   } else {
     begin = panel->disp_begin_pos;
     cursor = panel->cursor_pos;
@@ -475,10 +475,10 @@ BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *pane
       begin = target_idx;
       cursor = 0;
     }
-    panel->disp_begin_pos = begin;
-    panel->cursor_pos = cursor;
   }
 
+  if (!AppStateCommitPanelTreeViewport(panel, begin, cursor))
+    return FALSE;
   RememberPanelViewportTop(panel);
   if (!AppStateCommitPanelGeneration(panel))
     return FALSE;
@@ -498,8 +498,7 @@ BOOL RestorePanelTreeViewportSnapshot(ViewContext *ctx, YtreeNovaPanel *panel) {
 
   total_dirs = panel->vol->total_dirs;
   if (total_dirs <= 0) {
-    panel->disp_begin_pos = 0;
-    panel->cursor_pos = 0;
+    (void)AppStateCommitPanelTreeViewport(panel, 0, 0);
     return FALSE;
   }
 
@@ -531,22 +530,28 @@ BOOL RestorePanelTreeViewportSnapshot(ViewContext *ctx, YtreeNovaPanel *panel) {
   if (win_height <= 0)
     win_height = 1;
 
-  if (panel->disp_begin_pos < 0)
-    panel->disp_begin_pos = 0;
-  if (selected_index >= panel->disp_begin_pos &&
-      selected_index < panel->disp_begin_pos + win_height) {
-    panel->cursor_pos = selected_index - panel->disp_begin_pos;
+  {
+    int begin = panel->disp_begin_pos;
+    int cursor;
+
+    if (begin < 0)
+      begin = 0;
+    if (selected_index >= begin && selected_index < begin + win_height) {
+      cursor = selected_index - begin;
+      (void)AppStateCommitPanelTreeViewport(panel, begin, cursor);
+      return FALSE;
+    }
+
+    if (selected_index >= win_height) {
+      begin = selected_index - (win_height - 1);
+      cursor = win_height - 1;
+    } else {
+      begin = 0;
+      cursor = selected_index;
+    }
+    (void)AppStateCommitPanelTreeViewport(panel, begin, cursor);
     return FALSE;
   }
-
-  if (selected_index >= win_height) {
-    panel->disp_begin_pos = selected_index - (win_height - 1);
-    panel->cursor_pos = win_height - 1;
-  } else {
-    panel->disp_begin_pos = 0;
-    panel->cursor_pos = selected_index;
-  }
-  return FALSE;
 }
 
 void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,
@@ -685,8 +690,9 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
 
   FreeFileEntryList(dst);
   dst->vol = src->vol;
-  dst->cursor_pos = src->cursor_pos;
-  dst->disp_begin_pos = src->disp_begin_pos;
+  if (!AppStateCommitPanelTreeViewport(dst, src->disp_begin_pos,
+                                       src->cursor_pos))
+    return FALSE;
   memcpy(dst->tree_viewport_top_dir_path, src->tree_viewport_top_dir_path,
          sizeof(dst->tree_viewport_top_dir_path));
   if (!AppStateCommitPanelFileViewport(dst, src->start_file,
@@ -714,8 +720,9 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   dst->file_dir_entry = NULL;
   PanelTags_Copy(dst, src);
   if (!source_is_file) {
-    dst->cursor_pos = dst_cursor_pos;
-    dst->disp_begin_pos = dst_disp_begin_pos;
+    if (!AppStateCommitPanelTreeViewport(dst, dst_disp_begin_pos,
+                                         dst_cursor_pos))
+      return FALSE;
     dst->current_dir_entry = dst_current_dir_entry;
     if (!AppStateRestorePanelGeneration(dst, dst_panel_generation))
       return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6954,6 +6954,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     split_transition = Path("src/ui/split_transition.c").read_text(
         encoding="utf-8"
     )
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelTreeViewport(" in header
     assert 'include "ytnova_appstate_panel.h"' in dir_nav
@@ -6964,6 +6965,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     assert 'include "ytnova_appstate_panel.h"' in dir_ops
     assert 'include "ytnova_appstate_panel.h"' in f2_picker
     assert 'include "ytnova_appstate_panel.h"' in split_transition
+    assert 'include "ytnova_appstate_panel.h"' in panel_anchor
 
     helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
     helper_body = helper[helper_start:]
@@ -7117,6 +7119,34 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         )
         == 2
     )
+
+    anchor_tree_viewport_write = re.compile(
+        r"\b(?:panel|dst)->(?:disp_begin_pos|cursor_pos)\s*=(?!=)"
+    )
+    anchor_function_ranges = [
+        (
+            "void PositionPanelAtIndex(",
+            "\nstatic BOOL VisibleIndexWithinTopPath(",
+        ),
+        (
+            "BOOL RestorePanelViewportSnapshot(",
+            "\nBOOL RestorePanelTreeViewportSnapshot(",
+        ),
+        (
+            "BOOL RestorePanelTreeViewportSnapshot(",
+            "\nvoid RestorePanelAnchorPath(",
+        ),
+        (
+            "BOOL DonatePanelState(",
+            "\nDirEntry *FindDirByPathInTree(",
+        ),
+    ]
+    for start_marker, end_marker in anchor_function_ranges:
+        start = panel_anchor.index(start_marker)
+        end = panel_anchor.index(end_marker, start)
+        body = panel_anchor[start:end]
+        assert not anchor_tree_viewport_write.search(body)
+        assert "AppStateCommitPanelTreeViewport(" in body
 
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -184,9 +184,10 @@ def test_tree_viewport_stable_restore_preserves_visible_selection():
     restore_end = panel_anchor_source.index("\nvoid RestorePanelAnchorPath(", restore_start)
     restore_source = panel_anchor_source[restore_start:restore_end]
     visible_guard = (
-        r"selected_index\s*>=\s*panel->disp_begin_pos"
-        r"[\s\S]*selected_index\s*<\s*panel->disp_begin_pos\s*\+\s*win_height"
-        r"[\s\S]*panel->cursor_pos\s*=\s*selected_index\s*-\s*panel->disp_begin_pos"
+        r"selected_index\s*>=\s*begin"
+        r"[\s\S]*selected_index\s*<\s*begin\s*\+\s*win_height"
+        r"[\s\S]*cursor\s*=\s*selected_index\s*-\s*begin"
+        r"[\s\S]*AppStateCommitPanelTreeViewport\(\s*panel,\s*begin,\s*cursor\s*\)"
         r"[\s\S]*return\s+(?:TRUE|FALSE);"
     )
 


### PR DESCRIPTION
## Summary
- Route panel-anchor tree viewport positioning, snapshot restore, and donated panel restore through `AppStateCommitPanelTreeViewport`.
- Extend the AppState contract guard so panel-anchor tree viewport writes cannot bypass the panel helper.

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because `src/ui/panel_anchor.c` still wrote panel tree viewport fields directly.
- Focused guard after implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- AppState contract script after implementation: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Focused local build after implementation: `source .venv/bin/activate && make clean && make`
