### PR TITLE
refactor(appstate): route panel file snapshots through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -28,6 +28,11 @@ BOOL AppStateCommitPanelVolumeTreeViewportSnapshot(
     unsigned int volume_generation, BOOL has_selected_dir_path,
     const char *selected_dir_path, BOOL has_top_dir_path,
     const char *top_dir_path);
+BOOL AppStateCommitPanelVolumeFileSnapshot(
+    PanelVolumeFileState *state, int start_file, int file_cursor_pos,
+    unsigned int panel_generation, unsigned int volume_generation,
+    ViewFocus focus, BOOL big_file_view, const char *file_dir_path,
+    const char *file_selection_dir_path, const char *file_selection_name);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos);
 BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -32,6 +32,8 @@ static void ResetPanelFileContext(YtreeNovaPanel *panel) {
 
 static void SavePanelFileSelection(YtreeNovaPanel *panel) {
   PanelVolumeFileState *state;
+  char saved_file_dir_path[PATH_LENGTH + 1];
+  BOOL saved_big_file_view = FALSE;
 
   if (!panel || !panel->vol)
     return;
@@ -39,33 +41,25 @@ static void SavePanelFileSelection(YtreeNovaPanel *panel) {
          panel->file_selection_dir_path[0] != '\0');
 
   state = GetPanelVolumeFileState(panel, panel->vol->id);
-  state->saved_file_start = panel->start_file;
-  state->saved_file_cursor = panel->file_cursor_pos;
-  state->saved_panel_generation = panel->panel_generation;
-  state->saved_volume_generation = panel->vol->volume_generation;
-  state->saved_focus = panel->saved_focus;
-  state->saved_big_file_view = FALSE;
-
-  state->saved_file_dir_path[0] = '\0';
+  saved_file_dir_path[0] = '\0';
   if (panel->file_selection_dir_path[0] != '\0') {
-    (void)snprintf(state->saved_file_dir_path,
-                   sizeof(state->saved_file_dir_path), "%s",
+    (void)snprintf(saved_file_dir_path, sizeof(saved_file_dir_path), "%s",
                    panel->file_selection_dir_path);
-    state->saved_file_dir_path[PATH_LENGTH] = '\0';
+    saved_file_dir_path[PATH_LENGTH] = '\0';
   } else if (panel->file_dir_entry != NULL) {
-    GetPath(panel->file_dir_entry, state->saved_file_dir_path);
-    state->saved_file_dir_path[PATH_LENGTH] = '\0';
+    GetPath(panel->file_dir_entry, saved_file_dir_path);
+    saved_file_dir_path[PATH_LENGTH] = '\0';
   }
   if (panel->file_dir_entry != NULL)
-    state->saved_big_file_view = panel->file_dir_entry->big_window;
-  (void)AppStateCommitPanelFileShape(panel, state->saved_big_file_view);
-
-  (void)snprintf(state->saved_file_selection_name,
-                 sizeof(state->saved_file_selection_name), "%s",
-                 panel->file_selection_name);
-  (void)snprintf(state->saved_file_selection_dir_path,
-                 sizeof(state->saved_file_selection_dir_path), "%s",
-                 panel->file_selection_dir_path);
+    saved_big_file_view = panel->file_dir_entry->big_window;
+  if (!AppStateCommitPanelVolumeFileSnapshot(
+          state, panel->start_file, panel->file_cursor_pos,
+          panel->panel_generation, panel->vol->volume_generation,
+          panel->saved_focus, saved_big_file_view, saved_file_dir_path,
+          panel->file_selection_dir_path, panel->file_selection_name))
+    return;
+  if (!AppStateCommitPanelFileShape(panel, saved_big_file_view))
+    return;
 }
 
 static void PositionSavedFileSelection(ViewContext *ctx, YtreeNovaPanel *panel,

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -144,6 +144,45 @@ BOOL AppStateCommitPanelVolumeTreeViewportSnapshot(
   return TRUE;
 }
 
+BOOL AppStateCommitPanelVolumeFileSnapshot(
+    PanelVolumeFileState *state, int start_file, int file_cursor_pos,
+    unsigned int panel_generation, unsigned int volume_generation,
+    ViewFocus focus, BOOL big_file_view, const char *file_dir_path,
+    const char *file_selection_dir_path, const char *file_selection_name) {
+  if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
+    return FALSE;
+  if (!state)
+    return FALSE;
+
+  state->saved_file_start = start_file;
+  state->saved_file_cursor = file_cursor_pos;
+  state->saved_panel_generation = panel_generation;
+  state->saved_volume_generation = volume_generation;
+  state->saved_focus = focus;
+  state->saved_big_file_view = big_file_view;
+  state->saved_file_dir_path[0] = '\0';
+  state->saved_file_selection_dir_path[0] = '\0';
+  state->saved_file_selection_name[0] = '\0';
+  if (file_dir_path) {
+    (void)snprintf(state->saved_file_dir_path,
+                   sizeof(state->saved_file_dir_path), "%s", file_dir_path);
+    state->saved_file_dir_path[PATH_LENGTH] = '\0';
+  }
+  if (file_selection_dir_path) {
+    (void)snprintf(state->saved_file_selection_dir_path,
+                   sizeof(state->saved_file_selection_dir_path), "%s",
+                   file_selection_dir_path);
+    state->saved_file_selection_dir_path[PATH_LENGTH] = '\0';
+  }
+  if (file_selection_name) {
+    (void)snprintf(state->saved_file_selection_name,
+                   sizeof(state->saved_file_selection_name), "%s",
+                   file_selection_name);
+    state->saved_file_selection_name[PATH_LENGTH] = '\0';
+  }
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos) {
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6770,6 +6770,39 @@ def test_panel_volume_tree_viewport_snapshot_routes_through_appstate_helper() ->
         assert "AppStateCommitPanelVolumeTreeViewportSnapshot(" in body
 
 
+def test_panel_volume_file_snapshot_routes_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPanelVolumeFileSnapshot(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelVolumeFileSnapshot(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitPanelFileViewport(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("panel.restore_snapshot")'
+    viewport_write = "state->saved_file_start = start_file;"
+    selection_write = "state->saved_file_selection_dir_path[0] = '\\0';"
+    assert validation in helper_body
+    assert viewport_write in helper_body
+    assert selection_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(viewport_write)
+    assert helper_body.index(validation) < helper_body.index(selection_write)
+
+    save_start = log_source.index("static void SavePanelFileSelection(")
+    save_end = log_source.index("\nstatic void RestorePanelFileSelection(", save_start)
+    save_body = log_source[save_start:save_end]
+    assert "state->saved_file_" not in save_body
+    assert "state->saved_panel_generation =" not in save_body
+    assert "state->saved_volume_generation =" not in save_body
+    assert "state->saved_focus =" not in save_body
+    assert "state->saved_big_file_view =" not in save_body
+    assert "AppStateCommitPanelVolumeFileSnapshot(" in save_body
+    assert "AppStateCommitPanelFileShape(panel, saved_big_file_view)" in save_body
+
+
 def test_panel_generation_restores_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
@@ -8147,7 +8180,7 @@ def test_panel_file_shape_commits_use_appstate_helper() -> None:
         assert not direct_panel_shape_write.search(source)
 
     assert "AppStateCommitPanelFileShape(ctx->left, FALSE)" in sources["src/core/init.c"]
-    assert "AppStateCommitPanelFileShape(panel, state->saved_big_file_view)" in sources[
+    assert "AppStateCommitPanelFileShape(panel, saved_big_file_view)" in sources[
         "src/cmd/log.c"
     ]
     assert "AppStateCommitPanelFileShape(ctx->active, FALSE)" in sources[

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -271,8 +271,8 @@ def test_restore_snapshots_validate_generation_before_reuse():
             f"Missing generation field declaration: {needle}\n{defs_source}"
         )
 
-    assert "state->saved_panel_generation = panel->panel_generation;" in log_source
-    assert "state->saved_volume_generation = panel->vol->volume_generation;" in log_source
+    assert "AppStateCommitPanelVolumeFileSnapshot(" in log_source
+    assert "panel->panel_generation, panel->vol->volume_generation" in log_source
     assert "state->saved_panel_generation != panel->panel_generation" in log_source
     assert "state->saved_volume_generation != vol->volume_generation" in log_source
     assert "generation_valid =" in panel_anchor_source


### PR DESCRIPTION
## Summary
- add an AppState helper for per-volume panel file snapshot state
- route log-time file snapshot saves through the helper instead of direct saved-file writes
- extend the AppState contract and dispatch regression guards for the file snapshot boundary

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_file_snapshot_routes_through_appstate_helper` failed before the helper was implemented.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_file_snapshot_routes_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_volume_file_snapshot_routes_through_appstate_helper or panel_file_shape_commits_use_appstate_helper or panel_volume_tree_viewport_snapshot_routes_through_appstate_helper'`
- `source .venv/bin/activate && pytest tests/test_dir_window_dispatch_regressions.py -q -k restore_snapshots_validate_generation_before_reuse`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` (passes with existing warnings)
