### PR TITLE
refactor(appstate): route file navigation viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,8 +4,8 @@ Date: 2026-07-01
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-panel-donation-display-helper
-Active PR: https://github.com/robkam/ytreenova/pull/307
+Current branch: appstate-file-nav-dir-entry-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/308
 Stop condition: none; autonomous continuation remains active.
 
 Merged in this continuation:
@@ -29,14 +29,19 @@ Merged in this continuation:
 - refactor(appstate): route file sort order through helper
   - PR: https://github.com/robkam/ytreenova/pull/306
   - Merge commit: 4a04943b884c8781e5f4665ea183c85dfaae7bab
+- refactor(appstate): route panel donation display state through helpers
+  - PR: https://github.com/robkam/ytreenova/pull/307
+  - Merge commit: 1a8566f7ef92171073e6b903ac79739f67aac91a
 
 Current AppState batch:
-- Route DonatePanelState file display mode and max-column copies through existing panel AppState helpers.
-- Add guard coverage preventing direct panel donation writes to file_mode and max_column outside the helper boundary.
+- Route file navigation DirEntry file viewport mutations through a validated AppState helper.
+- Keep panel file viewport commits in the existing panel helper after the DirEntry viewport commit.
+- Add guard coverage preventing direct file navigation mutation of DirEntry start_file/cursor_pos outside the helper boundary.
 
 Validation recorded before PR creation:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_donation_file_display_state_commits_through_appstate_helpers` failed before DonatePanelState used the existing file display helpers.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_donation_file_display_state_commits_through_appstate_helpers or panel_file_display_state_commits_through_appstate_helper or panel_file_rendering_metrics_commit_through_appstate_helper or panel_file_sort_order_commits_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_dir_entry_viewports_commit_through_appstate_helper` failed before adding the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_dir_entry_viewports_commit_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_nav_dir_entry_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - Passed: `make clean && make` with existing warnings.

--- a/include/ytnova_appstate_panel.h
+++ b/include/ytnova_appstate_panel.h
@@ -44,6 +44,8 @@ BOOL AppStateCommitPanelVolumeFileSnapshot(
     unsigned int panel_generation, unsigned int volume_generation,
     ViewFocus focus, BOOL big_file_view, const char *file_dir_path,
     const char *file_selection_dir_path, const char *file_selection_name);
+BOOL AppStateCommitDirEntryFileViewport(DirEntry *dir_entry, int start_file,
+                                        int cursor_pos);
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos);
 BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -245,6 +245,18 @@ BOOL AppStateCommitPanelVolumeFileSnapshot(
   return TRUE;
 }
 
+BOOL AppStateCommitDirEntryFileViewport(DirEntry *dir_entry, int start_file,
+                                        int cursor_pos) {
+  if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->start_file = start_file;
+  dir_entry->cursor_pos = cursor_pos;
+  return TRUE;
+}
+
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos) {
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))

--- a/src/ui/file_nav.c
+++ b/src/ui/file_nav.c
@@ -61,28 +61,46 @@ static void RefreshFileSelection(ViewContext *ctx, DirEntry *dir_entry,
 }
 
 void FileNav_MoveDown(ViewContext *ctx, DirEntry *dir_entry, int start_x) {
+  int cursor_pos;
+  int start_file;
+
   if (!ctx || !ctx->active || !dir_entry)
     return;
 
-  Nav_MoveDown(&dir_entry->cursor_pos, &dir_entry->start_file,
+  cursor_pos = dir_entry->cursor_pos;
+  start_file = dir_entry->start_file;
+  Nav_MoveDown(&cursor_pos, &start_file,
                (int)ctx->active->file_count, GetSafeMaxDispFiles(ctx), 1);
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+    return;
   RefreshFileSelection(ctx, dir_entry, start_x);
 }
 
 void FileNav_MoveUp(ViewContext *ctx, DirEntry *dir_entry, int start_x) {
+  int cursor_pos;
+  int start_file;
+
   if (!ctx || !ctx->active || !dir_entry)
     return;
 
-  Nav_MoveUp(&dir_entry->cursor_pos, &dir_entry->start_file);
+  cursor_pos = dir_entry->cursor_pos;
+  start_file = dir_entry->start_file;
+  Nav_MoveUp(&cursor_pos, &start_file);
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+    return;
   RefreshFileSelection(ctx, dir_entry, start_x);
 }
 
 void FileNav_MoveRight(ViewContext *ctx, DirEntry *dir_entry, int *start_x) {
+  int cursor_pos;
+  int start_file;
   int x_step;
 
   if (!ctx || !ctx->active || !dir_entry || !start_x)
     return;
 
+  cursor_pos = dir_entry->cursor_pos;
+  start_file = dir_entry->start_file;
   x_step = GetSafeXStep(ctx);
   if (x_step == 1) {
     (*start_x)++;
@@ -92,16 +110,19 @@ void FileNav_MoveRight(ViewContext *ctx, DirEntry *dir_entry, int *start_x) {
     if (ctx->ctrl_file_hide_right <= 0)
       (*start_x)--;
   } else {
-    int current_index = dir_entry->start_file + dir_entry->cursor_pos;
+    int current_index = start_file + cursor_pos;
     int file_count = (int)ctx->active->file_count;
 
     if (current_index + x_step < file_count) {
-      if (dir_entry->cursor_pos + x_step < GetSafeMaxDispFiles(ctx)) {
-        dir_entry->cursor_pos += x_step;
+      if (cursor_pos + x_step < GetSafeMaxDispFiles(ctx)) {
+        cursor_pos += x_step;
       } else {
-        dir_entry->start_file += x_step;
+        start_file += x_step;
       }
 
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file,
+                                              cursor_pos))
+        return;
       DisplayFiles(ctx, ctx->active, dir_entry, dir_entry->start_file,
                    dir_entry->start_file + dir_entry->cursor_pos, *start_x,
                    ctx->ctx_file_window);
@@ -115,11 +136,15 @@ void FileNav_MoveRight(ViewContext *ctx, DirEntry *dir_entry, int *start_x) {
 }
 
 void FileNav_MoveLeft(ViewContext *ctx, DirEntry *dir_entry, int *start_x) {
+  int cursor_pos;
+  int start_file;
   int x_step;
 
   if (!ctx || !ctx->active || !dir_entry || !start_x)
     return;
 
+  cursor_pos = dir_entry->cursor_pos;
+  start_file = dir_entry->start_file;
   x_step = GetSafeXStep(ctx);
   if (x_step == 1) {
     if (*start_x > 0)
@@ -128,16 +153,20 @@ void FileNav_MoveLeft(ViewContext *ctx, DirEntry *dir_entry, int *start_x) {
                  dir_entry->start_file + dir_entry->cursor_pos, *start_x,
                  ctx->ctx_file_window);
   } else {
-    int current_index = dir_entry->start_file + dir_entry->cursor_pos;
+    int current_index = start_file + cursor_pos;
 
     if (current_index - x_step >= 0) {
-      if (dir_entry->cursor_pos - x_step >= 0) {
-        dir_entry->cursor_pos -= x_step;
+      if (cursor_pos - x_step >= 0) {
+        cursor_pos -= x_step;
       } else {
-        if ((dir_entry->start_file -= x_step) < 0)
-          dir_entry->start_file = 0;
+        start_file -= x_step;
+        if (start_file < 0)
+          start_file = 0;
       }
 
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file,
+                                              cursor_pos))
+        return;
       DisplayFiles(ctx, ctx->active, dir_entry, dir_entry->start_file,
                    dir_entry->start_file + dir_entry->cursor_pos, *start_x,
                    ctx->ctx_file_window);
@@ -151,20 +180,33 @@ void FileNav_MoveLeft(ViewContext *ctx, DirEntry *dir_entry, int *start_x) {
 }
 
 void FileNav_PageDown(ViewContext *ctx, DirEntry *dir_entry, int start_x) {
+  int cursor_pos;
+  int start_file;
+
   if (!ctx || !ctx->active || !dir_entry)
     return;
 
-  Nav_PageDown(&dir_entry->cursor_pos, &dir_entry->start_file,
+  cursor_pos = dir_entry->cursor_pos;
+  start_file = dir_entry->start_file;
+  Nav_PageDown(&cursor_pos, &start_file,
                (int)ctx->active->file_count, GetSafeMaxDispFiles(ctx));
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+    return;
   RefreshFileSelection(ctx, dir_entry, start_x);
 }
 
 void FileNav_PageUp(ViewContext *ctx, DirEntry *dir_entry, int start_x) {
+  int cursor_pos;
+  int start_file;
+
   if (!ctx || !ctx->active || !dir_entry)
     return;
 
-  Nav_PageUp(&dir_entry->cursor_pos, &dir_entry->start_file,
-             GetSafeMaxDispFiles(ctx));
+  cursor_pos = dir_entry->cursor_pos;
+  start_file = dir_entry->start_file;
+  Nav_PageUp(&cursor_pos, &start_file, GetSafeMaxDispFiles(ctx));
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+    return;
   RefreshFileSelection(ctx, dir_entry, start_x);
 }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7499,6 +7499,49 @@ def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     )
 
 
+def test_file_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    file_nav = Path("src/ui/file_nav.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryFileViewport(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryFileViewport(")
+    helper_end = helper.index("\nBOOL AppStateCommitPanelFileViewport(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("panel.file_viewport_origin")'
+    start_write = "dir_entry->start_file = start_file;"
+    cursor_write = "dir_entry->cursor_pos = cursor_pos;"
+    assert validation in helper_body
+    assert start_write in helper_body
+    assert cursor_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(start_write)
+    assert helper_body.index(validation) < helper_body.index(cursor_write)
+
+    function_names = [
+        "FileNav_MoveDown",
+        "FileNav_MoveUp",
+        "FileNav_MoveRight",
+        "FileNav_MoveLeft",
+        "FileNav_PageDown",
+        "FileNav_PageUp",
+    ]
+    mutation = re.compile(
+        r"(?:&dir_entry->(?:cursor_pos|start_file)|"
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--))"
+    )
+    for name in function_names:
+        function_start = file_nav.index(f"void {name}(")
+        next_function = file_nav.find("\nvoid ", function_start + 1)
+        function_body = (
+            file_nav[function_start:]
+            if next_function == -1
+            else file_nav[function_start:next_function]
+        )
+        assert not mutation.search(function_body)
+        assert "AppStateCommitDirEntryFileViewport(dir_entry," in function_body
+
+
 def test_panel_file_anchor_clears_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a validated AppState helper for DirEntry file viewport commits.
- Route file navigation viewport mutations through that helper before syncing panel viewport state.
- Guard file navigation against direct DirEntry viewport writes outside the helper boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_dir_entry_viewports_commit_through_appstate_helper` failed before adding the DirEntry viewport helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_dir_entry_viewports_commit_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_nav_dir_entry_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make` with existing warnings.
