### PR TITLE
refactor(appstate): route file refresh viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,9 +4,9 @@ Date: 2026-07-01
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-ops-dir-entry-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/309
-Stop condition: none; autonomous continuation remains active.
+Current branch: appstate-file-refresh-dir-entry-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/310
+Stop condition: STOP BEFORE 311. Resolve PR 310 only; do not start another PR.
 
 Merged in this continuation:
 - refactor(appstate): route display options through helpers
@@ -35,21 +35,27 @@ Merged in this continuation:
 - refactor(appstate): route file navigation viewports through helper
   - PR: https://github.com/robkam/ytreenova/pull/308
   - Merge commit: 522fae4cf843de2f9d249f6d2d2ff5c9d883fdc8
+- refactor(appstate): route file operation viewports through helper
+  - PR: https://github.com/robkam/ytreenova/pull/309
+  - Merge commit: ba7c619642cefe9f814a8bfcb7ffefb0d2daff67
 
 Current AppState batch:
-- Route ctrl_file_ops DirEntry file viewport corrections and resets through the validated AppState helper.
+- Route ctrl_file refresh and file-window handoff DirEntry viewport commits through the validated AppState helper.
 - Keep existing panel file viewport commits after the DirEntry viewport helper commits.
-- Add guard coverage preventing direct ctrl_file_ops mutation of DirEntry start_file/cursor_pos outside the helper boundary.
+- Add guard coverage preventing direct ctrl_file refresh/handoff mutation of DirEntry start_file/cursor_pos outside the helper boundary.
 
 Validation recorded before PR creation:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper` failed before ctrl_file_ops used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper` failed before ctrl_file refresh/handoff paths used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - Passed: `make clean && make` with existing warnings.
+- Passed after CI remediation: `make qa-cppcheck`
+- Red CI proof: PR full local-equivalent QA gate failed at `gitleaks detect --source . --redact --exit-code 1`; redacted report identified historical false-positive generic-api-key fingerprints in tracked `.agent/handoffs/prompt.1.5.txt` and `.agent/handoffs/report.1.5.txt` lines describing the old AppState refresh event label.
+- Passed after CI remediation: `make qa-gitleaks`
 
 Next action:
 - Follow the CI wait rule for the active draft PR.
-- If CI is green, mark ready if needed, merge when allowed, clean up branch state, update this checkpoint, and continue with the next small coherent AppState batch unless superseded.
+- If CI is green, mark ready if needed, merge when allowed, clean up branch state, update this checkpoint, then stop before starting any next PR.
 - If CI is red, inspect only failure-relevant summary/tail and fix clear repo-side failures.

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+# False-positive handoff references to a historical AppState refresh event label.
+09615cc198c020025d20123d9095398f5bfb5062:.agent/handoffs/prompt.1.5.txt:generic-api-key:12
+09615cc198c020025d20123d9095398f5bfb5062:.agent/handoffs/report.1.5.txt:generic-api-key:6

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -159,8 +159,10 @@ int ChangeFileGroup(ViewContext *ctx, FileEntry *fe_ptr) {
 DirEntry *RefreshFileView(ViewContext *ctx, DirEntry *dir_entry) {
   char *saved_name = NULL;
   const Statistic *s = &ctx->active->vol->vol_stats;
+  int cursor_pos;
   int found_idx = -1;
   int start_x = 0;
+  int start_file;
 
   /* 1. Save current filename */
   if (ctx->active->file_count > 0) {
@@ -198,28 +200,30 @@ DirEntry *RefreshFileView(ViewContext *ctx, DirEntry *dir_entry) {
 
   if (found_idx != -1) {
     /* Calculate new start_file and cursor_pos */
-    if (found_idx >= dir_entry->start_file &&
-        found_idx < dir_entry->start_file + FileNav_GetMaxDispFiles(ctx)) {
+    start_file = dir_entry->start_file;
+    if (found_idx >= start_file &&
+        found_idx < start_file + FileNav_GetMaxDispFiles(ctx)) {
       /* Still on screen, just move cursor */
-      dir_entry->cursor_pos = found_idx - dir_entry->start_file;
+      cursor_pos = found_idx - start_file;
     } else {
       /* Off screen, recenter or scroll */
-      dir_entry->start_file = found_idx;
-      dir_entry->cursor_pos = 0;
+      start_file = found_idx;
+      cursor_pos = 0;
       /* Bounds check */
-      if (dir_entry->start_file + FileNav_GetMaxDispFiles(ctx) >
+      if (start_file + FileNav_GetMaxDispFiles(ctx) >
           (int)ctx->active->file_count) {
-        dir_entry->start_file = MAXIMUM(0, (int)ctx->active->file_count -
-                                               FileNav_GetMaxDispFiles(ctx));
-        dir_entry->cursor_pos =
-            (int)ctx->active->file_count - 1 - dir_entry->start_file;
+        start_file = MAXIMUM(0, (int)ctx->active->file_count -
+                                    FileNav_GetMaxDispFiles(ctx));
+        cursor_pos = (int)ctx->active->file_count - 1 - start_file;
       }
     }
   } else {
     /* File gone, reset to top */
-    dir_entry->start_file = 0;
-    dir_entry->cursor_pos = 0;
+    start_file = 0;
+    cursor_pos = 0;
   }
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+    return dir_entry;
 
   /* 5. Update Display */
   if (dir_entry->global_flag)
@@ -248,6 +252,8 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   DEBUG_LOG("HandleFileWindow ENTERED for %s", dir_entry->name);
   FileEntry *fe_ptr;
   int ch;
+  int cursor_pos;
+  int start_file;
   int unput_char;
   int start_x = 0;
   BOOL need_dsp_help;
@@ -273,8 +279,9 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   if (!AppStateCommitPanelFileShape(ctx->active, big_file_shape))
     return ESC;
   if (tracked_file_dir == dir_entry) {
-    dir_entry->start_file = ctx->active->start_file;
-    dir_entry->cursor_pos = ctx->active->file_cursor_pos;
+    if (!AppStateCommitDirEntryFileViewport(
+            dir_entry, ctx->active->start_file, ctx->active->file_cursor_pos))
+      return ESC;
   }
   if (!AppStateCommitPanelFileAnchor(ctx->active, dir_entry))
     return ESC;
@@ -294,24 +301,27 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   ctx->ctrl_file_hide_right = 0;
 
   /* Sanitize cursor position immediately after BuildFileEntryList */
+  cursor_pos = dir_entry->cursor_pos;
+  start_file = dir_entry->start_file;
   if (ctx->active->file_count > 0) {
-    if (dir_entry->cursor_pos < 0)
-      dir_entry->cursor_pos = 0;
-    if (dir_entry->start_file < 0)
-      dir_entry->start_file = 0;
+    if (cursor_pos < 0)
+      cursor_pos = 0;
+    if (start_file < 0)
+      start_file = 0;
 
     /* Bounds Check: ensure we aren't past the end */
-    if ((unsigned int)(dir_entry->start_file + dir_entry->cursor_pos) >=
+    if ((unsigned int)(start_file + cursor_pos) >=
         ctx->active->file_count) {
-      dir_entry->start_file = MAXIMUM(0, (int)ctx->active->file_count -
-                                             FileNav_GetMaxDispFiles(ctx));
-      dir_entry->cursor_pos =
-          (int)ctx->active->file_count - 1 - dir_entry->start_file;
+      start_file = MAXIMUM(0, (int)ctx->active->file_count -
+                                  FileNav_GetMaxDispFiles(ctx));
+      cursor_pos = (int)ctx->active->file_count - 1 - start_file;
     }
   } else {
-    dir_entry->cursor_pos = 0;
-    dir_entry->start_file = 0;
+    cursor_pos = 0;
+    start_file = 0;
   }
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos))
+    return ESC;
   (void)AppStateCommitPanelFileViewport(ctx->active, dir_entry->start_file,
                                         dir_entry->cursor_pos);
   if (ctx->active->file_entry_list && ctx->active->file_count > 0) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7577,6 +7577,27 @@ def test_ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper() -> N
         )
 
 
+def test_ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper() -> None:
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    refresh_start = ctrl_file.index("DirEntry *RefreshFileView(")
+    handle_start = ctrl_file.index("\nint HandleFileWindow(", refresh_start)
+    refresh_body = ctrl_file[refresh_start:handle_start]
+    assert not mutation.search(refresh_body)
+    helper_call = re.compile(r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,")
+    assert len(helper_call.findall(refresh_body)) == 1
+
+    initial_display_start = ctrl_file.index(
+        "\n  /* Initial Display using Centralized Function", handle_start
+    )
+    handoff_body = ctrl_file[handle_start:initial_display_start]
+    assert not mutation.search(handoff_body)
+    assert len(helper_call.findall(handoff_body)) == 2
+
+
 def test_panel_file_anchor_clears_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route `ctrl_file` refresh and file-window handoff viewport commits through the AppState helper.
- Keep panel viewport synchronization after DirEntry viewport commits.
- Guard refresh/handoff paths against direct DirEntry viewport writes outside the helper boundary.
- Record the historical handoff false-positive fingerprints so the secret scan remains green without weakening the gate.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper` failed before `ctrl_file` refresh/handoff paths used the DirEntry viewport helper.
- Red proof: PR full local-equivalent QA gate failed at `gitleaks detect --source . --redact --exit-code 1`; redacted report identified historical false-positive generic-api-key fingerprints in tracked handoff text.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or runtime_owner_field_startup or runtime_invariant_startup or runtime_diff_harness_startup'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make` with existing warnings.
- `make qa-cppcheck`
- `make qa-gitleaks`
