### PR TITLE
refactor(appstate): route split file selection through helper

### DIFF
--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -345,12 +345,10 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
                                                ctx->left->start_file,
                                                ctx->left->file_cursor_pos))
             return FALSE;
-          (void)snprintf(ctx->right->file_selection_name,
-                         sizeof(ctx->right->file_selection_name), "%s",
-                         ctx->left->file_selection_name);
-          (void)snprintf(ctx->right->file_selection_dir_path,
-                         sizeof(ctx->right->file_selection_dir_path), "%s",
-                         ctx->left->file_selection_dir_path);
+          if (!AppStateCommitPanelFileSelection(
+                  ctx->right, ctx->left->file_selection_dir_path,
+                  ctx->left->file_selection_name))
+            return FALSE;
           if (!AppStateCommitPanelFileShape(
                   ctx->right, ctx->left->saved_big_file_view))
             return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6948,6 +6948,9 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
 
     assert "BOOL AppStateCommitPanelFileSelection(" in header
 
@@ -7020,6 +7023,27 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     assert re.search(
         r"AppStateCommitPanelFileSelection\(\s*panel,",
         restore_body,
+    )
+
+    file_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleFileWindowAction("
+    )
+    dir_split_start = split_transition.index(
+        "\nBOOL SplitTransition_HandleDirWindowAction(", file_split_start
+    )
+    file_split_body = split_transition[file_split_start:dir_split_start]
+    assert not re.search(
+        r"\bctx->right->(?:file_selection_name|file_selection_dir_path)"
+        r"(?:\[[^\n]*\])?\s*=(?!=)",
+        file_split_body,
+    )
+    assert "snprintf(ctx->right->file_selection_name" not in file_split_body
+    assert "snprintf(ctx->right->file_selection_dir_path" not in file_split_body
+    assert re.search(
+        r"AppStateCommitPanelFileSelection\(\s*ctx->right,\s*"
+        r"ctx->left->file_selection_dir_path,\s*"
+        r"ctx->left->file_selection_name\s*\)",
+        file_split_body,
     )
 
 


### PR DESCRIPTION
## Summary
- Route split peer file-selection identity copies through `AppStateCommitPanelFileSelection`.
- Extend the AppState contract guard to cover split file-window file-selection seeding.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper` failed before the runtime change because the split file-window path lacked the helper call.
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper`
- Passed: `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k split`
- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Passed: `source .venv/bin/activate && make clean && make` with existing warnings
