### PR TITLE
refactor(appstate): route archive root file viewports through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,24 +4,26 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-window-mode-helpers
-Active PR: https://github.com/robkam/ytreenova/pull/328
+Current branch: appstate-dir-enter-file-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/329
 Supersession state: maintainer resumed autonomous AppState work; no later pause or stop instruction is active.
 
 Recently confirmed remote state:
-- No open PRs were reported before this branch was created.
-- Local `main` and `origin/main` were at `93e2772` after the file-window mode reset helper PR merged.
+- PR https://github.com/robkam/ytreenova/pull/328 merged at `47bae1b` after green checks.
+- Local `main` is fast-forwarded to `origin/main` at `47bae1b`.
+- The feature branch `appstate-dir-window-mode-helpers` was pruned during merge cleanup.
 
 Current AppState batch:
-- Route directory-window show/global and switch-window mode handoffs through AppState helpers for DirEntry file shape, global filter, tagged filter, and file viewport state.
-- Add guard coverage that prevents direct writes to `global_flag`, `global_all_volumes`, `tagged_flag`, `big_window`, `start_file`, and `cursor_pos` in the directory-window mode handoff paths.
-- Scope is limited to `src/ui/dir_ops.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Route the archive-root exit file viewport handoff in `src/ui/ctrl_dir.c` through `AppStateCommitDirEntryFileViewport` and `AppStateCommitPanelFileViewport`.
+- Add guard coverage that prevents direct writes to the selected `DirEntry` file viewport fields in that path.
+- Scope is limited to `src/ui/ctrl_dir.c`, `tests/test_appstate_contract_guard.py`, `docs/quickstart.md`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_mode_handoffs_commit_through_appstate_helpers` failed before the directory-window handoffs used AppState helpers.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_mode_handoffs_commit_through_appstate_helpers or dir_ops_restore_file_shape_commits_use_appstate_helper or dir_ops_switch_window_viewports_commit_through_appstate_helper or dir_entry_tagged_filter_commits_through_appstate_helper or file_window_mode_resets_commit_through_appstate_helpers'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_dir_archive_root_file_viewport_commits_through_appstate_helper` failed before the archive-root handoff used AppState helpers.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_dir_archive_root_file_viewport_commits_through_appstate_helper or ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
+- Passed: `git diff --check`
 
 Next action:
 - Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -90,7 +90,7 @@ You may need to adjust the path settings in your clone to suit your setup.
 
 ## 7. Where to look next
 
-- `docs/CONTRIBUTING.md` for the full development workflow
-- `docs/ARCHITECTURE.md` for architecture constraints
-- `docs/SPECIFICATION.md` for behavior requirements
-- `docs/AUDIT.md` for validation rules
+- [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow
+- [ARCHITECTURE.md](ARCHITECTURE.md) for architecture constraints
+- [SPECIFICATION.md](SPECIFICATION.md) for behavior requirements
+- [AUDIT.md](AUDIT.md) for validation rules

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -308,6 +308,8 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
   int target_file_idx = -1;
   int visible_rows = 1;
   int file_idx;
+  int file_start = 0;
+  int file_cursor = focus_file ? 0 : -1;
 
   if (!ctx || !ctx->active || !ctx->active->vol || !dir_entry_ptr ||
       !*dir_entry_ptr || !s_ptr || !*s_ptr || !start_vol_ptr) {
@@ -349,8 +351,9 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
     *dir_entry_ptr = (*s_ptr)->tree;
   }
 
-  (*dir_entry_ptr)->start_file = 0;
-  (*dir_entry_ptr)->cursor_pos = focus_file ? 0 : -1;
+  if (!AppStateCommitDirEntryFileViewport(*dir_entry_ptr, file_start,
+                                          file_cursor))
+    return FALSE;
 
   BuildFileEntryList(ctx, ctx->active);
   if (ctx->ctx_small_file_window) {
@@ -370,29 +373,34 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
   }
 
   if (target_file_idx >= visible_rows) {
-    (*dir_entry_ptr)->start_file = target_file_idx - (visible_rows - 1);
+    file_start = target_file_idx - (visible_rows - 1);
   }
-  if ((*dir_entry_ptr)->start_file >= (int)ctx->active->file_count) {
-    (*dir_entry_ptr)->start_file = MAXIMUM(0, (int)ctx->active->file_count - 1);
+  if (file_start >= (int)ctx->active->file_count) {
+    file_start = MAXIMUM(0, (int)ctx->active->file_count - 1);
   }
-  if ((*dir_entry_ptr)->start_file < 0) {
-    (*dir_entry_ptr)->start_file = 0;
+  if (file_start < 0) {
+    file_start = 0;
   }
 
   if (focus_file && target_file_idx >= 0 && ctx->active->file_count > 0) {
-    int file_cursor = target_file_idx - (*dir_entry_ptr)->start_file;
+    file_cursor = target_file_idx - file_start;
     if (file_cursor < 0)
       file_cursor = 0;
     if (file_cursor >= visible_rows)
       file_cursor = visible_rows - 1;
-    (*dir_entry_ptr)->cursor_pos = file_cursor;
+    if (!AppStateCommitDirEntryFileViewport(*dir_entry_ptr, file_start,
+                                            file_cursor))
+      return FALSE;
     if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
       return FALSE;
     if (!AppStateCommitPanelFileShape(ctx->active, FALSE))
       return FALSE;
     CapturePanelSelectionAnchor(ctx, ctx->active, *dir_entry_ptr);
   } else {
-    (*dir_entry_ptr)->cursor_pos = -1;
+    file_cursor = -1;
+    if (!AppStateCommitDirEntryFileViewport(*dir_entry_ptr, file_start,
+                                            file_cursor))
+      return FALSE;
     if (!AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_TREE))
       return FALSE;
     if (!AppStateCommitPanelFileShape(ctx->active, FALSE))
@@ -401,9 +409,8 @@ static BOOL ExitArchiveRootToParent(ViewContext *ctx, DirEntry **dir_entry_ptr,
 
   if (!AppStateCommitPanelFileAnchor(ctx->active, *dir_entry_ptr))
     return FALSE;
-  (void)AppStateCommitPanelFileViewport(ctx->active,
-                                        (*dir_entry_ptr)->start_file,
-                                        (*dir_entry_ptr)->cursor_pos);
+  if (!AppStateCommitPanelFileViewport(ctx->active, file_start, file_cursor))
+    return FALSE;
 
   if (!AppStateCommitViewMode(ctx, ctx->active->vol->vol_stats.log_mode))
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7824,6 +7824,30 @@ def test_ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper() -
     )
 
 
+def test_ctrl_dir_archive_root_file_viewport_commits_through_appstate_helper() -> None:
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+
+    function_start = ctrl_dir.index("\nstatic BOOL ExitArchiveRootToParent(")
+    function_end = ctrl_dir.index("\nextern int HandleDirWindow(", function_start)
+    function_body = ctrl_dir[function_start:function_end]
+    mutation = re.compile(
+        r"\(\*dir_entry_ptr\)->(?:start_file|cursor_pos)\s*"
+        r"(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    assert not mutation.search(function_body)
+    assert re.search(
+        r"AppStateCommitDirEntryFileViewport\(\s*"
+        r"\*dir_entry_ptr,\s*file_start,\s*file_cursor\s*\)",
+        function_body,
+    )
+    assert re.search(
+        r"AppStateCommitPanelFileViewport\(\s*"
+        r"ctx->active,\s*file_start,\s*file_cursor\s*\)",
+        function_body,
+    )
+
+
 def test_sort_interaction_viewports_commit_through_appstate_helper() -> None:
     interactions = Path("src/ui/interactions.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route the archive-root exit file viewport handoff through AppState commit helpers.
- Keep selected directory and panel file viewport commits aligned through one local file viewport result.
- Guard the path against direct selected `DirEntry` file viewport writes.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_dir_archive_root_file_viewport_commits_through_appstate_helper` failed before the helper routing was implemented.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_dir_archive_root_file_viewport_commits_through_appstate_helper or ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
