### PR TITLE
refactor(appstate): route tree read state through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,23 +4,23 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-mkdir-dir-entry-init-helpers
-Active PR: https://github.com/robkam/ytreenova/pull/332
+Current branch: appstate-tree-read-dir-entry-init-helpers
+Active PR: https://github.com/robkam/ytreenova/pull/333
 Supersession state: maintainer resumed autonomous AppState work; no later pause or stop instruction is active.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/331 merged at `82ff846` after green checks.
-- Local `main` is fast-forwarded to `origin/main` at `82ff846`.
-- The feature branch `appstate-log-restored-file-shape-helper` was removed remotely during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/332 merged at `0d44e4d` after green checks.
+- Local `main` and `origin/main` are at `0d44e4d`.
+- There are no open GitHub PRs at checkpoint refresh time.
 
 Current AppState batch:
-- Route new `DirEntry` viewport, global filter, tagged filter, and file shape initialization in `MakeDirEntry` through AppState helpers.
-- Add guard coverage that prevents direct writes to those AppState-owned `DirEntry` fields in the mkdir path.
-- Scope is limited to `src/cmd/mkdir.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Route filesystem tree-read `DirEntry` viewport, global filter, tagged filter, and file shape initialization through AppState helpers.
+- Add guard coverage that prevents direct writes to those AppState-owned `DirEntry` fields in `ReadTree`.
+- Scope is limited to `src/fs/tree_read.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k mkdir_dir_entry_state_commits_through_appstate_helpers` failed before the mkdir path used AppState helper routing.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'mkdir_dir_entry_state_commits_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper or dir_ops_restore_file_shape_commits_use_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_dir_entry_state_commits_through_appstate_helpers` failed before `ReadTree` used AppState helper routing.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_dir_entry_state_commits_through_appstate_helpers or mkdir_dir_entry_state_commits_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/src/fs/tree_read.c
+++ b/src/fs/tree_read.c
@@ -5,6 +5,9 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_focus.h"
+#include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
 #include <stdarg.h>
 
@@ -128,12 +131,12 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
   dir_entry->matching_files = 0;
   dir_entry->tagged_files = 0;
   dir_entry->access_denied = FALSE;
-  dir_entry->start_file = 0;
-  dir_entry->cursor_pos = 0;
-  dir_entry->global_flag = FALSE;
-  dir_entry->global_all_volumes = FALSE;
   dir_entry->log_flag = FALSE;
-  dir_entry->big_window = FALSE;
+  if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, 0) ||
+      !AppStateCommitDirEntryGlobalFilter(dir_entry, FALSE, FALSE) ||
+      !AppStateCommitDirEntryTaggedFilter(dir_entry, FALSE) ||
+      !AppStateCommitDirEntryFileShape(dir_entry, FALSE))
+    return (-1);
   dir_entry->not_scanned = FALSE;
   dir_entry->unlogged_flag = FALSE;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7914,6 +7914,25 @@ def test_mkdir_dir_entry_state_commits_through_appstate_helpers() -> None:
     assert "AppStateCommitDirEntryFileShape(den_ptr, FALSE)" in function_body
 
 
+def test_tree_read_dir_entry_state_commits_through_appstate_helpers() -> None:
+    tree_read = Path("src/fs/tree_read.c").read_text(encoding="utf-8")
+
+    function_start = tree_read.index("int ReadTree(")
+    function_end = tree_read.index("\nvoid UnReadTree(", function_start)
+    function_body = tree_read[function_start:function_end]
+    direct_state_write = re.compile(
+        r"\bdir_entry->"
+        r"(?:cursor_pos|start_file|global_flag|global_all_volumes|tagged_flag|"
+        r"big_window)\s*=(?!=)"
+    )
+
+    assert not direct_state_write.search(function_body)
+    assert "AppStateCommitDirEntryFileViewport(dir_entry, 0, 0)" in function_body
+    assert "AppStateCommitDirEntryGlobalFilter(dir_entry, FALSE, FALSE)" in function_body
+    assert "AppStateCommitDirEntryTaggedFilter(dir_entry, FALSE)" in function_body
+    assert "AppStateCommitDirEntryFileShape(dir_entry, FALSE)" in function_body
+
+
 def test_dir_ops_delete_viewports_commit_through_appstate_helper() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     mutation = re.compile(


### PR DESCRIPTION
## Summary
- Route tree-read `DirEntry` AppState-owned initialization through commit helpers.
- Add guard coverage for direct tree-read writes to the same state boundary.
- Keep tree-read initialization fail-closed when helper commits reject invalid input.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_dir_entry_state_commits_through_appstate_helpers` failed before `ReadTree` used helper routing.
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_dir_entry_state_commits_through_appstate_helpers or mkdir_dir_entry_state_commits_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper'`
- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Passed: `make clean && make`
