### PR TITLE
refactor(appstate): route directory operation anchors through helper

### DIFF
--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -946,7 +946,8 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
         inactive_dir = inactive->vol->dir_entry_list[inactive_idx].dir_entry;
       }
       if (inactive_dir) {
-        inactive->file_dir_entry = inactive_dir;
+        if (!AppStateCommitPanelFileAnchor(inactive, inactive_dir))
+          return;
         CapturePanelSelectionAnchor(ctx, inactive, inactive_dir);
         (void)snprintf(inactive_file_dir_path, sizeof(inactive_file_dir_path),
                        "%s", inactive->file_selection_dir_path);
@@ -987,8 +988,11 @@ void HandleDirMakeDirectory(ViewContext *ctx, DirEntry *dir_entry,
           DirEntry *resolved_file_dir =
               ResolvePanelAnchorTarget(inactive, inactive->vol,
                                        inactive_file_dir_path);
-          if (resolved_file_dir)
-            inactive->file_dir_entry = resolved_file_dir;
+          if (resolved_file_dir &&
+              !AppStateCommitPanelFileAnchor(inactive, resolved_file_dir)) {
+            FreePathList(inactive_tagged_snapshot);
+            return;
+          }
           if (!AppStateCommitPanelFileViewport(inactive, inactive_start_file,
                                                inactive_file_cursor)) {
             FreePathList(inactive_tagged_snapshot);
@@ -1252,7 +1256,8 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
       if (!dir_entry)
         return;
 
-      p->file_dir_entry = dir_entry;
+      if (!AppStateCommitPanelFileAnchor(p, dir_entry))
+        return;
       if (!AppStateCommitPanelFileViewport(p, dir_entry->start_file,
                                            dir_entry->cursor_pos))
         return;
@@ -1501,7 +1506,8 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
     }
   }
 
-  panel->file_dir_entry = dir_entry;
+  if (!AppStateCommitPanelFileAnchor(panel, dir_entry))
+    return dir_entry;
   if (!AppStateCommitPanelFileViewport(panel, dir_entry->start_file,
                                        dir_entry->cursor_pos))
     return dir_entry;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7125,6 +7125,37 @@ def test_dir_window_file_anchors_route_through_appstate_helper() -> None:
     assert "AppStateCommitPanelFileAnchor(ctx->active, dir_entry)" in handle_body
 
 
+def test_dir_ops_file_anchors_route_through_appstate_helper() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    mkdir_start = dir_ops.index("\nvoid HandleDirMakeDirectory(")
+    delete_start = dir_ops.index(
+        "\nDirEntry *HandleDirDeleteDirectory(", mkdir_start
+    )
+    mkdir_body = dir_ops[mkdir_start:delete_start]
+    assert not re.search(r"\binactive->file_dir_entry\s*=(?!=)", mkdir_body)
+    assert "AppStateCommitPanelFileAnchor(inactive, inactive_dir)" in mkdir_body
+    assert (
+        "AppStateCommitPanelFileAnchor(inactive, resolved_file_dir)"
+        in mkdir_body
+    )
+
+    switch_start = dir_ops.index("\nvoid HandleSwitchWindow(")
+    sync_start = dir_ops.index("\nvoid SyncActivePanelWindows(", switch_start)
+    switch_body = dir_ops[switch_start:sync_start]
+    assert not re.search(r"\bp->file_dir_entry\s*=(?!=)", switch_body)
+    assert "AppStateCommitPanelFileAnchor(p, dir_entry)" in switch_body
+
+    restore_start = dir_ops.index("\nDirEntry *RestorePanelFileSelection(")
+    panel_action_start = dir_ops.index(
+        "\nDirWindowDispatchResult\nHandleDirWindowPanelAction(",
+        restore_start,
+    )
+    restore_body = dir_ops[restore_start:panel_action_start]
+    assert not re.search(r"\bpanel->file_dir_entry\s*=(?!=)", restore_body)
+    assert "AppStateCommitPanelFileAnchor(panel, dir_entry)" in restore_body
+
+
 def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route directory-operation file-anchor rebinds through `AppStateCommitPanelFileAnchor`.
- Extend the contract guard so directory-operation restore paths cannot write panel file anchors directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_file_anchors_route_through_appstate_helper` failed before the runtime change because directory-operation paths wrote `file_dir_entry` directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_file_anchors_route_through_appstate_helper or dir_window_file_anchors_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
