### PR TITLE
refactor(appstate): route log panel volume binding through helper

### DIFF
--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -302,7 +302,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
         const PanelVolumeFileState *state;
 
         ResetPanelFileContext(panel);
-        panel->vol = found_vol;
+        if (!AppStateCommitPanelVolume(panel, found_vol))
+          return -1;
         s = &panel->vol->vol_stats;
         if (!AppStateCommitPanelFocus(ctx, panel,
                                       (ViewFocus)panel->vol->saved_focus))
@@ -349,7 +350,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
       if (found_vol == panel->vol) {
         /* If the current volume is bad, we must delete it. */
         Volume_Delete(ctx, found_vol);
-        panel->vol = NULL; /* Temporarily NULL */
+        if (!AppStateCommitPanelVolume(panel, NULL))
+          return -1;
       } else {
         Volume_Delete(ctx, found_vol);
       }
@@ -425,7 +427,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
     } else if (old_vol != NULL) {
       /* We tried to create a NEW volume and failed. */
       /* panel->vol is still old_vol (valid). Restore its display. */
-      panel->vol = old_vol;
+      if (panel->vol != old_vol && !AppStateCommitPanelVolume(panel, old_vol))
+        return -1;
       if (!AppStateCommitViewMode(ctx, panel->vol->vol_stats.log_mode))
         return -1;
       s = &panel->vol->vol_stats;
@@ -457,7 +460,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
 
   /* Success */
   ResetPanelFileContext(panel);
-  panel->vol = loaded_vol;
+  if (panel->vol != loaded_vol && !AppStateCommitPanelVolume(panel, loaded_vol))
+    return -1;
   s = &panel->vol->vol_stats;
   if (!AppStateCommitPanelFocus(ctx, panel,
                                 (ViewFocus)panel->vol->saved_focus))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7291,6 +7291,7 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     f2_picker = Path("src/ui/f2_picker.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
     split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
@@ -7377,6 +7378,16 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
         r"AppStateCommitPanelVolume\(\s*panel,\s*owner_vol\s*\)",
         owner_jump_body,
     )
+
+    log_start = log_source.index("int LogDisk(")
+    log_end = log_source.index("\nint GetNewLogPath(", log_start)
+    log_body = log_source[log_start:log_end]
+    assert not re.search(r"\bpanel->vol\s*=(?!=)", log_body)
+    for volume_expr in ("found_vol", "NULL", "old_vol", "loaded_vol"):
+        assert re.search(
+            rf"AppStateCommitPanelVolume\(\s*panel,\s*{volume_expr}\s*\)",
+            log_body,
+        )
 
 
 def test_volume_generation_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route `LogDisk` panel volume rebinding through `AppStateCommitPanelVolume`.
- Preserve no-op restore and reload paths by only committing matching bindings when the panel volume actually changes.
- Extend the panel volume binding contract guard to cover `LogDisk`.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper` failed before the runtime helper change because `src/cmd/log.c` directly wrote `panel->vol` inside `LogDisk`.
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper`
- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Passed: `source .venv/bin/activate && make clean && make`
- Passed: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k log_disk`