### PR TITLE
refactor(appstate): route restored file shape through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,24 +4,25 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-restore-file-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/323
+Current branch: appstate-restore-file-shape-helper
+Active PR: https://github.com/robkam/ytreenova/pull/324
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/322 merged after PR checks were green.
-- Local main fast-forwarded to origin/main at merge commit 9e038a9.
-- Remote branch `appstate-init-file-anchor-helper` was pruned after merge.
+- PR https://github.com/robkam/ytreenova/pull/323 merged after PR checks were green.
+- Local main fast-forwarded to origin/main at merge commit 4a607be.
+- Remote branch `appstate-restore-file-viewport-helper` was pruned after merge.
 - No open PRs were present before this branch started.
 
 Current AppState batch:
-- Route `RestorePanelFileSelection` DirEntry file viewport restores through `AppStateCommitDirEntryFileViewport`.
-- Add guard coverage preventing direct `dir_entry->start_file` / `dir_entry->cursor_pos` writes inside `RestorePanelFileSelection`.
-- Scope is limited to `src/ui/dir_ops.c` and `tests/test_appstate_contract_guard.py`.
+- Add `AppStateCommitDirEntryFileShape` as a focus-shape compatibility helper for DirEntry file-window shape writes.
+- Route `RestorePanelFileSelection` DirEntry `big_window` restore through that helper.
+- Add guard coverage preventing direct `dir_entry->big_window` writes inside `RestorePanelFileSelection`.
+- Scope is limited to `include/ytnova_appstate_focus.h`, `src/ui/appstate_focus.c`, `src/ui/dir_ops.c`, and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_restore_file_viewports_commit_through_appstate_helper` failed before `RestorePanelFileSelection` used the DirEntry viewport helper.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_restore_file_viewports_commit_through_appstate_helper or dir_ops_switch_window_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_restore_file_shape_commits_use_appstate_helper` failed before the DirEntry file-shape helper existed.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_restore_file_shape_commits_use_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/include/ytnova_appstate_focus.h
+++ b/include/ytnova_appstate_focus.h
@@ -13,6 +13,7 @@
 BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
                               ViewFocus focus);
 BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view);
+BOOL AppStateCommitDirEntryFileShape(DirEntry *dir_entry, BOOL big_file_view);
 BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus);
 BOOL AppStateMirrorActivePanelFocus(ViewContext *ctx);
 

--- a/src/ui/appstate_focus.c
+++ b/src/ui/appstate_focus.c
@@ -35,6 +35,16 @@ BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view) {
   return TRUE;
 }
 
+BOOL AppStateCommitDirEntryFileShape(DirEntry *dir_entry, BOOL big_file_view) {
+  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->big_window = big_file_view ? TRUE : FALSE;
+  return TRUE;
+}
+
 BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus) {
   if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
     return FALSE;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1521,7 +1521,8 @@ DirEntry *RestorePanelFileSelection(ViewContext *ctx, DirEntry *dir_entry,
   if (!AppStateCommitPanelFocus(ctx, panel, FOCUS_FILE))
     return dir_entry;
   if (!dir_entry->global_flag && !dir_entry->tagged_flag) {
-    dir_entry->big_window = panel->saved_big_file_view;
+    if (!AppStateCommitDirEntryFileShape(dir_entry, panel->saved_big_file_view))
+      return dir_entry;
   }
   DEBUG_LOG(
       "RestorePanelFileSelection:dir='%s' total=%u matching=%u file_count=%u "

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -8975,6 +8975,38 @@ def test_panel_file_shape_commits_use_appstate_helper() -> None:
     )
 
 
+def test_dir_ops_restore_file_shape_commits_use_appstate_helper() -> None:
+    focus_header = Path("include/ytnova_appstate_focus.h").read_text(encoding="utf-8")
+    focus_helper = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryFileShape(" in focus_header
+
+    helper_start = focus_helper.index("BOOL AppStateCommitDirEntryFileShape(")
+    helper_end = focus_helper.index(
+        "\nBOOL AppStateCommitVolumeFocusMirror(",
+        helper_start,
+    )
+    helper_body = focus_helper[helper_start:helper_end]
+    assert (
+        'AppStateValidatedCompatibilityShim("shim.focused-window-session-flag")'
+        in helper_body
+    )
+    assert "dir_entry->big_window = big_file_view ? TRUE : FALSE;" in helper_body
+
+    restore_start = dir_ops.index("\nDirEntry *RestorePanelFileSelection(")
+    restore_end = dir_ops.index(
+        "\nDirWindowDispatchResult\nHandleDirWindowPanelAction(",
+        restore_start,
+    )
+    restore_body = dir_ops[restore_start:restore_end]
+    assert not re.search(r"\bdir_entry->big_window\s*=(?!=)", restore_body)
+    assert (
+        "AppStateCommitDirEntryFileShape(dir_entry, panel->saved_big_file_view)"
+        in restore_body
+    )
+
+
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     validation = (


### PR DESCRIPTION
## Summary
- Add an AppState focus-shape helper for DirEntry file-window shape commits.
- Route restored DirEntry file shape in `RestorePanelFileSelection` through the helper.
- Extend the AppState contract guard so that restore path cannot write `dir_entry->big_window` directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_restore_file_shape_commits_use_appstate_helper` failed before the DirEntry file-shape helper existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_restore_file_shape_commits_use_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
