### PR TITLE
refactor(appstate): route inactive file selection through helper

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -994,12 +994,12 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
             FreePathList(inactive_tagged_snapshot);
             return;
           }
-          (void)snprintf(inactive->file_selection_dir_path,
-                         sizeof(inactive->file_selection_dir_path), "%s",
-                         inactive_file_dir_path);
-          (void)snprintf(inactive->file_selection_name,
-                         sizeof(inactive->file_selection_name), "%s",
-                         inactive_file_name);
+          if (!AppStateCommitPanelFileSelection(inactive,
+                                                inactive_file_dir_path,
+                                                inactive_file_name)) {
+            FreePathList(inactive_tagged_snapshot);
+            return;
+          }
           if (resolved_file_dir) {
             DirOps_ReloadPanelFileAnchorIfMissing(ctx, inactive,
                                                   resolved_file_dir);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7000,6 +7000,22 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
         file_window_body,
     )
 
+    make_dir_start = dir_ops.index("void HandleDirMakeDirectory(")
+    make_dir_end = dir_ops.index("\nvoid HandleSwitchWindow(", make_dir_start)
+    make_dir_body = dir_ops[make_dir_start:make_dir_end]
+    assert not re.search(
+        r"\binactive->(?:file_selection_name|file_selection_dir_path)"
+        r"(?:\[[^\n]*\])?\s*=(?!=)",
+        make_dir_body,
+    )
+    assert "snprintf(inactive->file_selection_name" not in make_dir_body
+    assert "snprintf(inactive->file_selection_dir_path" not in make_dir_body
+    assert re.search(
+        r"AppStateCommitPanelFileSelection\(\s*inactive,\s*"
+        r"inactive_file_dir_path,\s*inactive_file_name\s*\)",
+        make_dir_body,
+    )
+
     switch_start = dir_ops.index("void HandleSwitchWindow(")
     switch_end = dir_ops.index("\nvoid SyncActivePanelWindows(", switch_start)
     switch_body = dir_ops[switch_start:switch_end]


### PR DESCRIPTION
## Summary
- routes inactive-panel file-selection restore in directory mutation handling through `AppStateCommitPanelFileSelection`
- keeps tagged-snapshot cleanup on helper failure
- extends the AppState contract guard over inactive-panel restore writes

## Validation
- Red proof: targeted guard failed before the runtime change because `HandleDirMakeDirectory` copied `inactive->file_selection_*` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_selection_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k 'make or split'`
- `source .venv/bin/activate && pytest tests/test_panel_isolation.py -q -k split`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passed with existing warnings
