### PR TITLE
refactor(appstate): route display options through helpers

### DIFF
--- a/TASK 1 PROMPT.md
+++ b/TASK 1 PROMPT.md
@@ -1,0 +1,98 @@
+You are continuing the ytreenova AppState roadmap work as a stateless AI.
+
+Repo: /home/rob/ytreenova
+Objective: continue the docs/ROADMAP.md item titled “Unified AppState Transition Machine + Projection Contract”.
+
+First, load required repo instructions:
+- Read AGENTS.md only as the discovery stub.
+- Read .ai/codex.md and .ai/shared.md before codebase research or edits.
+- Use the repo-required MCP semantic tools for codebase exploration.
+- Follow all repo commit, branch, PR, QA, and handoff rules.
+
+Local recovery state:
+- Use /home/rob/ytreenova/.agent/handoffs/prompt.1.txt as the live checkpoint if it is current.
+- If that checkpoint is stale or incomplete, reconstruct from local files in /home/rob/ytreenova/.agent/handoffs.
+- The handoff files are gitignored/local-only; do not expect GitHub to contain them.
+- Use docs/appstate*.json to identify remaining AppState registry/runtime boundary work.
+- Use git and GitHub to discover the current branch, current PR, merged PRs, and stale branches.
+- Do not rely on PR numbers, branch names, run IDs, or details from older chats.
+
+Run policy:
+- Work autonomously.
+- Do not ask for commit message approval.
+- Choose compliant, durable Conventional Commit messages yourself.
+- Keep commits atomic and outcome-focused.
+- Batch adjacent AppState units into one small, coherent PR when they share the same risk profile and validation path.
+- Do not force one PR per tiny subunit.
+- Do not mix unrelated risk classes just to reduce PR count.
+
+CI wait rule:
+- After CI starts or restarts, wait 15 minutes before the first status check.
+- If CI is still running or pending, check every 10 minutes until 50 minutes have elapsed.
+- After 50 minutes, check every 5 minutes until CI is green or red.
+- If you explicitly report that CI is red or green, stop waiting and handle that state immediately.
+- When checking CI, use only a compact pass/fail/running summary via `--jq`.
+- Fetch detailed check or log output only if a check is red.
+- Keep maintainer-facing updates to one short line.
+- If a pushed fix changes the PR, restart the wait cycle from the beginning.
+
+Continuation rule after merge:
+- After every merge, resume the next task 1 subunit without waiting for my go-ahead, unless a later supersession/stop/pause instruction says otherwise.
+
+Supersession rule:
+- If you give any later instruction to stop, pause, or stop after a named PR/branch/commit condition, that instruction overrides all prior autonomous-loop instructions and any persistent goal.
+- After satisfying that stop condition:
+  - cancel or mark blocked any active persistent goal;
+  - do not start another PR;
+  - do not poll CI;
+  - do not resume from codex_internal_context goal prompts;
+  - wait for an explicit new user command such as “resume AppState work”.
+
+What to do now:
+1. Inspect current git/GitHub state.
+2. If there is an active PR:
+   - Follow the CI wait rule.
+   - If checks are green, mark ready if needed, merge when allowed, clean up stale remote/local branch state, update .agent/handoffs/prompt.1.txt, then continue according to the autonomous continuation policy unless a superseding stop condition applies.
+   - If checks failed, inspect only the failure-relevant log tail/summary. Fix only clearly repo-side, in-scope failures. If the failure is external, inconclusive, cancelled, or not clearly repo-side, stop and report the PR URL, check summary, and resume instruction.
+3. If there is no active PR:
+   - Select the next small coherent AppState batch from docs/appstate*.json and the current handoff context.
+   - Implement it through the repo’s developer/auditor/PR workflow.
+   - Run focused local validation only.
+   - Push a draft PR.
+   - Update .agent/handoffs/prompt.1.txt as the live recovery checkpoint.
+   - Follow the CI wait rule.
+   - When CI is green, mark ready if needed, merge when allowed, clean up stale remote/local branch state, update .agent/handoffs/prompt.1.txt, then continue with the next small coherent AppState batch unless a superseding stop condition applies.
+
+Context discipline:
+- Do not stream full CI logs.
+- Do not paste long test output.
+- Do not read all historical handoffs unless reconstruction is impossible without them.
+- Do not provide broad recaps unless asked.
+- Report only completed state, current next action, and new/changed handles.
+
+Wording rules:
+- Do not put roadmap item numbers, subunit numbers, PR numbers, branch numbers, or volatile workflow IDs in commit messages, PR titles, or durable change descriptions.
+- Commit subjects and PR titles must describe durable outcomes only.
+- Do not present routine required test passes as roadmap progress. Use validation evidence only where required for PR/handoff/merge decisions, and keep it concise.
+- PR titles must use the same Conventional Commit Style as commit subjects: `<type>(<scope>): <durable outcome>`.
+- Keep PR title style consistent across the AppState series; do not mix sentence-case descriptive titles with Conventional Commit Style titles.
+- Use real Markdown newlines and code-formatted validation commands in PR bodies; do not submit literal escaped `\n` text or shell commands as raw prose.
+- PR bodies: put red proof as a bullet under `## Validation`, not as a separate section.
+
+What you must do from now until completion of task 1, unless I tell you to pause:
+
+For any active/open PR after CI starts or restarts, follow the CI wait rule from the main prompt.
+
+At each allowed CI status check:
+- If CI is green, mark the PR ready if needed, merge when branch protection and review requirements allow, clean up branch state, return to main, then proceed according to the final resume rule.
+- If CI is red, inspect only the failure-relevant summary/tail and fix clear repo-side failures. Each pushed fix restarts the CI wait rule.
+- If CI is still running or pending, continue following the CI wait rule.
+
+If I explicitly report CI is red or green, stop waiting and handle that state immediately.
+
+Stop only:
+- to fix red until green;
+- if you have a question/blocker; or
+- if I tell you the PR is red/green or tell you to pause/stop.
+
+After every merge, resume the next task 1 subunit without waiting for my go-ahead, unless a later supersession/stop/pause instruction says otherwise.

--- a/include/ytnova_appstate_layout.h
+++ b/include/ytnova_appstate_layout.h
@@ -16,5 +16,7 @@ BOOL AppStateCommitTerminalGeometryCache(ViewContext *ctx, int terminal_lines,
 BOOL AppStateCommitLayoutGeometry(ViewContext *ctx,
                                   const YtreeNovaLayout *layout);
 BOOL AppStateCommitFixedColumnWidth(ViewContext *ctx, int fixed_col_width);
+BOOL AppStateCommitSmallWindowBypass(ViewContext *ctx, BOOL bypass_small_window);
+BOOL AppStateCommitFullLineHighlight(ViewContext *ctx, BOOL highlight_full_line);
 
 #endif /* YTNOVA_APPSTATE_LAYOUT_H */

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -1032,12 +1032,17 @@ int Init(ViewContext *ctx, const char *configuration_file,
     ctx->number_seperator = ','; /* Fallback to English/Comma */
   DEBUG_LOG("Init: locale fallback done");
 
-  ctx->bypass_small_window =
-      ParseSmallWindowSkipValue(CoreInitGetProfileValue(ctx, "SMALLWINDOWSKIP"));
-  ctx->highlight_full_line =
-      (strtol(CoreInitGetProfileValue(ctx, "HIGHLIGHT_FULL_LINE"), NULL, 0))
-          ? TRUE
-          : FALSE;
+  if (!AppStateCommitSmallWindowBypass(
+          ctx,
+          ParseSmallWindowSkipValue(
+              CoreInitGetProfileValue(ctx, "SMALLWINDOWSKIP"))))
+    return -1;
+  if (!AppStateCommitFullLineHighlight(
+          ctx,
+          (strtol(CoreInitGetProfileValue(ctx, "HIGHLIGHT_FULL_LINE"), NULL, 0))
+              ? TRUE
+              : FALSE))
+    return -1;
   {
     BOOL hide_dot_files =
         (strtol(CoreInitGetProfileValue(ctx, "HIDEDOTFILES"), NULL, 0))

--- a/src/ui/appstate_layout.c
+++ b/src/ui/appstate_layout.c
@@ -50,3 +50,25 @@ BOOL AppStateCommitFixedColumnWidth(ViewContext *ctx, int fixed_col_width) {
   ctx->fixed_col_width = fixed_col_width;
   return TRUE;
 }
+
+BOOL AppStateCommitSmallWindowBypass(ViewContext *ctx,
+                                     BOOL bypass_small_window) {
+  if (!AppStateValidatedOwnerField("ctx.layout"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->bypass_small_window = bypass_small_window ? TRUE : FALSE;
+  return TRUE;
+}
+
+BOOL AppStateCommitFullLineHighlight(ViewContext *ctx,
+                                     BOOL highlight_full_line) {
+  if (!AppStateValidatedOwnerField("ctx.layout"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->highlight_full_line = highlight_full_line ? TRUE : FALSE;
+  return TRUE;
+}

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -959,8 +959,10 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
       need_dsp_help = TRUE;
       break;
     case ACTION_ENTER: {
-      ctx->bypass_small_window =
-          ParseSmallWindowSkipValue(GetProfileValue(ctx, "SMALLWINDOWSKIP"));
+      if (!AppStateCommitSmallWindowBypass(
+              ctx,
+              ParseSmallWindowSkipValue(GetProfileValue(ctx, "SMALLWINDOWSKIP"))))
+        return ESC;
       DirWindowDispatchResult enter_result =
           HandleDirWindowEnterAction(ctx, &dir_entry, &s, &start_vol,
                                      &need_dsp_help, &ch, &unput_char, &action);

--- a/src/ui/ui_edit_config.c
+++ b/src/ui/ui_edit_config.c
@@ -11,6 +11,7 @@
 
 #define NO_YTNOVA_MACROS
 #include "../core/default_profile_template.h"
+#include "ytnova_appstate_layout.h"
 #include "ytnova_cmd.h"
 #include "ytnova_ui.h"
 #include <errno.h>
@@ -171,8 +172,10 @@ void UI_OpenConfigProfile(ViewContext *ctx, DirEntry *dir_entry) {
   if (ctx->core_init_ops.read_profile != NULL &&
       access(profile_path, F_OK) == 0) {
     if (ctx->core_init_ops.read_profile(ctx, profile_path) == 0) {
-      ctx->bypass_small_window =
-          ParseSmallWindowSkipValue(GetProfileValue(ctx, "SMALLWINDOWSKIP"));
+      if (!AppStateCommitSmallWindowBypass(
+              ctx,
+              ParseSmallWindowSkipValue(GetProfileValue(ctx, "SMALLWINDOWSKIP"))))
+        return;
       if (ctx->core_init_ops.reinit_color_pairs != NULL) {
         ctx->core_init_ops.reinit_color_pairs(ctx);
       }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6324,6 +6324,44 @@ def test_fixed_column_width_commits_through_appstate_helper() -> None:
         )
 
 
+def test_display_options_commit_through_appstate_helpers() -> None:
+    header = Path("include/ytnova_appstate_layout.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_layout.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    edit_config = Path("src/ui/ui_edit_config.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitSmallWindowBypass(" in header
+    assert "BOOL AppStateCommitFullLineHighlight(" in header
+    assert 'include "ytnova_appstate_layout.h"' in init_source
+    assert 'include "ytnova_appstate_layout.h"' in ctrl_dir
+    assert 'include "ytnova_appstate_layout.h"' in edit_config
+
+    validation = 'AppStateValidatedOwnerField("ctx.layout")'
+    helper_start = helper.index("BOOL AppStateCommitSmallWindowBypass(")
+    helper_body = helper[helper_start:]
+    bypass_write = "ctx->bypass_small_window = bypass_small_window ? TRUE : FALSE;"
+    assert validation in helper_body
+    assert bypass_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(bypass_write)
+
+    helper_start = helper.index("BOOL AppStateCommitFullLineHighlight(")
+    helper_body = helper[helper_start:]
+    highlight_write = "ctx->highlight_full_line = highlight_full_line ? TRUE : FALSE;"
+    assert validation in helper_body
+    assert highlight_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(highlight_write)
+
+    for source in [init_source, ctrl_dir, edit_config]:
+        assert not re.search(r"\bctx->bypass_small_window\s*=[^=]", source)
+    assert not re.search(r"\bctx->highlight_full_line\s*=[^=]", init_source)
+
+    assert "AppStateCommitSmallWindowBypass(" in init_source
+    assert "AppStateCommitSmallWindowBypass(" in ctrl_dir
+    assert "AppStateCommitSmallWindowBypass(" in edit_config
+    assert "AppStateCommitFullLineHighlight(" in init_source
+
+
 def test_view_mode_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_mode.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_mode.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route small-window bypass and full-line highlight writes through AppState layout helpers.
- Add guard coverage that blocks direct display option assignments outside the helper boundary.
- Include the current continuation prompt file for this AppState handoff.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k display_options_commit_through_appstate_helpers` failed before the helpers existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'display_options_commit_through_appstate_helpers or fixed_column_width_commits_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
