### PR TITLE
refactor(appstate): route file operation viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,8 +4,8 @@ Date: 2026-07-01
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-nav-dir-entry-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/308
+Current branch: appstate-file-ops-dir-entry-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/309
 Stop condition: none; autonomous continuation remains active.
 
 Merged in this continuation:
@@ -32,16 +32,19 @@ Merged in this continuation:
 - refactor(appstate): route panel donation display state through helpers
   - PR: https://github.com/robkam/ytreenova/pull/307
   - Merge commit: 1a8566f7ef92171073e6b903ac79739f67aac91a
+- refactor(appstate): route file navigation viewports through helper
+  - PR: https://github.com/robkam/ytreenova/pull/308
+  - Merge commit: 522fae4cf843de2f9d249f6d2d2ff5c9d883fdc8
 
 Current AppState batch:
-- Route file navigation DirEntry file viewport mutations through a validated AppState helper.
-- Keep panel file viewport commits in the existing panel helper after the DirEntry viewport commit.
-- Add guard coverage preventing direct file navigation mutation of DirEntry start_file/cursor_pos outside the helper boundary.
+- Route ctrl_file_ops DirEntry file viewport corrections and resets through the validated AppState helper.
+- Keep existing panel file viewport commits after the DirEntry viewport helper commits.
+- Add guard coverage preventing direct ctrl_file_ops mutation of DirEntry start_file/cursor_pos outside the helper boundary.
 
 Validation recorded before PR creation:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_dir_entry_viewports_commit_through_appstate_helper` failed before adding the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_dir_entry_viewports_commit_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_nav_dir_entry_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper` failed before ctrl_file_ops used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - Passed: `make clean && make` with existing warnings.

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -178,17 +178,21 @@ static FileEntry *GetActivePanelSelectedFile(ViewContext *ctx,
 
 static void RebuildActiveFileListAfterMutation(ViewContext *ctx,
                                                DirEntry *dir_entry) {
+  int cursor_pos;
   int file_count;
+  int start_file;
 
   if (!ctx || !ctx->active || !dir_entry)
     return;
 
   BuildFileEntryList(ctx, ctx->active);
 
+  cursor_pos = dir_entry->cursor_pos;
+  start_file = dir_entry->start_file;
   file_count = (int)ctx->active->file_count;
   if (file_count <= 0) {
-    dir_entry->start_file = 0;
-    dir_entry->cursor_pos = 0;
+    start_file = 0;
+    cursor_pos = 0;
   } else {
     int max_disp_files;
 
@@ -196,21 +200,23 @@ static void RebuildActiveFileListAfterMutation(ViewContext *ctx,
     if (max_disp_files < 1)
       max_disp_files = 1;
 
-    if (dir_entry->start_file < 0)
-      dir_entry->start_file = 0;
-    if (dir_entry->start_file >= file_count)
-      dir_entry->start_file = file_count - 1;
-    if (dir_entry->cursor_pos < 0)
-      dir_entry->cursor_pos = 0;
-    if (dir_entry->cursor_pos >= max_disp_files)
-      dir_entry->cursor_pos = max_disp_files - 1;
+    if (start_file < 0)
+      start_file = 0;
+    if (start_file >= file_count)
+      start_file = file_count - 1;
+    if (cursor_pos < 0)
+      cursor_pos = 0;
+    if (cursor_pos >= max_disp_files)
+      cursor_pos = max_disp_files - 1;
 
-    if (dir_entry->start_file + dir_entry->cursor_pos >= file_count) {
-      dir_entry->start_file = MAXIMUM(0, file_count - max_disp_files);
-      dir_entry->cursor_pos = file_count - 1 - dir_entry->start_file;
+    if (start_file + cursor_pos >= file_count) {
+      start_file = MAXIMUM(0, file_count - max_disp_files);
+      cursor_pos = file_count - 1 - start_file;
     }
   }
 
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+    return;
   (void)AppStateCommitPanelFileViewport(ctx->active, dir_entry->start_file,
                                         dir_entry->cursor_pos);
 }
@@ -390,6 +396,9 @@ BOOL handle_file_window_navigation_action(
     BOOL *need_dsp_help_ptr, long *preview_line_offset_ptr,
     void (*update_preview)(ViewContext *, const DirEntry *),
     void (*list_jump)(ViewContext *, DirEntry *, char *)) {
+  int cursor_pos;
+  int start_file;
+
   if (!ctx || !dir_entry || !start_x_ptr)
     return FALSE;
 
@@ -441,8 +450,12 @@ BOOL handle_file_window_navigation_action(
     return TRUE;
 
   case ACTION_END:
-    Nav_End(&dir_entry->cursor_pos, &dir_entry->start_file,
+    cursor_pos = dir_entry->cursor_pos;
+    start_file = dir_entry->start_file;
+    Nav_End(&cursor_pos, &start_file,
             (int)ctx->active->file_count, FileNav_GetMaxDispFiles(ctx));
+    if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+      return FALSE;
     UI_RenderFilePanel(ctx, dir_entry, *start_x_ptr);
     FileNav_UpdateHeaderPath(ctx, dir_entry);
     ResetPreviewAfterNavigation(ctx, dir_entry, preview_line_offset_ptr,
@@ -452,7 +465,11 @@ BOOL handle_file_window_navigation_action(
     return TRUE;
 
   case ACTION_HOME:
-    Nav_Home(&dir_entry->cursor_pos, &dir_entry->start_file);
+    cursor_pos = dir_entry->cursor_pos;
+    start_file = dir_entry->start_file;
+    Nav_Home(&cursor_pos, &start_file);
+    if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+      return FALSE;
     UI_RenderFilePanel(ctx, dir_entry, *start_x_ptr);
     FileNav_UpdateHeaderPath(ctx, dir_entry);
     ResetPreviewAfterNavigation(ctx, dir_entry, preview_line_offset_ptr,
@@ -935,18 +952,22 @@ BOOL handle_file_window_misc_dispatch_action(
     break;
 
   case ACTION_TOGGLE_MODE: {
+    int cursor_pos;
     int list_pos;
+    int start_file;
     if (ctx->preview_mode) {
       UI_Beep(ctx, FALSE);
       break;
     }
     list_pos = dir_entry->start_file + dir_entry->cursor_pos;
+    cursor_pos = dir_entry->cursor_pos;
     RotatePanelFileMode(ctx, ctx->active);
     FileNav_SyncGridMetrics(ctx);
-    if (dir_entry->cursor_pos >= FileNav_GetMaxDispFiles(ctx)) {
-      dir_entry->cursor_pos = FileNav_GetMaxDispFiles(ctx) - 1;
-    }
-    dir_entry->start_file = list_pos - dir_entry->cursor_pos;
+    if (cursor_pos >= FileNav_GetMaxDispFiles(ctx))
+      cursor_pos = FileNav_GetMaxDispFiles(ctx) - 1;
+    start_file = list_pos - cursor_pos;
+    if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+      return FALSE;
     DisplayFiles(ctx, ctx->active, dir_entry, dir_entry->start_file,
                  dir_entry->start_file + dir_entry->cursor_pos, start_x,
                  ctx->ctx_file_window);
@@ -1030,8 +1051,8 @@ BOOL handle_file_window_misc_dispatch_action(
 
   case ACTION_FILTER:
     if (UI_ReadFilter(ctx) == 0) {
-      dir_entry->start_file = 0;
-      dir_entry->cursor_pos = 0;
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, 0))
+        return FALSE;
       BuildFileEntryList(ctx, ctx->active);
       DisplayFilter(ctx, s);
       DisplayFiles(ctx, ctx->active, dir_entry, dir_entry->start_file,
@@ -1320,8 +1341,8 @@ static BOOL HandleTaggedFileOpDispatchAction(
 
       BuildFileEntryList(ctx, ctx->active);
 
-      dir_entry->start_file = 0;
-      dir_entry->cursor_pos = 0;
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, 0))
+        return FALSE;
 
       RefreshView(ctx, dir_entry);
       maybe_change_x_step = TRUE;
@@ -1774,8 +1795,8 @@ static BOOL HandleTaggedSelectionDispatchAction(
       dir_entry->tagged_flag = FALSE;
 
     BuildFileEntryList(ctx, ctx->active);
-    dir_entry->start_file = 0;
-    dir_entry->cursor_pos = 0;
+    if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, 0))
+      return FALSE;
     UI_RenderFilePanel(ctx, dir_entry, start_x);
 
     if (maybe_change_x_step_ptr)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7542,6 +7542,41 @@ def test_file_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
         assert "AppStateCommitDirEntryFileViewport(dir_entry," in function_body
 
 
+def test_ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper() -> None:
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"(?:&dir_entry->(?:cursor_pos|start_file)|"
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--))"
+    )
+    expectations = {
+        "RebuildActiveFileListAfterMutation": 1,
+        "handle_file_window_navigation_action": 2,
+        "handle_file_window_misc_dispatch_action": 2,
+        "HandleTaggedFileOpDispatchAction": 1,
+        "HandleTaggedSelectionDispatchAction": 1,
+    }
+
+    for name, helper_count in expectations.items():
+        function_start = ctrl_file_ops.index(f"{name}(")
+        next_function = ctrl_file_ops.find("\nBOOL ", function_start + 1)
+        static_next_function = ctrl_file_ops.find("\nstatic ", function_start + 1)
+        if next_function == -1 or (
+            static_next_function != -1 and static_next_function < next_function
+        ):
+            next_function = static_next_function
+        function_body = (
+            ctrl_file_ops[function_start:]
+            if next_function == -1
+            else ctrl_file_ops[function_start:next_function]
+        )
+
+        assert not mutation.search(function_body)
+        assert (
+            function_body.count("AppStateCommitDirEntryFileViewport(dir_entry,")
+            == helper_count
+        )
+
+
 def test_panel_file_anchor_clears_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route `ctrl_file_ops` DirEntry viewport corrections and resets through the AppState helper.
- Keep panel viewport synchronization after DirEntry viewport commits.
- Guard `ctrl_file_ops` against direct DirEntry viewport writes outside the helper boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper` failed before `ctrl_file_ops` used the DirEntry viewport helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make` with existing warnings.
