### PR TITLE
refactor(appstate): route panel anchor file anchors through helper

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -580,7 +580,7 @@ void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,
     if (panel->saved_focus == FOCUS_FILE) {
       target = ResolvePanelAnchorTarget(panel, vol, anchor_path);
       if (target)
-        panel->file_dir_entry = target;
+        (void)AppStateCommitPanelFileAnchor(panel, target);
     }
     return;
   }
@@ -597,7 +597,7 @@ void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,
 
   PositionPanelAtIndex(panel, idx);
   if (panel->saved_focus == FOCUS_FILE)
-    panel->file_dir_entry = target;
+    (void)AppStateCommitPanelFileAnchor(panel, target);
 }
 
 static void FreePanelVolumeFileState(PanelVolumeFileState *state) {
@@ -699,7 +699,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   if (!AppStateCommitPanelFileViewport(dst, src->start_file,
                                        src->file_cursor_pos))
     return FALSE;
-  dst->file_dir_entry = src->file_dir_entry;
+  if (!AppStateCommitPanelFileAnchor(dst, src->file_dir_entry))
+    return FALSE;
   dst->file_mode = src->file_mode;
   dst->max_column = src->max_column;
   if (!AppStateCommitPanelTreeSelection(dst, src->current_dir_entry))
@@ -719,7 +720,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   dst->max_visual_linkname_len = src->max_visual_linkname_len;
   dst->max_visual_userview_len = src->max_visual_userview_len;
   dst->reverse_sort = src->reverse_sort;
-  dst->file_dir_entry = NULL;
+  if (!AppStateCommitPanelFileAnchor(dst, NULL))
+    return FALSE;
   PanelTags_Copy(dst, src);
   if (!source_is_file) {
     if (!AppStateCommitPanelTreeViewport(dst, dst_disp_begin_pos,
@@ -752,7 +754,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
       if (!AppStateCommitPanelFileViewport(dst, dst_start_file,
                                            dst_file_cursor_pos))
         return FALSE;
-      dst->file_dir_entry = (DirEntry *)dst_file_dir_entry;
+      if (!AppStateCommitPanelFileAnchor(dst, (DirEntry *)dst_file_dir_entry))
+        return FALSE;
       if (!AppStateCommitPanelFileSelection(dst, dst_file_selection_dir_path,
                                             dst_file_selection_name))
         return FALSE;
@@ -837,7 +840,7 @@ void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
     idx = FindDirIndexByPath(vol, target_path);
     if (idx >= 0) {
       PositionPanelAtIndex(panel, idx);
-      panel->file_dir_entry = target;
+      (void)AppStateCommitPanelFileAnchor(panel, target);
     }
   }
 }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5806,7 +5806,7 @@ def test_panel_anchor_rebind_fails_closed_before_anchor_state_work() -> None:
         "ResolvePanelAnchorTarget(",
         "RestorePanelViewportSnapshot(",
         "PositionPanelAtIndex(",
-        "panel->file_dir_entry =",
+        "AppStateCommitPanelFileAnchor(",
     ]
 
     assert validation in restore_body
@@ -5828,7 +5828,7 @@ def test_panel_anchor_rebind_fails_closed_before_anchor_state_work() -> None:
         "BuildDirEntryList(",
         "ResolvePanelAnchorTarget(",
         "PositionPanelAtIndex(",
-        "panel->file_dir_entry =",
+        "AppStateCommitPanelFileAnchor(",
     ]
 
     assert validation in ensure_body
@@ -7018,6 +7018,37 @@ def test_log_file_anchors_route_through_appstate_helper() -> None:
     restore_body = log_source[restore_start:restore_end]
     assert "panel->file_dir_entry = resolved_file_dir;" not in restore_body
     assert "AppStateCommitPanelFileAnchor(panel, resolved_file_dir)" in restore_body
+
+
+def test_panel_anchor_file_anchors_route_through_appstate_helper() -> None:
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    restore_start = panel_anchor.index("\nvoid RestorePanelAnchorPath(")
+    free_state_start = panel_anchor.index(
+        "\nstatic void FreePanelVolumeFileState(", restore_start
+    )
+    restore_body = panel_anchor[restore_start:free_state_start]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=", restore_body)
+    assert "AppStateCommitPanelFileAnchor(panel, target)" in restore_body
+
+    donate_start = panel_anchor.index("\nBOOL DonatePanelState(")
+    find_dir_start = panel_anchor.index(
+        "\nDirEntry *FindDirByPathInTree(", donate_start
+    )
+    donate_body = panel_anchor[donate_start:find_dir_start]
+    assert not re.search(r"\bdst->file_dir_entry\s*=", donate_body)
+    assert "AppStateCommitPanelFileAnchor(dst, src->file_dir_entry)" in donate_body
+    assert "AppStateCommitPanelFileAnchor(dst, NULL)" in donate_body
+    assert (
+        "AppStateCommitPanelFileAnchor(dst, (DirEntry *)dst_file_dir_entry)"
+        in donate_body
+    )
+
+    ensure_start = panel_anchor.index("\nvoid EnsurePanelAnchorVisible(")
+    debug_start = panel_anchor.index("\nvoid DebugLogDirLoopState(", ensure_start)
+    ensure_body = panel_anchor[ensure_start:debug_start]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=", ensure_body)
+    assert "AppStateCommitPanelFileAnchor(panel, target)" in ensure_body
 
 
 def test_panel_file_selection_commits_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route panel-anchor file-anchor restore and donation rebinds through `AppStateCommitPanelFileAnchor`.
- Extend the contract guard so panel-anchor restore paths cannot write `file_dir_entry` directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_anchor_file_anchors_route_through_appstate_helper` failed before the runtime change because panel-anchor restore paths wrote `file_dir_entry` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_anchor_file_anchors_route_through_appstate_helper or log_file_anchors_route_through_appstate_helper or panel_file_anchor_clears_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
