### PR TITLE
refactor(appstate): route dir window file viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,23 +4,24 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-list-jump-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/316
+Current branch: appstate-dir-window-file-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/317
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/315 merged after PR checks were green.
-- Local main was up to date with origin/main at merge commit 051049e.
+- PR https://github.com/robkam/ytreenova/pull/316 merged after PR checks were green.
+- Local main fast-forwarded to origin/main at merge commit 3937767.
 - No open PRs were present before this branch started.
 
 Current AppState batch:
-- Route file list-jump temporary DirEntry viewport updates through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes in `ListJump`.
-- Scope is limited to `src/ui/ctrl_file.c` and `tests/test_appstate_contract_guard.py`.
+- Route `HandleDirWindow` DirEntry file viewport restore and reset writes through `AppStateCommitDirEntryFileViewport`.
+- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `HandleDirWindow`.
+- Scope is limited to `src/ui/ctrl_dir.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_file_list_jump_viewports_commit_through_appstate_helper` failed before `ListJump` used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_list_jump_viewports_commit_through_appstate_helper or ctrl_file_owner_dir_entry_viewports_commit_through_appstate_helper or ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper` failed before `HandleDirWindow` used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or dir_nav_dir_entry_viewports_commit_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -625,31 +625,35 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     }
   }
 
-  /* REPLACEMENT START: Unified Rendering Call */
   if (!dir_entry->log_flag) {
     if (ctx->active && ctx->active->saved_focus == FOCUS_FILE) {
-      if (ctx->active->file_dir_entry == dir_entry) {
-        dir_entry->start_file = ctx->active->start_file;
-        dir_entry->cursor_pos = ctx->active->file_cursor_pos;
-      }
-      if (dir_entry->start_file < 0)
-        dir_entry->start_file = 0;
-      if (dir_entry->cursor_pos < 0 && dir_entry->total_files > 0)
-        dir_entry->cursor_pos = 0;
+      int file_start = dir_entry->start_file;
+      int file_cursor = dir_entry->cursor_pos;
 
+      if (ctx->active->file_dir_entry == dir_entry) {
+        file_start = ctx->active->start_file;
+        file_cursor = ctx->active->file_cursor_pos;
+      }
+      if (file_start < 0)
+        file_start = 0;
+      if (file_cursor < 0 && dir_entry->total_files > 0)
+        file_cursor = 0;
+
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, file_start,
+                                              file_cursor))
+        return ESC;
       if (!AppStateCommitPanelFileAnchor(ctx->active, dir_entry))
         return ESC;
       (void)AppStateCommitPanelFileViewport(ctx->active, dir_entry->start_file,
                                             dir_entry->cursor_pos);
       BuildFileEntryList(ctx, ctx->active);
     } else {
-      dir_entry->start_file = 0;
-      dir_entry->cursor_pos = -1;
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, -1))
+        return ESC;
     }
   }
 
   RefreshView(ctx, dir_entry);
-  /* REPLACEMENT END */
 
   if (dir_entry->log_flag) {
     if ((dir_entry->global_flag) || (dir_entry->tagged_flag)) {
@@ -912,8 +916,8 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     case ACTION_FILTER:
       if (UI_ReadFilter(ctx) == 0) {
         RecalculateSysStats(ctx, s);
-        dir_entry->start_file = 0;
-        dir_entry->cursor_pos = -1;
+        if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, -1))
+          return ESC;
         RefreshView(ctx, dir_entry);
       }
       need_dsp_help = TRUE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7669,6 +7669,28 @@ def test_ctrl_file_list_jump_viewports_commit_through_appstate_helper() -> None:
     )
 
 
+def test_ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper() -> None:
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    function_start = ctrl_dir.index("\nextern int HandleDirWindow(")
+    function_end = ctrl_dir.index("\nstatic void DirListJump(", function_start)
+    function_body = ctrl_dir[function_start:function_end]
+
+    assert not mutation.search(function_body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,",
+                function_body,
+            )
+        )
+        == 3
+    )
+
+
 def test_dir_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route `HandleDirWindow` file viewport restores and resets through `AppStateCommitDirEntryFileViewport`.
- Add a contract guard that prevents direct DirEntry file viewport writes in `HandleDirWindow`.
- Refresh the live recovery checkpoint for the current AppState batch.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper` failed before the helper routing change.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or dir_nav_dir_entry_viewports_commit_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings
