### PR TITLE
refactor(appstate): route file window anchors through helper

### DIFF
--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -275,7 +275,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
     dir_entry->start_file = ctx->active->start_file;
     dir_entry->cursor_pos = ctx->active->file_cursor_pos;
   }
-  ctx->active->file_dir_entry = dir_entry;
+  if (!AppStateCommitPanelFileAnchor(ctx->active, dir_entry))
+    return ESC;
 
   unput_char = '\0';
   fe_ptr = NULL;
@@ -704,7 +705,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
     }
 
     if (ctx->active == owner_panel) {
-      owner_panel->file_dir_entry = dir_entry;
+      if (!AppStateCommitPanelFileAnchor(owner_panel, dir_entry))
+        return ESC;
       (void)AppStateCommitPanelFileViewport(
           owner_panel, dir_entry->start_file, dir_entry->cursor_pos);
     }
@@ -737,7 +739,8 @@ file_window_done:
       return ESC;
   }
   if (!volume_changed) {
-    owner_panel->file_dir_entry = dir_entry;
+    if (!AppStateCommitPanelFileAnchor(owner_panel, dir_entry))
+      return ESC;
     (void)AppStateCommitPanelFileViewport(
         owner_panel, dir_entry->start_file, dir_entry->cursor_pos);
 
@@ -751,7 +754,8 @@ file_window_done:
       dir_entry->big_window = FALSE;
     }
   } else {
-    owner_panel->file_dir_entry = NULL;
+    if (!AppStateCommitPanelFileAnchor(owner_panel, NULL))
+      return ESC;
     (void)AppStateCommitPanelFileViewport(owner_panel, 0, 0);
     if (!AppStateCommitPanelFileShape(owner_panel, FALSE))
       return ESC;

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -125,7 +125,8 @@ BOOL RebindActiveFilePanelSelection(YtreeNovaPanel *panel, DirEntry **dir_entry_
   panel_dir->cursor_pos = panel->file_cursor_pos;
   if (!panel_dir->global_flag && !panel_dir->tagged_flag)
     panel_dir->big_window = panel->saved_big_file_view;
-  panel->file_dir_entry = panel_dir;
+  if (!AppStateCommitPanelFileAnchor(panel, panel_dir))
+    return FALSE;
   *dir_entry_io = panel_dir;
   DebugLogFilePanelState("RebindActiveFilePanelSelection", panel);
   return TRUE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7075,6 +7075,32 @@ def test_split_transition_file_anchors_route_through_appstate_helper() -> None:
     )
 
 
+def test_file_window_file_anchors_route_through_appstate_helper() -> None:
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+
+    rebind_start = ctrl_file_ops.index("\nBOOL RebindActiveFilePanelSelection(")
+    selected_start = ctrl_file_ops.index(
+        "\nstatic FileEntry *GetActivePanelSelectedFile(", rebind_start
+    )
+    rebind_body = ctrl_file_ops[rebind_start:selected_start]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=", rebind_body)
+    assert "AppStateCommitPanelFileAnchor(panel, panel_dir)" in rebind_body
+
+    handle_start = ctrl_file.index("\nint HandleFileWindow(")
+    handle_body = ctrl_file[handle_start:]
+    assert not re.search(
+        r"\b(?:ctx->active|owner_panel)->file_dir_entry\s*=",
+        handle_body,
+    )
+    assert "AppStateCommitPanelFileAnchor(ctx->active, dir_entry)" in handle_body
+    assert (
+        handle_body.count("AppStateCommitPanelFileAnchor(owner_panel, dir_entry)")
+        >= 2
+    )
+    assert "AppStateCommitPanelFileAnchor(owner_panel, NULL)" in handle_body
+
+
 def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route file-window controller file-anchor rebinds through `AppStateCommitPanelFileAnchor`.
- Extend the contract guard so file-window action paths cannot write panel file anchors directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_window_file_anchors_route_through_appstate_helper` failed before the runtime change because file-window paths wrote `file_dir_entry` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_window_file_anchors_route_through_appstate_helper or split_transition_file_anchors_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
