### PR TITLE
refactor(appstate): route file sort order through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,22 +4,9 @@ Date: 2026-07-01
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-render-metrics-helper
-Active PR: https://github.com/robkam/ytreenova/pull/305
-Stop condition: none; maintainer resumed and requested tracked handoff text artifacts.
-
-Current AppState batch:
-- Routes panel file rendering metric cache writes through the panel AppState helper boundary.
-- Expands panel.file_display_state metadata to cover max_visual_filename_len, max_visual_linkname_len, and max_visual_userview_len.
-- Blocks direct panel metric assignments in render_file.c and panel_anchor.c outside AppState helper commits.
-- Includes the .gitignore update that allows nested text artifacts and tracks .agent/handoffs/*.txt as requested.
-
-Validation recorded before PR creation:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_rendering_metrics_commit_through_appstate_helper` failed before metadata/helper routing existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_file_rendering_metrics_commit_through_appstate_helper or panel_file_display_state_commits_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
-- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
-- Passed: `make clean && make` with existing warnings.
+Current branch: appstate-file-sort-order-helper
+Active PR: https://github.com/robkam/ytreenova/pull/306
+Stop condition: none; autonomous continuation remains active.
 
 Merged in this continuation:
 - refactor(appstate): route display options through helpers
@@ -35,6 +22,22 @@ Merged in this continuation:
 - refactor(appstate): route file display state through helpers
   - PR: https://github.com/robkam/ytreenova/pull/304
   - Merge commit: 3ecfc804c4ccfcf08c1b8d2a0371d92434339b9d
+- refactor(appstate): route file render metrics through helper
+  - PR: https://github.com/robkam/ytreenova/pull/305
+  - Merge commit: 09615cc198c020025d20123d9095398f5bfb5062
+  - Included tracked .agent/handoffs/*.txt files and the .gitignore update.
+
+Current AppState batch:
+- Route panel file sort-order cache writes through the panel AppState helper boundary.
+- Expand panel.file_display_state metadata to cover reverse_sort.
+- Block direct reverse_sort assignments in render_file.c and panel_anchor.c outside AppState helper commits.
+
+Validation recorded before PR creation:
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_sort_order_commits_through_appstate_helper` failed before metadata/helper routing existed.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_file_sort_order_commits_through_appstate_helper or panel_file_rendering_metrics_commit_through_appstate_helper or panel_file_display_state_commits_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
+- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
+- Passed: `make clean && make` with existing warnings.
 
 Next action:
 - Follow the CI wait rule for the active draft PR.

--- a/docs/appstate_owner_fields.json
+++ b/docs/appstate_owner_fields.json
@@ -163,8 +163,8 @@
       "field": "panel.file_display_state",
       "owner_region": "panel-local state",
       "canonical_owner": "YtreeNovaPanel.file display projection state",
-      "runtime_carrier": "YtreeNovaPanel.file_mode, max_column, max_visual_filename_len, max_visual_linkname_len, and max_visual_userview_len",
-      "mutation_rule": "May change only through file display mode or render metric commits that validate supported presentation modes, derived column bounds, and cached file rendering widths.",
+      "runtime_carrier": "YtreeNovaPanel.file_mode, max_column, max_visual_filename_len, max_visual_linkname_len, max_visual_userview_len, and reverse_sort",
+      "mutation_rule": "May change only through file display mode, render metric, or sort-order commits that validate supported presentation modes, derived column bounds, cached file rendering widths, and file ordering projection.",
       "migration_status": "runtime_backed",
       "invariant_checks": [
         "invariant.inactive-panel-frozen",

--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -23,6 +23,8 @@ BOOL AppStateCommitPanelFileRenderingMetrics(YtreeNovaPanel *panel,
                                              unsigned max_linkname,
                                              unsigned max_userview,
                                              BOOL update_userview);
+BOOL AppStateCommitPanelFileSortOrder(YtreeNovaPanel *panel,
+                                      BOOL reverse_sort);
 BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *dir_path,
                                       const char *file_name);

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -291,8 +291,8 @@ static const AppStateOwnerFieldMetadata kAppStateOwnerFields[] = {
   {"panel.file_display_state",
    "panel-local state",
    "YtreeNovaPanel.file display projection state",
-   "YtreeNovaPanel.file_mode, max_column, max_visual_filename_len, max_visual_linkname_len, and max_visual_userview_len",
-   "May change only through file display mode or render metric commits that validate supported presentation modes, derived column bounds, and cached file rendering widths.",
+   "YtreeNovaPanel.file_mode, max_column, max_visual_filename_len, max_visual_linkname_len, max_visual_userview_len, and reverse_sort",
+   "May change only through file display mode, render metric, or sort-order commits that validate supported presentation modes, derived column bounds, cached file rendering widths, and file ordering projection.",
    "runtime_backed",
    kAppStateOwnerFieldInvariantChecks22,
    sizeof(kAppStateOwnerFieldInvariantChecks22) /

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -96,6 +96,17 @@ BOOL AppStateCommitPanelFileRenderingMetrics(YtreeNovaPanel *panel,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelFileSortOrder(YtreeNovaPanel *panel,
+                                      BOOL reverse_sort) {
+  if (!AppStateValidatedOwnerField("panel.file_display_state"))
+    return FALSE;
+  if (!panel)
+    return FALSE;
+
+  panel->reverse_sort = reverse_sort;
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *dir_path,
                                       const char *file_name) {

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -711,7 +711,8 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
           dst, src->max_visual_filename_len, src->max_visual_linkname_len,
           src->max_visual_userview_len, TRUE))
     return FALSE;
-  dst->reverse_sort = src->reverse_sort;
+  if (!AppStateCommitPanelFileSortOrder(dst, src->reverse_sort))
+    return FALSE;
   if (!AppStateCommitPanelFileAnchor(dst, NULL))
     return FALSE;
   PanelTags_Copy(dst, src);

--- a/src/ui/render_file.c
+++ b/src/ui/render_file.c
@@ -42,7 +42,7 @@ void SetFileRenderingMetrics(YtreeNovaPanel *p, unsigned max_filename,
 void SetRenderSortOrder(YtreeNovaPanel *p, BOOL reverse) {
   if (!p)
     return;
-  p->reverse_sort = reverse;
+  (void)AppStateCommitPanelFileSortOrder(p, reverse);
 }
 
 int GetPanelFileMode(const YtreeNovaPanel *p) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7029,6 +7029,39 @@ def test_panel_file_rendering_metrics_commit_through_appstate_helper() -> None:
         )
 
 
+def test_panel_file_sort_order_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    render_file = Path("src/ui/render_file.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    owner_fields = json.loads(
+        Path("docs/appstate_owner_fields.json").read_text(encoding="utf-8")
+    )["owner_fields"]
+    display_state = next(
+        record
+        for record in owner_fields
+        if record["field"] == "panel.file_display_state"
+    )
+    assert "reverse_sort" in display_state["runtime_carrier"]
+    assert "sort-order" in display_state["mutation_rule"]
+
+    assert "BOOL AppStateCommitPanelFileSortOrder(" in header
+    helper_start = helper.index("BOOL AppStateCommitPanelFileSortOrder(")
+    helper_end = helper.index("\nBOOL AppStateCommitPanelFileSelection(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("panel.file_display_state")'
+    sort_write = "panel->reverse_sort = reverse_sort;"
+    assert validation in helper_body
+    assert sort_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(sort_write)
+
+    assert "AppStateCommitPanelFileSortOrder(p, reverse)" in render_file
+    assert "AppStateCommitPanelFileSortOrder(dst, src->reverse_sort)" in panel_anchor
+    for source in [render_file, panel_anchor]:
+        assert not re.search(r"\b(?:p|dst)->reverse_sort\s*=[^=]", source)
+
+
 def test_global_search_term_writes_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_session.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_session.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route panel file sort-order cache writes through the AppState panel helper boundary.
- Expand file display state metadata/runtime registry coverage for `reverse_sort`.
- Block direct sort-order assignments in render projection and panel-state donation paths.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_sort_order_commits_through_appstate_helper` failed before metadata/helper routing existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_file_sort_order_commits_through_appstate_helper or panel_file_rendering_metrics_commit_through_appstate_helper or panel_file_display_state_commits_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make` passes with existing warnings.
