### PR TITLE
refactor(appstate): route log file anchors through helper

### DIFF
--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -79,7 +79,8 @@ static void PositionSavedFileSelection(ViewContext *ctx, YtreeNovaPanel *panel,
   if (!ctx || !panel || !dir_entry || !file_name || file_name[0] == '\0')
     return;
 
-  panel->file_dir_entry = dir_entry;
+  if (!AppStateCommitPanelFileAnchor(panel, dir_entry))
+    return;
   BuildFileEntryList(ctx, panel);
   for (i = 0; i < (int)panel->file_count; i++) {
     const FileEntry *file = panel->file_entry_list[i].file;
@@ -167,7 +168,8 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
 
   if (file_dir_path) {
     resolved_file_dir = ResolvePanelAnchorTarget(panel, vol, file_dir_path);
-    panel->file_dir_entry = resolved_file_dir;
+    if (!AppStateCommitPanelFileAnchor(panel, resolved_file_dir))
+      return;
     if (resolved_file_dir) {
       resolved_file_dir->big_window = state->saved_big_file_view;
       PositionSavedFileSelection(ctx, panel, resolved_file_dir,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7003,6 +7003,23 @@ def test_volume_menu_file_anchors_route_through_appstate_helper() -> None:
     )
 
 
+def test_log_file_anchors_route_through_appstate_helper() -> None:
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+
+    position_start = log_source.index("static void PositionSavedFileSelection(")
+    restore_start = log_source.index(
+        "\nstatic void RestorePanelFileSelection(", position_start
+    )
+    position_body = log_source[position_start:restore_start]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=", position_body)
+    assert "AppStateCommitPanelFileAnchor(panel, dir_entry)" in position_body
+
+    restore_end = log_source.index("\nstatic void SavePanelTreeSelection(", restore_start)
+    restore_body = log_source[restore_start:restore_end]
+    assert "panel->file_dir_entry = resolved_file_dir;" not in restore_body
+    assert "AppStateCommitPanelFileAnchor(panel, resolved_file_dir)" in restore_body
+
+
 def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- routes log restore file-anchor rebinds through `AppStateCommitPanelFileAnchor`
- keeps file-list rebuild and saved-file positioning after successful anchor commits
- extends the AppState contract guard over log file-anchor writes

## Validation
- Red proof: targeted guard failed before the runtime change because log restore paths wrote `panel->file_dir_entry` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'log_file_anchors_route_through_appstate_helper or panel_file_anchor_clears_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passed with existing warnings
