### PR TITLE
refactor(appstate): route refresh mode restore through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,25 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-enter-file-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/329
+Current branch: appstate-refresh-dir-entry-mode-helpers
+Active PR: https://github.com/robkam/ytreenova/pull/330
 Supersession state: maintainer resumed autonomous AppState work; no later pause or stop instruction is active.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/328 merged at `47bae1b` after green checks.
-- Local `main` is fast-forwarded to `origin/main` at `47bae1b`.
-- The feature branch `appstate-dir-window-mode-helpers` was pruned during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/329 merged at `df9b251` after green checks.
+- Local `main` is fast-forwarded to `origin/main` at `df9b251`.
+- The feature branch `appstate-dir-enter-file-viewport-helper` was removed remotely during merge cleanup.
 
 Current AppState batch:
-- Route the archive-root exit file viewport handoff in `src/ui/ctrl_dir.c` through `AppStateCommitDirEntryFileViewport` and `AppStateCommitPanelFileViewport`.
-- Add guard coverage that prevents direct writes to the selected `DirEntry` file viewport fields in that path.
-- Scope is limited to `src/ui/ctrl_dir.c`, `tests/test_appstate_contract_guard.py`, `docs/quickstart.md`, and this handoff file.
+- Route `RefreshTreeSafe` restoration of DirEntry file shape, global filter, and tagged filter state through AppState helpers after destructive rescans.
+- Add guard coverage that prevents direct writes to `global_flag`, `global_all_volumes`, `tagged_flag`, and `big_window` in that refresh path.
+- Scope is limited to `src/ui/dir_ops.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ctrl_dir_archive_root_file_viewport_commits_through_appstate_helper` failed before the archive-root handoff used AppState helpers.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'ctrl_dir_archive_root_file_viewport_commits_through_appstate_helper or ctrl_dir_handle_dir_window_viewports_commit_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_refresh_mode_restore_commits_through_appstate_helpers` failed before the refresh restore path used AppState helpers.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_refresh_mode_restore_commits_through_appstate_helpers or dir_ops_mode_handoffs_commit_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper or file_window_mode_resets_commit_through_appstate_helpers'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
-- Passed: `git diff --check`
 
 Next action:
 - Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow.

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -2087,11 +2087,14 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
     RescanDir(ctx, entry, strtol(TREEDEPTH, NULL, 0), s, Dir_Progress, ctx);
 
     /* 2a. Restore critical flags destroyed by ReadTree */
-    entry->big_window = saved_big_window;
+    if (!AppStateCommitDirEntryFileShape(entry, saved_big_window))
+      return entry;
     entry->log_flag = saved_log_flag;
-    entry->global_flag = saved_global_flag;
-    entry->global_all_volumes = saved_global_all_volumes;
-    entry->tagged_flag = saved_tagged_flag;
+    if (!AppStateCommitDirEntryGlobalFilter(entry, saved_global_flag,
+                                            saved_global_all_volumes))
+      return entry;
+    if (!AppStateCommitDirEntryTaggedFilter(entry, saved_tagged_flag))
+      return entry;
 
     /* 3. Restore State */
     RestoreTreeState(ctx, s->tree, &expanded, tagged, s);
@@ -2172,11 +2175,14 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
     /* Archive Mode - Standard Rescan */
     RescanDir(ctx, entry, strtol(TREEDEPTH, NULL, 0), s, Dir_Progress, ctx);
     /* Restore flags for Archive mode too, as RescanDir/ReadTree clears them */
-    entry->big_window = saved_big_window;
+    if (!AppStateCommitDirEntryFileShape(entry, saved_big_window))
+      return entry;
     entry->log_flag = saved_log_flag;
-    entry->global_flag = saved_global_flag;
-    entry->global_all_volumes = saved_global_all_volumes;
-    entry->tagged_flag = saved_tagged_flag;
+    if (!AppStateCommitDirEntryGlobalFilter(entry, saved_global_flag,
+                                            saved_global_all_volumes))
+      return entry;
+    if (!AppStateCommitDirEntryTaggedFilter(entry, saved_tagged_flag))
+      return entry;
     PanelTags_Restore(ctx, p);
 
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9205,6 +9205,35 @@ def test_dir_ops_mode_handoffs_commit_through_appstate_helpers() -> None:
     assert "AppStateCommitDirEntryFileShape(dir_entry, big_file_view)" in switch_body
 
 
+def test_dir_ops_refresh_mode_restore_commits_through_appstate_helpers() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+
+    refresh_start = dir_ops.index("\nDirEntry *RefreshTreeSafe(")
+    refresh_end = dir_ops.index("\nint RefreshDirWindow(", refresh_start)
+    refresh_body = dir_ops[refresh_start:refresh_end]
+    mode_write = re.compile(
+        r"\bentry->"
+        r"(?:global_flag|global_all_volumes|tagged_flag|big_window)\s*=(?!=)"
+    )
+
+    assert not mode_write.search(refresh_body)
+    assert len(re.findall(r"AppStateCommitDirEntryFileShape\(", refresh_body)) == 2
+    assert len(re.findall(r"AppStateCommitDirEntryGlobalFilter\(", refresh_body)) == 2
+    assert len(re.findall(r"AppStateCommitDirEntryTaggedFilter\(", refresh_body)) == 2
+    assert (
+        "AppStateCommitDirEntryFileShape(entry, saved_big_window)"
+        in refresh_body
+    )
+    assert (
+        "AppStateCommitDirEntryGlobalFilter(entry, saved_global_flag,"
+        in refresh_body
+    )
+    assert (
+        "AppStateCommitDirEntryTaggedFilter(entry, saved_tagged_flag)"
+        in refresh_body
+    )
+
+
 def test_directory_mutation_result_handlers_fail_closed_before_commit_work() -> None:
     source = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     validation = (


### PR DESCRIPTION
## Summary
- Route refresh-time DirEntry mode restoration through AppState commit helpers after destructive rescans.
- Keep file shape, global filter, and tagged filter restoration behind validated AppState boundaries.
- Guard the refresh path against direct DirEntry mode writes.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_refresh_mode_restore_commits_through_appstate_helpers` failed before the helper routing was implemented.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_refresh_mode_restore_commits_through_appstate_helpers or dir_ops_mode_handoffs_commit_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper or file_window_mode_resets_commit_through_appstate_helpers'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
