### PR TITLE
refactor(appstate): route directory mode handoffs through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,24 +4,22 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-window-mode-reset-helpers
-Active PR: https://github.com/robkam/ytreenova/pull/327
+Current branch: appstate-dir-window-mode-helpers
+Active PR: https://github.com/robkam/ytreenova/pull/328
 Supersession state: maintainer resumed autonomous AppState work; no later pause or stop instruction is active.
 
 Recently confirmed remote state:
-- Main is at `483db83` after the tagged-filter helper PR merged.
-- No open PRs were reported by `gh pr status` before this branch publication.
-- Untracked local files are present and intentionally untouched: `docs/quickstart.md`.
+- No open PRs were reported before this branch was created.
+- Local `main` and `origin/main` were at `93e2772` after the file-window mode reset helper PR merged.
 
 Current AppState batch:
-- Add `AppStateCommitDirEntryGlobalFilter` as the DirEntry global-filter boundary helper.
-- Route file-window mode reset writes in `src/ui/ctrl_file.c` through AppState helpers for global filter, tagged filter, and file shape state.
-- Add guard coverage that prevents direct writes to `global_flag`, `global_all_volumes`, `tagged_flag`, and `big_window` in the file-window reset paths.
-- Scope is limited to `include/ytnova_appstate_visibility.h`, `src/ui/appstate_visibility.c`, `src/ui/ctrl_file.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Route directory-window show/global and switch-window mode handoffs through AppState helpers for DirEntry file shape, global filter, tagged filter, and file viewport state.
+- Add guard coverage that prevents direct writes to `global_flag`, `global_all_volumes`, `tagged_flag`, `big_window`, `start_file`, and `cursor_pos` in the directory-window mode handoff paths.
+- Scope is limited to `src/ui/dir_ops.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_window_mode_resets_commit_through_appstate_helpers` failed before `AppStateCommitDirEntryGlobalFilter` existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'file_window_mode_resets_commit_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper or panel_file_shape_commits_use_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_mode_handoffs_commit_through_appstate_helpers` failed before the directory-window handoffs used AppState helpers.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_mode_handoffs_commit_through_appstate_helpers or dir_ops_restore_file_shape_commits_use_appstate_helper or dir_ops_switch_window_viewports_commit_through_appstate_helper or dir_entry_tagged_filter_commits_through_appstate_helper or file_window_mode_resets_commit_through_appstate_helpers'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ v1.0.0-alpha is being published early so people can use the program, inspect the
 
 ## Features (v1.0.0-alpha)
 
-*   **Classic XTree&trade; Interface:** Directory Tree + File List layout.
+*   **Classic XTree™ Interface:** Directory Tree + File List layout.
 *   **Split Screen Mode (F8):** Manage two independent file panels side-by-side.
 *   **File Preview (F7):** Instant view of file contents without launching external tools.
 *   **Multi-Volume Support:** Log multiple drives or archives simultaneously and switch instantly.
@@ -98,6 +98,7 @@ The project documentation is split into several focused files.
 | Document | Purpose |
 | :--- | :--- |
 | **[USAGE.md](docs/USAGE.md)** | **User Guide**: How to navigate, tag, and use command keys. (Generated from `ytnova.1.md`). |
+| **[quickstart.md](docs/quickstart.md)** | **Developer Setup**: How to set up the environment, run tests, and work on the codebase. |
 | **[BUGS.md](docs/BUGS.md)** | **Known Issues**: Current defects, reproductions, and fix status. |
 | **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** | **Developer Setup**: How to set up the environment, run tests, and submit code. |
 | **[PR_GATE.md](docs/PR_GATE.md)** | **PR Governance**: Required PR gate checks and triage rules needed for merge readiness. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,96 @@
+# Quickstart
+
+This page is for contributors and developers who want to clone the repo, set up a local environment, build, and run tests.
+
+If you want the user manual, see [USAGE.md](USAGE.md).
+If you want the full contribution workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## 1. Prerequisites
+
+You need:
+
+- a C compiler, `gcc` or `clang`
+- `make`
+- `libncurses-dev`
+- `libreadline-dev`
+- `libarchive-dev`
+- `python3`
+- `python3-venv`
+- `cmark`
+- `lcov`
+- `llvm-symbolizer` or equivalent LLVM tooling for sanitizer traces
+
+On Debian or Ubuntu, the typical install set is:
+
+```bash
+sudo apt-get update
+sudo apt-get install build-essential clang llvm libncurses-dev libtinfo-dev libreadline-dev libarchive-dev python3-venv cmark lcov
+```
+
+## 2. Clone the repo
+
+```bash
+git clone https://github.com/robkam/ytreenova.git
+cd ytreenova
+```
+
+## 3. Create the local Python environment
+
+```bash
+scripts/setup_dev.sh
+```
+
+That script creates `.venv` in the repo root and installs the pinned Python dependencies.
+
+Afterwards, activate it in each new shell:
+
+```bash
+source .venv/bin/activate
+```
+
+## 4. Build
+
+```bash
+make
+```
+
+For sanitizer enabled debugging:
+
+```bash
+make clean
+make DEBUG=1
+```
+
+## 5. Validation
+
+Use these commands to check the repo after changes:
+
+```bash
+pytest
+make qa-code-quality
+make qa-all
+```
+
+Start with focused build and test commands, then use the broader validation gate when you want the full local check.
+
+## 6. If you use Codex or another AI client
+
+The repository includes optional Codex related configuration under:
+
+- `.codex/config.toml`
+- `.ai/codex.md`
+
+If you use VSCodium with the Codex extension or another AI client, the setup should be easy to adapt. The main things to check are:
+
+- your editor points at the repo root
+- your AI client can adapt `.ai/codex.md`
+- your client can adapt the repo's `.codex/config.toml` or an equivalent local config
+
+You may need to adjust the path settings in your clone to suit your setup.
+
+## 7. Where to look next
+
+- `docs/CONTRIBUTING.md` for the full development workflow
+- `docs/ARCHITECTURE.md` for architecture constraints
+- `docs/SPECIFICATION.md` for behavior requirements
+- `docs/AUDIT.md` for validation rules

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1133,12 +1133,14 @@ void HandleShowAll(ViewContext *ctx, BOOL tagged_only, BOOL all_volumes,
     if (dir_entry->log_flag) {
       dir_entry->log_flag = FALSE;
     } else {
-      dir_entry->big_window = TRUE;
-      dir_entry->global_flag = TRUE;
-      dir_entry->global_all_volumes = all_volumes;
-      dir_entry->tagged_flag = tagged_only;
-      dir_entry->start_file = 0;
-      dir_entry->cursor_pos = 0;
+      if (!AppStateCommitDirEntryFileShape(dir_entry, TRUE))
+        return;
+      if (!AppStateCommitDirEntryGlobalFilter(dir_entry, TRUE, all_volumes))
+        return;
+      if (!AppStateCommitDirEntryTaggedFilter(dir_entry, tagged_only))
+        return;
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, 0))
+        return;
     }
     /*
      * Tree-to-file handoff must not replay queued tree keystrokes in the
@@ -1154,18 +1156,24 @@ void HandleShowAll(ViewContext *ctx, BOOL tagged_only, BOOL all_volumes,
 
     if (result != LOG_ESC) {
       /* Restore normal mode and refresh the entire view */
-      dir_entry->start_file = 0;
-      dir_entry->cursor_pos = -1;
+      if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, -1))
+        return;
       BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
       dir_entry = GetPanelDirEntry(p);
       RefreshView(ctx, dir_entry);
-      dir_entry->global_all_volumes = FALSE;
+      if (!dir_entry ||
+          !AppStateCommitDirEntryGlobalFilter(
+              dir_entry, dir_entry->global_flag, FALSE))
+        return;
     } else {
       BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
       dir_entry = GetPanelDirEntry(p);
       RefreshView(ctx, dir_entry);
       *ch = 'L';
-      dir_entry->global_all_volumes = FALSE;
+      if (!dir_entry ||
+          !AppStateCommitDirEntryGlobalFilter(
+              dir_entry, dir_entry->global_flag, FALSE))
+        return;
     }
   } else {
     dir_entry->log_flag = FALSE;
@@ -1212,13 +1220,17 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
     if (dir_entry->log_flag) {
       dir_entry->log_flag = FALSE;
     } else {
-      dir_entry->global_flag = FALSE;
-      dir_entry->global_all_volumes = FALSE;
-      dir_entry->tagged_flag = FALSE;
-      if (restore_saved_file_window && p->saved_big_file_view)
-        dir_entry->big_window = TRUE;
-      else
-        dir_entry->big_window = ctx->bypass_small_window;
+      BOOL big_file_view;
+
+      if (!AppStateCommitDirEntryGlobalFilter(dir_entry, FALSE, FALSE))
+        return;
+      if (!AppStateCommitDirEntryTaggedFilter(dir_entry, FALSE))
+        return;
+      big_file_view = restore_saved_file_window && p->saved_big_file_view
+                          ? TRUE
+                          : ctx->bypass_small_window;
+      if (!AppStateCommitDirEntryFileShape(dir_entry, big_file_view))
+        return;
       {
         int file_start;
         int file_cursor;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9140,6 +9140,47 @@ def test_dir_ops_restore_file_shape_commits_use_appstate_helper() -> None:
     )
 
 
+def test_dir_ops_mode_handoffs_commit_through_appstate_helpers() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    show_all_start = dir_ops.index("\nvoid HandleShowAll(")
+    show_all_end = dir_ops.index("\nvoid HandleSwitchWindow(", show_all_start)
+    show_all_body = dir_ops[show_all_start:show_all_end]
+    switch_start = show_all_end
+    switch_end = dir_ops.index("\nvoid SyncActivePanelWindows(", switch_start)
+    switch_body = dir_ops[switch_start:switch_end]
+
+    mode_write = re.compile(
+        r"\bdir_entry->"
+        r"(?:global_flag|global_all_volumes|tagged_flag|big_window)\s*=(?!=)"
+    )
+    viewport_write = re.compile(r"\bdir_entry->(?:start_file|cursor_pos)\s*=(?!=)")
+
+    assert not mode_write.search(show_all_body)
+    assert not viewport_write.search(show_all_body)
+    assert "AppStateCommitDirEntryFileShape(dir_entry, TRUE)" in show_all_body
+    assert (
+        "AppStateCommitDirEntryGlobalFilter(dir_entry, TRUE, all_volumes)"
+        in show_all_body
+    )
+    assert (
+        "AppStateCommitDirEntryTaggedFilter(dir_entry, tagged_only)"
+        in show_all_body
+    )
+    assert "AppStateCommitDirEntryFileViewport(dir_entry, 0, 0)" in show_all_body
+    assert re.search(
+        r"AppStateCommitDirEntryGlobalFilter\(\s*"
+        r"dir_entry,\s*dir_entry->global_flag,\s*FALSE\s*\)",
+        show_all_body,
+    )
+    assert "AppStateCommitDirEntryFileViewport(dir_entry, 0, -1)" in show_all_body
+
+    assert not mode_write.search(switch_body)
+    assert "AppStateCommitDirEntryGlobalFilter(dir_entry, FALSE, FALSE)" in switch_body
+    assert "AppStateCommitDirEntryTaggedFilter(dir_entry, FALSE)" in switch_body
+    assert "AppStateCommitDirEntryFileShape(dir_entry, big_file_view)" in switch_body
+
+
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     validation = (


### PR DESCRIPTION
## Summary
- Route directory-window show/global and switch-window mode handoffs through AppState commit helpers.
- Guard the directory-window mode handoff paths against direct DirEntry mode and viewport writes.
- Keep the current AppState continuation checkpoint current for recovery.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_mode_handoffs_commit_through_appstate_helpers` failed before the helper routing was implemented.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_mode_handoffs_commit_through_appstate_helpers or dir_ops_restore_file_shape_commits_use_appstate_helper or dir_ops_switch_window_viewports_commit_through_appstate_helper or dir_entry_tagged_filter_commits_through_appstate_helper or file_window_mode_resets_commit_through_appstate_helpers'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
