### PR TITLE
refactor(appstate): route file list jump viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,23 +4,23 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-grid-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/315
+Current branch: appstate-file-list-jump-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/316
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/314 merged after PR checks were green.
-- Local main was up to date with origin/main at merge commit 08e32cdaafbe1e293b56a9f85e613a9a682b9443.
+- PR https://github.com/robkam/ytreenova/pull/315 merged after PR checks were green.
+- Local main was up to date with origin/main at merge commit 051049e.
 - No open PRs were present before this branch started.
 
 Current AppState batch:
-- Route file-navigation window-size/grid viewport adjustments through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes in `FileNav_RereadWindowSize`.
-- Scope is limited to `src/ui/file_nav.c` and `tests/test_appstate_contract_guard.py`.
+- Route file list-jump temporary DirEntry viewport updates through `AppStateCommitDirEntryFileViewport`.
+- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes in `ListJump`.
+- Scope is limited to `src/ui/ctrl_file.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_nav_grid_metrics_viewport_commit_through_appstate_helper` failed before `FileNav_RereadWindowSize` used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_nav_grid_metrics_viewport_commit_through_appstate_helper or file_nav_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_list_jump_viewports_commit_through_appstate_helper` failed before `ListJump` used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_list_jump_viewports_commit_through_appstate_helper or ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -1024,6 +1024,8 @@ static void ListJump(ViewContext *ctx, DirEntry *dir_entry, char *str) {
   int max_disp_files;
   int original_start_file;
   int original_cursor_pos;
+  int start_file;
+  int cursor_pos;
   int i;
   int found_idx;
   int start_x = 0;
@@ -1035,6 +1037,8 @@ static void ListJump(ViewContext *ctx, DirEntry *dir_entry, char *str) {
   max_disp_files = FileNav_GetMaxDispFiles(ctx);
   original_start_file = dir_entry->start_file;
   original_cursor_pos = dir_entry->cursor_pos;
+  start_file = original_start_file;
+  cursor_pos = original_cursor_pos;
   jump_win = ctx->ctx_menu_window ? ctx->ctx_menu_window : stdscr;
 
   (void)str; /* Unused */
@@ -1057,8 +1061,9 @@ static void ListJump(ViewContext *ctx, DirEntry *dir_entry, char *str) {
 
     if (ch == ESC) {
       /* Cancel: Restore */
-      dir_entry->start_file = original_start_file;
-      dir_entry->cursor_pos = original_cursor_pos;
+      if (!AppStateCommitDirEntryFileViewport(
+              dir_entry, original_start_file, original_cursor_pos))
+        return;
       DisplayFiles(ctx, ctx->active, dir_entry, dir_entry->start_file,
                    dir_entry->start_file + dir_entry->cursor_pos, start_x,
                    ctx->ctx_file_window);
@@ -1077,8 +1082,8 @@ static void ListJump(ViewContext *ctx, DirEntry *dir_entry, char *str) {
 
         /* Re-search or Restore */
         if (buf_len == 0) {
-          dir_entry->start_file = original_start_file;
-          dir_entry->cursor_pos = original_cursor_pos;
+          start_file = original_start_file;
+          cursor_pos = original_cursor_pos;
         } else {
           /* Search again from top for the shorter string */
           found_idx = -1;
@@ -1091,15 +1096,18 @@ static void ListJump(ViewContext *ctx, DirEntry *dir_entry, char *str) {
           }
 
           if (found_idx != -1) {
-            if (found_idx >= dir_entry->start_file &&
-                found_idx < dir_entry->start_file + max_disp_files) {
-              dir_entry->cursor_pos = found_idx - dir_entry->start_file;
+            if (found_idx >= start_file &&
+                found_idx < start_file + max_disp_files) {
+              cursor_pos = found_idx - start_file;
             } else {
-              dir_entry->start_file = found_idx;
-              dir_entry->cursor_pos = 0;
+              start_file = found_idx;
+              cursor_pos = 0;
             }
           }
         }
+        if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file,
+                                                cursor_pos))
+          return;
         DisplayFiles(ctx, ctx->active, dir_entry, dir_entry->start_file,
                      dir_entry->start_file + dir_entry->cursor_pos, start_x,
                      ctx->ctx_file_window);
@@ -1121,13 +1129,16 @@ static void ListJump(ViewContext *ctx, DirEntry *dir_entry, char *str) {
 
         if (found_idx != -1) {
           buf_len++; /* Accept char */
-          if (found_idx >= dir_entry->start_file &&
-              found_idx < dir_entry->start_file + max_disp_files) {
-            dir_entry->cursor_pos = found_idx - dir_entry->start_file;
+          if (found_idx >= start_file &&
+              found_idx < start_file + max_disp_files) {
+            cursor_pos = found_idx - start_file;
           } else {
-            dir_entry->start_file = found_idx;
-            dir_entry->cursor_pos = 0;
+            start_file = found_idx;
+            cursor_pos = 0;
           }
+          if (!AppStateCommitDirEntryFileViewport(dir_entry, start_file,
+                                                  cursor_pos))
+            return;
           DisplayFiles(ctx, ctx->active, dir_entry, dir_entry->start_file,
                        dir_entry->start_file + dir_entry->cursor_pos, start_x,
                        ctx->ctx_file_window);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7646,6 +7646,29 @@ def test_ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper() ->
     )
 
 
+def test_ctrl_file_list_jump_viewports_commit_through_appstate_helper() -> None:
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    function_start = ctrl_file.index("static void ListJump(")
+    function_start = ctrl_file.index("static void ListJump(", function_start + 1)
+    function_end = ctrl_file.index("\nstatic void UpdatePreview(", function_start)
+    function_body = ctrl_file[function_start:function_end]
+
+    assert not mutation.search(function_body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,",
+                function_body,
+            )
+        )
+        == 3
+    )
+
+
 def test_dir_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- route file list-jump temporary viewport updates through the AppState DirEntry viewport helper
- guard `ListJump` against direct DirEntry viewport writes

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_list_jump_viewports_commit_through_appstate_helper` failed before `ListJump` used the helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_list_jump_viewports_commit_through_appstate_helper or ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings
