### PR TITLE
refactor(appstate): route panel snapshot list ownership through helper

### DIFF
--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -14,6 +14,8 @@ BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel);
 BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
                                     unsigned int panel_generation);
 BOOL AppStateCommitPanelVolume(YtreeNovaPanel *panel, struct Volume *vol);
+BOOL AppStateSetPanelVolumeFileStateList(
+    YtreeNovaPanel *panel, PanelVolumeFileState *volume_file_state);
 BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *dir_path,
                                       const char *file_name);

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -45,6 +45,17 @@ BOOL AppStateCommitPanelVolume(YtreeNovaPanel *panel, struct Volume *vol) {
   return TRUE;
 }
 
+BOOL AppStateSetPanelVolumeFileStateList(
+    YtreeNovaPanel *panel, PanelVolumeFileState *volume_file_state) {
+  if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->volume_file_state = volume_file_state;
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *dir_path,
                                       const char *file_name) {

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -156,7 +156,10 @@ PanelVolumeFileState *GetPanelVolumeFileState(YtreeNovaPanel *panel,
   state = (PanelVolumeFileState *)xcalloc(1, sizeof(PanelVolumeFileState));
   state->volume_id = volume_id;
   state->next = panel->volume_file_state;
-  panel->volume_file_state = state;
+  if (!AppStateSetPanelVolumeFileStateList(panel, state)) {
+    free(state);
+    return NULL;
+  }
   return state;
 }
 
@@ -627,6 +630,7 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   unsigned int dst_panel_generation;
   char dst_file_selection_name[PATH_LENGTH + 1];
   char dst_file_selection_dir_path[PATH_LENGTH + 1];
+  PanelVolumeFileState *dst_volume_state_head;
   const PanelVolumeFileState *dst_volume_state;
   const PanelVolumeFileState *dst_current_volume_state;
   PanelVolumeFileState *volume_file_state;
@@ -652,7 +656,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
   (void)snprintf(dst_file_selection_dir_path,
                  sizeof(dst_file_selection_dir_path), "%s",
                  dst->file_selection_dir_path);
-  dst_volume_state = dst->volume_file_state;
+  dst_volume_state_head = dst->volume_file_state;
+  dst_volume_state = dst_volume_state_head;
   dst_current_volume_state = NULL;
   if (dst->vol) {
     for (; dst_volume_state; dst_volume_state = dst_volume_state->next) {
@@ -751,8 +756,12 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
     if (!AppStateCommitPanelFocus(ctx, dst, FOCUS_TREE))
       return FALSE;
   } else {
-    FreePanelVolumeFileState(dst->volume_file_state);
-    dst->volume_file_state = volume_file_state;
+    if (!AppStateSetPanelVolumeFileStateList(dst, volume_file_state)) {
+      FreePanelVolumeFileState(volume_file_state);
+      return FALSE;
+    }
+    volume_file_state = NULL;
+    FreePanelVolumeFileState(dst_volume_state_head);
   }
   if (!AppStateCommitPanelVisibilityFilter(dst, src->hide_dot_files))
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6803,6 +6803,37 @@ def test_panel_volume_file_snapshot_routes_through_appstate_helper() -> None:
     assert "AppStateCommitPanelFileShape(panel, saved_big_file_view)" in save_body
 
 
+def test_panel_volume_file_state_list_routes_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateSetPanelVolumeFileStateList(" in header
+
+    helper_start = helper.index("BOOL AppStateSetPanelVolumeFileStateList(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitPanelFileSelection(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("panel.restore_snapshot")'
+    assignment = "panel->volume_file_state = volume_file_state;"
+    assert validation in helper_body
+    assert assignment in helper_body
+    assert helper_body.index(validation) < helper_body.index(assignment)
+
+    get_start = panel_anchor.index("PanelVolumeFileState *GetPanelVolumeFileState(")
+    save_start = panel_anchor.index("\nvoid SavePanelTreeViewportSnapshot(", get_start)
+    get_body = panel_anchor[get_start:save_start]
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+
+    assert "panel->volume_file_state = state;" not in get_body
+    assert "AppStateSetPanelVolumeFileStateList(panel, state)" in get_body
+    assert "dst->volume_file_state = volume_file_state;" not in donate_body
+    assert "AppStateSetPanelVolumeFileStateList(dst, volume_file_state)" in donate_body
+
+
 def test_panel_generation_restores_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an AppState helper for panel snapshot list ownership updates
- route per-volume snapshot list insertion and donation adoption through the helper
- extend the AppState contract guard for the restore snapshot list boundary

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_file_state_list_routes_through_appstate_helper` failed before the helper was implemented.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_volume_file_state_list_routes_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_volume_file_state_list_routes_through_appstate_helper or panel_volume_file_snapshot_routes_through_appstate_helper or panel_volume_tree_viewport_snapshot_routes_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` (passes with existing warnings)
