### PR TITLE
refactor(appstate): route logged file viewport restore through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,24 +4,24 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-sort-file-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/318
+Current branch: appstate-log-file-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/319
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/317 merged after PR checks were green.
-- Local main fast-forwarded to origin/main at merge commit 3a9c3c0.
+- PR https://github.com/robkam/ytreenova/pull/318 merged after PR checks were green.
+- Local main fast-forwarded to origin/main at merge commit a8d0fa8.
 - No open PRs were present before this branch started.
 
 Current AppState batch:
-- Route the `UI_HandleSort` DirEntry file viewport reset through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `UI_HandleSort`.
-- Scope is limited to `src/ui/interactions.c` and `tests/test_appstate_contract_guard.py`.
+- Route `PositionSavedFileSelection` DirEntry file viewport restore through `AppStateCommitDirEntryFileViewport`.
+- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `PositionSavedFileSelection`.
+- Scope is limited to `src/cmd/log.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k sort_interaction_viewports_commit_through_appstate_helper` failed before `UI_HandleSort` used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k sort_interaction_viewports_commit_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'sort_interaction_viewports_commit_through_appstate_helper or global_search_term_writes_route_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k log_file_selection_viewports_commit_through_appstate_helper` failed before `PositionSavedFileSelection` used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k log_file_selection_viewports_commit_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'log_file_selection_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or global_search_term_writes_route_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -103,8 +103,9 @@ static void PositionSavedFileSelection(ViewContext *ctx, YtreeNovaPanel *panel,
 
   if (!AppStateCommitPanelFileViewport(panel, start, selected_idx - start))
     return;
-  dir_entry->start_file = start;
-  dir_entry->cursor_pos = selected_idx - start;
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, start,
+                                          selected_idx - start))
+    return;
 }
 
 static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7713,6 +7713,31 @@ def test_sort_interaction_viewports_commit_through_appstate_helper() -> None:
     )
 
 
+def test_log_file_selection_viewports_commit_through_appstate_helper() -> None:
+    log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    function_start = log_source.index("static void PositionSavedFileSelection(")
+    function_end = log_source.index(
+        "\nstatic void RestorePanelFileSelection(", function_start
+    )
+    function_body = log_source[function_start:function_end]
+
+    assert not mutation.search(function_body)
+    assert 'include "ytnova_appstate_panel.h"' in log_source
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,",
+                function_body,
+            )
+        )
+        == 1
+    )
+
+
 def test_dir_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route `PositionSavedFileSelection` DirEntry file viewport restore through `AppStateCommitDirEntryFileViewport`.
- Add a contract guard that prevents direct DirEntry file viewport writes in `PositionSavedFileSelection`.
- Refresh the live recovery checkpoint for the current AppState batch.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k log_file_selection_viewports_commit_through_appstate_helper` failed before the helper routing change.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k log_file_selection_viewports_commit_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'log_file_selection_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or global_search_term_writes_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings
