### PR TITLE
refactor(appstate): route split panel volume mirror through helper

### DIFF
--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -320,7 +320,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
 
       if (ctx->is_split_screen) {
         if (ctx->right && ctx->left) {
-          ctx->right->vol = ctx->left->vol;
+          if (!AppStateCommitPanelVolume(ctx->right, ctx->left->vol))
+            return FALSE;
           if (!AppStateCommitPanelTreeViewport(ctx->right,
                                                ctx->left->disp_begin_pos,
                                                ctx->left->cursor_pos))
@@ -546,7 +547,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
 
       if (ctx->is_split_screen) {
         if (ctx->right && ctx->left) {
-          ctx->right->vol = ctx->left->vol;
+          if (!AppStateCommitPanelVolume(ctx->right, ctx->left->vol))
+            return FALSE;
           if (!AppStateCommitPanelTreeViewport(ctx->right,
                                                ctx->left->disp_begin_pos,
                                                ctx->left->cursor_pos))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7290,6 +7290,7 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelVolume(" in header
@@ -7329,6 +7330,26 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     assert re.search(
         r"AppStateCommitPanelVolume\(\s*ctx->right,\s*ctx->active->vol\s*\)",
         volume_menu_body,
+    )
+
+    file_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleFileWindowAction("
+    )
+    dir_split_start = split_transition.index(
+        "\nBOOL SplitTransition_HandleDirWindowAction(", file_split_start
+    )
+    file_split_body = split_transition[file_split_start:dir_split_start]
+    dir_split_body = split_transition[dir_split_start:]
+    assert not re.search(r"\bctx->right->vol\s*=(?!=)", file_split_body)
+    assert not re.search(r"\bctx->right->vol\s*=(?!=)", dir_split_body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelVolume\(\s*ctx->right,\s*ctx->left->vol\s*\)",
+                split_transition,
+            )
+        )
+        == 2
     )
 
 


### PR DESCRIPTION
## Summary
- route split-transition right-panel volume mirrors through `AppStateCommitPanelVolume`
- extend the AppState volume-binding guard to cover file-window and directory-window split mirror paths

## Validation
- RED before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper` failed because split-transition mirror paths still wrote `ctx->right->vol` directly.
- After implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper`
- After implementation: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py tests/test_file_window_dispatch_regressions.py -q -k 'split_transition_owner_path_is_canonical or dir_window_split_and_tab_keeps_file_focus or split_and_tab_dispatch_keeps_file_mode_footer or HandleFileWindow_delegates_split_transition_hotspot'`
- After implementation: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- After implementation: `source .venv/bin/activate && make clean && make`
