### PR TITLE
refactor(appstate): route tree viewport top path updates through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -19,6 +19,8 @@ BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *file_name);
 BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
                                       int current_dir_entry);
+BOOL AppStateCommitPanelTreeViewportTopPath(YtreeNovaPanel *panel, int slot,
+                                            const char *top_path);
 BOOL AppStateCommitPanelTreeViewportTopPaths(YtreeNovaPanel *panel,
                                              const YtreeNovaPanel *source);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -84,6 +84,23 @@ BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelTreeViewportTopPath(YtreeNovaPanel *panel, int slot,
+                                            const char *top_path) {
+  if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
+    return FALSE;
+  if (!panel || slot < 0 || slot >= 2)
+    return FALSE;
+
+  panel->tree_viewport_top_dir_path[slot][0] = '\0';
+  if (top_path) {
+    (void)snprintf(panel->tree_viewport_top_dir_path[slot],
+                   sizeof(panel->tree_viewport_top_dir_path[slot]), "%s",
+                   top_path);
+    panel->tree_viewport_top_dir_path[slot][PATH_LENGTH] = '\0';
+  }
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelTreeViewportTopPaths(YtreeNovaPanel *panel,
                                              const YtreeNovaPanel *source) {
   if (!AppStateValidatedOwnerField("panel.restore_snapshot"))

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -43,20 +43,22 @@ static int FindTopVisibleDirIndex(const YtreeNovaPanel *panel) {
 void RememberPanelViewportTop(YtreeNovaPanel *panel) {
   int idx;
   int slot;
+  char top_path[PATH_LENGTH + 1];
 
   if (!panel)
     return;
 
   slot = PanelViewportSlot(panel);
-  panel->tree_viewport_top_dir_path[slot][0] = '\0';
+  if (!AppStateCommitPanelTreeViewportTopPath(panel, slot, NULL))
+    return;
 
   idx = FindTopVisibleDirIndex(panel);
   if (idx < 0)
     return;
 
-  GetPath(panel->vol->dir_entry_list[idx].dir_entry,
-          panel->tree_viewport_top_dir_path[slot]);
-  panel->tree_viewport_top_dir_path[slot][PATH_LENGTH] = '\0';
+  GetPath(panel->vol->dir_entry_list[idx].dir_entry, top_path);
+  top_path[PATH_LENGTH] = '\0';
+  (void)AppStateCommitPanelTreeViewportTopPath(panel, slot, top_path);
 }
 
 BOOL CapturePanelAnchorPath(const YtreeNovaPanel *panel, const struct Volume *vol,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6699,6 +6699,34 @@ def test_panel_tree_viewport_top_paths_route_through_appstate_helper() -> None:
         assert "AppStateCommitPanelTreeViewportTopPaths(ctx->right, ctx->left)" in body
 
 
+def test_panel_tree_viewport_top_path_updates_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelTreeViewportTopPath(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelTreeViewportTopPath(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitPanelTreeViewportTopPaths(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("panel.restore_snapshot")'
+    top_path_write = "panel->tree_viewport_top_dir_path[slot][0] = '\\0';"
+    assert validation in helper_body
+    assert top_path_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(top_path_write)
+
+    remember_start = panel_anchor.index("void RememberPanelViewportTop(")
+    remember_end = panel_anchor.index("\nBOOL CapturePanelAnchorPath(", remember_start)
+    remember_body = panel_anchor[remember_start:remember_end]
+    assert "panel->tree_viewport_top_dir_path[slot]" not in remember_body
+    assert "AppStateCommitPanelTreeViewportTopPath(panel, slot, NULL)" in remember_body
+    assert "AppStateCommitPanelTreeViewportTopPath(panel, slot, top_path)" in (
+        remember_body
+    )
+
+
 def test_panel_generation_restores_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an AppState helper for single tree viewport top-path slot commits
- route RememberPanelViewportTop through the helper before writing restore snapshot state
- extend the AppState contract guard for the slot-level path boundary

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_tree_viewport_top_path_updates_route_through_appstate_helper` failed before the helper was implemented.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_tree_viewport_top_path_updates_route_through_appstate_helper or panel_tree_viewport_top_paths_route_through_appstate_helper or panel_anchor_viewport_generation_commits_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` (passes with existing warnings)
