### PR TITLE
refactor(appstate): route tree viewport top paths through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -19,6 +19,8 @@ BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *file_name);
 BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
                                       int current_dir_entry);
+BOOL AppStateCommitPanelTreeViewportTopPaths(YtreeNovaPanel *panel,
+                                             const YtreeNovaPanel *source);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos);
 BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -9,6 +9,7 @@
 
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_panel.h"
+#include <string.h>
 
 BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel) {
   if (!AppStateValidatedOwnerField("panel.panel_generation"))
@@ -80,6 +81,18 @@ BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
     return FALSE;
 
   panel->current_dir_entry = current_dir_entry;
+  return TRUE;
+}
+
+BOOL AppStateCommitPanelTreeViewportTopPaths(YtreeNovaPanel *panel,
+                                             const YtreeNovaPanel *source) {
+  if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
+    return FALSE;
+  if (!panel || !source)
+    return FALSE;
+
+  memcpy(panel->tree_viewport_top_dir_path, source->tree_viewport_top_dir_path,
+         sizeof(panel->tree_viewport_top_dir_path));
   return TRUE;
 }
 

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -694,8 +694,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   if (!AppStateCommitPanelTreeViewport(dst, src->disp_begin_pos,
                                        src->cursor_pos))
     return FALSE;
-  memcpy(dst->tree_viewport_top_dir_path, src->tree_viewport_top_dir_path,
-         sizeof(dst->tree_viewport_top_dir_path));
+  if (!AppStateCommitPanelTreeViewportTopPaths(dst, src))
+    return FALSE;
   if (!AppStateCommitPanelFileViewport(dst, src->start_file,
                                        src->file_cursor_pos))
     return FALSE;

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -328,9 +328,8 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
                                                ctx->left->disp_begin_pos,
                                                ctx->left->cursor_pos))
             return FALSE;
-          memcpy(ctx->right->tree_viewport_top_dir_path,
-                 ctx->left->tree_viewport_top_dir_path,
-                 sizeof(ctx->right->tree_viewport_top_dir_path));
+          if (!AppStateCommitPanelTreeViewportTopPaths(ctx->right, ctx->left))
+            return FALSE;
           if (!AppStateCommitPanelVisibilityFilter(ctx->right,
                                                    ctx->left->hide_dot_files))
             return FALSE;
@@ -557,9 +556,8 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
                                                ctx->left->disp_begin_pos,
                                                ctx->left->cursor_pos))
             return FALSE;
-          memcpy(ctx->right->tree_viewport_top_dir_path,
-                 ctx->left->tree_viewport_top_dir_path,
-                 sizeof(ctx->right->tree_viewport_top_dir_path));
+          if (!AppStateCommitPanelTreeViewportTopPaths(ctx->right, ctx->left))
+            return FALSE;
           if (!AppStateCommitPanelFileViewport(ctx->right,
                                                ctx->left->start_file,
                                                ctx->left->file_cursor_pos))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6658,6 +6658,47 @@ def test_panel_anchor_viewport_generation_commits_through_appstate_helper() -> N
     assert restore_body.count("AppStateCommitPanelGeneration(panel)") == 1
 
 
+def test_panel_tree_viewport_top_paths_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
+
+    assert "BOOL AppStateCommitPanelTreeViewportTopPaths(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelTreeViewportTopPaths(")
+    helper_end = helper.index("\nBOOL AppStateCommitPanelFileViewport(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("panel.restore_snapshot")'
+    copy_call = (
+        "memcpy(panel->tree_viewport_top_dir_path, "
+        "source->tree_viewport_top_dir_path,"
+    )
+    assert validation in helper_body
+    assert copy_call in helper_body
+    assert helper_body.index(validation) < helper_body.index(copy_call)
+
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+    assert "memcpy(dst->tree_viewport_top_dir_path" not in donate_body
+    assert "AppStateCommitPanelTreeViewportTopPaths(dst, src)" in donate_body
+
+    file_split_start = split_transition.index(
+        "BOOL SplitTransition_HandleFileWindowAction("
+    )
+    dir_split_start = split_transition.index(
+        "\nBOOL SplitTransition_HandleDirWindowAction(", file_split_start
+    )
+    file_split_body = split_transition[file_split_start:dir_split_start]
+    dir_split_body = split_transition[dir_split_start:]
+    for body in [file_split_body, dir_split_body]:
+        assert "memcpy(ctx->right->tree_viewport_top_dir_path" not in body
+        assert "AppStateCommitPanelTreeViewportTopPaths(ctx->right, ctx->left)" in body
+
+
 def test_panel_generation_restores_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState panel helper for restore-snapshot tree viewport top-path copies.
- Route panel donation and split seeding through that helper instead of copying restore-snapshot storage directly.
- Extend the contract guard so these top-path copies validate the `panel.restore_snapshot` owner boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_top_paths_route_through_appstate_helper` failed before the helper change because the helper did not exist and copy sites wrote restore-snapshot top paths directly.
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_top_paths_route_through_appstate_helper`
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_tree_viewport_top_paths_route_through_appstate_helper or panel_tree_viewport_commits_route_through_appstate_helper or panel_anchor_viewport_generation_commits_through_appstate_helper'`
- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Passed: `make clean && make` with existing warnings.
