### PR TITLE
refactor(appstate): route new directory state through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,23 +4,23 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-log-restored-file-shape-helper
-Active PR: https://github.com/robkam/ytreenova/pull/331
+Current branch: appstate-mkdir-dir-entry-init-helpers
+Active PR: https://github.com/robkam/ytreenova/pull/332
 Supersession state: maintainer resumed autonomous AppState work; no later pause or stop instruction is active.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/330 merged at `c71ba72` after green checks.
-- Local `main` is fast-forwarded to `origin/main` at `c71ba72`.
-- The feature branch `appstate-refresh-dir-entry-mode-helpers` was removed remotely during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/331 merged at `82ff846` after green checks.
+- Local `main` is fast-forwarded to `origin/main` at `82ff846`.
+- The feature branch `appstate-log-restored-file-shape-helper` was removed remotely during merge cleanup.
 
 Current AppState batch:
-- Route restored file-window shape for resolved log file anchors through `AppStateCommitDirEntryFileShape`.
-- Extend guard coverage so direct writes to `resolved_file_dir->big_window` are blocked in the log restore path.
-- Scope is limited to `src/cmd/log.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Route new `DirEntry` viewport, global filter, tagged filter, and file shape initialization in `MakeDirEntry` through AppState helpers.
+- Add guard coverage that prevents direct writes to those AppState-owned `DirEntry` fields in the mkdir path.
+- Scope is limited to `src/cmd/mkdir.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k dir_ops_restore_file_shape_commits_use_appstate_helper` failed before the log restore path used AppState helper routing.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'dir_ops_restore_file_shape_commits_use_appstate_helper or panel_file_shape_commits_use_appstate_helper or log_file_anchors_route_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k mkdir_dir_entry_state_commits_through_appstate_helpers` failed before the mkdir path used AppState helper routing.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'mkdir_dir_entry_state_commits_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper or dir_ops_restore_file_shape_commits_use_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/cmd/mkdir.c
+++ b/src/cmd/mkdir.c
@@ -6,6 +6,9 @@
  ***************************************************************************/
 
 #include "ytnova_cmd.h"
+#include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
 #include <dirent.h>
 #include <errno.h>
@@ -169,11 +172,14 @@ static DirEntry *MakeDirEntry(const ViewContext *ctx, YtreeNovaPanel *panel,
     den_ptr->matching_files = 0;
     den_ptr->tagged_files = 0;
     den_ptr->access_denied = FALSE;
-    den_ptr->cursor_pos = 0;
-    den_ptr->start_file = 0;
-    den_ptr->global_flag = FALSE;
     den_ptr->log_flag = FALSE;
-    den_ptr->big_window = FALSE;
+    if (!AppStateCommitDirEntryFileViewport(den_ptr, 0, 0) ||
+        !AppStateCommitDirEntryGlobalFilter(den_ptr, FALSE, FALSE) ||
+        !AppStateCommitDirEntryTaggedFilter(den_ptr, FALSE) ||
+        !AppStateCommitDirEntryFileShape(den_ptr, FALSE)) {
+      free(den_ptr);
+      return NULL;
+    }
     den_ptr->up_tree = father_dir_entry;
     den_ptr->not_scanned = FALSE;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7895,6 +7895,25 @@ def test_log_file_selection_viewports_commit_through_appstate_helper() -> None:
     )
 
 
+def test_mkdir_dir_entry_state_commits_through_appstate_helpers() -> None:
+    mkdir_source = Path("src/cmd/mkdir.c").read_text(encoding="utf-8")
+
+    function_start = mkdir_source.index("static DirEntry *MakeDirEntry(")
+    function_end = mkdir_source.index("\nint MakePath(", function_start)
+    function_body = mkdir_source[function_start:function_end]
+    direct_state_write = re.compile(
+        r"\bden_ptr->"
+        r"(?:cursor_pos|start_file|global_flag|global_all_volumes|tagged_flag|"
+        r"big_window)\s*=(?!=)"
+    )
+
+    assert not direct_state_write.search(function_body)
+    assert "AppStateCommitDirEntryFileViewport(den_ptr, 0, 0)" in function_body
+    assert "AppStateCommitDirEntryGlobalFilter(den_ptr, FALSE, FALSE)" in function_body
+    assert "AppStateCommitDirEntryTaggedFilter(den_ptr, FALSE)" in function_body
+    assert "AppStateCommitDirEntryFileShape(den_ptr, FALSE)" in function_body
+
+
 def test_dir_ops_delete_viewports_commit_through_appstate_helper() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route new directory DirEntry viewport and mode initialization through AppState helpers.
- Keep initial global, tagged, and file-shape state behind validated AppState boundaries.
- Guard MakeDirEntry against direct writes to migrated DirEntry state fields.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k mkdir_dir_entry_state_commits_through_appstate_helpers` failed before the helper routing was implemented.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'mkdir_dir_entry_state_commits_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper or dir_ops_restore_file_shape_commits_use_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
