### PR TITLE
refactor(appstate): route core panel volume bindings through helper

### DIFF
--- a/src/core/init.c
+++ b/src/core/init.c
@@ -883,10 +883,13 @@ int Init(ViewContext *ctx, const char *configuration_file,
 
   /* Allocate and initialize the first volume using the dedicated module */
   struct Volume *initial_vol = Volume_Create(ctx);
+  if (initial_vol == NULL)
+    return -1;
   /* Assign initial volume to ActivePanel */
   if (!AppStateCommitActivePanel(ctx, ctx->left))
     return -1;
-  ctx->active->vol = initial_vol;
+  if (!AppStateCommitPanelVolume(ctx->active, initial_vol))
+    return -1;
 
   ctx->show_stats = TRUE;
   ctx->fixed_col_width = 0; /* ADDED */

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -152,13 +152,15 @@ void Volume_Delete(ViewContext *ctx, struct Volume *vol) {
     Volume_ClearPanelFileEntries(ctx->left);
     Volume_ClearPanelFileAnchor(ctx->left);
     Volume_ClearPanelTags(ctx->left);
-    ctx->left->vol = NULL;
+    if (!AppStateCommitPanelVolume(ctx->left, NULL))
+      return;
   }
   if (ctx->right && ctx->right->vol == vol) {
     Volume_ClearPanelFileEntries(ctx->right);
     Volume_ClearPanelFileAnchor(ctx->right);
     Volume_ClearPanelTags(ctx->right);
-    ctx->right->vol = NULL;
+    if (!AppStateCommitPanelVolume(ctx->right, NULL))
+      return;
   }
 
   /* Free the associated directory tree if it exists */
@@ -183,12 +185,15 @@ void Volume_FreeAll(ViewContext *ctx) {
 
   /* Safely iterate and delete everything */
   HASH_ITER(hh, ctx->volumes_head, s, tmp) { Volume_Delete(ctx, s); }
-  if (ctx->active)
-    ctx->active->vol = NULL;
-  if (ctx->left)
-    ctx->left->vol = NULL;
-  if (ctx->right)
-    ctx->right->vol = NULL;
+  if (ctx->active && ctx->active->vol &&
+      !AppStateCommitPanelVolume(ctx->active, NULL))
+    return;
+  if (ctx->left && ctx->left->vol &&
+      !AppStateCommitPanelVolume(ctx->left, NULL))
+    return;
+  if (ctx->right && ctx->right->vol &&
+      !AppStateCommitPanelVolume(ctx->right, NULL))
+    return;
   (void)AppStateClearVolumeRegistry(ctx);
 }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7292,8 +7292,10 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     f2_picker = Path("src/ui/f2_picker.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
     split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
+    volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
     volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
 
     assert "BOOL AppStateCommitPanelVolume(" in header
@@ -7387,6 +7389,45 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
         assert re.search(
             rf"AppStateCommitPanelVolume\(\s*panel,\s*{volume_expr}\s*\)",
             log_body,
+        )
+
+    init_start = init_source.index("int Init(")
+    init_body = init_source[init_start:]
+    assert not re.search(r"\bctx->active->vol\s*=(?!=)", init_body)
+    assert re.search(
+        r"AppStateCommitPanelVolume\(\s*ctx->active,\s*initial_vol\s*\)",
+        init_body,
+    )
+
+    volume_delete_start = volume_source.index("void Volume_Delete(")
+    volume_free_all_start = volume_source.index(
+        "\nvoid Volume_FreeAll(", volume_delete_start
+    )
+    volume_get_by_path_start = volume_source.index(
+        "\nstruct Volume *Volume_GetByPath(", volume_free_all_start
+    )
+    volume_delete_body = volume_source[
+        volume_delete_start:volume_free_all_start
+    ]
+    volume_free_all_body = volume_source[
+        volume_free_all_start:volume_get_by_path_start
+    ]
+    assert not re.search(
+        r"\bctx->(?:left|right)->vol\s*=(?!=)", volume_delete_body
+    )
+    for panel_expr in ("ctx->left", "ctx->right"):
+        assert re.search(
+            rf"AppStateCommitPanelVolume\(\s*{panel_expr},\s*NULL\s*\)",
+            volume_delete_body,
+        )
+    assert not re.search(
+        r"\bctx->(?:active|left|right)->vol\s*=(?!=)",
+        volume_free_all_body,
+    )
+    for panel_expr in ("ctx->active", "ctx->left", "ctx->right"):
+        assert re.search(
+            rf"AppStateCommitPanelVolume\(\s*{panel_expr},\s*NULL\s*\)",
+            volume_free_all_body,
         )
 
 


### PR DESCRIPTION
## Summary
- Route initial and shutdown panel volume binding changes through `AppStateCommitPanelVolume`.
- Extend the AppState contract guard to cover core initialization and volume lifecycle bindings.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper` failed before the runtime changes because `Init` still wrote `ctx->active->vol` directly.
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_binding_commits_route_through_appstate_helper`
- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Passed: `source .venv/bin/activate && make clean && make` with existing warnings
