### PR TITLE
refactor(appstate): route panel window geometry through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,28 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-completion-viewport-helper
-Active PR: https://github.com/robkam/ytreenova/pull/335
-Supersession state: maintainer instructed to continue current work until the next idle boundary, then stop and do not start another batch.
+Current branch: appstate-panel-window-geometry-helper
+Active PR: https://github.com/robkam/ytreenova/pull/337
+Supersession state: maintainer instructed autonomous continuation of AppState task work until completion or a later stop/pause instruction.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/334 merged at `81439e4` after green checks.
-- Local `main` and `origin/main` are at `81439e4`.
-- The feature branch `appstate-history-viewport-helper` was removed remotely during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/336 is merged.
+- Local `main` and `origin/main` were fast-forwarded to `de34c00` before this branch was created.
+- Stale local branch `update-uthash-dep` was removed after its remote was pruned.
+- MCP doctor reports `serena` and `jcodemunch` configured, but this runner's MCP resource handshake timed out; exact-file reads and repo guards were used after the semantic tools were unavailable.
 
 Current AppState batch:
-- Route completion dialog viewport cursor/origin mutations through the modal AppState helper boundary.
-- Add guard coverage that prevents direct writes to the completion dialog viewport fields in `GetMatches` and completion preparation.
-- Scope is limited to `include/ytnova_appstate_modal.h`, `src/ui/appstate_modal.c`, `src/ui/completion_dialog.c`, `src/util/completion_utils.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Route panel window geometry mirror writes in `Layout_Recalculate` through an AppState layout helper boundary.
+- Add guard coverage that prevents direct `ctx->active/left/right` panel geometry writes in `Layout_Recalculate`.
+- Scope is limited to `include/ytnova_appstate_layout.h`, `src/ui/appstate_layout.c`, `src/core/init.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k completion_viewport_routes_through_appstate_helper` failed before the helper existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k completion_viewport_routes_through_appstate_helper`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_window_geometry_commits_through_appstate_helper` failed before the helper existed.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_window_geometry_commits_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'layout_geometry_commits_through_appstate_helper or panel_window_geometry_commits_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'completion_viewport_routes_through_appstate_helper or history_viewport_routes_through_appstate_helper or preview_modal_state_routes_through_appstate_helper'`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - Passed: `make clean && make` with existing warnings.
 
 Next action:
-- Follow the CI wait rule for the draft PR, then mark ready and merge only after checks and review requirements allow. After merge, clean up, update this checkpoint, mark the active goal blocked due the stop instruction, and stop without selecting another batch.
+- Follow the CI wait rule for the draft PR. When checks are green and merge requirements allow, mark ready if needed, merge, clean branch state, update this checkpoint, and continue with the next AppState batch unless a superseding stop condition applies.

--- a/include/ytnova_appstate_layout.h
+++ b/include/ytnova_appstate_layout.h
@@ -10,11 +10,28 @@
 
 #include "ytnova_defs.h"
 
+typedef struct {
+  int dir_x;
+  int dir_y;
+  int dir_w;
+  int dir_h;
+  int small_file_x;
+  int small_file_y;
+  int small_file_w;
+  int small_file_h;
+  int big_file_x;
+  int big_file_y;
+  int big_file_w;
+  int big_file_h;
+} YtreeNovaPanelWindowGeometry;
+
 BOOL AppStateCommitSplitScreenLayout(ViewContext *ctx, BOOL is_split_screen);
 BOOL AppStateCommitTerminalGeometryCache(ViewContext *ctx, int terminal_lines,
                                          int terminal_cols);
 BOOL AppStateCommitLayoutGeometry(ViewContext *ctx,
                                   const YtreeNovaLayout *layout);
+BOOL AppStateCommitPanelWindowGeometry(
+    YtreeNovaPanel *panel, const YtreeNovaPanelWindowGeometry *geometry);
 BOOL AppStateCommitFixedColumnWidth(ViewContext *ctx, int fixed_col_width);
 BOOL AppStateCommitSmallWindowBypass(ViewContext *ctx, BOOL bypass_small_window);
 BOOL AppStateCommitFullLineHighlight(ViewContext *ctx, BOOL highlight_full_line);

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -236,22 +236,24 @@ void Layout_Recalculate(ViewContext *ctx) {
     if (!AppStateCommitLayoutGeometry(ctx, &layout))
       return;
 
-    /* Update ActivePanel Geometry */
     if (ctx->active) {
-      ctx->active->dir_x = layout.dir_win_x;
-      ctx->active->dir_y = layout.dir_win_y;
-      ctx->active->dir_w = layout.dir_win_width;
-      ctx->active->dir_h = layout.dir_win_height;
+      YtreeNovaPanelWindowGeometry geometry;
 
-      ctx->active->small_file_x = layout.small_file_win_x;
-      ctx->active->small_file_y = layout.small_file_win_y;
-      ctx->active->small_file_w = layout.small_file_win_width;
-      ctx->active->small_file_h = layout.small_file_win_height;
+      geometry.dir_x = layout.dir_win_x;
+      geometry.dir_y = layout.dir_win_y;
+      geometry.dir_w = layout.dir_win_width;
+      geometry.dir_h = layout.dir_win_height;
+      geometry.small_file_x = layout.small_file_win_x;
+      geometry.small_file_y = layout.small_file_win_y;
+      geometry.small_file_w = layout.small_file_win_width;
+      geometry.small_file_h = layout.small_file_win_height;
+      geometry.big_file_x = layout.big_file_win_x;
+      geometry.big_file_y = layout.big_file_win_y;
+      geometry.big_file_w = layout.big_file_win_width;
+      geometry.big_file_h = available_height;
 
-      ctx->active->big_file_x = layout.big_file_win_x;
-      ctx->active->big_file_y = layout.big_file_win_y;
-      ctx->active->big_file_w = layout.big_file_win_width;
-      ctx->active->big_file_h = available_height;
+      if (!AppStateCommitPanelWindowGeometry(ctx->active, &geometry))
+        return;
     }
 
     /* Inactive Panel is not used for file listing in Preview Mode */
@@ -320,44 +322,46 @@ void Layout_Recalculate(ViewContext *ctx) {
   if (!AppStateCommitLayoutGeometry(ctx, &layout))
     return;
 
-  /* Update LeftPanel Geometry */
   if (ctx->left) {
-    ctx->left->dir_x = layout.dir_win_x;
-    ctx->left->dir_y = layout.dir_win_y;
-    ctx->left->dir_w = layout.dir_win_width;
-    ctx->left->dir_h = layout.dir_win_height;
+    YtreeNovaPanelWindowGeometry geometry;
 
-    ctx->left->small_file_x = layout.small_file_win_x;
-    ctx->left->small_file_y = layout.small_file_win_y;
-    ctx->left->small_file_w = layout.small_file_win_width;
-    ctx->left->small_file_h = layout.small_file_win_height;
+    geometry.dir_x = layout.dir_win_x;
+    geometry.dir_y = layout.dir_win_y;
+    geometry.dir_w = layout.dir_win_width;
+    geometry.dir_h = layout.dir_win_height;
+    geometry.small_file_x = layout.small_file_win_x;
+    geometry.small_file_y = layout.small_file_win_y;
+    geometry.small_file_w = layout.small_file_win_width;
+    geometry.small_file_h = layout.small_file_win_height;
+    geometry.big_file_x = layout.big_file_win_x;
+    geometry.big_file_y = layout.big_file_win_y;
+    geometry.big_file_w = layout.big_file_win_width;
+    geometry.big_file_h = available_height;
 
-    ctx->left->big_file_x = layout.big_file_win_x;
-    ctx->left->big_file_y = layout.big_file_win_y;
-    ctx->left->big_file_w = layout.big_file_win_width;
-    ctx->left->big_file_h = available_height;
+    if (!AppStateCommitPanelWindowGeometry(ctx->left, &geometry))
+      return;
   }
 
-  /* Update RightPanel Geometry */
   if (ctx->right && ctx->is_split_screen) {
-    /* Right panel starts after left panel + vertical separator */
     int right_x = layout.dir_win_x + panel_width + 1;
     int right_w = layout.main_win_width - panel_width - 1;
+    YtreeNovaPanelWindowGeometry geometry;
 
-    ctx->right->dir_x = right_x;
-    ctx->right->dir_y = 2;
-    ctx->right->dir_w = right_w;
-    ctx->right->dir_h = dir_h;
+    geometry.dir_x = right_x;
+    geometry.dir_y = 2;
+    geometry.dir_w = right_w;
+    geometry.dir_h = dir_h;
+    geometry.small_file_x = right_x;
+    geometry.small_file_y = geometry.dir_y + dir_h + 1;
+    geometry.small_file_w = right_w;
+    geometry.small_file_h = small_file_h;
+    geometry.big_file_x = right_x;
+    geometry.big_file_y = 2;
+    geometry.big_file_w = right_w;
+    geometry.big_file_h = available_height;
 
-    ctx->right->small_file_x = right_x;
-    ctx->right->small_file_y = ctx->right->dir_y + dir_h + 1;
-    ctx->right->small_file_w = right_w;
-    ctx->right->small_file_h = small_file_h;
-
-    ctx->right->big_file_x = right_x;
-    ctx->right->big_file_y = 2;
-    ctx->right->big_file_w = right_w;
-    ctx->right->big_file_h = available_height;
+    if (!AppStateCommitPanelWindowGeometry(ctx->right, &geometry))
+      return;
   }
 }
 

--- a/src/ui/appstate_layout.c
+++ b/src/ui/appstate_layout.c
@@ -41,6 +41,28 @@ BOOL AppStateCommitLayoutGeometry(ViewContext *ctx,
   return TRUE;
 }
 
+BOOL AppStateCommitPanelWindowGeometry(
+    YtreeNovaPanel *panel, const YtreeNovaPanelWindowGeometry *geometry) {
+  if (!AppStateValidatedOwnerField("ctx.layout"))
+    return FALSE;
+  if (!panel || !geometry)
+    return FALSE;
+
+  panel->dir_x = geometry->dir_x;
+  panel->dir_y = geometry->dir_y;
+  panel->dir_w = geometry->dir_w;
+  panel->dir_h = geometry->dir_h;
+  panel->small_file_x = geometry->small_file_x;
+  panel->small_file_y = geometry->small_file_y;
+  panel->small_file_w = geometry->small_file_w;
+  panel->small_file_h = geometry->small_file_h;
+  panel->big_file_x = geometry->big_file_x;
+  panel->big_file_y = geometry->big_file_y;
+  panel->big_file_w = geometry->big_file_w;
+  panel->big_file_h = geometry->big_file_h;
+  return TRUE;
+}
+
 BOOL AppStateCommitFixedColumnWidth(ViewContext *ctx, int fixed_col_width) {
   if (!AppStateValidatedOwnerField("ctx.layout"))
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6379,6 +6379,49 @@ def test_layout_geometry_commits_through_appstate_helper() -> None:
     assert not re.search(r"\bctx->layout\.[A-Za-z0-9_]+\s*=[^=]", layout_body)
 
 
+def test_panel_window_geometry_commits_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_layout.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_layout.c").read_text(encoding="utf-8")
+    init_source = Path("src/core/init.c").read_text(encoding="utf-8")
+
+    assert "YtreeNovaPanelWindowGeometry" in header
+    assert "BOOL AppStateCommitPanelWindowGeometry(" in header
+
+    helper_start = helper.index("BOOL AppStateCommitPanelWindowGeometry(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("ctx.layout")'
+    assignments = [
+        "panel->dir_x = geometry->dir_x;",
+        "panel->dir_y = geometry->dir_y;",
+        "panel->dir_w = geometry->dir_w;",
+        "panel->dir_h = geometry->dir_h;",
+        "panel->small_file_x = geometry->small_file_x;",
+        "panel->small_file_y = geometry->small_file_y;",
+        "panel->small_file_w = geometry->small_file_w;",
+        "panel->small_file_h = geometry->small_file_h;",
+        "panel->big_file_x = geometry->big_file_x;",
+        "panel->big_file_y = geometry->big_file_y;",
+        "panel->big_file_w = geometry->big_file_w;",
+        "panel->big_file_h = geometry->big_file_h;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    layout_start = init_source.index("void Layout_Recalculate(")
+    layout_end = init_source.index("\n\nvoid InitView(", layout_start)
+    layout_body = init_source[layout_start:layout_end]
+    direct_geometry_write = (
+        r"\bctx->(?:active|left|right)->"
+        r"(?:dir_[xywh]|small_file_[xywh]|big_file_[xywh])\s*=[^=]"
+    )
+
+    assert "AppStateCommitPanelWindowGeometry(" in layout_body
+    assert not re.search(direct_geometry_write, layout_body)
+
+
 def test_fixed_column_width_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_layout.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_layout.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an AppState layout helper for panel window geometry mirror writes
- route `Layout_Recalculate` panel geometry commits through the helper
- guard the layout path against direct panel geometry writes

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_window_geometry_commits_through_appstate_helper` failed before the helper existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_window_geometry_commits_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'layout_geometry_commits_through_appstate_helper or panel_window_geometry_commits_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make` with existing warnings
