### PR TITLE
refactor(appstate): route refresh policy through helper

### DIFF
--- a/docs/appstate_diff_harness.json
+++ b/docs/appstate_diff_harness.json
@@ -82,6 +82,7 @@
       "owner_field_refs": [
         "ctx.active",
         "ctx.command_state",
+        "ctx.refresh_mode",
         "ctx.view_mode",
         "ctx.message_state",
         "ctx.modal_state",

--- a/docs/appstate_invariants.json
+++ b/docs/appstate_invariants.json
@@ -260,6 +260,7 @@
       "owner_region": "ctx/session state",
       "protected_fields": [
         "ctx.command_state",
+        "ctx.refresh_mode",
         "ctx.view_mode",
         "ctx.message_state",
         "ctx.modal_state",

--- a/docs/appstate_owner_fields.json
+++ b/docs/appstate_owner_fields.json
@@ -28,6 +28,18 @@
       ]
     },
     {
+      "field": "ctx.refresh_mode",
+      "owner_region": "ctx/session state",
+      "canonical_owner": "ViewContext.refresh_policy",
+      "runtime_carrier": "ViewContext.refresh_mode",
+      "mutation_rule": "May change only through initialization or profile refresh policy commits before refresh dispatch observes it.",
+      "migration_status": "runtime_backed",
+      "invariant_checks": [
+        "invariant.blocked-transition-determinism",
+        "invariant.shared-state-panel-local-isolation"
+      ]
+    },
+    {
       "field": "ctx.view_mode",
       "owner_region": "ctx/session state",
       "canonical_owner": "ViewContext.view_mode",

--- a/include/ytnova_appstate_session.h
+++ b/include/ytnova_appstate_session.h
@@ -12,5 +12,6 @@
 
 BOOL AppStateCommitActivePanel(ViewContext *ctx, YtreeNovaPanel *panel);
 BOOL AppStateCommitGlobalSearchTerm(ViewContext *ctx, const char *term);
+BOOL AppStateCommitRefreshMode(ViewContext *ctx, int refresh_mode);
 
 #endif /* YTNOVA_APPSTATE_SESSION_H */

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -196,6 +196,14 @@ static const AppStateOwnerFieldMetadata kAppStateOwnerFields[] = {
    "runtime_backed",
    kAppStateOwnerFieldInvariantChecks1,
    sizeof(kAppStateOwnerFieldInvariantChecks1) / sizeof(kAppStateOwnerFieldInvariantChecks1[0])},
+  {"ctx.refresh_mode",
+   "ctx/session state",
+   "ViewContext.refresh_policy",
+   "ViewContext.refresh_mode",
+   "May change only through initialization or profile refresh policy commits before refresh dispatch observes it.",
+   "runtime_backed",
+   kAppStateOwnerFieldInvariantChecks1,
+   sizeof(kAppStateOwnerFieldInvariantChecks1) / sizeof(kAppStateOwnerFieldInvariantChecks1[0])},
   {"ctx.view_mode",
    "ctx/session state",
    "ViewContext.view_mode",
@@ -868,6 +876,7 @@ static const char *const kAppStateDiffHarnessTransitionIds1[] = {
 static const char *const kAppStateDiffHarnessOwnerFieldRefs1[] = {
   "ctx.active",
   "ctx.command_state",
+  "ctx.refresh_mode",
   "ctx.view_mode",
   "ctx.message_state",
   "ctx.modal_state",
@@ -3038,6 +3047,7 @@ static const char *const kAppStateInvariantMigrationNotes6[] = {
 
 static const char *const kAppStateInvariantProtectedFields7[] = {
   "ctx.command_state",
+  "ctx.refresh_mode",
   "ctx.view_mode",
   "ctx.message_state",
   "ctx.modal_state",

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -895,8 +895,9 @@ int Init(ViewContext *ctx, const char *configuration_file,
   ctx->show_stats = TRUE;
   if (!AppStateCommitFixedColumnWidth(ctx, 0))
     return -1;
-  ctx->refresh_mode =
-      0; /* Will be set after ReadProfile initializes profile_data */
+  /* Will be set after ReadProfile initializes profile_data. */
+  if (!AppStateCommitRefreshMode(ctx, 0))
+    return -1;
   if (!AppStateCommitPreviewMode(ctx, FALSE))
     return -1;
   if (!AppStateSetPreviewWindowHandle(ctx, NULL))
@@ -1056,8 +1057,9 @@ int Init(ViewContext *ctx, const char *configuration_file,
       strtol(CoreInitGetProfileValue(ctx, "ANIMATION"), NULL, 0);
   ctx->initial_directory = (char *)CoreInitGetProfileValue(ctx, "INITIALDIR");
 
-  ctx->refresh_mode =
-      strtol(CoreInitGetProfileValue(ctx, "AUTO_REFRESH"), NULL, 0);
+  if (!AppStateCommitRefreshMode(
+          ctx, strtol(CoreInitGetProfileValue(ctx, "AUTO_REFRESH"), NULL, 0)))
+    return -1;
   DEBUG_LOG("Init: Profile variables done");
 
   if (ctx->hook_init_clock != NULL)

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -178,6 +178,7 @@ static const char *const kAppStateRequiredTransitionIds[] = {
 static const char *const kAppStateRequiredOwnerFieldIds[] = {
   "ctx.active",
   "ctx.command_state",
+  "ctx.refresh_mode",
   "ctx.view_mode",
   "ctx.message_state",
   "ctx.modal_state",

--- a/src/ui/appstate_session.c
+++ b/src/ui/appstate_session.c
@@ -36,3 +36,13 @@ BOOL AppStateCommitGlobalSearchTerm(ViewContext *ctx, const char *term) {
   }
   return TRUE;
 }
+
+BOOL AppStateCommitRefreshMode(ViewContext *ctx, int refresh_mode) {
+  if (!AppStateValidatedOwnerField("ctx.refresh_mode"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->refresh_mode = refresh_mode;
+  return TRUE;
+}

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6943,6 +6943,32 @@ def test_global_search_term_writes_route_through_appstate_helper() -> None:
     assert "strncpy(raw_pattern, input_buf, 255)" not in search_body
 
 
+def test_refresh_mode_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_session.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_session.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+
+    owner_fields = json.loads(
+        Path("docs/appstate_owner_fields.json").read_text(encoding="utf-8")
+    )["owner_fields"]
+    assert any(record["field"] == "ctx.refresh_mode" for record in owner_fields)
+    assert "BOOL AppStateCommitRefreshMode(" in header
+    assert 'include "ytnova_appstate_session.h"' in init_source
+
+    helper_start = helper.index("BOOL AppStateCommitRefreshMode(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.refresh_mode")'
+    write = "ctx->refresh_mode = refresh_mode;"
+    assert validation in helper_body
+    assert write in helper_body
+    assert helper_body.index(validation) < helper_body.index(write)
+
+    assert not re.search(r"\bctx->refresh_mode\s*=[^=]", init_source)
+    assert "AppStateCommitRefreshMode(ctx, 0)" in init_source
+    assert "AppStateCommitRefreshMode(" in init_source
+    assert 'CoreInitGetProfileValue(ctx, "AUTO_REFRESH")' in init_source
+
+
 def test_preview_modal_state_routes_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_modal.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_modal.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Register `ctx.refresh_mode` as a runtime-backed AppState owner field.
- Route refresh policy initialization through a session helper boundary.
- Extend guard coverage for the refresh policy owner and helper contract.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k refresh_mode_commits_through_appstate_helper` failed before the owner metadata and helper existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'refresh_mode_commits_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
