### PR TITLE
refactor(appstate): route initial file anchors through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,29 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-switch-window-file-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/321
+Current branch: appstate-init-file-anchor-helper
+Active PR: https://github.com/robkam/ytreenova/pull/322
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/320 merged after PR checks were green.
-- Local main fast-forwarded to origin/main at merge commit ccffdab.
+- PR https://github.com/robkam/ytreenova/pull/321 merged.
+- Local main fast-forwarded to origin/main at merge commit 364dfab.
 - No open PRs were present before this branch started.
+- No stale AppState local or remote branch was present after fetch/prune.
 
 Current AppState batch:
-- Route `HandleSwitchWindow` DirEntry file viewport handoff through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `HandleSwitchWindow`.
-- Scope is limited to `src/ui/dir_ops.c` and `tests/test_appstate_contract_guard.py`.
+- Route `InitView` initial `ctx->left/right->file_dir_entry` clears through `AppStateCommitPanelFileAnchor`.
+- Add guard coverage preventing direct initial panel file-anchor writes in `InitView`.
+- Scope is limited to `src/core/init.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_switch_window_viewports_commit_through_appstate_helper` failed before `HandleSwitchWindow` used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_switch_window_viewports_commit_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_switch_window_viewports_commit_through_appstate_helper or dir_ops_delete_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_anchor_clears_route_through_appstate_helper` failed before `InitView` used the panel file-anchor helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_file_anchor_clears_route_through_appstate_helper or current_repository_appstate_contract_passes'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
+
+Committed change:
+- `e3f00ca refactor(appstate): route initial file anchors through helper`
 
 Next action:
 - Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow.

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -392,7 +392,12 @@ void InitView(ViewContext *ctx) {
     ctx->left = NULL;
     exit(1);
   }
-  ctx->left->file_dir_entry = NULL;
+  if (!AppStateCommitPanelFileAnchor(ctx->left, NULL)) {
+    fprintf(stderr, "InitView: failed to initialize left panel file anchor\n");
+    free(ctx->left);
+    ctx->left = NULL;
+    exit(1);
+  }
   if (!AppStateCommitPanelFileViewport(ctx->left, 0, 0)) {
     fprintf(stderr, "InitView: failed to initialize left panel file viewport\n");
     free(ctx->left);
@@ -422,7 +427,14 @@ void InitView(ViewContext *ctx) {
     ctx->left = NULL;
     exit(1);
   }
-  ctx->right->file_dir_entry = NULL;
+  if (!AppStateCommitPanelFileAnchor(ctx->right, NULL)) {
+    fprintf(stderr, "InitView: failed to initialize right panel file anchor\n");
+    free(ctx->right);
+    free(ctx->left);
+    ctx->right = NULL;
+    ctx->left = NULL;
+    exit(1);
+  }
   if (!AppStateCommitPanelFileViewport(ctx->right, 0, 0)) {
     fprintf(stderr, "InitView: failed to initialize right panel file viewport\n");
     free(ctx->right);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7846,6 +7846,7 @@ def test_dir_tag_dir_entry_viewports_commit_through_appstate_helper() -> None:
 def test_panel_file_anchor_clears_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
     log_source = Path("src/cmd/log.c").read_text(encoding="utf-8")
     volume_source = Path("src/core/volume.c").read_text(encoding="utf-8")
 
@@ -7874,6 +7875,20 @@ def test_panel_file_anchor_clears_route_through_appstate_helper() -> None:
     restore_body = log_source[restore_start:restore_end]
     assert not re.search(r"\bpanel->file_dir_entry\s*=\s*NULL", restore_body)
     assert "AppStateCommitPanelFileAnchor(panel, NULL)" in restore_body
+
+    init_start = init_source.index("void InitView(")
+    init_end = init_source.index("\nvoid CoreMainOps_Register(", init_start)
+    init_body = init_source[init_start:init_end]
+    assert not re.search(r"\bctx->(?:left|right)->file_dir_entry\s*=", init_body)
+    assert (
+        len(
+            re.findall(
+                r"AppStateCommitPanelFileAnchor\(\s*ctx->(?:left|right),\s*NULL\s*\)",
+                init_body,
+            )
+        )
+        == 2
+    )
 
 
 def test_volume_menu_file_anchors_route_through_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- Route initial panel file-anchor clears in `InitView` through the AppState panel helper.
- Extend the AppState contract guard so startup file-anchor initialization cannot bypass the helper.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_anchor_clears_route_through_appstate_helper` failed before `InitView` used the helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_file_anchor_clears_route_through_appstate_helper or current_repository_appstate_contract_passes'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
