### PR TITLE
refactor(appstate): route file ops dir entry state through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,25 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-restore-file-shape-helper
-Active PR: https://github.com/robkam/ytreenova/pull/324
+Current branch: appstate-file-ops-dir-entry-state-helpers
+Active PR: https://github.com/robkam/ytreenova/pull/325
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/323 merged after PR checks were green.
-- Local main fast-forwarded to origin/main at merge commit 4a607be.
-- Remote branch `appstate-restore-file-viewport-helper` was pruned after merge.
+- PR https://github.com/robkam/ytreenova/pull/324 merged after PR checks were green.
+- Local main fast-forwarded to origin/main at merge commit b465dae.
+- Remote branch `appstate-restore-file-shape-helper` was pruned after merge.
 - No open PRs were present before this branch started.
 
 Current AppState batch:
-- Add `AppStateCommitDirEntryFileShape` as a focus-shape compatibility helper for DirEntry file-window shape writes.
-- Route `RestorePanelFileSelection` DirEntry `big_window` restore through that helper.
-- Add guard coverage preventing direct `dir_entry->big_window` writes inside `RestorePanelFileSelection`.
-- Scope is limited to `include/ytnova_appstate_focus.h`, `src/ui/appstate_focus.c`, `src/ui/dir_ops.c`, and `tests/test_appstate_contract_guard.py`.
+- Route `RebindActiveFilePanelSelection` DirEntry file viewport restore through `AppStateCommitDirEntryFileViewport`.
+- Route `RebindActiveFilePanelSelection` and file-window Enter DirEntry file shape writes through `AppStateCommitDirEntryFileShape`.
+- Add guard coverage preventing direct `panel_dir` viewport/shape writes and direct Enter `dir_entry->big_window` writes in `src/ui/ctrl_file_ops.c`.
+- Scope is limited to `src/ui/ctrl_file_ops.c` and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_restore_file_shape_commits_use_appstate_helper` failed before the DirEntry file-shape helper existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_restore_file_shape_commits_use_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_rebind_dir_entry_state_commits_through_appstate_helpers or ctrl_file_ops_enter_dir_entry_shape_commits_through_appstate_helper'` failed before `ctrl_file_ops` used the helpers.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_rebind_dir_entry_state_commits_through_appstate_helpers or ctrl_file_ops_enter_dir_entry_shape_commits_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -123,10 +123,13 @@ BOOL RebindActiveFilePanelSelection(YtreeNovaPanel *panel, DirEntry **dir_entry_
    * window shape so the next keypress continues that panel's own selection
    * instead of inheriting the last pane's row or zoom state.
    */
-  panel_dir->start_file = panel->start_file;
-  panel_dir->cursor_pos = panel->file_cursor_pos;
-  if (!panel_dir->global_flag && !panel_dir->tagged_flag)
-    panel_dir->big_window = panel->saved_big_file_view;
+  if (!AppStateCommitDirEntryFileViewport(panel_dir, panel->start_file,
+                                          panel->file_cursor_pos))
+    return FALSE;
+  if (!panel_dir->global_flag && !panel_dir->tagged_flag) {
+    if (!AppStateCommitDirEntryFileShape(panel_dir, panel->saved_big_file_view))
+      return FALSE;
+  }
   if (!AppStateCommitPanelFileAnchor(panel, panel_dir))
     return FALSE;
   *dir_entry_io = panel_dir;
@@ -1102,7 +1105,8 @@ BOOL handle_file_window_misc_dispatch_action(
       break;
     if (!AppStateCommitPanelFileShape(ctx->active, TRUE))
       return FALSE;
-    dir_entry->big_window = TRUE;
+    if (!AppStateCommitDirEntryFileShape(dir_entry, TRUE))
+      return FALSE;
     RefreshView(ctx, dir_entry);
     FileNav_RereadWindowSize(ctx, dir_entry);
     loop_action = ACTION_NONE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7602,6 +7602,49 @@ def test_ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper() -> N
         )
 
 
+def test_ctrl_file_ops_rebind_dir_entry_state_commits_through_appstate_helpers() -> None:
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    viewport_mutation = re.compile(
+        r"\bpanel_dir->(?:cursor_pos|start_file)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    shape_mutation = re.compile(r"\bpanel_dir->big_window\s*=(?!=)")
+
+    function_start = ctrl_file_ops.index("BOOL RebindActiveFilePanelSelection(")
+    function_end = ctrl_file_ops.index(
+        "\nstatic void DebugLogFilePanelState(",
+        function_start,
+    )
+    function_body = ctrl_file_ops[function_start:function_end]
+
+    assert not viewport_mutation.search(function_body)
+    assert not shape_mutation.search(function_body)
+    assert (
+        "AppStateCommitDirEntryFileViewport(panel_dir, panel->start_file,"
+        in function_body
+    )
+    assert (
+        "AppStateCommitDirEntryFileShape(panel_dir, panel->saved_big_file_view)"
+        in function_body
+    )
+
+
+def test_ctrl_file_ops_enter_dir_entry_shape_commits_through_appstate_helper() -> None:
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    mutation = re.compile(r"\bdir_entry->big_window\s*=(?!=)")
+
+    function_start = ctrl_file_ops.index(
+        "BOOL handle_file_window_misc_dispatch_action("
+    )
+    function_end = ctrl_file_ops.index(
+        "\nstatic BOOL HandleTaggedFileOpDispatchAction(",
+        function_start,
+    )
+    function_body = ctrl_file_ops[function_start:function_end]
+
+    assert not mutation.search(function_body)
+    assert "AppStateCommitDirEntryFileShape(dir_entry, TRUE)" in function_body
+
+
 def test_ctrl_file_refresh_dir_entry_viewports_commit_through_appstate_helper() -> None:
     ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route file-panel rebind DirEntry viewport and shape restoration through AppState helpers.
- Route file-window Enter DirEntry shape changes through the AppState shape helper.
- Extend the AppState contract guard so these file ops paths cannot write DirEntry state directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_rebind_dir_entry_state_commits_through_appstate_helpers or ctrl_file_ops_enter_dir_entry_shape_commits_through_appstate_helper'` failed before `ctrl_file_ops` used the helpers.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_rebind_dir_entry_state_commits_through_appstate_helpers or ctrl_file_ops_enter_dir_entry_shape_commits_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
