### PR TITLE
refactor(appstate): route directory refresh tree viewports through helper

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -541,8 +541,8 @@ static void ReanchorPanelToDir(YtreeNovaPanel *panel, const DirEntry *target) {
   if (!panel)
     return;
   if (!panel->vol || panel->vol->total_dirs <= 0) {
-    panel->disp_begin_pos = 0;
-    panel->cursor_pos = 0;
+    if (!AppStateCommitPanelTreeViewport(panel, 0, 0))
+      return;
     RememberPanelViewportTop(panel);
     return;
   }
@@ -1798,13 +1798,18 @@ HandleDirWindowVolumeAction(ViewContext *ctx, YtreeNovaAction action,
     if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
         ctx->active->vol->total_dirs) {
       int last_idx = ctx->active->vol->total_dirs - 1;
+      int next_disp_begin_pos;
+      int next_cursor_pos;
       if (last_idx >= ctx->layout.dir_win_height) {
-        ctx->active->disp_begin_pos = last_idx - (ctx->layout.dir_win_height - 1);
-        ctx->active->cursor_pos = ctx->layout.dir_win_height - 1;
+        next_disp_begin_pos = last_idx - (ctx->layout.dir_win_height - 1);
+        next_cursor_pos = ctx->layout.dir_win_height - 1;
       } else {
-        ctx->active->disp_begin_pos = 0;
-        ctx->active->cursor_pos = last_idx;
+        next_disp_begin_pos = 0;
+        next_cursor_pos = last_idx;
       }
+      if (!AppStateCommitPanelTreeViewport(ctx->active, next_disp_begin_pos,
+                                           next_cursor_pos))
+        return DIR_WINDOW_DISPATCH_RETURN_ESC;
     }
     *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
   } else {
@@ -1858,13 +1863,18 @@ HandleDirWindowLogAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
     if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
         ctx->active->vol->total_dirs) {
       int last_idx = ctx->active->vol->total_dirs - 1;
+      int next_disp_begin_pos;
+      int next_cursor_pos;
       if (last_idx >= ctx->layout.dir_win_height) {
-        ctx->active->disp_begin_pos = last_idx - (ctx->layout.dir_win_height - 1);
-        ctx->active->cursor_pos = ctx->layout.dir_win_height - 1;
+        next_disp_begin_pos = last_idx - (ctx->layout.dir_win_height - 1);
+        next_cursor_pos = ctx->layout.dir_win_height - 1;
       } else {
-        ctx->active->disp_begin_pos = 0;
-        ctx->active->cursor_pos = last_idx;
+        next_disp_begin_pos = 0;
+        next_cursor_pos = last_idx;
       }
+      if (!AppStateCommitPanelTreeViewport(ctx->active, next_disp_begin_pos,
+                                           next_cursor_pos))
+        return DIR_WINDOW_DISPATCH_RETURN_ESC;
     }
     *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
   } else {
@@ -2243,22 +2253,27 @@ int RefreshDirWindow(ViewContext *ctx, YtreeNovaPanel *p) {
     result = -1;
   } else {
     int window_height;
+    int next_disp_begin_pos = p->disp_begin_pos;
+    int next_cursor_pos = p->cursor_pos;
 
-    if (n != (p->disp_begin_pos + p->cursor_pos)) {
+    if (n != (next_disp_begin_pos + next_cursor_pos)) {
       /* Position changed */
-      if ((n - p->disp_begin_pos) >= 0) {
-        p->cursor_pos = n - p->disp_begin_pos;
+      if ((n - next_disp_begin_pos) >= 0) {
+        next_cursor_pos = n - next_disp_begin_pos;
       } else {
-        p->disp_begin_pos = n;
-        p->cursor_pos = 0;
+        next_disp_begin_pos = n;
+        next_cursor_pos = 0;
       }
     }
 
     window_height = getmaxy(win);
-    while (p->cursor_pos >= window_height) {
-      (p->cursor_pos)--;
-      (p->disp_begin_pos)++;
+    while (next_cursor_pos >= window_height) {
+      next_cursor_pos--;
+      next_disp_begin_pos++;
     }
+    if (!AppStateCommitPanelTreeViewport(p, next_disp_begin_pos,
+                                         next_cursor_pos))
+      return -1;
     DisplayTree(ctx, p->vol, win, p->disp_begin_pos,
                 p->disp_begin_pos + p->cursor_pos, TRUE);
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7080,6 +7080,46 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         enter_body,
     )
 
+    count_start = dir_ops.index("static int CountPathSnapshot(")
+    reanchor_start = dir_ops.index("\nstatic void ReanchorPanelToDir(", count_start)
+    reanchor_end = dir_ops.index(
+        "\nBOOL DirOps_SelectVisibleDirAndRefresh(", reanchor_start
+    )
+    reanchor_body = dir_ops[reanchor_start:reanchor_end]
+    assert not re.search(
+        r"\bpanel->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+        reanchor_body,
+    )
+    assert "AppStateCommitPanelTreeViewport(panel, 0, 0)" in reanchor_body
+
+    volume_start = dir_ops.index("HandleDirWindowVolumeAction(")
+    log_start = dir_ops.index("\nDirWindowDispatchResult\nHandleDirWindowLogAction(")
+    volume_body = dir_ops[volume_start:log_start]
+    log_end = dir_ops.index("\nvoid ToggleDotFiles(", log_start)
+    log_body = dir_ops[log_start:log_end]
+    for body in [volume_body, log_body]:
+        assert not re.search(
+            r"\bctx->active->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+            body,
+        )
+        assert re.search(
+            r"AppStateCommitPanelTreeViewport\(\s*ctx->active,\s*"
+            r"next_disp_begin_pos,\s*next_cursor_pos\s*\)",
+            body,
+        )
+
+    refresh_dir_start = dir_ops.index("int RefreshDirWindow(")
+    refresh_dir_body = dir_ops[refresh_dir_start:]
+    assert not re.search(
+        r"\bp->(?:disp_begin_pos|cursor_pos)\s*=(?!=)",
+        refresh_dir_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeViewport\(\s*p,\s*next_disp_begin_pos,\s*"
+        r"next_cursor_pos\s*\)",
+        refresh_dir_body,
+    )
+
     f2_exit_start = f2_picker.index(
         "\n  if (ctx->active->vol != original_vol) {"
     )


### PR DESCRIPTION
## Summary
- Route directory reanchor, volume/log bounds correction, and refresh tree viewport updates through `AppStateCommitPanelTreeViewport`.
- Extend the AppState contract guard so those directory refresh paths reject direct tree viewport field writes.

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper` failed because `src/ui/dir_ops.c` wrote `disp_begin_pos` and `cursor_pos` directly in directory reanchor refresh paths.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_commits_route_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && make clean && make`
