### PR TITLE
refactor(appstate): route file window selection through helper

### DIFF
--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -324,13 +324,13 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
           ctx->active->file_entry_list[selection_idx].file;
 
       if (selected_file) {
-        ctx->active->file_selection_name[0] = '\0';
-        ctx->active->file_selection_dir_path[0] = '\0';
-        (void)snprintf(ctx->active->file_selection_name,
-                       sizeof(ctx->active->file_selection_name), "%s",
-                       selected_file->name);
-        GetPath(dir_entry, ctx->active->file_selection_dir_path);
-        ctx->active->file_selection_dir_path[PATH_LENGTH] = '\0';
+        char file_selection_dir_path[PATH_LENGTH + 1];
+
+        file_selection_dir_path[0] = '\0';
+        GetPath(dir_entry, file_selection_dir_path);
+        file_selection_dir_path[PATH_LENGTH] = '\0';
+        (void)AppStateCommitPanelFileSelection(
+            ctx->active, file_selection_dir_path, selected_file->name);
       }
     }
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6945,6 +6945,7 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelFileSelection(" in header
 
@@ -6977,6 +6978,21 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
         capture_body,
     )
     assert "AppStateCommitPanelFileSelection(" in capture_body
+
+    file_window_start = ctrl_file.index("int HandleFileWindow(")
+    file_window_end = ctrl_file.index(
+        "\nstatic int FindDirIndexInVolume(", file_window_start
+    )
+    file_window_body = ctrl_file[file_window_start:file_window_end]
+    assert not re.search(
+        r"\bctx->active->(?:file_selection_name|file_selection_dir_path)"
+        r"(?:\[[^\n]*\])?\s*=(?!=)",
+        file_window_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelFileSelection\(\s*ctx->active,",
+        file_window_body,
+    )
 
 
 def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route the initial file-window selection name/path commit through `AppStateCommitPanelFileSelection`.
- Extend the AppState contract guard so file-window entry rejects direct active-panel file selection writes.

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper` failed because `HandleFileWindow` still wrote active-panel file selection fields directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && make clean && make`
