### PR TITLE
refactor(appstate): route restored file viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,29 +4,26 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-init-file-anchor-helper
-Active PR: https://github.com/robkam/ytreenova/pull/322
+Current branch: appstate-restore-file-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/323
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/321 merged.
-- Local main fast-forwarded to origin/main at merge commit 364dfab.
+- PR https://github.com/robkam/ytreenova/pull/322 merged after PR checks were green.
+- Local main fast-forwarded to origin/main at merge commit 9e038a9.
+- Remote branch `appstate-init-file-anchor-helper` was pruned after merge.
 - No open PRs were present before this branch started.
-- No stale AppState local or remote branch was present after fetch/prune.
 
 Current AppState batch:
-- Route `InitView` initial `ctx->left/right->file_dir_entry` clears through `AppStateCommitPanelFileAnchor`.
-- Add guard coverage preventing direct initial panel file-anchor writes in `InitView`.
-- Scope is limited to `src/core/init.c` and `tests/test_appstate_contract_guard.py`.
+- Route `RestorePanelFileSelection` DirEntry file viewport restores through `AppStateCommitDirEntryFileViewport`.
+- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `RestorePanelFileSelection`.
+- Scope is limited to `src/ui/dir_ops.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_file_anchor_clears_route_through_appstate_helper` failed before `InitView` used the panel file-anchor helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'panel_file_anchor_clears_route_through_appstate_helper or current_repository_appstate_contract_passes'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_restore_file_viewports_commit_through_appstate_helper` failed before `RestorePanelFileSelection` used the DirEntry viewport helper.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_restore_file_viewports_commit_through_appstate_helper or dir_ops_switch_window_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
-
-Committed change:
-- `e3f00ca refactor(appstate): route initial file anchors through helper`
 
 Next action:
 - Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow.

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1395,6 +1395,8 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
                                     YtreeNovaPanel *panel) {
   int selected_idx = -1;
   unsigned int file_count = 0;
+  int restored_start;
+  int restored_cursor;
 
   if (!ctx || !dir_entry || !panel)
     return dir_entry;
@@ -1433,8 +1435,8 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
 
   DirOps_ReloadPanelFileAnchorIfMissing(ctx, panel, dir_entry);
 
-  dir_entry->start_file = panel->start_file;
-  dir_entry->cursor_pos = panel->file_cursor_pos;
+  restored_start = panel->start_file;
+  restored_cursor = panel->file_cursor_pos;
 
   if (panel->file_selection_name[0] != '\0' &&
       panel->file_selection_dir_path[0] != '\0') {
@@ -1459,7 +1461,7 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
 
   if (selected_idx >= 0) {
     int max_disp_files = FileNav_GetMaxDispFiles(ctx);
-    int start = dir_entry->start_file;
+    int start = restored_start;
 
     if (max_disp_files < 1)
       max_disp_files = 1;
@@ -1473,8 +1475,8 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
     if (start < 0)
       start = 0;
 
-    dir_entry->start_file = start;
-    dir_entry->cursor_pos = selected_idx - start;
+    restored_start = start;
+    restored_cursor = selected_idx - start;
   }
 
   file_count = panel->file_count;
@@ -1485,46 +1487,42 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
   if (file_count == 0) {
     DEBUG_LOG("RestorePanelFileSelection:empty_file_list path='%s' file='%s'",
               panel->file_selection_dir_path, panel->file_selection_name);
-    dir_entry->start_file = 0;
-    dir_entry->cursor_pos = 0;
+    restored_start = 0;
+    restored_cursor = 0;
   } else {
-    int original_start = dir_entry->start_file;
-    int original_cursor = dir_entry->cursor_pos;
-    if (dir_entry->start_file < 0)
-      dir_entry->start_file = 0;
-    if ((unsigned int)dir_entry->start_file >= file_count)
-      dir_entry->start_file = (int)file_count - 1;
-    if (dir_entry->cursor_pos < 0)
-      dir_entry->cursor_pos = 0;
-    if ((unsigned int)(dir_entry->start_file + dir_entry->cursor_pos) >=
-        file_count) {
-      dir_entry->cursor_pos = (int)file_count - 1 - dir_entry->start_file;
-      if (dir_entry->cursor_pos < 0)
-        dir_entry->cursor_pos = 0;
+    int original_start = restored_start;
+    int original_cursor = restored_cursor;
+    if (restored_start < 0)
+      restored_start = 0;
+    if ((unsigned int)restored_start >= file_count)
+      restored_start = (int)file_count - 1;
+    if (restored_cursor < 0)
+      restored_cursor = 0;
+    if ((unsigned int)(restored_start + restored_cursor) >= file_count) {
+      restored_cursor = (int)file_count - 1 - restored_start;
+      if (restored_cursor < 0)
+        restored_cursor = 0;
     }
-    if (original_start != dir_entry->start_file ||
-        original_cursor != dir_entry->cursor_pos) {
+    if (original_start != restored_start || original_cursor != restored_cursor) {
       DEBUG_LOG(
           "RestorePanelFileSelection:clamp start=%d->%d cursor=%d->%d count=%u",
-          original_start, dir_entry->start_file, original_cursor,
-          dir_entry->cursor_pos, file_count);
+          original_start, restored_start, original_cursor, restored_cursor,
+          file_count);
     }
   }
 
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, restored_start,
+                                          restored_cursor))
+    return dir_entry;
   if (!AppStateCommitPanelFileAnchor(panel, dir_entry))
     return dir_entry;
-  if (!AppStateCommitPanelFileViewport(panel, dir_entry->start_file,
-                                       dir_entry->cursor_pos))
+  if (!AppStateCommitPanelFileViewport(panel, restored_start, restored_cursor))
     return dir_entry;
   if (!AppStateCommitPanelFocus(ctx, panel, FOCUS_FILE))
     return dir_entry;
   if (!dir_entry->global_flag && !dir_entry->tagged_flag) {
     dir_entry->big_window = panel->saved_big_file_view;
   }
-  if (dir_entry->start_file < 0)
-    dir_entry->start_file = 0;
-  if (dir_entry->cursor_pos < 0 && dir_entry->total_files > 0)
-    dir_entry->cursor_pos = 0;
   DEBUG_LOG(
       "RestorePanelFileSelection:dir='%s' total=%u matching=%u file_count=%u "
       "start=%d cursor=%d focus=%d spec='%s'",

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7788,6 +7788,27 @@ def test_dir_ops_switch_window_viewports_commit_through_appstate_helper() -> Non
     )
 
 
+def test_dir_ops_restore_file_viewports_commit_through_appstate_helper() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    mutation = re.compile(
+        r"\bdir_entry->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    helper_call = re.compile(
+        r"AppStateCommitDirEntryFileViewport\(\s*dir_entry,\s*"
+        r"restored_start,\s*restored_cursor\s*\)"
+    )
+
+    function_start = dir_ops.index("\nDirEntry *RestorePanelFileSelection(")
+    function_end = dir_ops.index(
+        "\nDirWindowDispatchResult\nHandleDirWindowPanelAction(",
+        function_start,
+    )
+    function_body = dir_ops[function_start:function_end]
+
+    assert not mutation.search(function_body)
+    assert len(helper_call.findall(function_body)) == 1
+
+
 def test_dir_nav_dir_entry_viewports_commit_through_appstate_helper() -> None:
     dir_nav = Path("src/ui/dir_nav.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route restored DirEntry file viewports through the AppState panel helper.
- Extend the AppState contract guard so `RestorePanelFileSelection` cannot write file viewport fields directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_restore_file_viewports_commit_through_appstate_helper` failed before `RestorePanelFileSelection` used the helper.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_restore_file_viewports_commit_through_appstate_helper or dir_ops_switch_window_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
