### PR TITLE
refactor(appstate): route switch window file viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,24 +4,24 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-delete-file-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/320
+Current branch: appstate-switch-window-file-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/321
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/319 merged after PR checks were green.
-- Local main fast-forwarded to origin/main at merge commit 2c4efa1.
+- PR https://github.com/robkam/ytreenova/pull/320 merged after PR checks were green.
+- Local main fast-forwarded to origin/main at merge commit ccffdab.
 - No open PRs were present before this branch started.
 
 Current AppState batch:
-- Route `HandleDirDeleteDirectory` DirEntry file viewport reset paths through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `HandleDirDeleteDirectory`.
+- Route `HandleSwitchWindow` DirEntry file viewport handoff through `AppStateCommitDirEntryFileViewport`.
+- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `HandleSwitchWindow`.
 - Scope is limited to `src/ui/dir_ops.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_delete_viewports_commit_through_appstate_helper` failed before `HandleDirDeleteDirectory` used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_delete_viewports_commit_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_delete_viewports_commit_through_appstate_helper or dir_ops_file_anchors_route_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_switch_window_viewports_commit_through_appstate_helper` failed before `HandleSwitchWindow` used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_switch_window_viewports_commit_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_switch_window_viewports_commit_through_appstate_helper or dir_ops_delete_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1219,24 +1219,31 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
         dir_entry->big_window = TRUE;
       else
         dir_entry->big_window = ctx->bypass_small_window;
-      if (restore_saved_file_window) {
-        dir_entry->start_file = p->start_file;
-        dir_entry->cursor_pos = p->file_cursor_pos;
-      } else {
-        /*
-         * A fresh file-view entry should start at the top of the file list,
-         * not inherit the tree cursor position that happened to select the
-         * directory. Preserve the saved file cursor only for the directory
-         * that already owns a file-selection snapshot.
-         */
-        dir_entry->start_file = 0;
-        dir_entry->cursor_pos = 0;
+      {
+        int file_start;
+        int file_cursor;
+
+        if (restore_saved_file_window) {
+          file_start = p->start_file;
+          file_cursor = p->file_cursor_pos;
+        } else {
+          /*
+           * A fresh file-view entry should start at the top of the file list,
+           * not inherit the tree cursor position that happened to select the
+           * directory. Preserve the saved file cursor only for the directory
+           * that already owns a file-selection snapshot.
+           */
+          file_start = 0;
+          file_cursor = 0;
+        }
+        if (file_start < 0)
+          file_start = 0;
+        if (file_cursor < 0)
+          file_cursor = 0;
+        if (!AppStateCommitDirEntryFileViewport(dir_entry, file_start,
+                                                file_cursor))
+          return;
       }
-      /* Preserve per-directory file selection when returning to file view. */
-      if (dir_entry->start_file < 0)
-        dir_entry->start_file = 0;
-      if (dir_entry->cursor_pos < 0)
-        dir_entry->cursor_pos = 0;
     }
     DEBUG_LOG("DEBUG: HandleSwitchWindow calling HandleFileWindow for %s",
               dir_entry->name);
@@ -1278,15 +1285,12 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
         return;
       }
 
-      /* REPLACEMENT: Use Centralized Refresh */
       RefreshView(ctx, dir_entry);
 
     } else {
-      /* ... existing LOG_ESC handling ... */
       BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
       dir_entry = GetPanelDirEntry(p);
 
-      /* Ensure visual consistency here too */
       if (dir_entry)
         RefreshView(ctx, dir_entry);
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7763,6 +7763,31 @@ def test_dir_ops_delete_viewports_commit_through_appstate_helper() -> None:
     )
 
 
+def test_dir_ops_switch_window_viewports_commit_through_appstate_helper() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    function_start = dir_ops.index("void HandleSwitchWindow(")
+    function_end = dir_ops.index(
+        "\nvoid RefreshVolumeSwitchViews(", function_start
+    )
+    function_body = dir_ops[function_start:function_end]
+
+    assert not mutation.search(function_body)
+    assert 'include "ytnova_appstate_panel.h"' in dir_ops
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,",
+                function_body,
+            )
+        )
+        == 1
+    )
+
+
 def test_dir_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route the switch-window DirEntry file viewport handoff through `AppStateCommitDirEntryFileViewport`.
- Keep the fresh file-view clamp before the projection helper and remove touched stale comments.
- Add contract guard coverage for `HandleSwitchWindow` viewport writes.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_switch_window_viewports_commit_through_appstate_helper` failed before `HandleSwitchWindow` used the DirEntry viewport helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_switch_window_viewports_commit_through_appstate_helper or dir_ops_delete_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` passed with existing warnings.
