### PR TITLE
refactor(appstate): route tagged filters through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,25 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-ops-dir-entry-state-helpers
-Active PR: https://github.com/robkam/ytreenova/pull/325
+Current branch: appstate-tagged-filter-helper
+Active PR: https://github.com/robkam/ytreenova/pull/326
 Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/324 merged after PR checks were green.
-- Local main fast-forwarded to origin/main at merge commit b465dae.
-- Remote branch `appstate-restore-file-shape-helper` was pruned after merge.
+- PR https://github.com/robkam/ytreenova/pull/325 merged after PR checks were green.
+- Local main fast-forwarded to origin/main at merge commit 82930b2.
+- Remote branch `appstate-file-ops-dir-entry-state-helpers` was pruned after merge.
 - No open PRs were present before this branch started.
 
 Current AppState batch:
-- Route `RebindActiveFilePanelSelection` DirEntry file viewport restore through `AppStateCommitDirEntryFileViewport`.
-- Route `RebindActiveFilePanelSelection` and file-window Enter DirEntry file shape writes through `AppStateCommitDirEntryFileShape`.
-- Add guard coverage preventing direct `panel_dir` viewport/shape writes and direct Enter `dir_entry->big_window` writes in `src/ui/ctrl_file_ops.c`.
-- Scope is limited to `src/ui/ctrl_file_ops.c` and `tests/test_appstate_contract_guard.py`.
+- Add `AppStateCommitDirEntryTaggedFilter` as a visibility/filter helper for DirEntry tagged-only filter state.
+- Route directory and file tagged-only toggles through that helper.
+- Add guard coverage preventing direct `dir_entry->tagged_flag` writes in the tagged-only toggle paths.
+- Scope is limited to `include/ytnova_appstate_visibility.h`, `src/ui/appstate_visibility.c`, `src/ui/dir_tags.c`, `src/ui/ctrl_file_ops.c`, and `tests/test_appstate_contract_guard.py`.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_rebind_dir_entry_state_commits_through_appstate_helpers or ctrl_file_ops_enter_dir_entry_shape_commits_through_appstate_helper'` failed before `ctrl_file_ops` used the helpers.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_file_ops_rebind_dir_entry_state_commits_through_appstate_helpers or ctrl_file_ops_enter_dir_entry_shape_commits_through_appstate_helper or ctrl_file_ops_dir_entry_viewports_commit_through_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_entry_tagged_filter_commits_through_appstate_helper` failed before the tagged-filter helper existed.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_entry_tagged_filter_commits_through_appstate_helper or panel_visibility_filter_commits_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/include/ytnova_appstate_visibility.h
+++ b/include/ytnova_appstate_visibility.h
@@ -14,5 +14,6 @@ BOOL AppStateCommitPanelVisibilityFilter(YtreeNovaPanel *panel,
                                          BOOL hide_dot_files);
 BOOL AppStateSeedPanelVisibilityFilter(YtreeNovaPanel *panel,
                                        BOOL hide_dot_files);
+BOOL AppStateCommitDirEntryTaggedFilter(DirEntry *dir_entry, BOOL tagged_only);
 
 #endif /* YTNOVA_APPSTATE_VISIBILITY_H */

--- a/src/ui/appstate_visibility.c
+++ b/src/ui/appstate_visibility.c
@@ -41,3 +41,13 @@ BOOL AppStateSeedPanelVisibilityFilter(YtreeNovaPanel *panel,
   panel->hide_dot_files = hide_dot_files ? TRUE : FALSE;
   return TRUE;
 }
+
+BOOL AppStateCommitDirEntryTaggedFilter(DirEntry *dir_entry, BOOL tagged_only) {
+  if (!AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->tagged_flag = tagged_only ? TRUE : FALSE;
+  return TRUE;
+}

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -13,6 +13,7 @@
 #include "ytnova_appstate_modal.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
+#include "ytnova_appstate_visibility.h"
 #include "ytnova_appstate_window.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
@@ -1793,10 +1794,10 @@ static BOOL HandleTaggedSelectionDispatchAction(
     return TRUE;
 
   case ACTION_TOGGLE_TAGGED_MODE:
-    if (dir_entry->tagged_files)
-      dir_entry->tagged_flag = !dir_entry->tagged_flag;
-    else
-      dir_entry->tagged_flag = FALSE;
+    if (!AppStateCommitDirEntryTaggedFilter(
+            dir_entry,
+            dir_entry->tagged_files ? !dir_entry->tagged_flag : FALSE))
+      return FALSE;
 
     BuildFileEntryList(ctx, ctx->active);
     if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, 0))

--- a/src/ui/dir_tags.c
+++ b/src/ui/dir_tags.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_visibility.h"
 #include "ytnova_ui.h"
 
 void HandleTagDir(ViewContext *ctx, DirEntry *dir_entry, BOOL value,
@@ -116,10 +117,10 @@ static void HandleInvertDirTags(ViewContext *ctx, DirEntry *dir_entry,
 
 static void HandleDirTaggedOnlyToggle(ViewContext *ctx, DirEntry *dir_entry,
                                       YtreeNovaPanel *p) {
-  if (dir_entry->tagged_files)
-    dir_entry->tagged_flag = !dir_entry->tagged_flag;
-  else
-    dir_entry->tagged_flag = FALSE;
+  BOOL tagged_only =
+      dir_entry->tagged_files ? !dir_entry->tagged_flag : FALSE;
+  if (!AppStateCommitDirEntryTaggedFilter(dir_entry, tagged_only))
+    return;
 
   BuildFileEntryList(ctx, p);
   (void)AppStateCommitDirEntryFileViewport(dir_entry, 0, 0);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6083,6 +6083,40 @@ def test_panel_visibility_filter_commits_through_appstate_helper() -> None:
     )
 
 
+def test_dir_entry_tagged_filter_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_visibility.h").read_text(
+        encoding="utf-8"
+    )
+    helper = Path("src/ui/appstate_visibility.c").read_text(encoding="utf-8")
+    dir_tags = Path("src/ui/dir_tags.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryTaggedFilter(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryTaggedFilter(")
+    helper_body = helper[helper_start:]
+    assert (
+        'AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume")'
+        in helper_body
+    )
+    assert "dir_entry->tagged_flag = tagged_only ? TRUE : FALSE;" in helper_body
+
+    dir_toggle_start = dir_tags.index("static void HandleDirTaggedOnlyToggle(")
+    dir_toggle_end = dir_tags.index("\nBOOL HandleDirTagActions(", dir_toggle_start)
+    dir_toggle_body = dir_tags[dir_toggle_start:dir_toggle_end]
+    file_toggle_start = ctrl_file_ops.index(
+        "static BOOL HandleTaggedSelectionDispatchAction("
+    )
+    file_toggle_body = ctrl_file_ops[file_toggle_start:]
+
+    for body in [dir_toggle_body, file_toggle_body]:
+        assert not re.search(r"\bdir_entry->tagged_flag\s*=(?!=)", body)
+        assert re.search(
+            r"AppStateCommitDirEntryTaggedFilter\(\s*dir_entry,",
+            body,
+        )
+
+
 def test_active_panel_session_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_session.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_session.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState visibility helper for DirEntry tagged-only filter state.
- Route directory and file tagged-only toggles through the helper.
- Extend the AppState contract guard so those paths cannot write `dir_entry->tagged_flag` directly.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_entry_tagged_filter_commits_through_appstate_helper` failed before the tagged-filter helper existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_entry_tagged_filter_commits_through_appstate_helper or panel_visibility_filter_commits_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make` with existing warnings.
