### PR TITLE
refactor(appstate): route owner file panel volume binding through helper

### DIFF
--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -919,7 +919,8 @@ static BOOL JumpToOwnerDirectory(ViewContext *ctx,
   owner_vol = FindVolumeForDir(ctx, owner_dir, &owner_dir_idx);
   if (!owner_vol || owner_dir_idx < 0)
     return FALSE;
-  panel->vol = owner_vol;
+  if (!AppStateCommitPanelVolume(panel, owner_vol))
+    return FALSE;
 
   if (!panel->vol->dir_entry_list || panel->vol->total_dirs <= 0) {
     BuildDirEntryList(ctx, panel->vol, &panel->current_dir_entry);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7289,6 +7289,7 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
 def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     f2_picker = Path("src/ui/f2_picker.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
     split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
@@ -7364,6 +7365,17 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
         r"AppStateRestorePanelGeneration\(\s*ctx->active,\s*"
         r"original_panel_generation\s*\)",
         f2_body,
+    )
+
+    owner_jump_start = ctrl_file.index("static BOOL JumpToOwnerDirectory(")
+    owner_jump_end = ctrl_file.index(
+        "\nstatic void DrawFileListJumpPrompt(", owner_jump_start
+    )
+    owner_jump_body = ctrl_file[owner_jump_start:owner_jump_end]
+    assert not re.search(r"\bpanel->vol\s*=(?!=)", owner_jump_body)
+    assert re.search(
+        r"AppStateCommitPanelVolume\(\s*panel,\s*owner_vol\s*\)",
+        owner_jump_body,
     )
 
 


### PR DESCRIPTION
## Summary
- Route the owner-directory file-panel volume binding through `AppStateCommitPanelVolume`.
- Extend the panel volume binding contract guard to cover `JumpToOwnerDirectory`.

## Red proof
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper` failed before the runtime helper change because `src/ui/ctrl_file.c` directly wrote `panel->vol = owner_vol`.

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && make clean && make`
- `source .venv/bin/activate && pytest tests/test_display_layout.py -q -k test_backslash_to_dir_in_showall_and_global`
