### PR TITLE
refactor(appstate): route global search term updates through helper

### DIFF
--- a/include/ytnova_appstate_session.h
+++ b/include/ytnova_appstate_session.h
@@ -11,5 +11,6 @@
 #include "ytnova_defs.h"
 
 BOOL AppStateCommitActivePanel(ViewContext *ctx, YtreeNovaPanel *panel);
+BOOL AppStateCommitGlobalSearchTerm(ViewContext *ctx, const char *term);
 
 #endif /* YTNOVA_APPSTATE_SESSION_H */

--- a/include/ytnova_cmd.h
+++ b/include/ytnova_cmd.h
@@ -220,6 +220,6 @@ extern int UI_ArchiveCallback(int status, const char *msg, void *user_data);
 extern void RefreshView(ViewContext *ctx, DirEntry *dir_entry);
 extern int GetCommandLine(ViewContext *ctx, char *command_line);
 extern int GetSearchCommandLine(ViewContext *ctx, char *command_line,
-                                char *raw_pattern);
+                                char *search_pattern);
 
 #endif /* YTNOVA_CMD_H */

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -9,6 +9,7 @@
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_session.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
 #include <assert.h>
@@ -310,7 +311,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
         if (state && !AppStateRestorePanelGeneration(
                          panel, state->saved_tree_panel_generation))
           return -1;
-        ctx->global_search_term[0] = '\0';
+        if (!AppStateCommitGlobalSearchTerm(ctx, NULL))
+          return -1;
         if (!AppStateCommitViewMode(ctx, panel->vol->vol_stats.log_mode))
           return -1;
 
@@ -464,7 +466,8 @@ int LogDisk(ViewContext *ctx, YtreeNovaPanel *panel, char *path) {
   if (!AppStateCommitPanelFocus(ctx, panel,
                                 (ViewFocus)panel->vol->saved_focus))
     return -1;
-  ctx->global_search_term[0] = '\0';
+  if (!AppStateCommitGlobalSearchTerm(ctx, NULL))
+    return -1;
   if (!AppStateCommitViewMode(ctx, s->log_mode))
     return -1;
 

--- a/src/ui/appstate_session.c
+++ b/src/ui/appstate_session.c
@@ -21,3 +21,18 @@ BOOL AppStateCommitActivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
   ctx->active = panel;
   return TRUE;
 }
+
+BOOL AppStateCommitGlobalSearchTerm(ViewContext *ctx, const char *term) {
+  if (!AppStateValidatedOwnerField("ctx.command_state"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->global_search_term[0] = '\0';
+  if (term) {
+    (void)snprintf(ctx->global_search_term, sizeof(ctx->global_search_term),
+                   "%s", term);
+    ctx->global_search_term[sizeof(ctx->global_search_term) - 1] = '\0';
+  }
+  return TRUE;
+}

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -335,7 +335,8 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
 
   *s_ptr = &ctx->active->vol->vol_stats;
   *start_vol_ptr = ctx->active->vol;
-  ctx->global_search_term[0] = '\0';
+  if (!AppStateCommitGlobalSearchTerm(ctx, NULL))
+    return FALSE;
 
   if (ctx->active->vol->total_dirs > 0) {
     *dir_entry_ptr = ctx->active->vol

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -1424,6 +1424,7 @@ static BOOL HandleTaggedFileOpDispatchAction(
       MESSAGE(ctx, "^S is not available in archive mode");
     } else {
       char *command_line;
+      char search_pattern[256];
 
       if ((command_line = (char *)malloc(COMMAND_LINE_LENGTH + 1)) == NULL) {
         UI_Error(ctx, "", 0, "Malloc failed");
@@ -1442,9 +1443,15 @@ static BOOL HandleTaggedFileOpDispatchAction(
 
       need_dsp_help = TRUE;
       *command_line = '\0';
+      search_pattern[0] = '\0';
 
       /* Filter Mode */
-      if (!GetSearchCommandLine(ctx, command_line, ctx->global_search_term)) {
+      if (!GetSearchCommandLine(ctx, command_line, search_pattern)) {
+        if (!AppStateCommitGlobalSearchTerm(ctx, search_pattern)) {
+          free(command_line);
+          free(silent_cmd);
+          return FALSE;
+        }
         NormalizeQuotedExecPlaceholders(
             command_line, (size_t)COMMAND_LINE_LENGTH + 1U);
         /* Construct Silent Command */

--- a/src/ui/interactions.c
+++ b/src/ui/interactions.c
@@ -582,7 +582,7 @@ int GetCommandLine(ViewContext *ctx, char *command_line) {
 }
 
 int GetSearchCommandLine(ViewContext *ctx, char *command_line,
-                         char *raw_pattern) {
+                         char *search_pattern) {
   int result = -1;
   char input_buf[256];
 
@@ -594,9 +594,9 @@ int GetSearchCommandLine(ViewContext *ctx, char *command_line,
                     HST_SEARCH) == CR) {
     size_t command_len;
 
-    if (raw_pattern) {
-      strncpy(raw_pattern, input_buf, 255);
-      raw_pattern[255] = '\0';
+    if (search_pattern) {
+      (void)snprintf(search_pattern, 256, "%s", input_buf);
+      search_pattern[255] = '\0';
     }
 
     if (!Path_CommandInit(command_line, COMMAND_LINE_LENGTH + 1, &command_len,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6834,6 +6834,42 @@ def test_panel_volume_file_state_list_routes_through_appstate_helper() -> None:
     assert "AppStateSetPanelVolumeFileStateList(dst, volume_file_state)" in donate_body
 
 
+def test_global_search_term_writes_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_session.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_session.c").read_text(encoding="utf-8")
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    interactions = Path("src/ui/interactions.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitGlobalSearchTerm(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitGlobalSearchTerm(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.command_state")'
+    write = "ctx->global_search_term[0] = '\\0';"
+    assert validation in helper_body
+    assert write in helper_body
+    assert helper_body.index(validation) < helper_body.index(write)
+
+    for source in [log_source, ctrl_dir]:
+        assert "ctx->global_search_term[0] = '\\0';" not in source
+        assert "AppStateCommitGlobalSearchTerm(ctx, NULL)" in source
+
+    filter_start = ctrl_file_ops.index("      /* Filter Mode */")
+    filter_end = ctrl_file_ops.index("      free(silent_cmd);", filter_start)
+    filter_body = ctrl_file_ops[filter_start:filter_end]
+    assert "GetSearchCommandLine(ctx, command_line, ctx->global_search_term)" not in (
+        filter_body
+    )
+    assert "AppStateCommitGlobalSearchTerm(ctx, search_pattern)" in filter_body
+
+    search_start = interactions.index("int GetSearchCommandLine(")
+    search_end = interactions.index("\nint GetPipeCommand(", search_start)
+    search_body = interactions[search_start:search_end]
+    assert "strncpy(raw_pattern, input_buf, 255)" not in search_body
+
+
 def test_panel_generation_restores_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState session helper for global search term commits under the command-state owner boundary.
- Route search-term clears and tagged-search entry updates through the helper.
- Keep search prompt output in a local buffer before committing state.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k global_search_term_writes_route_through_appstate_helper` failed before the helper existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'global_search_term_writes_route_through_appstate_helper or panel_volume_file_state_list_routes_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passes with existing warnings.
