### PR TITLE
refactor(appstate): route directory window anchors through helper

### DIFF
--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -396,7 +396,8 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
       return FALSE;
   }
 
-  ctx->active->file_dir_entry = *dir_entry_ptr;
+  if (!AppStateCommitPanelFileAnchor(ctx->active, *dir_entry_ptr))
+    return FALSE;
   (void)AppStateCommitPanelFileViewport(ctx->active,
                                         (*dir_entry_ptr)->start_file,
                                         (*dir_entry_ptr)->cursor_pos);
@@ -632,7 +633,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       if (dir_entry->cursor_pos < 0 && dir_entry->total_files > 0)
         dir_entry->cursor_pos = 0;
 
-      ctx->active->file_dir_entry = dir_entry;
+      if (!AppStateCommitPanelFileAnchor(ctx->active, dir_entry))
+        return ESC;
       (void)AppStateCommitPanelFileViewport(ctx->active, dir_entry->start_file,
                                             dir_entry->cursor_pos);
       BuildFileEntryList(ctx, ctx->active);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7101,6 +7101,30 @@ def test_file_window_file_anchors_route_through_appstate_helper() -> None:
     assert "AppStateCommitPanelFileAnchor(owner_panel, NULL)" in handle_body
 
 
+def test_dir_window_file_anchors_route_through_appstate_helper() -> None:
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+
+    archive_exit_start = ctrl_dir.index("\nstatic BOOL ExitArchiveRootToParent(")
+    compare_start = ctrl_dir.index(
+        "\nstatic void HandleDirectoryCompare(", archive_exit_start
+    )
+    archive_exit_body = ctrl_dir[archive_exit_start:compare_start]
+    assert not re.search(
+        r"\bctx->active->file_dir_entry\s*=(?!=)",
+        archive_exit_body,
+    )
+    assert (
+        "AppStateCommitPanelFileAnchor(ctx->active, *dir_entry_ptr)"
+        in archive_exit_body
+    )
+
+    handle_start = ctrl_dir.index("\nextern int HandleDirWindow(")
+    dir_list_jump_start = ctrl_dir.index("\nstatic void DirListJump(", handle_start)
+    handle_body = ctrl_dir[handle_start:dir_list_jump_start]
+    assert not re.search(r"\bctx->active->file_dir_entry\s*=(?!=)", handle_body)
+    assert "AppStateCommitPanelFileAnchor(ctx->active, dir_entry)" in handle_body
+
+
 def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route directory-window file-anchor rebinds through `AppStateCommitPanelFileAnchor`.
- Extend the contract guard so directory-window action paths cannot write panel file anchors directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_window_file_anchors_route_through_appstate_helper` failed before the runtime change because directory-window paths wrote `file_dir_entry` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_window_file_anchors_route_through_appstate_helper or file_window_file_anchors_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
