### PR TITLE
refactor(appstate): route panel tree selection through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -17,6 +17,8 @@ BOOL AppStateCommitPanelVolume(YtreeNovaPanel *panel, struct Volume *vol);
 BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *dir_path,
                                       const char *file_name);
+BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
+                                      int current_dir_entry);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos);
 BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -72,6 +72,17 @@ BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
+                                      int current_dir_entry) {
+  if (!AppStateValidatedOwnerField("panel.tree_selection_key"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->current_dir_entry = current_dir_entry;
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos) {
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -702,7 +702,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   dst->file_dir_entry = src->file_dir_entry;
   dst->file_mode = src->file_mode;
   dst->max_column = src->max_column;
-  dst->current_dir_entry = src->current_dir_entry;
+  if (!AppStateCommitPanelTreeSelection(dst, src->current_dir_entry))
+    return FALSE;
   if (!AppStateRestorePanelGeneration(dst, src->panel_generation))
     return FALSE;
   if (!AppStateCommitPanelFocus(ctx, dst, src->saved_focus))
@@ -724,7 +725,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
     if (!AppStateCommitPanelTreeViewport(dst, dst_disp_begin_pos,
                                          dst_cursor_pos))
       return FALSE;
-    dst->current_dir_entry = dst_current_dir_entry;
+    if (!AppStateCommitPanelTreeSelection(dst, dst_current_dir_entry))
+      return FALSE;
     if (!AppStateRestorePanelGeneration(dst, dst_panel_generation))
       return FALSE;
     if (dst_current_volume_state &&

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -521,7 +521,9 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         if (!AppStateCommitPanelTreeViewport(ctx->left, source_disp_begin_pos,
                                              source_cursor_pos))
           return FALSE;
-        ctx->left->current_dir_entry = source_current_dir_entry;
+        if (!AppStateCommitPanelTreeSelection(ctx->left,
+                                              source_current_dir_entry))
+          return FALSE;
         if (!AppStateRestorePanelGeneration(ctx->left,
                                             source_panel_generation))
           return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7286,6 +7286,53 @@ def test_panel_tree_viewport_commits_route_through_appstate_helper() -> None:
         assert "AppStateCommitPanelTreeViewport(" in body
 
 
+def test_panel_tree_selection_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelTreeSelection(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelTreeSelection(")
+    helper_end = helper.index("\nBOOL AppStateCommitPanelFileViewport(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("panel.tree_selection_key")'
+    selection_write = "panel->current_dir_entry = current_dir_entry;"
+    assert validation in helper_body
+    assert selection_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(selection_write)
+
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+    assert not re.search(r"\bdst->current_dir_entry\s*=(?!=)", donate_body)
+    assert re.search(
+        r"AppStateCommitPanelTreeSelection\(\s*dst,\s*"
+        r"src->current_dir_entry\s*\)",
+        donate_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeSelection\(\s*dst,\s*"
+        r"dst_current_dir_entry\s*\)",
+        donate_body,
+    )
+
+    dir_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleDirWindowAction("
+    )
+    dir_split_body = split_transition[dir_split_start:]
+    assert not re.search(
+        r"\bctx->left->current_dir_entry\s*=(?!=)",
+        dir_split_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelTreeSelection\(\s*ctx->left,\s*"
+        r"source_current_dir_entry\s*\)",
+        dir_split_body,
+    )
+
+
 def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add `AppStateCommitPanelTreeSelection` for panel tree selection authority.
- Route split donation and panel-state donation tree selection restores through the helper.
- Extend the AppState contract guard to reject direct `current_dir_entry` writes in those paths.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_selection_commits_route_through_appstate_helper` failed before the runtime changes because the helper was absent and `DonatePanelState` still wrote `dst->current_dir_entry` directly.
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_selection_commits_route_through_appstate_helper`
- Passed: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k split`
- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Passed: `source .venv/bin/activate && make clean && make` with existing warnings
