### PR TITLE
refactor(appstate): route enter tree viewport through helper

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1647,6 +1647,8 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
         int selected_idx = -1;
         int top_idx = -1;
         int max_begin = MAXIMUM(0, ctx->active->vol->total_dirs - win_height);
+        int next_cursor_pos;
+        int next_disp_begin;
 
         for (i = 0; i < ctx->active->vol->total_dirs; i++) {
           char path[PATH_LENGTH + 1];
@@ -1666,7 +1668,7 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
           if (saved_selected_idx < 0)
             saved_selected_idx = saved_disp_begin + saved_cursor_pos;
           int idx_delta = selected_idx - saved_selected_idx;
-          int next_disp_begin =
+          next_disp_begin =
               (top_idx >= 0) ? top_idx : MAXIMUM(0, saved_disp_begin);
 
           if (next_disp_begin < 0)
@@ -1674,29 +1676,30 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
           if (next_disp_begin > max_begin)
             next_disp_begin = max_begin;
 
-          ctx->active->disp_begin_pos = next_disp_begin;
-          ctx->active->cursor_pos = saved_cursor_pos + idx_delta;
+          next_cursor_pos = saved_cursor_pos + idx_delta;
         } else {
-          int next_disp_begin =
+          next_disp_begin =
               (top_idx >= 0) ? top_idx : MAXIMUM(0, saved_disp_begin);
           if (next_disp_begin < 0)
             next_disp_begin = 0;
           if (next_disp_begin > max_begin)
             next_disp_begin = max_begin;
-          ctx->active->disp_begin_pos = next_disp_begin;
-          ctx->active->cursor_pos = saved_cursor_pos;
+          next_cursor_pos = saved_cursor_pos;
         }
-      }
 
-      if (ctx->active->cursor_pos < 0)
-        ctx->active->cursor_pos = 0;
-      if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
-          ctx->active->vol->total_dirs) {
-        ctx->active->cursor_pos =
-            ctx->active->vol->total_dirs - 1 - ctx->active->disp_begin_pos;
+        if (next_cursor_pos < 0)
+          next_cursor_pos = 0;
+        if (next_disp_begin + next_cursor_pos >=
+            ctx->active->vol->total_dirs) {
+          next_cursor_pos =
+              ctx->active->vol->total_dirs - 1 - next_disp_begin;
+        }
+        if (next_cursor_pos < 0)
+          next_cursor_pos = 0;
+        if (!AppStateCommitPanelTreeViewport(ctx->active, next_disp_begin,
+                                             next_cursor_pos))
+          return DIR_WINDOW_DISPATCH_RETURN_ESC;
       }
-      if (ctx->active->cursor_pos < 0)
-        ctx->active->cursor_pos = 0;
       *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
       RefreshView(ctx, *dir_entry_ptr);
     }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7065,6 +7065,21 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
     )
     assert "AppStateCommitPanelTreeViewport(p, 0, 0)" in refresh_body
 
+    enter_start = dir_ops.index("HandleDirWindowEnterAction(")
+    enter_end = dir_ops.index(
+        "\nDirWindowDispatchResult\nHandleDirWindowVolumeAction(", enter_start
+    )
+    enter_body = dir_ops[enter_start:enter_end]
+    assert not re.search(
+        r"\bctx->active->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+        enter_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeViewport\(\s*ctx->active,\s*"
+        r"next_disp_begin,\s*next_cursor_pos\s*\)",
+        enter_body,
+    )
+
     f2_exit_start = f2_picker.index(
         "\n  if (ctx->active->vol != original_vol) {"
     )


### PR DESCRIPTION
## Summary
- Route directory enter-action tree viewport restore and bounds correction through `AppStateCommitPanelTreeViewport`.
- Extend the AppState contract guard so the enter-action restore path cannot bypass the panel helper.

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because `src/ui/dir_ops.c` still wrote active panel tree viewport fields directly in the enter-action restore path.
- Focused guard after implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- AppState contract script after implementation: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Focused local build after implementation: `source .venv/bin/activate && make clean && make`
