### PR TITLE
refactor(appstate): route split transition file anchors through helper

### DIFF
--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -237,7 +237,8 @@ static BOOL PanelHasVisibleFiles(ViewContext *ctx, YtreeNovaPanel *panel,
                                  DirEntry *dir_entry) {
   if (!ctx || !panel || !dir_entry)
     return FALSE;
-  panel->file_dir_entry = dir_entry;
+  if (!AppStateCommitPanelFileAnchor(panel, dir_entry))
+    return FALSE;
   BuildFileEntryList(ctx, panel);
   return panel->file_count > 0;
 }
@@ -268,7 +269,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
       return FALSE;
 
     if (!ctx->is_split_screen) {
-      owner_panel->file_dir_entry = dir_entry;
+      if (!AppStateCommitPanelFileAnchor(owner_panel, dir_entry))
+        return FALSE;
       if (!AppStateCommitPanelFileViewport(owner_panel, dir_entry->start_file,
                                            dir_entry->cursor_pos))
         return FALSE;
@@ -407,7 +409,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
 
       CaptureSplitFilePanelSnapshot(target_panel, &target_panel_snapshot);
 
-      owner_panel->file_dir_entry = dir_entry;
+      if (!AppStateCommitPanelFileAnchor(owner_panel, dir_entry))
+        return FALSE;
       if (!AppStateCommitPanelFileViewport(owner_panel, dir_entry->start_file,
                                            dir_entry->cursor_pos))
         return FALSE;
@@ -432,7 +435,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
                                             &target_panel_snapshot);
     }
 #else
-    owner_panel->file_dir_entry = dir_entry;
+    if (!AppStateCommitPanelFileAnchor(owner_panel, dir_entry))
+      return FALSE;
     if (!AppStateCommitPanelFileViewport(owner_panel, dir_entry->start_file,
                                          dir_entry->cursor_pos))
       return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7051,6 +7051,30 @@ def test_panel_anchor_file_anchors_route_through_appstate_helper() -> None:
     assert "AppStateCommitPanelFileAnchor(panel, target)" in ensure_body
 
 
+def test_split_transition_file_anchors_route_through_appstate_helper() -> None:
+    split_transition = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
+
+    panel_has_start = split_transition.index("\nstatic BOOL PanelHasVisibleFiles(")
+    file_action_start = split_transition.index(
+        "\nBOOL SplitTransition_HandleFileWindowAction(", panel_has_start
+    )
+    panel_has_body = split_transition[panel_has_start:file_action_start]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=", panel_has_body)
+    assert "AppStateCommitPanelFileAnchor(panel, dir_entry)" in panel_has_body
+
+    dir_action_start = split_transition.index(
+        "\nBOOL SplitTransition_HandleDirWindowAction(", file_action_start
+    )
+    file_action_body = split_transition[file_action_start:dir_action_start]
+    assert not re.search(r"\bowner_panel->file_dir_entry\s*=", file_action_body)
+    assert (
+        file_action_body.count(
+            "AppStateCommitPanelFileAnchor(owner_panel, dir_entry)"
+        )
+        >= 3
+    )
+
+
 def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route split-transition file-anchor rebinds through `AppStateCommitPanelFileAnchor`.
- Extend the contract guard so split-transition file-window paths cannot write panel file anchors directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k split_transition_file_anchors_route_through_appstate_helper` failed before the runtime change because split-transition paths wrote `file_dir_entry` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'split_transition_file_anchors_route_through_appstate_helper or panel_anchor_file_anchors_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
