### PR TITLE
refactor(appstate): route panel tree snapshots through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -23,6 +23,11 @@ BOOL AppStateCommitPanelTreeViewportTopPath(YtreeNovaPanel *panel, int slot,
                                             const char *top_path);
 BOOL AppStateCommitPanelTreeViewportTopPaths(YtreeNovaPanel *panel,
                                              const YtreeNovaPanel *source);
+BOOL AppStateCommitPanelVolumeTreeViewportSnapshot(
+    PanelVolumeFileState *state, unsigned int panel_generation,
+    unsigned int volume_generation, BOOL has_selected_dir_path,
+    const char *selected_dir_path, BOOL has_top_dir_path,
+    const char *top_dir_path);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos);
 BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -113,6 +113,37 @@ BOOL AppStateCommitPanelTreeViewportTopPaths(YtreeNovaPanel *panel,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelVolumeTreeViewportSnapshot(
+    PanelVolumeFileState *state, unsigned int panel_generation,
+    unsigned int volume_generation, BOOL has_selected_dir_path,
+    const char *selected_dir_path, BOOL has_top_dir_path,
+    const char *top_dir_path) {
+  if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
+    return FALSE;
+  if (!state)
+    return FALSE;
+
+  state->saved_tree_panel_generation = panel_generation;
+  state->saved_tree_volume_generation = volume_generation;
+  state->has_saved_tree_selection = has_selected_dir_path;
+  state->has_saved_tree_top = has_top_dir_path;
+  state->saved_tree_selected_dir_path[0] = '\0';
+  state->saved_tree_top_dir_path[0] = '\0';
+  if (has_selected_dir_path && selected_dir_path) {
+    (void)snprintf(state->saved_tree_selected_dir_path,
+                   sizeof(state->saved_tree_selected_dir_path), "%s",
+                   selected_dir_path);
+    state->saved_tree_selected_dir_path[PATH_LENGTH] = '\0';
+  }
+  if (has_top_dir_path && top_dir_path) {
+    (void)snprintf(state->saved_tree_top_dir_path,
+                   sizeof(state->saved_tree_top_dir_path), "%s",
+                   top_dir_path);
+    state->saved_tree_top_dir_path[PATH_LENGTH] = '\0';
+  }
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos) {
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -167,25 +167,11 @@ void SavePanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
     return;
   state = GetPanelVolumeFileState(panel, panel->vol->id);
   CapturePanelViewportSnapshot(panel, panel->vol, &snapshot);
-  state->saved_tree_panel_generation = panel->panel_generation;
-  state->saved_tree_volume_generation = panel->vol->volume_generation;
-  state->has_saved_tree_selection = snapshot.has_selected_dir_path;
-  state->has_saved_tree_top = snapshot.has_top_dir_path;
-  state->saved_tree_selected_dir_path[0] = '\0';
-  state->saved_tree_top_dir_path[0] = '\0';
-  if (snapshot.has_selected_dir_path) {
-    (void)snprintf(state->saved_tree_selected_dir_path,
-                   sizeof(state->saved_tree_selected_dir_path), "%s",
-                   snapshot.selected_dir_path);
-    state->saved_tree_selected_dir_path[PATH_LENGTH] = '\0';
-  }
-  if (snapshot.has_top_dir_path) {
-    (void)snprintf(state->saved_tree_top_dir_path,
-                   sizeof(state->saved_tree_top_dir_path), "%s",
-                   snapshot.top_dir_path);
-    state->saved_tree_top_dir_path[PATH_LENGTH] = '\0';
-  }
-
+  if (!AppStateCommitPanelVolumeTreeViewportSnapshot(
+          state, panel->panel_generation, panel->vol->volume_generation,
+          snapshot.has_selected_dir_path, snapshot.selected_dir_path,
+          snapshot.has_top_dir_path, snapshot.top_dir_path))
+    return;
 }
 
 void ResetPanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
@@ -195,12 +181,10 @@ void ResetPanelTreeViewportSnapshot(YtreeNovaPanel *panel) {
     return;
 
   state = GetPanelVolumeFileState(panel, panel->vol->id);
-  state->saved_tree_panel_generation = panel->panel_generation;
-  state->saved_tree_volume_generation = panel->vol->volume_generation;
-  state->has_saved_tree_selection = FALSE;
-  state->has_saved_tree_top = FALSE;
-  state->saved_tree_selected_dir_path[0] = '\0';
-  state->saved_tree_top_dir_path[0] = '\0';
+  if (!AppStateCommitPanelVolumeTreeViewportSnapshot(
+          state, panel->panel_generation, panel->vol->volume_generation, FALSE,
+          NULL, FALSE, NULL))
+    return;
 }
 
 int FindDirIndexByPath(const struct Volume *vol, const char *path) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6727,6 +6727,49 @@ def test_panel_tree_viewport_top_path_updates_route_through_appstate_helper() ->
     )
 
 
+def test_panel_volume_tree_viewport_snapshot_routes_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelVolumeTreeViewportSnapshot(" in header
+
+    helper_start = helper.index(
+        "BOOL AppStateCommitPanelVolumeTreeViewportSnapshot("
+    )
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitPanelFileViewport(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("panel.restore_snapshot")'
+    generation_write = "state->saved_tree_panel_generation = panel_generation;"
+    selected_path_write = "state->saved_tree_selected_dir_path[0] = '\\0';"
+    top_path_write = "state->saved_tree_top_dir_path[0] = '\\0';"
+    assert validation in helper_body
+    assert generation_write in helper_body
+    assert selected_path_write in helper_body
+    assert top_path_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(generation_write)
+    assert helper_body.index(validation) < helper_body.index(selected_path_write)
+    assert helper_body.index(validation) < helper_body.index(top_path_write)
+
+    save_start = panel_anchor.index("void SavePanelTreeViewportSnapshot(")
+    reset_start = panel_anchor.index(
+        "\nvoid ResetPanelTreeViewportSnapshot(", save_start
+    )
+    save_body = panel_anchor[save_start:reset_start]
+    reset_end = panel_anchor.index("\nint FindDirIndexByPath(", reset_start)
+    reset_body = panel_anchor[reset_start:reset_end]
+    for body in [save_body, reset_body]:
+        assert "state->saved_tree_panel_generation =" not in body
+        assert "state->saved_tree_volume_generation =" not in body
+        assert "state->has_saved_tree_selection =" not in body
+        assert "state->has_saved_tree_top =" not in body
+        assert "state->saved_tree_selected_dir_path" not in body
+        assert "state->saved_tree_top_dir_path" not in body
+        assert "AppStateCommitPanelVolumeTreeViewportSnapshot(" in body
+
+
 def test_panel_generation_restores_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -321,13 +321,12 @@ def test_volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb():
         )
 
     assert "CapturePanelViewportSnapshot(panel, panel->vol, &snapshot);" in save_source
-    assert "state->saved_tree_panel_generation = panel->panel_generation;" in save_source
     assert (
-        "state->saved_tree_volume_generation = panel->vol->volume_generation;"
+        "AppStateCommitPanelVolumeTreeViewportSnapshot("
         in save_source
     )
     assert (
-        "snprintf(state->saved_tree_selected_dir_path,"
+        "snapshot.has_selected_dir_path, snapshot.selected_dir_path,"
         in save_source
     ), save_source
 
@@ -366,8 +365,11 @@ def test_log_disk_restore_does_not_use_volume_tree_breadcrumbs():
     assert "panel->disp_begin_pos = 0;" not in log_disk_source
     assert "panel->cursor_pos = 0;" not in log_disk_source
     assert "ResetPanelTreeViewportSnapshot(panel);" in log_disk_source
-    assert "state->has_saved_tree_selection = FALSE;" in reset_snapshot_source
-    assert "state->has_saved_tree_top = FALSE;" in reset_snapshot_source
+    assert (
+        "AppStateCommitPanelVolumeTreeViewportSnapshot("
+        in reset_snapshot_source
+    )
+    assert "NULL, FALSE, NULL" in reset_snapshot_source
     assert "saved_tree_index" not in reset_snapshot_source
     assert "saved_tree_generation" not in reset_snapshot_source
 


### PR DESCRIPTION
## Summary
- add an AppState helper for per-volume panel tree viewport snapshot state
- route panel tree snapshot save and reset paths through the helper
- extend the AppState contract and dispatch regression guards for the restore snapshot boundary

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_tree_viewport_snapshot_routes_through_appstate_helper` failed before the helper was implemented.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_tree_viewport_snapshot_routes_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k 'volume_tree_restore_uses_panel_path_snapshot_before_index_breadcrumb or log_disk_restore_does_not_use_volume_tree_breadcrumbs'`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_volume_tree_viewport_snapshot_routes_through_appstate_helper or panel_tree_viewport_top_path_updates_route_through_appstate_helper or panel_tree_viewport_top_paths_route_through_appstate_helper or panel_anchor_viewport_generation_commits_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` (passes with existing warnings)
- `make qa-code-quality`