### PR TITLE
refactor(appstate): route picker panel volume restore through helper

### DIFF
--- a/src/ui/f2_picker.c
+++ b/src/ui/f2_picker.c
@@ -14,6 +14,7 @@
 
 int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
   struct Volume *original_vol; /* Declare first */
+  unsigned int original_panel_generation;
   int result = -1;
   int win_width, win_height;
   struct Volume *target_vol;
@@ -29,6 +30,7 @@ int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
   char new_log_path[PATH_LENGTH + 1];
 
   original_vol = ctx->active->vol;
+  original_panel_generation = ctx->active->panel_generation;
   SavePanelTreeViewportSnapshot(ctx->active);
   DEBUG_LOG("ENTER HandleDirWindow: Panel=%s Vol=%s Cursor=%d",
             (panel == ctx->left ? "LEFT" : "RIGHT"),
@@ -363,7 +365,10 @@ int KeyF2Get(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
            action != ACTION_LOG);
 
   if (ctx->active->vol != original_vol) {
-    ctx->active->vol = original_vol;
+    if (!AppStateCommitPanelVolume(ctx->active, original_vol))
+      return -1;
+    if (!AppStateRestorePanelGeneration(ctx->active, original_panel_generation))
+      return -1;
     if (!AppStateCommitViewMode(ctx, ctx->active->vol->vol_stats.log_mode))
       return -1;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7289,6 +7289,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
 def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    f2_picker = Path("src/ui/f2_picker.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
     split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
@@ -7350,6 +7351,19 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
             )
         )
         == 2
+    )
+
+    f2_start = f2_picker.index("int KeyF2Get(")
+    f2_body = f2_picker[f2_start:]
+    assert not re.search(r"\bctx->active->vol\s*=(?!=)", f2_body)
+    assert re.search(
+        r"AppStateCommitPanelVolume\(\s*ctx->active,\s*original_vol\s*\)",
+        f2_body,
+    )
+    assert re.search(
+        r"AppStateRestorePanelGeneration\(\s*ctx->active,\s*"
+        r"original_panel_generation\s*\)",
+        f2_body,
     )
 
 


### PR DESCRIPTION
## Summary
- Route the picker active-panel volume restore through `AppStateCommitPanelVolume`.
- Preserve the original panel generation when restoring the picker volume binding.
- Extend the AppState contract guard to cover this restore path.

## Red proof
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper` failed before the runtime helper change because `src/ui/f2_picker.c` directly wrote `ctx->active->vol = original_vol`.

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && make clean && make`
