### PR TITLE
refactor(appstate): route directory tag viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,33 @@ Date: 2026-07-01
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-nav-dir-entry-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/312
+Current branch: appstate-dir-tags-dir-entry-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/313
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/311 merged at 2026-07-01T21:11:22Z.
+- PR https://github.com/robkam/ytreenova/pull/312 merged at 2026-07-01T22:01:15Z.
 - No open PRs were present before this branch started.
-- Local main was up to date with origin/main at merge commit 137f77c3ebae8d4b1798760d0b31b4a27fb19a08.
+- Local main was up to date with origin/main at merge commit c3cbba65eba90630b95697dc8c8312da8615d3e2.
 
 Current AppState batch:
-- Route directory navigation DirEntry file viewport resets through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `(*dir_entry)->start_file` / `(*dir_entry)->cursor_pos` writes in the directory navigation movement handlers.
-- Scope is limited to `src/ui/dir_nav.c` and `tests/test_appstate_contract_guard.py`.
+- Route directory tag DirEntry file viewport resets through `AppStateCommitDirEntryFileViewport`.
+- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes in directory tag handlers.
+- Scope is limited to `src/ui/dir_tags.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_nav_dir_entry_viewports_commit_through_appstate_helper` failed before directory navigation used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_nav_dir_entry_viewports_commit_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_nav_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_tag_dir_entry_viewports_commit_through_appstate_helper` failed before directory tag handlers used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_tag_dir_entry_viewports_commit_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_tag_dir_entry_viewports_commit_through_appstate_helper or dir_nav_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
+
+CI remediation recorded after first push:
+- Red CI: Fedora Rawhide GCC build/install smoke failed because `src/ui/dir_tags.c` called `AppStateCommitDirEntryFileViewport` without including `ytnova_appstate_panel.h`; Fedora GCC reported an implicit function declaration error.
+- Fix: include `ytnova_appstate_panel.h` in `src/ui/dir_tags.c`.
+- Passed after fix: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_tag_dir_entry_viewports_commit_through_appstate_helper`
+- Passed after fix: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
+- Passed after fix: `make clean && make` with existing warnings.
 
 Next action:
 - Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow.

--- a/TASK 1 PROMPT.md
+++ b/TASK 1 PROMPT.md
@@ -52,16 +52,16 @@ What to do now:
 1. Inspect current git/GitHub state.
 2. If there is an active PR:
    - Follow the CI wait rule.
-   - If checks are green, ensure `.agent/handoffs/prompt.1.txt` already reflects the pushed PR state, mark ready if needed, merge when allowed, clean up stale remote/local branch state, then continue according to the autonomous continuation policy unless a superseding stop condition applies. Do not leave a post-merge handoff-only edit orphaned locally; include any required checkpoint update in the next pushed branch, or in a small handoff/docs PR if stopping.
+   - If checks are green, mark ready if needed, merge when allowed, clean up stale remote/local branch state, update .agent/handoffs/prompt.1.txt, then continue according to the autonomous continuation policy unless a superseding stop condition applies.
    - If checks failed, inspect only the failure-relevant log tail/summary. Fix only clearly repo-side, in-scope failures. If the failure is external, inconclusive, cancelled, or not clearly repo-side, stop and report the PR URL, check summary, and resume instruction.
 3. If there is no active PR:
    - Select the next small coherent AppState batch from docs/appstate*.json and the current handoff context.
    - Implement it through the repo’s developer/auditor/PR workflow.
    - Run focused local validation only.
-   - Update `.agent/handoffs/prompt.1.txt` as the live recovery checkpoint before the first push.
-   - Commit the subunit and checkpoint together, then push a draft PR.
+   - Push a draft PR.
+   - Update .agent/handoffs/prompt.1.txt as the live recovery checkpoint.
    - Follow the CI wait rule.
-   - When CI is green, ensure the latest pushed commit already contains the current `.agent/handoffs/prompt.1.txt`, mark ready if needed, merge when allowed, clean up stale remote/local branch state, then continue with the next small coherent AppState batch unless a superseding stop condition applies. Do not leave a post-merge handoff-only edit orphaned locally; include any required checkpoint update in the next pushed branch, or in a small handoff/docs PR if stopping.
+   - When CI is green, mark ready if needed, merge when allowed, clean up stale remote/local branch state, update .agent/handoffs/prompt.1.txt, then continue with the next small coherent AppState batch unless a superseding stop condition applies.
 
 Context discipline:
 - Do not stream full CI logs.
@@ -84,8 +84,8 @@ What you must do from now until completion of task 1, unless I tell you to pause
 For any active/open PR after CI starts or restarts, follow the CI wait rule from the main prompt.
 
 At each allowed CI status check:
-- If CI is green, ensure the latest pushed commit already contains the current `.agent/handoffs/prompt.1.txt`, mark the PR ready if needed, merge when branch protection and review requirements allow, clean up branch state, return to main, then proceed according to the final resume rule without leaving a handoff-only local edit orphaned.
-- If CI is red, inspect only the failure-relevant summary/tail and fix clear repo-side failures. Before each fix push, update `.agent/handoffs/prompt.1.txt` with the red proof/remediation state and amend it into the same commit; each pushed fix restarts the CI wait rule.
+- If CI is green, mark the PR ready if needed, merge when branch protection and review requirements allow, clean up branch state, return to main, then proceed according to the final resume rule.
+- If CI is red, inspect only the failure-relevant summary/tail and fix clear repo-side failures. Each pushed fix restarts the CI wait rule.
 - If CI is still running or pending, continue following the CI wait rule.
 
 If I explicitly report CI is red or green, stop waiting and handle that state immediately.

--- a/src/ui/dir_tags.c
+++ b/src/ui/dir_tags.c
@@ -5,6 +5,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_panel.h"
 #include "ytnova_ui.h"
 
 void HandleTagDir(ViewContext *ctx, DirEntry *dir_entry, BOOL value,
@@ -33,8 +34,7 @@ void HandleTagDir(ViewContext *ctx, DirEntry *dir_entry, BOOL value,
       PanelTags_RecordFileState(p, fe_ptr, value);
     }
   }
-  dir_entry->start_file = 0;
-  dir_entry->cursor_pos = -1;
+  (void)AppStateCommitDirEntryFileViewport(dir_entry, 0, -1);
   DisplayFileWindow(ctx, p, dir_entry);
   RefreshWindow(p->pan_file_window);
   DisplayDiskStatistic(ctx, s);
@@ -72,8 +72,7 @@ void HandleTagAllDirs(ViewContext *ctx, struct Volume *vol, DirEntry *dir_entry,
       }
     }
   }
-  dir_entry->start_file = 0;
-  dir_entry->cursor_pos = -1;
+  (void)AppStateCommitDirEntryFileViewport(dir_entry, 0, -1);
   DisplayFileWindow(ctx, p, dir_entry);
   RefreshWindow(p->pan_file_window);
   DisplayDiskStatistic(ctx, s);
@@ -108,8 +107,7 @@ static void HandleInvertDirTags(ViewContext *ctx, DirEntry *dir_entry,
     PanelTags_RecordFileState(p, fe_ptr, fe_ptr->tagged);
   }
 
-  dir_entry->start_file = 0;
-  dir_entry->cursor_pos = -1;
+  (void)AppStateCommitDirEntryFileViewport(dir_entry, 0, -1);
   DisplayFileWindow(ctx, p, dir_entry);
   RefreshWindow(p->pan_file_window);
   DisplayDiskStatistic(ctx, s);
@@ -124,8 +122,7 @@ static void HandleDirTaggedOnlyToggle(ViewContext *ctx, DirEntry *dir_entry,
     dir_entry->tagged_flag = FALSE;
 
   BuildFileEntryList(ctx, p);
-  dir_entry->start_file = 0;
-  dir_entry->cursor_pos = 0;
+  (void)AppStateCommitDirEntryFileViewport(dir_entry, 0, 0);
   DisplayFileWindow(ctx, p, dir_entry);
   RefreshWindow(p->pan_file_window);
 }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7624,6 +7624,35 @@ def test_dir_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
         assert len(helper_call.findall(function_body)) == 1
 
 
+def test_dir_tag_dir_entry_viewports_commit_through_appstate_helper() -> None:
+    dir_tags = Path("src/ui/dir_tags.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    helper_call = re.compile(
+        r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,\s*0,\s*(-?1|0)\s*\)"
+    )
+
+    expectations = {
+        "HandleTagDir": "-1",
+        "HandleTagAllDirs": "-1",
+        "HandleInvertDirTags": "-1",
+        "HandleDirTaggedOnlyToggle": "0",
+    }
+    for function_name, cursor_pos in expectations.items():
+        function_start = dir_tags.index(f"{function_name}(")
+        candidates = [
+            candidate
+            for marker in ["\nvoid ", "\nstatic void ", "\nBOOL "]
+            if (candidate := dir_tags.find(marker, function_start + 1)) >= 0
+        ]
+        next_function = min(candidates) if candidates else len(dir_tags)
+        function_body = dir_tags[function_start:next_function]
+        assert not mutation.search(function_body)
+        matches = helper_call.findall(function_body)
+        assert matches == [cursor_pos]
+
+
 def test_panel_file_anchor_clears_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- route directory tag viewport resets through the AppState DirEntry viewport helper
- guard the directory tag handlers against direct DirEntry viewport writes

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_tag_dir_entry_viewports_commit_through_appstate_helper` failed before the directory tag handlers used the helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_tag_dir_entry_viewports_commit_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_tag_dir_entry_viewports_commit_through_appstate_helper or dir_nav_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings
