### PR TITLE
refactor(appstate): route donation file selection through helper

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -710,15 +710,15 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
     return FALSE;
   if (!AppStateCommitPanelFileShape(dst, src->saved_big_file_view))
     return FALSE;
+  if (!AppStateCommitPanelFileSelection(dst, src->file_selection_dir_path,
+                                        src->file_selection_name))
+    return FALSE;
+  if (!AppStateRestorePanelGeneration(dst, src->panel_generation))
+    return FALSE;
   dst->max_visual_filename_len = src->max_visual_filename_len;
   dst->max_visual_linkname_len = src->max_visual_linkname_len;
   dst->max_visual_userview_len = src->max_visual_userview_len;
   dst->reverse_sort = src->reverse_sort;
-  (void)snprintf(dst->file_selection_name, sizeof(dst->file_selection_name),
-                 "%s", src->file_selection_name);
-  (void)snprintf(dst->file_selection_dir_path,
-                 sizeof(dst->file_selection_dir_path), "%s",
-                 src->file_selection_dir_path);
   dst->file_dir_entry = NULL;
   PanelTags_Copy(dst, src);
   if (!source_is_file) {
@@ -738,12 +738,12 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
               dst, dst_current_volume_state->saved_file_start,
               dst_current_volume_state->saved_file_cursor))
         return FALSE;
-      (void)snprintf(dst->file_selection_name,
-                     sizeof(dst->file_selection_name), "%s",
-                     dst_current_volume_state->saved_file_selection_name);
-      (void)snprintf(dst->file_selection_dir_path,
-                     sizeof(dst->file_selection_dir_path), "%s",
-                     dst_current_volume_state->saved_file_selection_dir_path);
+      if (!AppStateCommitPanelFileSelection(
+              dst, dst_current_volume_state->saved_file_selection_dir_path,
+              dst_current_volume_state->saved_file_selection_name))
+        return FALSE;
+      if (!AppStateRestorePanelGeneration(dst, dst_panel_generation))
+        return FALSE;
     } else {
       if (!AppStateCommitPanelFocus(ctx, dst, FOCUS_FILE))
         return FALSE;
@@ -753,12 +753,11 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
                                            dst_file_cursor_pos))
         return FALSE;
       dst->file_dir_entry = (DirEntry *)dst_file_dir_entry;
-      (void)snprintf(dst->file_selection_name,
-                     sizeof(dst->file_selection_name), "%s",
-                     dst_file_selection_name);
-      (void)snprintf(dst->file_selection_dir_path,
-                     sizeof(dst->file_selection_dir_path), "%s",
-                     dst_file_selection_dir_path);
+      if (!AppStateCommitPanelFileSelection(dst, dst_file_selection_dir_path,
+                                            dst_file_selection_name))
+        return FALSE;
+      if (!AppStateRestorePanelGeneration(dst, dst_panel_generation))
+        return FALSE;
     }
     if (!AppStateCommitPanelFocus(ctx, dst, FOCUS_TREE))
       return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6681,7 +6681,7 @@ def test_panel_generation_restores_route_through_appstate_helper() -> None:
     assert "ctx->left->panel_generation = source_panel_generation;" not in split_body
     assert log_body.count("AppStateRestorePanelGeneration(") == 1
     assert "state->saved_tree_panel_generation" in log_body
-    assert donate_body.count("AppStateRestorePanelGeneration(dst,") == 2
+    assert donate_body.count("AppStateRestorePanelGeneration(dst,") == 5
     assert split_body.count("AppStateRestorePanelGeneration(") == 1
     assert "source_panel_generation" in split_body
 
@@ -6948,6 +6948,7 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
     split_transition = Path("src/ui/split_transition.c").read_text(
         encoding="utf-8"
     )
@@ -7044,6 +7045,28 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
         r"ctx->left->file_selection_dir_path,\s*"
         r"ctx->left->file_selection_name\s*\)",
         file_split_body,
+    )
+
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+    assert "snprintf(dst->file_selection_name" not in donate_body
+    assert "snprintf(dst->file_selection_dir_path" not in donate_body
+    assert re.search(
+        r"AppStateCommitPanelFileSelection\(\s*dst,\s*"
+        r"src->file_selection_dir_path,\s*src->file_selection_name\s*\)",
+        donate_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelFileSelection\(\s*dst,\s*"
+        r"dst_current_volume_state->saved_file_selection_dir_path,\s*"
+        r"dst_current_volume_state->saved_file_selection_name\s*\)",
+        donate_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelFileSelection\(\s*dst,\s*"
+        r"dst_file_selection_dir_path,\s*dst_file_selection_name\s*\)",
+        donate_body,
     )
 
 


### PR DESCRIPTION
## Summary
- routes donated panel file-selection identities through `AppStateCommitPanelFileSelection`
- preserves existing panel generations around donation restores
- extends the AppState contract guard over donation file-selection copies

## Validation
- Red proof: targeted guard failed before the runtime change because `DonatePanelState` copied `dst->file_selection_*` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_generation_restores_route_through_appstate_helper or panel_file_selection_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k split`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -q -k split`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passed with existing warnings