### PR TITLE
refactor(appstate): route file selection anchors through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -13,6 +13,9 @@
 BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel);
 BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
                                     unsigned int panel_generation);
+BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
+                                      const char *dir_path,
+                                      const char *file_name);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos);
 BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -31,6 +31,34 @@ BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
+                                      const char *dir_path,
+                                      const char *file_name) {
+  if (!AppStateValidatedOwnerField("panel.file_selection_key"))
+    return FALSE;
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->file_selection_dir_path[0] = '\0';
+  if (dir_path) {
+    (void)snprintf(panel->file_selection_dir_path,
+                   sizeof(panel->file_selection_dir_path), "%s", dir_path);
+    panel->file_selection_dir_path[PATH_LENGTH] = '\0';
+  }
+
+  panel->file_selection_name[0] = '\0';
+  if (file_name) {
+    (void)snprintf(panel->file_selection_name,
+                   sizeof(panel->file_selection_name), "%s", file_name);
+    panel->file_selection_name[PATH_LENGTH] = '\0';
+  }
+
+  panel->panel_generation++;
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos) {
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -55,6 +55,8 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
                                  const DirEntry *dir_entry) {
   int idx;
   const FileEntry *selected_file;
+  char file_selection_dir_path[PATH_LENGTH + 1];
+  char file_selection_name[PATH_LENGTH + 1];
 
   if (!panel)
     return;
@@ -65,13 +67,13 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
   if (!panel->file_entry_list || panel->file_count == 0)
     BuildFileEntryList(ctx, panel);
 
-  panel->file_selection_dir_path[0] = '\0';
-  GetPath((DirEntry *)dir_entry, panel->file_selection_dir_path);
-  panel->file_selection_dir_path[PATH_LENGTH] = '\0';
+  file_selection_dir_path[0] = '\0';
+  GetPath((DirEntry *)dir_entry, file_selection_dir_path);
+  file_selection_dir_path[PATH_LENGTH] = '\0';
+  file_selection_name[0] = '\0';
 
   if (!panel->file_entry_list || panel->file_count == 0) {
-    panel->file_selection_name[0] = '\0';
-    if (!AppStateCommitPanelGeneration(panel))
+    if (!AppStateCommitPanelFileSelection(panel, file_selection_dir_path, NULL))
       return;
     return;
   }
@@ -85,13 +87,13 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
     idx = 0;
 
   selected_file = panel->file_entry_list[idx].file;
-  panel->file_selection_name[0] = '\0';
   if (selected_file) {
-    (void)snprintf(panel->file_selection_name,
-                   sizeof(panel->file_selection_name), "%s",
+    (void)snprintf(file_selection_name, sizeof(file_selection_name), "%s",
                    selected_file->name);
+    file_selection_name[PATH_LENGTH] = '\0';
   }
-  if (!AppStateCommitPanelGeneration(panel))
+  if (!AppStateCommitPanelFileSelection(panel, file_selection_dir_path,
+                                        file_selection_name))
     return;
 }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6613,7 +6613,7 @@ def test_file_selection_anchor_generation_commits_through_appstate_helper() -> N
     capture_body = ctrl_file_ops[capture_start:capture_end]
 
     assert "panel->panel_generation++;" not in capture_body
-    assert capture_body.count("AppStateCommitPanelGeneration(panel)") == 2
+    assert capture_body.count("AppStateCommitPanelFileSelection(") == 2
 
 
 def test_panel_anchor_viewport_generation_commits_through_appstate_helper() -> None:
@@ -6939,6 +6939,44 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
         )
         == 1
     )
+
+
+def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelFileSelection(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelFileSelection(")
+    helper_end = helper.index("\nBOOL AppStateCommitPanelFileViewport(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    selection_validation = 'AppStateValidatedOwnerField("panel.file_selection_key")'
+    generation_validation = 'AppStateValidatedOwnerField("panel.panel_generation")'
+    selection_name_write = "panel->file_selection_name[0] = '\\0';"
+    selection_dir_write = "panel->file_selection_dir_path[0] = '\\0';"
+    assert selection_validation in helper_body
+    assert generation_validation in helper_body
+    assert selection_name_write in helper_body
+    assert selection_dir_write in helper_body
+    assert helper_body.index(selection_validation) < helper_body.index(
+        selection_name_write
+    )
+    assert helper_body.index(generation_validation) < helper_body.index(
+        "panel->panel_generation++;"
+    )
+
+    capture_start = ctrl_file_ops.index("void CapturePanelSelectionAnchor(")
+    capture_end = ctrl_file_ops.index(
+        "\nBOOL RebindActiveFilePanelSelection(", capture_start
+    )
+    capture_body = ctrl_file_ops[capture_start:capture_end]
+    assert not re.search(
+        r"\bpanel->(?:file_selection_name|file_selection_dir_path)"
+        r"(?:\[[^\n]*\])?\s*=(?!=)",
+        capture_body,
+    )
+    assert "AppStateCommitPanelFileSelection(" in capture_body
 
 
 def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Add an AppState helper for panel file selection anchor commits.
- Route captured file selection names and directory paths through the helper so the owner field and panel generation are validated together.
- Extend the AppState contract guard to reject direct captured file selection writes.

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper` failed because the AppState file selection helper did not exist and capture wrote selection fields directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && make clean && make`
