### PR TITLE
refactor(appstate): route split file selection path through helper

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1188,10 +1188,8 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
      * empty. Rehydrate it from the authoritative tree selection before any
      * restore logic consumes the snapshot.
      */
-    (void)snprintf(p->file_selection_dir_path,
-                   sizeof(p->file_selection_dir_path), "%s",
-                   current_dir_path);
-    p->file_selection_dir_path[PATH_LENGTH] = '\0';
+    (void)AppStateCommitPanelFileSelection(p, current_dir_path,
+                                           p->file_selection_name);
   }
   assert(p->saved_focus != FOCUS_FILE || p->file_selection_dir_path[0] != '\0');
   /*

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6946,6 +6946,7 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelFileSelection(" in header
 
@@ -6992,6 +6993,19 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     assert re.search(
         r"AppStateCommitPanelFileSelection\(\s*ctx->active,",
         file_window_body,
+    )
+
+    switch_start = dir_ops.index("void HandleSwitchWindow(")
+    switch_end = dir_ops.index("\nvoid SyncActivePanelWindows(", switch_start)
+    switch_body = dir_ops[switch_start:switch_end]
+    assert not re.search(
+        r"\bp->(?:file_selection_name|file_selection_dir_path)"
+        r"(?:\[[^\n]*\])?\s*=(?!=)",
+        switch_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelFileSelection\(\s*p,",
+        switch_body,
     )
 
 


### PR DESCRIPTION
## Summary
- Route split handoff file selection path rehydration through `AppStateCommitPanelFileSelection`.
- Extend the AppState contract guard so `HandleSwitchWindow` rejects direct panel file selection path writes.

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper` failed because `HandleSwitchWindow` still wrote the panel file selection path directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && make clean && make`
