### PR TITLE
chore(appstate): prune stale event sequence registry reference

### DIFF
--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -3745,9 +3745,6 @@ static const char *const kAppStateEventCoverageTransitionSequenceRefs2[] = {
 static const char *const kAppStateEventCoverageTransitionSequenceRefs3[] = {
   "sequence.search-jump",
 };
-static const char *const kAppStateEventCoverageTransitionSequenceRefs4[] = {
-  "sequence.esc-modal-dismissal",
-};
 static const char *const kAppStateEventCoverageTransitionSequenceRefs5[] = {
   "sequence.volume-cycling-release",
 };

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6870,6 +6870,28 @@ def test_global_search_term_writes_route_through_appstate_helper() -> None:
     assert "strncpy(raw_pattern, input_buf, 255)" not in search_body
 
 
+def test_event_coverage_transition_sequence_arrays_are_referenced() -> None:
+    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
+    array_names = set(
+        re.findall(
+            r"static const char \*const "
+            r"(kAppStateEventCoverageTransitionSequenceRefs\d+)\[\]",
+            source,
+        )
+    )
+
+    table_start = source.index(
+        "static const AppStateEventCoverageMetadata\n"
+        "    kAppStateEventCoverages[APPSTATE_EVENT_COVERAGE_COUNT]"
+    )
+    table_source = source[table_start:]
+    referenced_names = set(
+        re.findall(r"\b(kAppStateEventCoverageTransitionSequenceRefs\d+)\b", table_source)
+    )
+
+    assert array_names <= referenced_names
+
+
 def test_panel_generation_restores_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Remove a stale modal-dismissal sequence array from the AppState event coverage registry.
- Add a guard that event coverage transition-sequence arrays must be referenced by runtime event metadata.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k event_coverage_transition_sequence_arrays_are_referenced` failed before pruning the stale array.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k event_coverage_transition_sequence_arrays_are_referenced`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passes with existing warnings.
