### PR TITLE
refactor(appstate): route panel donation display state through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,8 +4,8 @@ Date: 2026-07-01
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-sort-order-helper
-Active PR: https://github.com/robkam/ytreenova/pull/306
+Current branch: appstate-panel-donation-display-helper
+Active PR: https://github.com/robkam/ytreenova/pull/307
 Stop condition: none; autonomous continuation remains active.
 
 Merged in this continuation:
@@ -26,15 +26,17 @@ Merged in this continuation:
   - PR: https://github.com/robkam/ytreenova/pull/305
   - Merge commit: 09615cc198c020025d20123d9095398f5bfb5062
   - Included tracked .agent/handoffs/*.txt files and the .gitignore update.
+- refactor(appstate): route file sort order through helper
+  - PR: https://github.com/robkam/ytreenova/pull/306
+  - Merge commit: 4a04943b884c8781e5f4665ea183c85dfaae7bab
 
 Current AppState batch:
-- Route panel file sort-order cache writes through the panel AppState helper boundary.
-- Expand panel.file_display_state metadata to cover reverse_sort.
-- Block direct reverse_sort assignments in render_file.c and panel_anchor.c outside AppState helper commits.
+- Route DonatePanelState file display mode and max-column copies through existing panel AppState helpers.
+- Add guard coverage preventing direct panel donation writes to file_mode and max_column outside the helper boundary.
 
 Validation recorded before PR creation:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_sort_order_commits_through_appstate_helper` failed before metadata/helper routing existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_file_sort_order_commits_through_appstate_helper or panel_file_rendering_metrics_commit_through_appstate_helper or panel_file_display_state_commits_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_donation_file_display_state_commits_through_appstate_helpers` failed before DonatePanelState used the existing file display helpers.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_donation_file_display_state_commits_through_appstate_helpers or panel_file_display_state_commits_through_appstate_helper or panel_file_rendering_metrics_commit_through_appstate_helper or panel_file_sort_order_commits_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - Passed: `make clean && make` with existing warnings.

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -692,8 +692,10 @@ BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
     return FALSE;
   if (!AppStateCommitPanelFileAnchor(dst, src->file_dir_entry))
     return FALSE;
-  dst->file_mode = src->file_mode;
-  dst->max_column = src->max_column;
+  if (!AppStateCommitPanelFileDisplayMode(dst, src->file_mode))
+    return FALSE;
+  if (!AppStateCommitPanelFileMaxColumn(dst, src->max_column))
+    return FALSE;
   if (!AppStateCommitPanelTreeSelection(dst, src->current_dir_entry))
     return FALSE;
   if (!AppStateRestorePanelGeneration(dst, src->panel_generation))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7062,6 +7062,19 @@ def test_panel_file_sort_order_commits_through_appstate_helper() -> None:
         assert not re.search(r"\b(?:p|dst)->reverse_sort\s*=[^=]", source)
 
 
+def test_panel_donation_file_display_state_commits_through_appstate_helpers() -> None:
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    donate_start = panel_anchor.index("BOOL DonatePanelState(")
+    donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
+    donate_body = panel_anchor[donate_start:donate_end]
+
+    assert "AppStateCommitPanelFileDisplayMode(dst, src->file_mode)" in donate_body
+    assert "AppStateCommitPanelFileMaxColumn(dst, src->max_column)" in donate_body
+    assert not re.search(r"\bdst->file_mode\s*=[^=]", donate_body)
+    assert not re.search(r"\bdst->max_column\s*=[^=]", donate_body)
+
+
 def test_global_search_term_writes_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_session.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_session.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route `DonatePanelState` file display mode and max-column copies through the existing AppState panel helpers.
- Add guard coverage preventing direct panel donation writes to `file_mode` and `max_column`.
- Preserve the existing panel donation ordering while moving writes behind the validated owner boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_donation_file_display_state_commits_through_appstate_helpers` failed before `DonatePanelState` used the existing file display helpers.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_donation_file_display_state_commits_through_appstate_helpers or panel_file_display_state_commits_through_appstate_helper or panel_file_rendering_metrics_commit_through_appstate_helper or panel_file_sort_order_commits_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make` passes with existing warnings.
