### PR TITLE
refactor(appstate): route file grid viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -1,26 +1,26 @@
 # ytreenova AppState continuation checkpoint
 
-Date: 2026-07-01
+Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-owner-dir-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/314
+Current branch: appstate-file-grid-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/315
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/313 merged at 2026-07-01T23:35:20Z.
-- Local main was up to date with origin/main at merge commit 4d2bcee87bdd81c3c396f64e2ef08629d6acb0a1.
-- The prior remote branch was already deleted by GitHub when local cleanup ran.
+- PR https://github.com/robkam/ytreenova/pull/314 merged after PR checks were green.
+- Local main was up to date with origin/main at merge commit 08e32cdaafbe1e293b56a9f85e613a9a682b9443.
+- No open PRs were present before this branch started.
 
 Current AppState batch:
-- Route owner-directory file cursor positioning in `src/ui/ctrl_file.c` through `AppStateCommitDirEntryFileViewport` before mirroring into the panel viewport snapshot.
-- Add guard coverage preventing direct `owner_dir->start_file` / `owner_dir->cursor_pos` writes in `PositionOwnerFileCursor`.
-- Scope is limited to `src/ui/ctrl_file.c` and `tests/test_appstate_contract_guard.py`.
+- Route file-navigation window-size/grid viewport adjustments through `AppStateCommitDirEntryFileViewport`.
+- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes in `FileNav_RereadWindowSize`.
+- Scope is limited to `src/ui/file_nav.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper` failed before owner-directory positioning used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper or dir_tag_dir_entry_viewports_commit_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_grid_metrics_viewport_commit_through_appstate_helper` failed before `FileNav_RereadWindowSize` used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_nav_grid_metrics_viewport_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/ui/file_nav.c
+++ b/src/ui/file_nav.c
@@ -232,16 +232,22 @@ void FileNav_SyncGridMetrics(ViewContext *ctx) {
 }
 
 void FileNav_RereadWindowSize(ViewContext *ctx, DirEntry *dir_entry) {
+  int start_file;
+  int cursor_pos;
+
   if (!ctx || !ctx->active || !dir_entry)
     return;
 
   FileNav_SyncGridMetrics(ctx);
 
+  start_file = dir_entry->start_file;
+  cursor_pos = dir_entry->cursor_pos;
   if (dir_entry->start_file + dir_entry->cursor_pos <
       (int)ctx->active->file_count) {
-    while (dir_entry->cursor_pos >= GetSafeMaxDispFiles(ctx)) {
-      dir_entry->start_file += GetSafeXStep(ctx);
-      dir_entry->cursor_pos -= GetSafeXStep(ctx);
+    while (cursor_pos >= GetSafeMaxDispFiles(ctx)) {
+      start_file += GetSafeXStep(ctx);
+      cursor_pos -= GetSafeXStep(ctx);
     }
   }
+  (void)AppStateCommitDirEntryFileViewport(dir_entry, start_file, cursor_pos);
 }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7542,6 +7542,31 @@ def test_file_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
         assert "AppStateCommitDirEntryFileViewport(dir_entry," in function_body
 
 
+def test_file_nav_grid_metrics_viewport_commit_through_appstate_helper() -> None:
+    file_nav = Path("src/ui/file_nav.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"(?:&dir_entry->(?:cursor_pos|start_file)|"
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--))"
+    )
+
+    function_start = file_nav.index("void FileNav_RereadWindowSize(")
+    next_function = file_nav.find("\nvoid ", function_start + 1)
+    function_body = file_nav[
+        function_start : (next_function if next_function >= 0 else len(file_nav))
+    ]
+
+    assert not mutation.search(function_body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,",
+                function_body,
+            )
+        )
+        == 1
+    )
+
+
 def test_ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper() -> None:
     ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- route file-navigation grid/window-size viewport adjustments through the AppState DirEntry viewport helper
- guard `FileNav_RereadWindowSize` against direct DirEntry viewport writes

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_grid_metrics_viewport_commit_through_appstate_helper` failed before `FileNav_RereadWindowSize` used the helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_nav_grid_metrics_viewport_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings
