### PR TITLE
refactor(appstate): route file anchor clears through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -21,6 +21,8 @@ BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
                                       int current_dir_entry);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos);
+BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,
+                                   DirEntry *file_dir_entry);
 BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,
                                      int cursor_pos);
 

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -25,7 +25,8 @@ static void ResetPanelFileContext(YtreeNovaPanel *panel) {
   FreeFileEntryList(panel);
   if (!AppStateCommitPanelFileViewport(panel, 0, 0))
     return;
-  panel->file_dir_entry = NULL;
+  if (!AppStateCommitPanelFileAnchor(panel, NULL))
+    return;
   (void)AppStateCommitPanelFileShape(panel, FALSE);
 }
 
@@ -130,7 +131,8 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
     return;
   if (!AppStateRestorePanelGeneration(panel, restore_generation))
     return;
-  panel->file_dir_entry = NULL;
+  if (!AppStateCommitPanelFileAnchor(panel, NULL))
+    return;
   if (!AppStateCommitPanelFileShape(panel, FALSE))
     return;
   if (!state)

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -26,7 +26,8 @@ static void Volume_ClearPanelFileAnchor(YtreeNovaPanel *panel) {
     return;
   if (!AppStateCommitPanelFileViewport(panel, 0, 0))
     return;
-  panel->file_dir_entry = NULL;
+  if (!AppStateCommitPanelFileAnchor(panel, NULL))
+    return;
 }
 
 static void Volume_ClearPanelTags(YtreeNovaPanel *panel) {

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -95,6 +95,17 @@ BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,
+                                   DirEntry *file_dir_entry) {
+  if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->file_dir_entry = file_dir_entry;
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,
                                      int cursor_pos) {
   if (!AppStateValidatedOwnerField("panel.tree_viewport_origin"))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6941,6 +6941,39 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     )
 
 
+def test_panel_file_anchor_clears_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelFileAnchor(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelFileAnchor(")
+    helper_end = helper.index("\nBOOL AppStateCommitPanelTreeViewport(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    assert 'AppStateValidatedOwnerField("panel.file_viewport_origin")' in helper_body
+    assert "panel->file_dir_entry = file_dir_entry;" in helper_body
+
+    volume_clear_start = volume_source.index("static void Volume_ClearPanelFileAnchor(")
+    volume_clear_end = volume_source.index("\nstatic void Volume_ClearPanelTags(", volume_clear_start)
+    volume_clear_body = volume_source[volume_clear_start:volume_clear_end]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=\s*NULL", volume_clear_body)
+    assert "AppStateCommitPanelFileAnchor(panel, NULL)" in volume_clear_body
+
+    log_clear_start = log_source.index("static void ResetPanelFileContext(")
+    log_clear_end = log_source.index("\nstatic void SavePanelFileSelection(", log_clear_start)
+    log_clear_body = log_source[log_clear_start:log_clear_end]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=\s*NULL", log_clear_body)
+    assert "AppStateCommitPanelFileAnchor(panel, NULL)" in log_clear_body
+
+    restore_start = log_source.index("\nstatic void RestorePanelFileSelection(")
+    restore_end = log_source.index("\nstatic void SavePanelTreeSelection(", restore_start)
+    restore_body = log_source[restore_start:restore_end]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=\s*NULL", restore_body)
+    assert "AppStateCommitPanelFileAnchor(panel, NULL)" in restore_body
+
+
 def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- adds `AppStateCommitPanelFileAnchor` for panel file-anchor pointer commits
- routes log/volume file-anchor clear paths through the helper
- extends the AppState contract guard over file-anchor clear writes

## Validation
- Red proof: targeted guard failed before the runtime change because `AppStateCommitPanelFileAnchor` was absent and clear paths wrote `panel->file_dir_entry = NULL` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_file_anchor_clears_route_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passed with existing warnings
