### PR TITLE
refactor(appstate): route owner directory viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,33 +4,25 @@ Date: 2026-07-01
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-tags-dir-entry-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/313
+Current branch: appstate-file-owner-dir-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/314
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/312 merged at 2026-07-01T22:01:15Z.
-- No open PRs were present before this branch started.
-- Local main was up to date with origin/main at merge commit c3cbba65eba90630b95697dc8c8312da8615d3e2.
+- PR https://github.com/robkam/ytreenova/pull/313 merged at 2026-07-01T23:35:20Z.
+- Local main was up to date with origin/main at merge commit 4d2bcee87bdd81c3c396f64e2ef08629d6acb0a1.
+- The prior remote branch was already deleted by GitHub when local cleanup ran.
 
 Current AppState batch:
-- Route directory tag DirEntry file viewport resets through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes in directory tag handlers.
-- Scope is limited to `src/ui/dir_tags.c` and `tests/test_appstate_contract_guard.py`.
+- Route owner-directory file cursor positioning in `src/ui/ctrl_file.c` through `AppStateCommitDirEntryFileViewport` before mirroring into the panel viewport snapshot.
+- Add guard coverage preventing direct `owner_dir->start_file` / `owner_dir->cursor_pos` writes in `PositionOwnerFileCursor`.
+- Scope is limited to `src/ui/ctrl_file.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_tag_dir_entry_viewports_commit_through_appstate_helper` failed before directory tag handlers used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_tag_dir_entry_viewports_commit_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_tag_dir_entry_viewports_commit_through_appstate_helper or dir_nav_dir_entry_viewports_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper` failed before owner-directory positioning used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper or dir_tag_dir_entry_viewports_commit_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
-
-CI remediation recorded after first push:
-- Red CI: Fedora Rawhide GCC build/install smoke failed because `src/ui/dir_tags.c` called `AppStateCommitDirEntryFileViewport` without including `ytnova_appstate_panel.h`; Fedora GCC reported an implicit function declaration error.
-- Fix: include `ytnova_appstate_panel.h` in `src/ui/dir_tags.c`.
-- Passed after fix: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_tag_dir_entry_viewports_commit_through_appstate_helper`
-- Passed after fix: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- Passed after fix: `make clean && make` with existing warnings.
 
 Next action:
 - Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow.

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -848,6 +848,8 @@ static void PositionOwnerFileCursor(ViewContext *ctx, DirEntry *owner_dir,
   int page_size;
   int column_count;
   int file_count;
+  int start_file;
+  int cursor_pos;
 
   if (!ctx || !ctx->active || !owner_dir || !target_file)
     return;
@@ -856,10 +858,9 @@ static void PositionOwnerFileCursor(ViewContext *ctx, DirEntry *owner_dir,
 
   file_count = (int)ctx->active->file_count;
   if (file_count <= 0) {
-    owner_dir->start_file = 0;
-    owner_dir->cursor_pos = 0;
-    (void)AppStateCommitPanelFileViewport(ctx->active, owner_dir->start_file,
-                                          owner_dir->cursor_pos);
+    if (!AppStateCommitDirEntryFileViewport(owner_dir, 0, 0))
+      return;
+    (void)AppStateCommitPanelFileViewport(ctx->active, 0, 0);
     return;
   }
 
@@ -871,10 +872,9 @@ static void PositionOwnerFileCursor(ViewContext *ctx, DirEntry *owner_dir,
   }
 
   if (file_idx < 0) {
-    owner_dir->start_file = 0;
-    owner_dir->cursor_pos = 0;
-    (void)AppStateCommitPanelFileViewport(ctx->active, owner_dir->start_file,
-                                          owner_dir->cursor_pos);
+    if (!AppStateCommitDirEntryFileViewport(owner_dir, 0, 0))
+      return;
+    (void)AppStateCommitPanelFileViewport(ctx->active, 0, 0);
     return;
   }
 
@@ -889,21 +889,22 @@ static void PositionOwnerFileCursor(ViewContext *ctx, DirEntry *owner_dir,
   if (page_size < 1)
     page_size = 1;
 
-  owner_dir->start_file = file_idx;
-  owner_dir->cursor_pos = 0;
+  start_file = file_idx;
+  cursor_pos = 0;
 
-  if (owner_dir->start_file + page_size > file_count) {
-    owner_dir->start_file = MAXIMUM(0, file_count - page_size);
-    owner_dir->cursor_pos = file_idx - owner_dir->start_file;
+  if (start_file + page_size > file_count) {
+    start_file = MAXIMUM(0, file_count - page_size);
+    cursor_pos = file_idx - start_file;
   }
 
-  if (owner_dir->cursor_pos < 0)
-    owner_dir->cursor_pos = 0;
-  if (owner_dir->cursor_pos >= page_size)
-    owner_dir->cursor_pos = page_size - 1;
+  if (cursor_pos < 0)
+    cursor_pos = 0;
+  if (cursor_pos >= page_size)
+    cursor_pos = page_size - 1;
 
-  (void)AppStateCommitPanelFileViewport(ctx->active, owner_dir->start_file,
-                                        owner_dir->cursor_pos);
+  if (!AppStateCommitDirEntryFileViewport(owner_dir, start_file, cursor_pos))
+    return;
+  (void)AppStateCommitPanelFileViewport(ctx->active, start_file, cursor_pos);
 }
 
 static BOOL JumpToOwnerDirectory(ViewContext *ctx,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7598,6 +7598,29 @@ def test_ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper() 
     assert len(helper_call.findall(handoff_body)) == 2
 
 
+def test_ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper() -> None:
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bowner_dir->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    function_start = ctrl_file.index("static void PositionOwnerFileCursor(")
+    function_start = ctrl_file.index("static void PositionOwnerFileCursor(", function_start + 1)
+    function_end = ctrl_file.index("\nstatic BOOL JumpToOwnerDirectory(", function_start)
+    function_body = ctrl_file[function_start:function_end]
+
+    assert not mutation.search(function_body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitDirEntryFileViewport\(\s*owner_dir,",
+                function_body,
+            )
+        )
+        == 3
+    )
+
+
 def test_dir_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- route owner-directory file cursor positioning through the AppState DirEntry viewport helper
- guard owner-directory positioning against direct DirEntry viewport writes

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper` failed before owner-directory positioning used the helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper or dir_tag_dir_entry_viewports_commit_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings
