### PR TITLE
refactor(appstate): route fixed column width through helper

### DIFF
--- a/include/ytnova_appstate_layout.h
+++ b/include/ytnova_appstate_layout.h
@@ -15,5 +15,6 @@ BOOL AppStateCommitTerminalGeometryCache(ViewContext *ctx, int terminal_lines,
                                          int terminal_cols);
 BOOL AppStateCommitLayoutGeometry(ViewContext *ctx,
                                   const YtreeNovaLayout *layout);
+BOOL AppStateCommitFixedColumnWidth(ViewContext *ctx, int fixed_col_width);
 
 #endif /* YTNOVA_APPSTATE_LAYOUT_H */

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -893,7 +893,8 @@ int Init(ViewContext *ctx, const char *configuration_file,
     return -1;
 
   ctx->show_stats = TRUE;
-  ctx->fixed_col_width = 0; /* ADDED */
+  if (!AppStateCommitFixedColumnWidth(ctx, 0))
+    return -1;
   ctx->refresh_mode =
       0; /* Will be set after ReadProfile initializes profile_data */
   if (!AppStateCommitPreviewMode(ctx, FALSE))

--- a/src/ui/appstate_layout.c
+++ b/src/ui/appstate_layout.c
@@ -40,3 +40,13 @@ BOOL AppStateCommitLayoutGeometry(ViewContext *ctx,
   ctx->layout = *layout;
   return TRUE;
 }
+
+BOOL AppStateCommitFixedColumnWidth(ViewContext *ctx, int fixed_col_width) {
+  if (!AppStateValidatedOwnerField("ctx.layout"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->fixed_col_width = fixed_col_width;
+  return TRUE;
+}

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -10,6 +10,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_modal.h"
 #include "ytnova_appstate_mode.h"
 #include "ytnova_appstate_panel.h"
@@ -1104,7 +1105,9 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     } break;
 
     case ACTION_TOGGLE_COMPACT:
-      ctx->fixed_col_width = (ctx->fixed_col_width == 0) ? 32 : 0;
+      if (!AppStateCommitFixedColumnWidth(
+              ctx, (ctx->fixed_col_width == 0) ? 32 : 0))
+        return ESC;
       (void)AppStateMarkResizeRequest(ctx);
       break;
 

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -16,6 +16,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_panel.h"
 #include "../../include/ytnova_cmd.h"
 #include "../../include/ytnova_fs.h"
@@ -338,14 +339,18 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
 
   /* Initial Display using Centralized Function if applicable */
   if (ctx->preview_mode) {
+    int fixed_col_width;
+
     /* F7 entered from tree mode arrives here with preview already enabled.
      * Mirror the same initialization contract used by ACTION_VIEW_PREVIEW.
      */
     saved_fixed_width = ctx->fixed_col_width;
     ReCreateWindows(ctx);
-    ctx->fixed_col_width = ctx->layout.big_file_win_width - 2;
-    if (ctx->fixed_col_width < 1)
-      ctx->fixed_col_width = 1;
+    fixed_col_width = ctx->layout.big_file_win_width - 2;
+    if (fixed_col_width < 1)
+      fixed_col_width = 1;
+    if (!AppStateCommitFixedColumnWidth(ctx, fixed_col_width))
+      return ESC;
     FileNav_RereadWindowSize(ctx, dir_entry);
 
     RefreshView(ctx, dir_entry);

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -9,6 +9,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_modal.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
@@ -278,11 +279,15 @@ BOOL handle_file_window_preview_action(
     if (!AppStateCommitPreviewMode(ctx, !ctx->preview_mode))
       return FALSE;
     if (ctx->preview_mode) {
+      int fixed_col_width;
+
       *saved_fixed_width_ptr = ctx->fixed_col_width;
       ReCreateWindows(ctx);
-      ctx->fixed_col_width = ctx->layout.big_file_win_width - 2;
-      if (ctx->fixed_col_width < 1)
-        ctx->fixed_col_width = 1;
+      fixed_col_width = ctx->layout.big_file_win_width - 2;
+      if (fixed_col_width < 1)
+        fixed_col_width = 1;
+      if (!AppStateCommitFixedColumnWidth(ctx, fixed_col_width))
+        return FALSE;
       FileNav_RereadWindowSize(ctx, dir_entry);
     } else {
       Statistic *stats_local;
@@ -302,7 +307,8 @@ BOOL handle_file_window_preview_action(
       if (!AppStateSyncActiveWindowHandles(ctx))
         return FALSE;
 
-      ctx->fixed_col_width = *saved_fixed_width_ptr;
+      if (!AppStateCommitFixedColumnWidth(ctx, *saved_fixed_width_ptr))
+        return FALSE;
       ReCreateWindows(ctx);
       FileNav_RereadWindowSize(ctx, dir_entry);
       RefreshView(ctx, dir_entry);
@@ -1117,7 +1123,9 @@ BOOL handle_file_window_misc_dispatch_action(
     break;
 
   case ACTION_TOGGLE_COMPACT:
-    ctx->fixed_col_width = (ctx->fixed_col_width == 0) ? 32 : 0;
+    if (!AppStateCommitFixedColumnWidth(ctx,
+                                        (ctx->fixed_col_width == 0) ? 32 : 0))
+      return FALSE;
     (void)AppStateMarkResizeRequest(ctx);
     break;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6289,6 +6289,41 @@ def test_layout_geometry_commits_through_appstate_helper() -> None:
     assert not re.search(r"\bctx->layout\.[A-Za-z0-9_]+\s*=[^=]", layout_body)
 
 
+def test_fixed_column_width_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_layout.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_layout.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitFixedColumnWidth(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitFixedColumnWidth(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.layout")'
+    assignment = "ctx->fixed_col_width = fixed_col_width;"
+    assert validation in helper_body
+    assert assignment in helper_body
+    assert helper_body.index(validation) < helper_body.index(assignment)
+
+    for source in [init_source, ctrl_dir, ctrl_file, ctrl_file_ops]:
+        assert not re.search(r"\bctx->fixed_col_width\s*=[^=]", source)
+
+    assert "AppStateCommitFixedColumnWidth(ctx, 0)" in init_source
+    assert "AppStateCommitFixedColumnWidth(ctx, fixed_col_width)" in ctrl_file
+    assert "AppStateCommitFixedColumnWidth(ctx, fixed_col_width)" in ctrl_file_ops
+    assert "AppStateCommitFixedColumnWidth(ctx, *saved_fixed_width_ptr)" in (
+        ctrl_file_ops
+    )
+    for source in [ctrl_dir, ctrl_file_ops]:
+        assert re.search(
+            r"AppStateCommitFixedColumnWidth\(\s*ctx,\s*"
+            r"\(ctx->fixed_col_width == 0\) \? 32 : 0\)",
+            source,
+        )
+
+
 def test_view_mode_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_mode.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_mode.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an AppState layout helper for fixed column width ownership
- route preview sizing and compact toggles through the helper
- guard the ownership boundary in the AppState contract test

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k fixed_column_width_commits_through_appstate_helper` failed before the helper existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k fixed_column_width_commits_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passes with existing warnings.
