### PR TITLE
refactor(appstate): route history viewport through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,23 +4,24 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-tree-read-dir-entry-init-helpers
-Active PR: https://github.com/robkam/ytreenova/pull/333
+Current branch: appstate-history-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/334
 Supersession state: maintainer resumed autonomous AppState work; no later pause or stop instruction is active.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/332 merged at `0d44e4d` after green checks.
-- Local `main` and `origin/main` are at `0d44e4d`.
-- There are no open GitHub PRs at checkpoint refresh time.
+- PR https://github.com/robkam/ytreenova/pull/333 merged at `9679f33` after green checks.
+- Local `main` and `origin/main` are at `9679f33`.
+- The feature branch `appstate-tree-read-dir-entry-init-helpers` was removed remotely during merge cleanup.
 
 Current AppState batch:
-- Route filesystem tree-read `DirEntry` viewport, global filter, tagged filter, and file shape initialization through AppState helpers.
-- Add guard coverage that prevents direct writes to those AppState-owned `DirEntry` fields in `ReadTree`.
-- Scope is limited to `src/fs/tree_read.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Route history dialog viewport cursor/origin mutations through the modal AppState helper boundary.
+- Add guard coverage that prevents direct writes to the history dialog viewport fields in `GetHistory`.
+- Scope is limited to `include/ytnova_appstate_modal.h`, `src/ui/appstate_modal.c`, `src/ui/history_dialog.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_dir_entry_state_commits_through_appstate_helpers` failed before `ReadTree` used AppState helper routing.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_dir_entry_state_commits_through_appstate_helpers or mkdir_dir_entry_state_commits_through_appstate_helpers or dir_entry_tagged_filter_commits_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k history_viewport_routes_through_appstate_helper` failed before the helper existed.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k history_viewport_routes_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'history_viewport_routes_through_appstate_helper or preview_modal_state_routes_through_appstate_helper or panel_tree_viewport_commits_route_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `make clean && make` with existing warnings.
 

--- a/include/ytnova_appstate_modal.h
+++ b/include/ytnova_appstate_modal.h
@@ -7,5 +7,7 @@ BOOL AppStateCommitPreviewMode(ViewContext *ctx, BOOL preview_mode);
 BOOL AppStateCommitPreviewReturn(ViewContext *ctx, YtreeNovaPanel *panel,
                                  ViewFocus focus);
 BOOL AppStateCommitPreviewEntryFocus(ViewContext *ctx, ViewFocus focus);
+BOOL AppStateCommitHistoryViewport(ViewContext *ctx, int disp_begin_pos,
+                                   int cursor_pos);
 
 #endif /* YTNOVA_APPSTATE_MODAL_H */

--- a/src/ui/appstate_modal.c
+++ b/src/ui/appstate_modal.c
@@ -33,3 +33,15 @@ BOOL AppStateCommitPreviewEntryFocus(ViewContext *ctx, ViewFocus focus) {
   ctx->preview_entry_focus = focus;
   return TRUE;
 }
+
+BOOL AppStateCommitHistoryViewport(ViewContext *ctx, int disp_begin_pos,
+                                   int cursor_pos) {
+  if (!AppStateValidatedOwnerField("ctx.modal_state"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->disp_begin_pos = disp_begin_pos;
+  ctx->cursor_pos = cursor_pos;
+  return TRUE;
+}

--- a/src/ui/history_dialog.c
+++ b/src/ui/history_dialog.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_ui.h"
+#include "ytnova_appstate_modal.h"
 #include "ytnova_cmd.h"
 #include <stdlib.h>
 #include <string.h>
@@ -149,6 +150,8 @@ char *GetHistory(ViewContext *ctx, int type) {
   char *RetVal = NULL;
   History *TMP;
   int hide_left, hide_right;
+  int next_begin;
+  int next_cursor;
 
   /* Initialize View */
   BuildHistoryViewList(ctx, type);
@@ -157,8 +160,8 @@ char *GetHistory(ViewContext *ctx, int type) {
   if (ctx->total_hist == 0)
     return NULL;
 
-  ctx->disp_begin_pos = 0;
-  ctx->cursor_pos = 0;
+  if (!AppStateCommitHistoryViewport(ctx, 0, 0))
+    return NULL;
   start_x = 0;
 
   UI_Dialog_Push(ctx->ctx_history_window, UI_TIER_POPOVER);
@@ -213,10 +216,16 @@ char *GetHistory(ViewContext *ctx, int type) {
 
         /* Adjust cursor */
         if (ctx->disp_begin_pos + ctx->cursor_pos >= ctx->total_hist) {
-          if (ctx->cursor_pos > 0)
-            ctx->cursor_pos--;
-          else if (ctx->disp_begin_pos > 0)
-            ctx->disp_begin_pos--;
+          next_begin = ctx->disp_begin_pos;
+          next_cursor = ctx->cursor_pos;
+          if (next_cursor > 0)
+            next_cursor--;
+          else if (next_begin > 0)
+            next_begin--;
+          if (!AppStateCommitHistoryViewport(ctx, next_begin, next_cursor)) {
+            RetVal = NULL;
+            ch = ESC;
+          }
         }
         if (ctx->total_hist == 0) {
           RetVal = NULL;
@@ -267,7 +276,12 @@ char *GetHistory(ViewContext *ctx, int type) {
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HST, start_x, &hide_left,
                         &hide_right);
-          ctx->cursor_pos++;
+          if (!AppStateCommitHistoryViewport(ctx, ctx->disp_begin_pos,
+                                             ctx->cursor_pos + 1)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                         &hide_right);
@@ -276,7 +290,12 @@ char *GetHistory(ViewContext *ctx, int type) {
                         ctx->cursor_pos, CPAIR_HST, start_x, &hide_left,
                         &hide_right);
           scroll(ctx->ctx_history_window);
-          ctx->disp_begin_pos++;
+          if (!AppStateCommitHistoryViewport(ctx, ctx->disp_begin_pos + 1,
+                                             ctx->cursor_pos)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                         &hide_right);
@@ -292,7 +311,12 @@ char *GetHistory(ViewContext *ctx, int type) {
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HST, start_x, &hide_left,
                         &hide_right);
-          ctx->cursor_pos--;
+          if (!AppStateCommitHistoryViewport(ctx, ctx->disp_begin_pos,
+                                             ctx->cursor_pos - 1)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                         &hide_right);
@@ -302,7 +326,12 @@ char *GetHistory(ViewContext *ctx, int type) {
                         &hide_right);
           wmove(ctx->ctx_history_window, 0, 0);
           winsertln(ctx->ctx_history_window);
-          ctx->disp_begin_pos--;
+          if (!AppStateCommitHistoryViewport(ctx, ctx->disp_begin_pos - 1,
+                                             ctx->cursor_pos)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                         &hide_right);
@@ -318,22 +347,33 @@ char *GetHistory(ViewContext *ctx, int type) {
                         ctx->cursor_pos, CPAIR_HST, start_x, &hide_left,
                         &hide_right);
           if (ctx->disp_begin_pos + HISTORY_WINDOW_HEIGHT > ctx->total_hist - 1)
-            ctx->cursor_pos = ctx->total_hist - ctx->disp_begin_pos - 1;
+            next_cursor = ctx->total_hist - ctx->disp_begin_pos - 1;
           else
-            ctx->cursor_pos = HISTORY_WINDOW_HEIGHT - 1;
+            next_cursor = HISTORY_WINDOW_HEIGHT - 1;
+          if (!AppStateCommitHistoryViewport(ctx, ctx->disp_begin_pos,
+                                             next_cursor)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                         &hide_right);
         } else {
           if (ctx->disp_begin_pos + ctx->cursor_pos + HISTORY_WINDOW_HEIGHT <
               ctx->total_hist) {
-            ctx->disp_begin_pos += HISTORY_WINDOW_HEIGHT;
-            ctx->cursor_pos = HISTORY_WINDOW_HEIGHT - 1;
+            next_begin = ctx->disp_begin_pos + HISTORY_WINDOW_HEIGHT;
+            next_cursor = HISTORY_WINDOW_HEIGHT - 1;
           } else {
-            ctx->disp_begin_pos = ctx->total_hist - HISTORY_WINDOW_HEIGHT;
-            if (ctx->disp_begin_pos < 0)
-              ctx->disp_begin_pos = 0;
-            ctx->cursor_pos = ctx->total_hist - ctx->disp_begin_pos - 1;
+            next_begin = ctx->total_hist - HISTORY_WINDOW_HEIGHT;
+            if (next_begin < 0)
+              next_begin = 0;
+            next_cursor = ctx->total_hist - next_begin - 1;
+          }
+          if (!AppStateCommitHistoryViewport(ctx, next_begin, next_cursor)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
           }
           DisplayHistory(ctx);
         }
@@ -347,15 +387,23 @@ char *GetHistory(ViewContext *ctx, int type) {
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HST, start_x, &hide_left,
                         &hide_right);
-          ctx->cursor_pos = 0;
+          if (!AppStateCommitHistoryViewport(ctx, ctx->disp_begin_pos, 0)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintHstEntry(ctx, ctx->disp_begin_pos + ctx->cursor_pos,
                         ctx->cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                         &hide_right);
         } else {
-          if ((ctx->disp_begin_pos -= HISTORY_WINDOW_HEIGHT) < 0) {
-            ctx->disp_begin_pos = 0;
+          next_begin = ctx->disp_begin_pos - HISTORY_WINDOW_HEIGHT;
+          if (next_begin < 0)
+            next_begin = 0;
+          if (!AppStateCommitHistoryViewport(ctx, next_begin, 0)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
           }
-          ctx->cursor_pos = 0;
           DisplayHistory(ctx);
         }
       }
@@ -364,14 +412,22 @@ char *GetHistory(ViewContext *ctx, int type) {
       if (ctx->disp_begin_pos == 0 && ctx->cursor_pos == 0) {
         UI_Beep(ctx, FALSE);
       } else {
-        ctx->disp_begin_pos = 0;
-        ctx->cursor_pos = 0;
+        if (!AppStateCommitHistoryViewport(ctx, 0, 0)) {
+          RetVal = NULL;
+          ch = ESC;
+          break;
+        }
         DisplayHistory(ctx);
       }
       break;
     case KEY_END:
-      ctx->disp_begin_pos = MAX(0, ctx->total_hist - HISTORY_WINDOW_HEIGHT);
-      ctx->cursor_pos = ctx->total_hist - ctx->disp_begin_pos - 1;
+      next_begin = MAX(0, ctx->total_hist - HISTORY_WINDOW_HEIGHT);
+      next_cursor = ctx->total_hist - next_begin - 1;
+      if (!AppStateCommitHistoryViewport(ctx, next_begin, next_cursor)) {
+        RetVal = NULL;
+        ch = ESC;
+        break;
+      }
       DisplayHistory(ctx);
       break;
     case LF:

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7264,6 +7264,35 @@ def test_preview_modal_state_routes_through_appstate_helper() -> None:
     assert "AppStateCommitPreviewEntryFocus(ctx, FOCUS_TREE)" in dir_ops
 
 
+def test_history_viewport_routes_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_modal.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_modal.c").read_text(encoding="utf-8")
+    history_dialog = Path("src/ui/history_dialog.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitHistoryViewport(" in header
+    assert 'include "ytnova_appstate_modal.h"' in history_dialog
+
+    helper_start = helper.index("BOOL AppStateCommitHistoryViewport(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.modal_state")'
+    disp_write = "ctx->disp_begin_pos = disp_begin_pos;"
+    cursor_write = "ctx->cursor_pos = cursor_pos;"
+    assert validation in helper_body
+    assert disp_write in helper_body
+    assert cursor_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(disp_write)
+    assert helper_body.index(validation) < helper_body.index(cursor_write)
+
+    get_start = history_dialog.index("char *GetHistory(")
+    get_body = history_dialog[get_start:]
+    direct_state_write = re.compile(
+        r"\bctx->(?:disp_begin_pos|cursor_pos)\s*(?:\+\+|--|[+*/-]?=(?!=))"
+    )
+    assert not direct_state_write.search(get_body)
+    assert "AppStateCommitHistoryViewport(ctx, 0, 0)" in get_body
+    assert "AppStateCommitHistoryViewport(ctx, next_begin, next_cursor)" in get_body
+
+
 def test_event_coverage_transition_sequence_arrays_are_referenced() -> None:
     source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
     array_names = set(


### PR DESCRIPTION
## Summary
- Route history dialog viewport cursor/origin updates through the modal AppState helper boundary.
- Add guard coverage that prevents direct history viewport field mutations in the dialog loop.
- Keep helper failures fail-closed by exiting the dialog without a selected value.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k history_viewport_routes_through_appstate_helper` failed before the helper existed.
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k history_viewport_routes_through_appstate_helper`
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'history_viewport_routes_through_appstate_helper or preview_modal_state_routes_through_appstate_helper or panel_tree_viewport_commits_route_through_appstate_helper'`
- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Passed: `make clean && make`
