### PR TITLE
refactor(appstate): route volume menu file anchors through helper

### DIFF
--- a/src/ui/volume_menu.c
+++ b/src/ui/volume_menu.c
@@ -23,7 +23,8 @@ static void NormalizePanelCursorForVolume(YtreeNovaPanel *panel) {
   if (panel->vol->total_dirs <= 0) {
     if (!AppStateCommitPanelTreeViewport(panel, 0, 0))
       return;
-    panel->file_dir_entry = NULL;
+    if (!AppStateCommitPanelFileAnchor(panel, NULL))
+      return;
     return;
   }
 
@@ -63,7 +64,9 @@ static void EnsurePanelsReferenceActiveVolume(ViewContext *ctx) {
     NormalizePanelCursorForVolume(ctx->left);
     idx = ctx->left->disp_begin_pos + ctx->left->cursor_pos;
     if (ctx->left->vol->total_dirs > 0) {
-      ctx->left->file_dir_entry = ctx->left->vol->dir_entry_list[idx].dir_entry;
+      if (!AppStateCommitPanelFileAnchor(
+              ctx->left, ctx->left->vol->dir_entry_list[idx].dir_entry))
+        return;
       BuildFileEntryList(ctx, ctx->left);
     }
   }
@@ -73,7 +76,9 @@ static void EnsurePanelsReferenceActiveVolume(ViewContext *ctx) {
     NormalizePanelCursorForVolume(ctx->right);
     idx = ctx->right->disp_begin_pos + ctx->right->cursor_pos;
     if (ctx->right->vol->total_dirs > 0) {
-      ctx->right->file_dir_entry = ctx->right->vol->dir_entry_list[idx].dir_entry;
+      if (!AppStateCommitPanelFileAnchor(
+              ctx->right, ctx->right->vol->dir_entry_list[idx].dir_entry))
+        return;
       BuildFileEntryList(ctx, ctx->right);
     }
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6974,6 +6974,35 @@ def test_panel_file_anchor_clears_route_through_appstate_helper() -> None:
     assert "AppStateCommitPanelFileAnchor(panel, NULL)" in restore_body
 
 
+def test_volume_menu_file_anchors_route_through_appstate_helper() -> None:
+    volume_menu = Path("src/ui/volume_menu.c").read_text(encoding="utf-8")
+
+    normalize_start = volume_menu.index("static void NormalizePanelCursorForVolume(")
+    ensure_start = volume_menu.index(
+        "\nstatic void EnsurePanelsReferenceActiveVolume(", normalize_start
+    )
+    normalize_body = volume_menu[normalize_start:ensure_start]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=", normalize_body)
+    assert "AppStateCommitPanelFileAnchor(panel, NULL)" in normalize_body
+
+    select_start = volume_menu.index("\nint SelectLoadedVolume(", ensure_start)
+    ensure_body = volume_menu[ensure_start:select_start]
+    assert not re.search(
+        r"\bctx->(?:left|right)->file_dir_entry\s*=",
+        ensure_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelFileAnchor\(\s*ctx->left,\s*"
+        r"ctx->left->vol->dir_entry_list\[idx\]\.dir_entry\s*\)",
+        ensure_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelFileAnchor\(\s*ctx->right,\s*"
+        r"ctx->right->vol->dir_entry_list\[idx\]\.dir_entry\s*\)",
+        ensure_body,
+    )
+
+
 def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- routes volume-menu panel file-anchor rebinds through `AppStateCommitPanelFileAnchor`
- keeps volume-menu file-list rebuilds after successful anchor commits
- extends the AppState contract guard over volume-menu file-anchor writes

## Validation
- Red proof: targeted guard failed before the runtime change because `NormalizePanelCursorForVolume` and `EnsurePanelsReferenceActiveVolume` wrote `file_dir_entry` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'volume_menu_file_anchors_route_through_appstate_helper or panel_file_anchor_clears_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passed with existing warnings
