### PR TITLE
refactor(appstate): route panel anchor volume binding through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -13,6 +13,7 @@
 BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel);
 BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
                                     unsigned int panel_generation);
+BOOL AppStateCommitPanelVolume(YtreeNovaPanel *panel, struct Volume *vol);
 BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *dir_path,
                                       const char *file_name);

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -31,6 +31,19 @@ BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelVolume(YtreeNovaPanel *panel, struct Volume *vol) {
+  if (!AppStateValidatedOwnerField("panel.volume_key"))
+    return FALSE;
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->vol = vol;
+  panel->panel_generation++;
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *dir_path,
                                       const char *file_name) {

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -689,7 +689,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   }
 
   FreeFileEntryList(dst);
-  dst->vol = src->vol;
+  if (!AppStateCommitPanelVolume(dst, src->vol))
+    return FALSE;
   if (!AppStateCommitPanelTreeViewport(dst, src->disp_begin_pos,
                                        src->cursor_pos))
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7286,6 +7286,36 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         assert "AppStateCommitPanelTreeViewport(" in body
 
 
+def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelVolume(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelVolume(")
+    helper_end = helper.index("\nBOOL AppStateCommitPanelFileSelection(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    volume_validation = 'AppStateValidatedOwnerField("panel.volume_key")'
+    generation_validation = 'AppStateValidatedOwnerField("panel.panel_generation")'
+    volume_write = "panel->vol = vol;"
+    generation_write = "panel->panel_generation++;"
+    assert volume_validation in helper_body
+    assert generation_validation in helper_body
+    assert volume_write in helper_body
+    assert generation_write in helper_body
+    assert helper_body.index(volume_validation) < helper_body.index(volume_write)
+    assert helper_body.index(generation_validation) < helper_body.index(
+        generation_write
+    )
+
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+    assert not re.search(r"\bdst->vol\s*=(?!=)", donate_body)
+    assert re.search(r"AppStateCommitPanelVolume\(\s*dst,\s*src->vol\s*\)", donate_body)
+
+
 def test_volume_generation_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add `AppStateCommitPanelVolume` for panel volume-key commits
- route panel-anchor donation volume rebinding through the AppState panel helper
- extend the AppState contract guard to cover the panel-anchor volume binding path

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper` failed because the panel volume helper did not exist and `DonatePanelState` still wrote `dst->vol` directly.
- After implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper`
- After implementation: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- After implementation: `source .venv/bin/activate && make clean && make`
