### PR TITLE
refactor(appstate): route file window mode resets through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,24 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-tagged-filter-helper
-Active PR: https://github.com/robkam/ytreenova/pull/326
-Supersession state: maintainer resumed autonomous AppState work after the earlier prompt-process stop condition.
+Current branch: appstate-file-window-mode-reset-helpers
+Active PR: https://github.com/robkam/ytreenova/pull/327
+Supersession state: maintainer resumed autonomous AppState work; no later pause or stop instruction is active.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/325 merged after PR checks were green.
-- Local main fast-forwarded to origin/main at merge commit 82930b2.
-- Remote branch `appstate-file-ops-dir-entry-state-helpers` was pruned after merge.
-- No open PRs were present before this branch started.
+- Main is at `483db83` after the tagged-filter helper PR merged.
+- No open PRs were reported by `gh pr status` before this branch publication.
+- Untracked local files are present and intentionally untouched: `docs/quickstart.md`.
 
 Current AppState batch:
-- Add `AppStateCommitDirEntryTaggedFilter` as a visibility/filter helper for DirEntry tagged-only filter state.
-- Route directory and file tagged-only toggles through that helper.
-- Add guard coverage preventing direct `dir_entry->tagged_flag` writes in the tagged-only toggle paths.
-- Scope is limited to `include/ytnova_appstate_visibility.h`, `src/ui/appstate_visibility.c`, `src/ui/dir_tags.c`, `src/ui/ctrl_file_ops.c`, and `tests/test_appstate_contract_guard.py`.
+- Add `AppStateCommitDirEntryGlobalFilter` as the DirEntry global-filter boundary helper.
+- Route file-window mode reset writes in `src/ui/ctrl_file.c` through AppState helpers for global filter, tagged filter, and file shape state.
+- Add guard coverage that prevents direct writes to `global_flag`, `global_all_volumes`, `tagged_flag`, and `big_window` in the file-window reset paths.
+- Scope is limited to `include/ytnova_appstate_visibility.h`, `src/ui/appstate_visibility.c`, `src/ui/ctrl_file.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_entry_tagged_filter_commits_through_appstate_helper` failed before the tagged-filter helper existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_entry_tagged_filter_commits_through_appstate_helper or panel_visibility_filter_commits_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_window_mode_resets_commit_through_appstate_helpers` failed before `AppStateCommitDirEntryGlobalFilter` existed.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_window_mode_resets_commit_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/include/ytnova_appstate_visibility.h
+++ b/include/ytnova_appstate_visibility.h
@@ -15,5 +15,7 @@ BOOL AppStateCommitPanelVisibilityFilter(YtreeNovaPanel *panel,
 BOOL AppStateSeedPanelVisibilityFilter(YtreeNovaPanel *panel,
                                        BOOL hide_dot_files);
 BOOL AppStateCommitDirEntryTaggedFilter(DirEntry *dir_entry, BOOL tagged_only);
+BOOL AppStateCommitDirEntryGlobalFilter(DirEntry *dir_entry, BOOL global_filter,
+                                        BOOL all_volumes);
 
 #endif /* YTNOVA_APPSTATE_VISIBILITY_H */

--- a/src/ui/appstate_visibility.c
+++ b/src/ui/appstate_visibility.c
@@ -51,3 +51,16 @@ BOOL AppStateCommitDirEntryTaggedFilter(DirEntry *dir_entry, BOOL tagged_only) {
   dir_entry->tagged_flag = tagged_only ? TRUE : FALSE;
   return TRUE;
 }
+
+BOOL AppStateCommitDirEntryGlobalFilter(DirEntry *dir_entry, BOOL global_filter,
+                                        BOOL all_volumes) {
+  if (!AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->global_flag = global_filter ? TRUE : FALSE;
+  dir_entry->global_all_volumes =
+      global_filter && all_volumes ? TRUE : FALSE;
+  return TRUE;
+}

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -18,6 +18,7 @@
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_visibility.h"
 #include "../../include/ytnova_cmd.h"
 #include "../../include/ytnova_fs.h"
 #include "../../include/ytnova_split_transition.h"
@@ -763,10 +764,12 @@ file_window_done:
       /* Ensure all mode flags are cleared when exiting back to the tree.
        * This guarantees that RefreshView returns to small window
        * ctx->layout. */
-      dir_entry->global_flag = FALSE;
-      dir_entry->global_all_volumes = FALSE;
-      dir_entry->tagged_flag = FALSE;
-      dir_entry->big_window = FALSE;
+      if (!AppStateCommitDirEntryGlobalFilter(dir_entry, FALSE, FALSE))
+        return ESC;
+      if (!AppStateCommitDirEntryTaggedFilter(dir_entry, FALSE))
+        return ESC;
+      if (!AppStateCommitDirEntryFileShape(dir_entry, FALSE))
+        return ESC;
     }
   } else {
     if (!AppStateCommitPanelFileAnchor(owner_panel, NULL))
@@ -979,10 +982,12 @@ static BOOL JumpToOwnerDirectory(ViewContext *ctx,
   if (!AppStateCommitPanelTreeViewport(panel, next_begin, next_cursor))
     return FALSE;
 
-  owner_dir->global_flag = FALSE;
-  owner_dir->global_all_volumes = FALSE;
-  owner_dir->tagged_flag = FALSE;
-  owner_dir->big_window = FALSE;
+  if (!AppStateCommitDirEntryGlobalFilter(owner_dir, FALSE, FALSE))
+    return FALSE;
+  if (!AppStateCommitDirEntryTaggedFilter(owner_dir, FALSE))
+    return FALSE;
+  if (!AppStateCommitDirEntryFileShape(owner_dir, FALSE))
+    return FALSE;
 
   PositionOwnerFileCursor(ctx, owner_dir, selected_file);
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6117,6 +6117,62 @@ def test_dir_entry_tagged_filter_commits_through_appstate_helper() -> None:
         )
 
 
+def test_file_window_mode_resets_commit_through_appstate_helpers() -> None:
+    visibility_header = Path("include/ytnova_appstate_visibility.h").read_text(
+        encoding="utf-8"
+    )
+    visibility_helper = Path("src/ui/appstate_visibility.c").read_text(
+        encoding="utf-8"
+    )
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryGlobalFilter(" in visibility_header
+
+    helper_start = visibility_helper.index(
+        "BOOL AppStateCommitDirEntryGlobalFilter("
+    )
+    helper_body = visibility_helper[helper_start:]
+    assert (
+        'AppStateValidatedGenerationDomain("state.visibility-filter.panel-volume")'
+        in helper_body
+    )
+    assert "dir_entry->global_flag = global_filter ? TRUE : FALSE;" in helper_body
+    assert re.search(
+        r"dir_entry->global_all_volumes\s*=\s*"
+        r"global_filter && all_volumes \? TRUE : FALSE;",
+        helper_body,
+    )
+
+    handle_start = ctrl_file.index("int HandleFileWindow(")
+    find_start = ctrl_file.index("\nstatic int FindDirIndexInVolume(", handle_start)
+    handle_body = ctrl_file[handle_start:find_start]
+    owner_start = ctrl_file.index("\nstatic BOOL JumpToOwnerDirectory(", find_start)
+    draw_prompt_start = ctrl_file.index("\nstatic void DrawFileListJumpPrompt(", owner_start)
+    owner_body = ctrl_file[owner_start:draw_prompt_start]
+
+    flag_write = re.compile(
+        r"\b(?:dir_entry|owner_dir)->"
+        r"(?:global_flag|global_all_volumes|tagged_flag|big_window)\s*=(?!=)"
+    )
+    for body in [handle_body, owner_body]:
+        assert not flag_write.search(body)
+        assert re.search(
+            r"AppStateCommitDirEntryGlobalFilter\(\s*"
+            r"(?:dir_entry|owner_dir),\s*FALSE,\s*FALSE\s*\)",
+            body,
+        )
+        assert re.search(
+            r"AppStateCommitDirEntryTaggedFilter\(\s*"
+            r"(?:dir_entry|owner_dir),\s*FALSE\s*\)",
+            body,
+        )
+        assert re.search(
+            r"AppStateCommitDirEntryFileShape\(\s*"
+            r"(?:dir_entry|owner_dir),\s*FALSE\s*\)",
+            body,
+        )
+
+
 def test_active_panel_session_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_session.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_session.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a DirEntry global-filter AppState helper.
- Route file-window mode reset writes through AppState helpers for global, tagged, and file shape state.
- Guard the file-window reset paths against direct DirEntry mode flag writes.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_window_mode_resets_commit_through_appstate_helpers` failed before `AppStateCommitDirEntryGlobalFilter` existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_window_mode_resets_commit_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
