### PR TITLE
refactor(appstate): route completion viewport through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,26 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-history-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/334
-Supersession state: maintainer resumed autonomous AppState work; no later pause or stop instruction is active.
+Current branch: appstate-completion-viewport-helper
+Active PR: https://github.com/robkam/ytreenova/pull/335
+Supersession state: maintainer instructed to continue current work until the next idle boundary, then stop and do not start another batch.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/333 merged at `9679f33` after green checks.
-- Local `main` and `origin/main` are at `9679f33`.
-- The feature branch `appstate-tree-read-dir-entry-init-helpers` was removed remotely during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/334 merged at `81439e4` after green checks.
+- Local `main` and `origin/main` are at `81439e4`.
+- The feature branch `appstate-history-viewport-helper` was removed remotely during merge cleanup.
 
 Current AppState batch:
-- Route history dialog viewport cursor/origin mutations through the modal AppState helper boundary.
-- Add guard coverage that prevents direct writes to the history dialog viewport fields in `GetHistory`.
-- Scope is limited to `include/ytnova_appstate_modal.h`, `src/ui/appstate_modal.c`, `src/ui/history_dialog.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Route completion dialog viewport cursor/origin mutations through the modal AppState helper boundary.
+- Add guard coverage that prevents direct writes to the completion dialog viewport fields in `GetMatches` and completion preparation.
+- Scope is limited to `include/ytnova_appstate_modal.h`, `src/ui/appstate_modal.c`, `src/ui/completion_dialog.c`, `src/util/completion_utils.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k history_viewport_routes_through_appstate_helper` failed before the helper existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k history_viewport_routes_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'history_viewport_routes_through_appstate_helper or preview_modal_state_routes_through_appstate_helper or panel_tree_viewport_commits_route_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k completion_viewport_routes_through_appstate_helper` failed before the helper existed.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k completion_viewport_routes_through_appstate_helper`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'completion_viewport_routes_through_appstate_helper or history_viewport_routes_through_appstate_helper or preview_modal_state_routes_through_appstate_helper'`
 - Passed: `make clean && make` with existing warnings.
 
 Next action:
-- Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow.
+- Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow. After merge, clean up, update this checkpoint, mark the active goal blocked due the stop instruction, and stop without selecting another batch.

--- a/include/ytnova_appstate_modal.h
+++ b/include/ytnova_appstate_modal.h
@@ -9,5 +9,7 @@ BOOL AppStateCommitPreviewReturn(ViewContext *ctx, YtreeNovaPanel *panel,
 BOOL AppStateCommitPreviewEntryFocus(ViewContext *ctx, ViewFocus focus);
 BOOL AppStateCommitHistoryViewport(ViewContext *ctx, int disp_begin_pos,
                                    int cursor_pos);
+BOOL AppStateCommitCompletionViewport(ViewContext *ctx, int disp_begin_pos,
+                                      int cursor_pos);
 
 #endif /* YTNOVA_APPSTATE_MODAL_H */

--- a/src/ui/appstate_modal.c
+++ b/src/ui/appstate_modal.c
@@ -45,3 +45,15 @@ BOOL AppStateCommitHistoryViewport(ViewContext *ctx, int disp_begin_pos,
   ctx->cursor_pos = cursor_pos;
   return TRUE;
 }
+
+BOOL AppStateCommitCompletionViewport(ViewContext *ctx, int disp_begin_pos,
+                                      int cursor_pos) {
+  if (!AppStateValidatedOwnerField("ctx.modal_state"))
+    return FALSE;
+  if (!ctx)
+    return FALSE;
+
+  ctx->tab_disp_begin_pos = disp_begin_pos;
+  ctx->tab_cursor_pos = cursor_pos;
+  return TRUE;
+}

--- a/src/ui/completion_dialog.c
+++ b/src/ui/completion_dialog.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_ui.h"
+#include "ytnova_appstate_modal.h"
 #include "ytnova_cmd.h"
 #include <string.h>
 
@@ -122,6 +123,8 @@ char *GetMatches(ViewContext *ctx, char *base) {
   char *RetVal = NULL;
   char *TMP;
   int hide_left, hide_right;
+  int next_begin;
+  int next_cursor;
 
   RetVal = PrepareCompletionMatches(ctx, base, &show_dialog);
   if (!show_dialog)
@@ -179,7 +182,12 @@ char *GetMatches(ViewContext *ctx, char *base) {
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HST, start_x, &hide_left,
                          &hide_right);
-          ctx->tab_cursor_pos++;
+          if (!AppStateCommitCompletionViewport(ctx, ctx->tab_disp_begin_pos,
+                                                ctx->tab_cursor_pos + 1)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                          &hide_right);
@@ -188,7 +196,12 @@ char *GetMatches(ViewContext *ctx, char *base) {
                          ctx->tab_cursor_pos, CPAIR_HST, start_x, &hide_left,
                          &hide_right);
           scroll(ctx->ctx_matches_window);
-          ctx->tab_disp_begin_pos++;
+          if (!AppStateCommitCompletionViewport(ctx, ctx->tab_disp_begin_pos + 1,
+                                                ctx->tab_cursor_pos)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                          &hide_right);
@@ -204,7 +217,12 @@ char *GetMatches(ViewContext *ctx, char *base) {
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HST, start_x, &hide_left,
                          &hide_right);
-          ctx->tab_cursor_pos--;
+          if (!AppStateCommitCompletionViewport(ctx, ctx->tab_disp_begin_pos,
+                                                ctx->tab_cursor_pos - 1)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                          &hide_right);
@@ -214,7 +232,12 @@ char *GetMatches(ViewContext *ctx, char *base) {
                          &hide_right);
           wmove(ctx->ctx_matches_window, 0, 0);
           winsertln(ctx->ctx_matches_window);
-          ctx->tab_disp_begin_pos--;
+          if (!AppStateCommitCompletionViewport(ctx, ctx->tab_disp_begin_pos - 1,
+                                                ctx->tab_cursor_pos)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                          &hide_right);
@@ -232,10 +255,16 @@ char *GetMatches(ViewContext *ctx, char *base) {
                          &hide_right);
           if (ctx->tab_disp_begin_pos + MATCHES_WINDOW_HEIGHT >
               ctx->tab_total_matches - 1)
-            ctx->tab_cursor_pos =
+            next_cursor =
                 ctx->tab_total_matches - ctx->tab_disp_begin_pos - 1;
           else
-            ctx->tab_cursor_pos = MATCHES_WINDOW_HEIGHT - 1;
+            next_cursor = MATCHES_WINDOW_HEIGHT - 1;
+          if (!AppStateCommitCompletionViewport(ctx, ctx->tab_disp_begin_pos,
+                                                next_cursor)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                          &hide_right);
@@ -243,15 +272,18 @@ char *GetMatches(ViewContext *ctx, char *base) {
           if (ctx->tab_disp_begin_pos + ctx->tab_cursor_pos +
                   MATCHES_WINDOW_HEIGHT <
               ctx->tab_total_matches) {
-            ctx->tab_disp_begin_pos += MATCHES_WINDOW_HEIGHT;
-            ctx->tab_cursor_pos = MATCHES_WINDOW_HEIGHT - 1;
+            next_begin = ctx->tab_disp_begin_pos + MATCHES_WINDOW_HEIGHT;
+            next_cursor = MATCHES_WINDOW_HEIGHT - 1;
           } else {
-            ctx->tab_disp_begin_pos =
-                ctx->tab_total_matches - MATCHES_WINDOW_HEIGHT;
-            if (ctx->tab_disp_begin_pos < 1)
-              ctx->tab_disp_begin_pos = 1;
-            ctx->tab_cursor_pos =
-                ctx->tab_total_matches - ctx->tab_disp_begin_pos - 1;
+            next_begin = ctx->tab_total_matches - MATCHES_WINDOW_HEIGHT;
+            if (next_begin < 1)
+              next_begin = 1;
+            next_cursor = ctx->tab_total_matches - next_begin - 1;
+          }
+          if (!AppStateCommitCompletionViewport(ctx, next_begin, next_cursor)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
           }
           DisplayMatches(ctx);
         }
@@ -265,15 +297,24 @@ char *GetMatches(ViewContext *ctx, char *base) {
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HST, start_x, &hide_left,
                          &hide_right);
-          ctx->tab_cursor_pos = 0;
+          if (!AppStateCommitCompletionViewport(ctx, ctx->tab_disp_begin_pos,
+                                                0)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
+          }
           PrintMtchEntry(ctx, ctx->tab_disp_begin_pos + ctx->tab_cursor_pos,
                          ctx->tab_cursor_pos, CPAIR_HIHST, start_x, &hide_left,
                          &hide_right);
         } else {
-          if ((ctx->tab_disp_begin_pos -= MATCHES_WINDOW_HEIGHT) < 1) {
-            ctx->tab_disp_begin_pos = 1;
+          next_begin = ctx->tab_disp_begin_pos - MATCHES_WINDOW_HEIGHT;
+          if (next_begin < 1)
+            next_begin = 1;
+          if (!AppStateCommitCompletionViewport(ctx, next_begin, 0)) {
+            RetVal = NULL;
+            ch = ESC;
+            break;
           }
-          ctx->tab_cursor_pos = 0;
           DisplayMatches(ctx);
         }
       }
@@ -282,16 +323,22 @@ char *GetMatches(ViewContext *ctx, char *base) {
       if (ctx->tab_disp_begin_pos == 1 && ctx->tab_cursor_pos == 0) {
         UI_Beep(ctx, FALSE);
       } else {
-        ctx->tab_disp_begin_pos = 1;
-        ctx->tab_cursor_pos = 0;
+        if (!AppStateCommitCompletionViewport(ctx, 1, 0)) {
+          RetVal = NULL;
+          ch = ESC;
+          break;
+        }
         DisplayMatches(ctx);
       }
       break;
     case KEY_END:
-      ctx->tab_disp_begin_pos =
-          MAX(1, ctx->tab_total_matches - MATCHES_WINDOW_HEIGHT);
-      ctx->tab_cursor_pos =
-          ctx->tab_total_matches - ctx->tab_disp_begin_pos - 1;
+      next_begin = MAX(1, ctx->tab_total_matches - MATCHES_WINDOW_HEIGHT);
+      next_cursor = ctx->tab_total_matches - next_begin - 1;
+      if (!AppStateCommitCompletionViewport(ctx, next_begin, next_cursor)) {
+        RetVal = NULL;
+        ch = ESC;
+        break;
+      }
       DisplayMatches(ctx);
       break;
     case LF:

--- a/src/util/completion_utils.c
+++ b/src/util/completion_utils.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_defs.h"
+#include "ytnova_appstate_modal.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -73,8 +74,10 @@ char *PrepareCompletionMatches(ViewContext *ctx, char *base, int *show_dialog) {
     return NULL;
   }
 
-  ctx->tab_disp_begin_pos = 1;
-  ctx->tab_cursor_pos = 0;
+  if (!AppStateCommitCompletionViewport(ctx, 1, 0)) {
+    free(expanded_base);
+    return NULL;
+  }
   if (show_dialog != NULL)
     *show_dialog = 1;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7293,6 +7293,45 @@ def test_history_viewport_routes_through_appstate_helper() -> None:
     assert "AppStateCommitHistoryViewport(ctx, next_begin, next_cursor)" in get_body
 
 
+def test_completion_viewport_routes_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_modal.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_modal.c").read_text(encoding="utf-8")
+    completion_dialog = Path("src/ui/completion_dialog.c").read_text(
+        encoding="utf-8"
+    )
+    completion_utils = Path("src/util/completion_utils.c").read_text(
+        encoding="utf-8"
+    )
+
+    assert "BOOL AppStateCommitCompletionViewport(" in header
+    assert 'include "ytnova_appstate_modal.h"' in completion_dialog
+    assert 'include "ytnova_appstate_modal.h"' in completion_utils
+
+    helper_start = helper.index("BOOL AppStateCommitCompletionViewport(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.modal_state")'
+    disp_write = "ctx->tab_disp_begin_pos = disp_begin_pos;"
+    cursor_write = "ctx->tab_cursor_pos = cursor_pos;"
+    assert validation in helper_body
+    assert disp_write in helper_body
+    assert cursor_write in helper_body
+    assert helper_body.index(validation) < helper_body.index(disp_write)
+    assert helper_body.index(validation) < helper_body.index(cursor_write)
+
+    get_start = completion_dialog.index("char *GetMatches(")
+    get_body = completion_dialog[get_start:]
+    direct_state_write = re.compile(
+        r"\bctx->(?:tab_disp_begin_pos|tab_cursor_pos)\s*"
+        r"(?:\+\+|--|[+*/-]?=(?!=))"
+    )
+    assert not direct_state_write.search(get_body)
+    assert not direct_state_write.search(completion_utils)
+    assert "AppStateCommitCompletionViewport(ctx, 1, 0)" in completion_utils
+    assert "AppStateCommitCompletionViewport(ctx, next_begin, next_cursor)" in (
+        get_body
+    )
+
+
 def test_event_coverage_transition_sequence_arrays_are_referenced() -> None:
     source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
     array_names = set(


### PR DESCRIPTION
## Summary
- Route completion dialog viewport cursor/origin updates through the modal AppState helper boundary.
- Add guard coverage that prevents direct completion viewport field mutations in completion preparation and the dialog loop.
- Keep helper failures fail-closed by leaving completion without a selected value.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k completion_viewport_routes_through_appstate_helper` failed before the helper existed.
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k completion_viewport_routes_through_appstate_helper`
- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'completion_viewport_routes_through_appstate_helper or history_viewport_routes_through_appstate_helper or preview_modal_state_routes_through_appstate_helper'`
- Passed: `make clean && make`
