### PR TITLE
refactor(appstate): route volume menu panel binding through helper

### DIFF
--- a/src/ui/volume_menu.c
+++ b/src/ui/volume_menu.c
@@ -48,10 +48,12 @@ static void EnsurePanelsReferenceActiveVolume(ViewContext *ctx) {
   if (!ctx || !ctx->active || !ctx->active->vol)
     return;
 
-  if (ctx->left && ctx->left->vol == NULL)
-    ctx->left->vol = ctx->active->vol;
-  if (ctx->right && ctx->right->vol == NULL)
-    ctx->right->vol = ctx->active->vol;
+  if (ctx->left && ctx->left->vol == NULL &&
+      !AppStateCommitPanelVolume(ctx->left, ctx->active->vol))
+    return;
+  if (ctx->right && ctx->right->vol == NULL &&
+      !AppStateCommitPanelVolume(ctx->right, ctx->active->vol))
+    return;
 
   if (!ctx->is_split_screen)
     return;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7290,6 +7290,7 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelVolume(" in header
 
@@ -7314,6 +7315,21 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     donate_body = panel_anchor[donate_start:donate_end]
     assert not re.search(r"\bdst->vol\s*=(?!=)", donate_body)
     assert re.search(r"AppStateCommitPanelVolume\(\s*dst,\s*src->vol\s*\)", donate_body)
+
+    volume_menu_start = volume_menu.index(
+        "static void EnsurePanelsReferenceActiveVolume("
+    )
+    volume_menu_end = volume_menu.index("\n/*\n * SelectLoadedVolume", volume_menu_start)
+    volume_menu_body = volume_menu[volume_menu_start:volume_menu_end]
+    assert not re.search(r"\bctx->(?:left|right)->vol\s*=(?!=)", volume_menu_body)
+    assert re.search(
+        r"AppStateCommitPanelVolume\(\s*ctx->left,\s*ctx->active->vol\s*\)",
+        volume_menu_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelVolume\(\s*ctx->right,\s*ctx->active->vol\s*\)",
+        volume_menu_body,
+    )
 
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- route volume-menu fallback panel volume rebinding through `AppStateCommitPanelVolume`
- extend the AppState volume-binding guard to cover `EnsurePanelsReferenceActiveVolume`

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper` failed because `EnsurePanelsReferenceActiveVolume` still wrote `ctx->left->vol` and `ctx->right->vol` directly.
- After implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper`
- After implementation: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- After implementation: `source .venv/bin/activate && make clean && make`
