### PR TITLE
docs(appstate): keep handoff checkpoints with pushed subunits

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,9 +4,9 @@ Date: 2026-07-01
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-refresh-dir-entry-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/310
-Stop condition: STOP BEFORE 311. Resolve PR 310 only; do not start another PR.
+Current branch: appstate-handoff-push-checkpoint
+Active PR: https://github.com/robkam/ytreenova/pull/311
+Stop condition: maintainer requested one final prompt-process fix; do not resume AppState subunits after this fix without explicit instruction.
 
 Merged in this continuation:
 - refactor(appstate): route display options through helpers
@@ -38,11 +38,19 @@ Merged in this continuation:
 - refactor(appstate): route file operation viewports through helper
   - PR: https://github.com/robkam/ytreenova/pull/309
   - Merge commit: ba7c619642cefe9f814a8bfcb7ffefb0d2daff67
+- refactor(appstate): route file refresh viewports through helper
+  - PR: https://github.com/robkam/ytreenova/pull/310
+  - Merge commit: a85e9433d3519854eea92e4934c53cfa08c53a8c
 
-Current AppState batch:
+Last AppState batch:
 - Route ctrl_file refresh and file-window handoff DirEntry viewport commits through the validated AppState helper.
 - Keep existing panel file viewport commits after the DirEntry viewport helper commits.
 - Add guard coverage preventing direct ctrl_file refresh/handoff mutation of DirEntry start_file/cursor_pos outside the helper boundary.
+
+Current process fix:
+- Update `TASK 1 PROMPT.md` so future AppState subunit checkpoints are committed with the subunit branch before each push.
+- Require red-PR remediation pushes to amend the latest `.agent/handoffs/prompt.1.txt` state into the same commit.
+- Prevent post-merge handoff-only checkpoint edits from remaining orphaned locally.
 
 Validation recorded before PR creation:
 - Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper` failed before ctrl_file refresh/handoff paths used the DirEntry viewport helper.
@@ -54,8 +62,7 @@ Validation recorded before PR creation:
 - Passed after CI remediation: `make qa-cppcheck`
 - Red CI proof: PR full local-equivalent QA gate failed at `gitleaks detect --source . --redact --exit-code 1`; redacted report identified historical false-positive generic-api-key fingerprints in tracked `.agent/handoffs/prompt.1.5.txt` and `.agent/handoffs/report.1.5.txt` lines describing the old AppState refresh event label.
 - Passed after CI remediation: `make qa-gitleaks`
+- Passed for process prompt update: `make qa-gitleaks`
 
 Next action:
-- Follow the CI wait rule for the active draft PR.
-- If CI is green, mark ready if needed, merge when allowed, clean up branch state, update this checkpoint, then stop before starting any next PR.
-- If CI is red, inspect only failure-relevant summary/tail and fix clear repo-side failures.
+- Open a small prompt-process PR, merge when green, return to main, then wait for explicit maintainer instruction before starting another PR.

--- a/TASK 1 PROMPT.md
+++ b/TASK 1 PROMPT.md
@@ -12,7 +12,7 @@ First, load required repo instructions:
 Local recovery state:
 - Use /home/rob/ytreenova/.agent/handoffs/prompt.1.txt as the live checkpoint if it is current.
 - If that checkpoint is stale or incomplete, reconstruct from local files in /home/rob/ytreenova/.agent/handoffs.
-- The handoff files are gitignored/local-only; do not expect GitHub to contain them.
+- The handoff files are tracked recovery context; keep `/home/rob/ytreenova/.agent/handoffs/prompt.1.txt` current and include it in the same branch push as the subunit it describes.
 - Use docs/appstate*.json to identify remaining AppState registry/runtime boundary work.
 - Use git and GitHub to discover the current branch, current PR, merged PRs, and stale branches.
 - Do not rely on PR numbers, branch names, run IDs, or details from older chats.
@@ -52,16 +52,16 @@ What to do now:
 1. Inspect current git/GitHub state.
 2. If there is an active PR:
    - Follow the CI wait rule.
-   - If checks are green, mark ready if needed, merge when allowed, clean up stale remote/local branch state, update .agent/handoffs/prompt.1.txt, then continue according to the autonomous continuation policy unless a superseding stop condition applies.
+   - If checks are green, ensure `.agent/handoffs/prompt.1.txt` already reflects the pushed PR state, mark ready if needed, merge when allowed, clean up stale remote/local branch state, then continue according to the autonomous continuation policy unless a superseding stop condition applies. Do not leave a post-merge handoff-only edit orphaned locally; include any required checkpoint update in the next pushed branch, or in a small handoff/docs PR if stopping.
    - If checks failed, inspect only the failure-relevant log tail/summary. Fix only clearly repo-side, in-scope failures. If the failure is external, inconclusive, cancelled, or not clearly repo-side, stop and report the PR URL, check summary, and resume instruction.
 3. If there is no active PR:
    - Select the next small coherent AppState batch from docs/appstate*.json and the current handoff context.
    - Implement it through the repo’s developer/auditor/PR workflow.
    - Run focused local validation only.
-   - Push a draft PR.
-   - Update .agent/handoffs/prompt.1.txt as the live recovery checkpoint.
+   - Update `.agent/handoffs/prompt.1.txt` as the live recovery checkpoint before the first push.
+   - Commit the subunit and checkpoint together, then push a draft PR.
    - Follow the CI wait rule.
-   - When CI is green, mark ready if needed, merge when allowed, clean up stale remote/local branch state, update .agent/handoffs/prompt.1.txt, then continue with the next small coherent AppState batch unless a superseding stop condition applies.
+   - When CI is green, ensure the latest pushed commit already contains the current `.agent/handoffs/prompt.1.txt`, mark ready if needed, merge when allowed, clean up stale remote/local branch state, then continue with the next small coherent AppState batch unless a superseding stop condition applies. Do not leave a post-merge handoff-only edit orphaned locally; include any required checkpoint update in the next pushed branch, or in a small handoff/docs PR if stopping.
 
 Context discipline:
 - Do not stream full CI logs.
@@ -84,8 +84,8 @@ What you must do from now until completion of task 1, unless I tell you to pause
 For any active/open PR after CI starts or restarts, follow the CI wait rule from the main prompt.
 
 At each allowed CI status check:
-- If CI is green, mark the PR ready if needed, merge when branch protection and review requirements allow, clean up branch state, return to main, then proceed according to the final resume rule.
-- If CI is red, inspect only the failure-relevant summary/tail and fix clear repo-side failures. Each pushed fix restarts the CI wait rule.
+- If CI is green, ensure the latest pushed commit already contains the current `.agent/handoffs/prompt.1.txt`, mark the PR ready if needed, merge when branch protection and review requirements allow, clean up branch state, return to main, then proceed according to the final resume rule without leaving a handoff-only local edit orphaned.
+- If CI is red, inspect only the failure-relevant summary/tail and fix clear repo-side failures. Before each fix push, update `.agent/handoffs/prompt.1.txt` with the red proof/remediation state and amend it into the same commit; each pushed fix restarts the CI wait rule.
 - If CI is still running or pending, continue following the CI wait rule.
 
 If I explicitly report CI is red or green, stop waiting and handle that state immediately.


### PR DESCRIPTION
## Summary
- Update the AppState continuation prompt so live handoff checkpoints are committed before branch pushes.
- Require red-PR remediation pushes to amend the current checkpoint into the same branch state.
- Avoid post-merge handoff-only edits remaining orphaned locally when stopping.

## Validation
- `make qa-gitleaks`
