### PR TITLE
refactor(appstate): route preview modal state through helper

### DIFF
--- a/include/ytnova_appstate_modal.h
+++ b/include/ytnova_appstate_modal.h
@@ -1,0 +1,11 @@
+#ifndef YTNOVA_APPSTATE_MODAL_H
+#define YTNOVA_APPSTATE_MODAL_H
+
+#include "ytnova_defs.h"
+
+BOOL AppStateCommitPreviewMode(ViewContext *ctx, BOOL preview_mode);
+BOOL AppStateCommitPreviewReturn(ViewContext *ctx, YtreeNovaPanel *panel,
+                                 ViewFocus focus);
+BOOL AppStateCommitPreviewEntryFocus(ViewContext *ctx, ViewFocus focus);
+
+#endif /* YTNOVA_APPSTATE_MODAL_H */

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -11,6 +11,7 @@
 #include "ytnova_defs.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_layout.h"
+#include "ytnova_appstate_modal.h"
 #include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
@@ -895,7 +896,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
   ctx->fixed_col_width = 0; /* ADDED */
   ctx->refresh_mode =
       0; /* Will be set after ReadProfile initializes profile_data */
-  ctx->preview_mode = FALSE; /* Initialize Preview Mode */
+  if (!AppStateCommitPreviewMode(ctx, FALSE))
+    return -1;
   if (!AppStateSetPreviewWindowHandle(ctx, NULL))
     return -1;
 

--- a/src/ui/appstate_modal.c
+++ b/src/ui/appstate_modal.c
@@ -1,0 +1,35 @@
+#include "ytnova_appstate_modal.h"
+
+#include "ytnova_appstate_actions.h"
+
+BOOL AppStateCommitPreviewMode(ViewContext *ctx, BOOL preview_mode) {
+  if (!AppStateValidatedOwnerField("ctx.modal_state"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->preview_mode = preview_mode ? TRUE : FALSE;
+  return TRUE;
+}
+
+BOOL AppStateCommitPreviewReturn(ViewContext *ctx, YtreeNovaPanel *panel,
+                                 ViewFocus focus) {
+  if (!AppStateValidatedOwnerField("ctx.modal_state"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->preview_return_panel = panel;
+  ctx->preview_return_focus = focus;
+  return TRUE;
+}
+
+BOOL AppStateCommitPreviewEntryFocus(ViewContext *ctx, ViewFocus focus) {
+  if (!AppStateValidatedOwnerField("ctx.modal_state"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->preview_entry_focus = focus;
+  return TRUE;
+}

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -10,6 +10,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_modal.h"
 #include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
@@ -510,7 +511,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   /* Safety Reset for Preview Mode */
   if (ctx->preview_mode) {
     DEBUG_LOG("HandleDirWindow: Resetting preview mode");
-    ctx->preview_mode = FALSE;
+    if (!AppStateCommitPreviewMode(ctx, FALSE))
+      return ESC;
     ReCreateWindows(ctx);
     DisplayMenu(ctx);
     /* Update context again after ReCreateWindows */

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -9,6 +9,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_modal.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_appstate_window.h"
@@ -270,11 +271,12 @@ BOOL handle_file_window_preview_action(
   switch (action) {
   case ACTION_VIEW_PREVIEW:
     if (!ctx->preview_mode) {
-      ctx->preview_return_panel = ctx->active;
-      ctx->preview_return_focus = ctx->focused_window;
+      if (!AppStateCommitPreviewReturn(ctx, ctx->active, ctx->focused_window))
+        return FALSE;
     }
 
-    ctx->preview_mode = !ctx->preview_mode;
+    if (!AppStateCommitPreviewMode(ctx, !ctx->preview_mode))
+      return FALSE;
     if (ctx->preview_mode) {
       *saved_fixed_width_ptr = ctx->fixed_col_width;
       ReCreateWindows(ctx);

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -9,6 +9,7 @@
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_modal.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_appstate_volume.h"
@@ -1547,15 +1548,18 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeNovaAction action,
   case ACTION_VIEW_PREVIEW: {
     const YtreeNovaPanel *saved_panel = ctx->active;
 
-    ctx->preview_return_panel = ctx->active;
-    ctx->preview_return_focus = ctx->focused_window;
-    ctx->preview_mode = TRUE;
-    ctx->preview_entry_focus = FOCUS_TREE;
+    if (!AppStateCommitPreviewReturn(ctx, ctx->active, ctx->focused_window))
+      return DIR_WINDOW_DISPATCH_RETURN_ESC;
+    if (!AppStateCommitPreviewMode(ctx, TRUE))
+      return DIR_WINDOW_DISPATCH_RETURN_ESC;
+    if (!AppStateCommitPreviewEntryFocus(ctx, FOCUS_TREE))
+      return DIR_WINDOW_DISPATCH_RETURN_ESC;
 
     HandleSwitchWindow(ctx, *dir_entry_ptr, need_dsp_help_ptr, ch_ptr,
                        ctx->active);
 
-    ctx->preview_mode = FALSE;
+    if (!AppStateCommitPreviewMode(ctx, FALSE))
+      return DIR_WINDOW_DISPATCH_RETURN_ESC;
     if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_TREE))
       return DIR_WINDOW_DISPATCH_RETURN_ESC;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5772,7 +5772,7 @@ def test_handle_dir_window_dispatch_fails_closed_before_directory_work() -> None
         "DisplayMenu(",
         "AppStateMirrorActivePanelFocus(ctx)",
         "SyncActivePanelWindows(",
-        "ctx->preview_mode = FALSE;",
+        "AppStateCommitPreviewMode(ctx, FALSE)",
         "BuildDirEntryList(",
         "RefreshView(",
         "GetEventOrKey(",
@@ -6868,6 +6868,43 @@ def test_global_search_term_writes_route_through_appstate_helper() -> None:
     search_end = interactions.index("\nint GetPipeCommand(", search_start)
     search_body = interactions[search_start:search_end]
     assert "strncpy(raw_pattern, input_buf, 255)" not in search_body
+
+
+def test_preview_modal_state_routes_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_modal.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_modal.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitPreviewMode(" in header
+    assert "BOOL AppStateCommitPreviewReturn(" in header
+    assert "BOOL AppStateCommitPreviewEntryFocus(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPreviewMode(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.modal_state")'
+    assert validation in helper_body
+    assert "ctx->preview_mode = preview_mode ? TRUE : FALSE;" in helper_body
+
+    for source in [init_source, ctrl_dir, ctrl_file_ops, dir_ops]:
+        assert not re.search(r"\bctx->preview_mode\s*=[^=]", source)
+    for source in [ctrl_file_ops, dir_ops]:
+        assert not re.search(r"\bctx->preview_return_panel\s*=[^=]", source)
+        assert not re.search(r"\bctx->preview_return_focus\s*=[^=]", source)
+        assert not re.search(r"\bctx->preview_entry_focus\s*=[^=]", source)
+
+    assert "AppStateCommitPreviewMode(ctx, FALSE)" in init_source
+    assert "AppStateCommitPreviewMode(ctx, FALSE)" in ctrl_dir
+    assert "AppStateCommitPreviewReturn(ctx, ctx->active, ctx->focused_window)" in (
+        ctrl_file_ops
+    )
+    assert "AppStateCommitPreviewMode(ctx, !ctx->preview_mode)" in ctrl_file_ops
+    assert "AppStateCommitPreviewReturn(ctx, ctx->active, ctx->focused_window)" in (
+        dir_ops
+    )
+    assert "AppStateCommitPreviewEntryFocus(ctx, FOCUS_TREE)" in dir_ops
 
 
 def test_event_coverage_transition_sequence_arrays_are_referenced() -> None:

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -678,9 +678,9 @@ def test_file_window_preview_return_uses_visible_selection_authority():
     preview_source = _extract_function_block(
         source, "BOOL handle_file_window_preview_action("
     )
-    return_source = preview_source.split("ctx->preview_mode = !ctx->preview_mode;", 1)[
-        1
-    ].split("RefreshView(ctx, dir_entry);", 1)[0]
+    return_source = preview_source.split(
+        "AppStateCommitPreviewMode(ctx, !ctx->preview_mode)", 1
+    )[1].split("RefreshView(ctx, dir_entry);", 1)[0]
 
     assert "ResolveActiveDirEntry(ctx, stats_local)" in return_source, (
         "File-window preview return must restore the active directory through "


### PR DESCRIPTION
## Summary
- Add AppState modal helpers for preview mode, return target, and preview entry focus.
- Route preview modal-state writes in initialization, directory reset, file preview toggle, and tree preview entry through the helpers.
- Guard preview modal-state writes against direct mutation outside the helper boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k preview_modal_state_routes_through_appstate_helper` failed before the helpers existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py::test_handle_dir_window_dispatch_fails_closed_before_directory_work tests/test_dir_window_dispatch_regressions.py::test_file_window_preview_return_uses_visible_selection_authority tests/test_appstate_contract_guard.py::test_preview_modal_state_routes_through_appstate_helper -q`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'preview_modal_state_routes_through_appstate_helper or handle_dir_window_dispatch_fails_closed_before_directory_work'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passes with existing warnings.
