### PR TITLE
refactor(appstate): route deleted directory file viewport resets through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,24 +4,24 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-log-file-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/319
+Current branch: appstate-dir-delete-file-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/320
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/318 merged after PR checks were green.
-- Local main fast-forwarded to origin/main at merge commit a8d0fa8.
+- PR https://github.com/robkam/ytreenova/pull/319 merged after PR checks were green.
+- Local main fast-forwarded to origin/main at merge commit 2c4efa1.
 - No open PRs were present before this branch started.
 
 Current AppState batch:
-- Route `PositionSavedFileSelection` DirEntry file viewport restore through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `PositionSavedFileSelection`.
-- Scope is limited to `src/cmd/log.c` and `tests/test_appstate_contract_guard.py`.
+- Route `HandleDirDeleteDirectory` DirEntry file viewport reset paths through `AppStateCommitDirEntryFileViewport`.
+- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `HandleDirDeleteDirectory`.
+- Scope is limited to `src/ui/dir_ops.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k log_file_selection_viewports_commit_through_appstate_helper` failed before `PositionSavedFileSelection` used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k log_file_selection_viewports_commit_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'log_file_selection_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or global_search_term_writes_route_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_delete_viewports_commit_through_appstate_helper` failed before `HandleDirDeleteDirectory` used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_delete_viewports_commit_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_delete_viewports_commit_through_appstate_helper or dir_ops_file_anchors_route_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1067,16 +1067,16 @@ DirEntry *HandleDirDeleteDirectory(ViewContext *ctx, DirEntry *dir_entry) {
       ctx->active->vol->total_dirs <= 0) {
     dir_entry = ResolveActiveDirEntry(ctx, s);
     if (dir_entry) {
-      dir_entry->start_file = 0;
-      dir_entry->cursor_pos = -1;
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, -1))
+        return dir_entry;
       RefreshView(ctx, dir_entry);
     }
     return dir_entry;
   }
   dir_entry = ResolveActiveDirEntry(ctx, s);
   if (dir_entry) {
-    dir_entry->start_file = 0;
-    dir_entry->cursor_pos = -1;
+    if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, -1))
+      return dir_entry;
     RefreshView(ctx, dir_entry);
   }
   return dir_entry;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7738,6 +7738,31 @@ def test_log_file_selection_viewports_commit_through_appstate_helper() -> None:
     )
 
 
+def test_dir_ops_delete_viewports_commit_through_appstate_helper() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    function_start = dir_ops.index("DirEntry *HandleDirDeleteDirectory(")
+    function_end = dir_ops.index(
+        "\nDirEntry *HandleDirRenameDirectory(", function_start
+    )
+    function_body = dir_ops[function_start:function_end]
+
+    assert not mutation.search(function_body)
+    assert 'include "ytnova_appstate_panel.h"' in dir_ops
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,",
+                function_body,
+            )
+        )
+        == 2
+    )
+
+
 def test_dir_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route `HandleDirDeleteDirectory` DirEntry file viewport reset paths through `AppStateCommitDirEntryFileViewport`.
- Add a contract guard that prevents direct DirEntry file viewport writes in `HandleDirDeleteDirectory`.
- Refresh the live recovery checkpoint for the current AppState batch.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_delete_viewports_commit_through_appstate_helper` failed before the helper routing change.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_delete_viewports_commit_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_delete_viewports_commit_through_appstate_helper or dir_ops_file_anchors_route_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings
