### PR TITLE
refactor(appstate): route volume directory cache through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,25 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-panel-window-geometry-helper
-Active PR: https://github.com/robkam/ytreenova/pull/337
+Current branch: appstate-volume-dir-list-cache-helper
+Active PR: https://github.com/robkam/ytreenova/pull/338
 Supersession state: maintainer instructed autonomous continuation of AppState task work until completion or a later stop/pause instruction.
 
 Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/336 is merged.
-- Local `main` and `origin/main` were fast-forwarded to `de34c00` before this branch was created.
-- Stale local branch `update-uthash-dep` was removed after its remote was pruned.
+- PR https://github.com/robkam/ytreenova/pull/337 merged at `09ecdee` after green checks.
+- Local `main` and `origin/main` were fast-forwarded to `09ecdee` before this branch was created.
+- The feature branch `appstate-panel-window-geometry-helper` was removed remotely during merge cleanup.
 - MCP doctor reports `serena` and `jcodemunch` configured, but this runner's MCP resource handshake timed out; exact-file reads and repo guards were used after the semantic tools were unavailable.
 
 Current AppState batch:
-- Route panel window geometry mirror writes in `Layout_Recalculate` through an AppState layout helper boundary.
-- Add guard coverage that prevents direct `ctx->active/left/right` panel geometry writes in `Layout_Recalculate`.
-- Scope is limited to `include/ytnova_appstate_layout.h`, `src/ui/appstate_layout.c`, `src/core/init.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Route volume directory-list cache pointer/capacity/count commits through volume AppState helpers.
+- Add guard coverage that prevents direct `vol->dir_entry_list`, `vol->dir_entry_list_capacity`, and `vol->total_dirs` writes in `src/core/volume.c` and `src/ui/dir_list.c`.
+- Scope is limited to `include/ytnova_appstate_volume.h`, `src/ui/appstate_volume.c`, `src/core/volume.c`, `src/ui/dir_list.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
 
 Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_window_geometry_commits_through_appstate_helper` failed before the helper existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k panel_window_geometry_commits_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'layout_geometry_commits_through_appstate_helper or panel_window_geometry_commits_through_appstate_helper'`
+- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_dir_entry_list_cache_commits_route_through_appstate_helper` failed before the helper existed.
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_dir_entry_list_cache_commits_route_through_appstate_helper`
+- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
 - Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - Passed: `make clean && make` with existing warnings.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,7 +84,7 @@ If you use VSCodium with the Codex extension or another AI client, the setup sho
 
 - your editor points at the repo root
 - your AI client can adapt `.ai/codex.md`
-- your client can adapt the repo's `.codex/config.toml` or an equivalent local config
+- your client can adapt the repo's `.codex/config.toml`
 
 You may need to adjust the path settings in your clone to suit your setup.
 

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -11,5 +11,9 @@
 #include "ytnova_defs.h"
 
 BOOL AppStateCommitVolumeGeneration(struct Volume *volume);
+BOOL AppStateCommitVolumeDirEntryList(struct Volume *volume,
+                                      DirEntryList *dir_entry_list,
+                                      size_t capacity, int total_dirs);
+BOOL AppStateReleaseVolumeDirEntryList(struct Volume *volume);
 
 #endif /* YTNOVA_APPSTATE_VOLUME_H */

--- a/src/core/volume.c
+++ b/src/core/volume.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_volume_registry.h"
 #include "ytnova_defs.h"
 
@@ -38,12 +39,9 @@ static void Volume_ClearPanelTags(YtreeNovaPanel *panel) {
 }
 
 static void Volume_FreeCache(struct Volume *vol) {
-  if (vol && vol->dir_entry_list != NULL) {
-    free(vol->dir_entry_list);
-    vol->dir_entry_list = NULL;
-    vol->dir_entry_list_capacity = 0;
-    vol->total_dirs = 0;
-  }
+  if (!vol)
+    return;
+  (void)AppStateReleaseVolumeDirEntryList(vol);
 }
 
 static BOOL Volume_HasUserActions(const ViewContext *ctx) {
@@ -144,10 +142,8 @@ void Volume_Delete(ViewContext *ctx, struct Volume *vol) {
   if (!AppStateUnregisterVolume(ctx, vol))
     return;
 
-  if (vol->dir_entry_list) {
-    free(vol->dir_entry_list);
-    vol->dir_entry_list = NULL;
-  }
+  if (vol->dir_entry_list && !AppStateReleaseVolumeDirEntryList(vol))
+    return;
   /* Invalidate any panels using this volume to prevent stale references */
   if (ctx->left && ctx->left->vol == vol) {
     Volume_ClearPanelFileEntries(ctx->left);

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -17,3 +17,30 @@ BOOL AppStateCommitVolumeGeneration(struct Volume *volume) {
   volume->volume_generation++;
   return TRUE;
 }
+
+BOOL AppStateCommitVolumeDirEntryList(struct Volume *volume,
+                                      DirEntryList *dir_entry_list,
+                                      size_t capacity, int total_dirs) {
+  if (!AppStateValidatedOwnerField("volume.dir_tree"))
+    return FALSE;
+  if (!volume)
+    return FALSE;
+
+  volume->dir_entry_list = dir_entry_list;
+  volume->dir_entry_list_capacity = capacity;
+  volume->total_dirs = total_dirs;
+  return TRUE;
+}
+
+BOOL AppStateReleaseVolumeDirEntryList(struct Volume *volume) {
+  if (!AppStateValidatedOwnerField("volume.dir_tree"))
+    return FALSE;
+  if (!volume)
+    return FALSE;
+
+  free(volume->dir_entry_list);
+  volume->dir_entry_list = NULL;
+  volume->dir_entry_list_capacity = 0;
+  volume->total_dirs = 0;
+  return TRUE;
+}

--- a/src/ui/dir_list.c
+++ b/src/ui/dir_list.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_ui.h"
+#include "ytnova_appstate_volume.h"
 
 /* Internal recursive helper for BuildDirEntryList */
 static void ReadDirList(ViewContext *ctx, DirEntry *dir_entry,
@@ -18,18 +19,29 @@ static void ReadDirList(ViewContext *ctx, DirEntry *dir_entry,
     /* Bounds Checking & Dynamic Reallocation */
     if (*index_ptr >= (int)vol->dir_entry_list_capacity) {
       size_t new_capacity = vol->dir_entry_list_capacity * 2;
+      DirEntryList *new_list;
       if (new_capacity == 0)
         new_capacity = 128;
 
-      DirEntryList *new_list = (DirEntryList *)xrealloc(
-          vol->dir_entry_list, new_capacity * sizeof(DirEntryList));
+      if (!AppStateCommitVolumeDirEntryList(
+              vol, vol->dir_entry_list, vol->dir_entry_list_capacity,
+              vol->total_dirs)) {
+        UI_Error(ctx, "", 0, "AppState volume cache boundary failed*ABORT");
+        exit(1);
+      }
+
+      new_list = (DirEntryList *)xrealloc(vol->dir_entry_list,
+                                          new_capacity * sizeof(DirEntryList));
 
       memset(new_list + vol->dir_entry_list_capacity, 0,
              (new_capacity - vol->dir_entry_list_capacity) *
                  sizeof(DirEntryList));
 
-      vol->dir_entry_list = new_list;
-      vol->dir_entry_list_capacity = new_capacity;
+      if (!AppStateCommitVolumeDirEntryList(vol, new_list, new_capacity,
+                                            vol->total_dirs)) {
+        UI_Error(ctx, "", 0, "AppState volume cache update failed*ABORT");
+        exit(1);
+      }
     }
 
     indent &= ~(1L << level);
@@ -51,29 +63,31 @@ static void ReadDirList(ViewContext *ctx, DirEntry *dir_entry,
 }
 
 void BuildDirEntryList(ViewContext *ctx, struct Volume *vol, int *index_ptr) {
-  if (vol->dir_entry_list != NULL) {
-    free(vol->dir_entry_list);
-    vol->dir_entry_list = NULL;
-    vol->dir_entry_list_capacity = 0;
-  }
+  DirEntryList *new_list;
+  size_t alloc_count;
 
-  /* Initialize with the estimated count, but enforce a minimum safety size */
-  size_t alloc_count = vol->vol_stats.disk_total_directories;
+  if (vol->dir_entry_list != NULL &&
+      !AppStateReleaseVolumeDirEntryList(vol))
+    return;
+
+  alloc_count = vol->vol_stats.disk_total_directories;
   if (alloc_count < 16)
     alloc_count = 16;
 
-  vol->dir_entry_list =
-      (DirEntryList *)xcalloc(alloc_count, sizeof(DirEntryList));
+  new_list = (DirEntryList *)xcalloc(alloc_count, sizeof(DirEntryList));
+  if (!AppStateCommitVolumeDirEntryList(vol, new_list, alloc_count, 0)) {
+    free(new_list);
+    return;
+  }
 
-  vol->dir_entry_list_capacity = alloc_count;
   *index_ptr = 0;
 
-  /* Only read if we have a valid tree structure */
   if (vol->vol_stats.tree) {
     ReadDirList(ctx, vol->vol_stats.tree, vol, index_ptr);
   }
 
-  vol->total_dirs = *index_ptr;
+  (void)AppStateCommitVolumeDirEntryList(
+      vol, vol->dir_entry_list, vol->dir_entry_list_capacity, *index_ptr);
 
 #ifdef DEBUG
   if (vol->vol_stats.disk_total_directories != vol->total_dirs) {
@@ -296,12 +310,8 @@ int GetPanelVisibleSelectionIndex(const YtreeNovaPanel *p) {
  * Frees the memory allocated for the dir_entry_list array of a volume.
  */
 void FreeVolumeCache(struct Volume *vol) {
-  if (vol && vol->dir_entry_list != NULL) {
-    free(vol->dir_entry_list);
-    vol->dir_entry_list = NULL;
-    vol->dir_entry_list_capacity = 0;
-    vol->total_dirs = 0;
-  }
+  if (vol)
+    (void)AppStateReleaseVolumeDirEntryList(vol);
 }
 
 /*

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9025,6 +9025,41 @@ def test_volume_generation_commits_route_through_appstate_helper() -> None:
     assert dir_ops.count("AppStateCommitVolumeGeneration(") == 4
 
 
+def test_volume_dir_entry_list_cache_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    volume = Path("src/core/volume.c").read_text(encoding="utf-8")
+    dir_list = Path("src/ui/dir_list.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitVolumeDirEntryList(" in header
+    assert "BOOL AppStateReleaseVolumeDirEntryList(" in header
+    assert 'include "ytnova_appstate_volume.h"' in volume
+    assert 'include "ytnova_appstate_volume.h"' in dir_list
+
+    helper_start = helper.index("BOOL AppStateCommitVolumeDirEntryList(")
+    helper_body = helper[helper_start:]
+    validation = 'AppStateValidatedOwnerField("volume.dir_tree")'
+    assignments = [
+        "volume->dir_entry_list = dir_entry_list;",
+        "volume->dir_entry_list_capacity = capacity;",
+        "volume->total_dirs = total_dirs;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    direct_cache_write = (
+        r"\bvol->(?:dir_entry_list|dir_entry_list_capacity|total_dirs)\s*=[^=]"
+    )
+    assert not re.search(direct_cache_write, volume)
+    assert not re.search(direct_cache_write, dir_list)
+    assert volume.count("AppStateReleaseVolumeDirEntryList(") >= 2
+    assert dir_list.count("AppStateCommitVolumeDirEntryList(") >= 3
+    assert dir_list.count("AppStateReleaseVolumeDirEntryList(") >= 2
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add AppState helpers for volume directory-list cache commits and releases
- route volume cache allocation and clear paths through those helpers
- guard volume and directory-list code against direct cache pointer/count writes

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_dir_entry_list_cache_commits_route_through_appstate_helper` failed before the helper existed.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_dir_entry_list_cache_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make` with existing warnings
