### PR TITLE
refactor(appstate): route log file selection restore through helper

### DIFF
--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -115,6 +115,7 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
   const PanelVolumeFileState *state;
   DirEntry *resolved_file_dir = NULL;
   const char *file_dir_path = NULL;
+  unsigned int restore_generation = 0;
 
   if (!panel || !panel->vol)
     return;
@@ -122,10 +123,13 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
   ResetPanelFileContext(panel);
   vol = panel->vol;
   state = FindPanelVolumeFileState(panel, vol->id);
+  restore_generation = panel->panel_generation;
   if (!AppStateCommitPanelFileViewport(panel, 0, 0))
     return;
-  panel->file_selection_name[0] = '\0';
-  panel->file_selection_dir_path[0] = '\0';
+  if (!AppStateCommitPanelFileSelection(panel, NULL, NULL))
+    return;
+  if (!AppStateRestorePanelGeneration(panel, restore_generation))
+    return;
   panel->file_dir_entry = NULL;
   if (!AppStateCommitPanelFileShape(panel, FALSE))
     return;
@@ -147,11 +151,12 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
     if (!AppStateCommitPanelFileViewport(panel, start_file, file_cursor_pos))
       return;
   }
-  (void)snprintf(panel->file_selection_name, sizeof(panel->file_selection_name),
-                 "%s", state->saved_file_selection_name);
-  (void)snprintf(panel->file_selection_dir_path,
-                  sizeof(panel->file_selection_dir_path), "%s",
-                  state->saved_file_selection_dir_path);
+  if (!AppStateCommitPanelFileSelection(
+          panel, state->saved_file_selection_dir_path,
+          state->saved_file_selection_name))
+    return;
+  if (!AppStateRestorePanelGeneration(panel, restore_generation))
+    return;
 
   assert(state->saved_focus != FOCUS_FILE ||
          state->saved_file_selection_dir_path[0] != '\0');

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6947,6 +6947,7 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelFileSelection(" in header
 
@@ -7006,6 +7007,19 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     assert re.search(
         r"AppStateCommitPanelFileSelection\(\s*p,",
         switch_body,
+    )
+
+    restore_start = log_source.index("\nstatic void RestorePanelFileSelection(")
+    restore_end = log_source.index("\nstatic void SavePanelTreeSelection(", restore_start)
+    restore_body = log_source[restore_start:restore_end]
+    assert not re.search(
+        r"\bpanel->(?:file_selection_name|file_selection_dir_path)"
+        r"(?:\[[^\n]*\])?\s*=(?!=)",
+        restore_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelFileSelection\(\s*panel,",
+        restore_body,
     )
 
 


### PR DESCRIPTION
## Summary
- route log restore file selection clear and restore writes through `AppStateCommitPanelFileSelection`
- preserve panel generation while replaying saved file selection so directory restore snapshots remain reusable
- extend the AppState contract guard to cover `RestorePanelFileSelection`

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper` failed because `RestorePanelFileSelection` still wrote `panel->file_selection_*` directly.
- After implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper`
- After implementation: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k restore_snapshots_validate_generation_before_reuse`
- After implementation: `source .venv/bin/activate && pytest tests/test_panel_isolation.py -q -k volume_cycle_restores_prior_directory_selection`
- After implementation: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- After implementation: `source .venv/bin/activate && make clean && make`
