### PR TITLE
refactor(appstate): route directory logged state through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,28 +4,22 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-volume-dir-list-cache-helper
-Active PR: https://github.com/robkam/ytreenova/pull/338
-Supersession state: maintainer instructed autonomous continuation of AppState task work until completion or a later stop/pause instruction.
-
-Recently confirmed remote state:
-- PR https://github.com/robkam/ytreenova/pull/337 merged at `09ecdee` after green checks.
-- Local `main` and `origin/main` were fast-forwarded to `09ecdee` before this branch was created.
-- The feature branch `appstate-panel-window-geometry-helper` was removed remotely during merge cleanup.
-- MCP doctor reports `serena` and `jcodemunch` configured, but this runner's MCP resource handshake timed out; exact-file reads and repo guards were used after the semantic tools were unavailable.
+Current branch: appstate-volume-logged-state-helper
+Active PR: https://github.com/robkam/ytreenova/pull/339 (draft)
+Supersession state: maintainer explicitly resumed autonomous AppState work after the prior idle-boundary stop checkpoint.
 
 Current AppState batch:
-- Route volume directory-list cache pointer/capacity/count commits through volume AppState helpers.
-- Add guard coverage that prevents direct `vol->dir_entry_list`, `vol->dir_entry_list_capacity`, and `vol->total_dirs` writes in `src/core/volume.c` and `src/ui/dir_list.c`.
-- Scope is limited to `include/ytnova_appstate_volume.h`, `src/ui/appstate_volume.c`, `src/core/volume.c`, `src/ui/dir_list.c`, `tests/test_appstate_contract_guard.py`, and this handoff file.
+- Routes directory logged-state commits (`DirEntry.not_scanned` and `DirEntry.unlogged_flag`) through `AppStateCommitDirEntryLoggedState` with `volume.logged_state` owner-field validation.
+- Covered direct logged-state writes in `src/fs/tree_read.c`, `src/cmd/mkdir.c`, `src/ui/dir_ops.c`, and `src/ui/panel_anchor.c`.
+- Added guard coverage in `tests/test_appstate_contract_guard.py` to keep those runtime boundaries helper-routed.
 
-Validation recorded before first push:
-- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_dir_entry_list_cache_commits_route_through_appstate_helper` failed before the helper existed.
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_dir_entry_list_cache_commits_route_through_appstate_helper`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
-- Passed: `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- Passed: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
-- Passed: `make clean && make` with existing warnings.
+Local validation:
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_logged_state_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryLoggedState` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_logged_state_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'volume_logged_state_commits_route_through_appstate_helper or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
+- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
+- `make clean && make` passed with existing warnings.
 
 Next action:
-- Follow the CI wait rule for the draft PR. When checks are green and merge requirements allow, mark ready if needed, merge, clean branch state, update this checkpoint, and continue with the next AppState batch unless a superseding stop condition applies.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/339. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -10,6 +10,8 @@
 
 #include "ytnova_defs.h"
 
+BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
+                                       BOOL unlogged_flag);
 BOOL AppStateCommitVolumeGeneration(struct Volume *volume);
 BOOL AppStateCommitVolumeDirEntryList(struct Volume *volume,
                                       DirEntryList *dir_entry_list,

--- a/src/cmd/mkdir.c
+++ b/src/cmd/mkdir.c
@@ -8,6 +8,7 @@
 #include "ytnova_cmd.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
 #include <dirent.h>
@@ -181,7 +182,10 @@ static DirEntry *MakeDirEntry(const ViewContext *ctx, YtreeNovaPanel *panel,
       return NULL;
     }
     den_ptr->up_tree = father_dir_entry;
-    den_ptr->not_scanned = FALSE;
+    if (!AppStateCommitDirEntryLoggedState(den_ptr, FALSE, FALSE)) {
+      free(den_ptr);
+      return NULL;
+    }
 
     if (s)
       s->disk_total_directories++;

--- a/src/fs/tree_read.c
+++ b/src/fs/tree_read.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
 #include <stdarg.h>
@@ -137,8 +138,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
       !AppStateCommitDirEntryTaggedFilter(dir_entry, FALSE) ||
       !AppStateCommitDirEntryFileShape(dir_entry, FALSE))
     return (-1);
-  dir_entry->not_scanned = FALSE;
-  dir_entry->unlogged_flag = FALSE;
+  if (!AppStateCommitDirEntryLoggedState(dir_entry, FALSE, FALSE))
+    return (-1);
 
   if (S_ISBLK(dir_entry->stat_struct.st_mode))
     return (0); /* Block-Device */
@@ -146,8 +147,11 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
   if (depth < 0) {
     if (dir_entry->up_tree) {
       /* Keep both parent and this node expandable for progressive scans. */
-      dir_entry->not_scanned = TRUE;
-      dir_entry->up_tree->not_scanned = TRUE;
+      if (!AppStateCommitDirEntryLoggedState(dir_entry, TRUE,
+                                             dir_entry->unlogged_flag) ||
+          !AppStateCommitDirEntryLoggedState(dir_entry->up_tree, TRUE,
+                                             dir_entry->up_tree->unlogged_flag))
+        return (-1);
       return (1);
     }
   }
@@ -392,8 +396,8 @@ void UnReadTree(ViewContext *ctx, DirEntry *dir_entry, Statistic *s) {
       UnReadSubTree(ctx, dir_entry->sub_tree, s);
       dir_entry->sub_tree = NULL;
     }
-    dir_entry->not_scanned = TRUE;
-    dir_entry->unlogged_flag = TRUE;
+    if (!AppStateCommitDirEntryLoggedState(dir_entry, TRUE, TRUE))
+      return;
     if (s->disk_total_directories > 0)
       s->disk_total_directories--;
     (void)GetAvailBytes(&s->disk_space, s);

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -8,6 +8,18 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_volume.h"
 
+BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
+                                       BOOL unlogged_flag) {
+  if (!AppStateValidatedOwnerField("volume.logged_state"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->not_scanned = not_scanned ? TRUE : FALSE;
+  dir_entry->unlogged_flag = unlogged_flag ? TRUE : FALSE;
+  return TRUE;
+}
+
 BOOL AppStateCommitVolumeGeneration(struct Volume *volume) {
   if (!AppStateValidatedOwnerField("volume.volume_generation"))
     return FALSE;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -170,7 +170,9 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
       (dir_entry->sub_tree != NULL || dir_entry->file != NULL)) {
     if (!AppStateCommitVolumeGeneration(p->vol))
       return;
-    dir_entry->not_scanned = FALSE;
+    if (!AppStateCommitDirEntryLoggedState(dir_entry, FALSE,
+                                           dir_entry->unlogged_flag))
+      return;
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     if (inactive && inactive->vol == p->vol) {
@@ -201,8 +203,8 @@ void HandlePlus(ViewContext *ctx, DirEntry *dir_entry, DirEntry *de_ptr,
     ApplyFilter(dir_entry, s);
     InitClock(ctx); /* Resume clock after scanning */
 
-    dir_entry->not_scanned = FALSE;
-    dir_entry->unlogged_flag = FALSE;
+    if (!AppStateCommitDirEntryLoggedState(dir_entry, FALSE, FALSE))
+      return;
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
     if (inactive && inactive->vol == p->vol) {
@@ -232,7 +234,9 @@ void HandleReadSubTree(ViewContext *ctx, DirEntry *dir_entry,
     /* Aborted. Fall through to refresh what we have. */
   }
   InitClock(ctx); /* Resume clock after scanning */
-  dir_entry->unlogged_flag = FALSE;
+  if (!AppStateCommitDirEntryLoggedState(dir_entry, dir_entry->not_scanned,
+                                         FALSE))
+    return;
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
   if (inactive && inactive->vol == p->vol) {
@@ -399,7 +403,9 @@ static BOOL EnsureDirVisible(ViewContext *ctx, YtreeNovaPanel *panel, DirEntry *
 
   for (ancestor = target->up_tree; ancestor; ancestor = ancestor->up_tree) {
     if (ancestor->not_scanned && ancestor->sub_tree) {
-      ancestor->not_scanned = FALSE;
+      if (!AppStateCommitDirEntryLoggedState(ancestor, FALSE,
+                                             ancestor->unlogged_flag))
+        return FALSE;
       changed = TRUE;
     }
   }
@@ -783,8 +789,8 @@ void HandleCollapseSubTree(ViewContext *ctx, DirEntry *dir_entry,
     RemoveFile(ctx, fe_ptr, s);
   }
 
-  dir_entry->not_scanned = TRUE;
-  dir_entry->unlogged_flag = TRUE;
+  if (!AppStateCommitDirEntryLoggedState(dir_entry, TRUE, TRUE))
+    return;
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
 
@@ -831,8 +837,8 @@ void HandleUnreadSubTree(ViewContext *ctx, DirEntry *dir_entry,
     next_fe_ptr = fe_ptr->next;
     RemoveFile(ctx, fe_ptr, s);
   }
-  dir_entry->not_scanned = TRUE;
-  dir_entry->unlogged_flag = TRUE;
+  if (!AppStateCommitDirEntryLoggedState(dir_entry, TRUE, TRUE))
+    return;
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
   BuildDirEntryList(ctx, p->vol, &p->current_dir_entry);
 
@@ -1657,8 +1663,8 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
 
     if (*dir_entry_ptr) {
       for (child = (*dir_entry_ptr)->sub_tree; child; child = child->next) {
-        child->not_scanned = TRUE;
-        child->unlogged_flag = TRUE;
+        if (!AppStateCommitDirEntryLoggedState(child, TRUE, TRUE))
+          return DIR_WINDOW_DISPATCH_RETURN_ESC;
       }
       BuildDirEntryList(ctx, ctx->active->vol, &ctx->active->current_dir_entry);
 
@@ -2104,8 +2110,8 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
           FindDirByPathInSubTree(s->tree, collapsed_curr->path);
       if (!collapsed_dir)
         continue;
-      collapsed_dir->not_scanned = TRUE;
-      collapsed_dir->unlogged_flag = TRUE;
+      if (!AppStateCommitDirEntryLoggedState(collapsed_dir, TRUE, TRUE))
+        return entry;
     }
     PanelTags_Restore(ctx, p);
     FreePathList(expanded);
@@ -2220,7 +2226,9 @@ int ScanSubTree(ViewContext *ctx, DirEntry *dir_entry, Statistic *s) {
       }
       ApplyFilter(de_ptr, s);
     }
-    dir_entry->not_scanned = FALSE;
+    if (!AppStateCommitDirEntryLoggedState(dir_entry, FALSE,
+                                           dir_entry->unlogged_flag))
+      return -1;
   } else {
     for (de_ptr = dir_entry->sub_tree; de_ptr; de_ptr = de_ptr->next) {
       if (ScanSubTree(ctx, de_ptr, s) == -1) {

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -8,6 +8,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_visibility.h"
 #include "ytnova_fs.h"
 #include "ytnova_panel_anchor.h"
@@ -818,7 +819,9 @@ void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,
 
   for (ancestor = target->up_tree; ancestor; ancestor = ancestor->up_tree) {
     if (ancestor->not_scanned && ancestor->sub_tree) {
-      ancestor->not_scanned = FALSE;
+      if (!AppStateCommitDirEntryLoggedState(ancestor, FALSE,
+                                             ancestor->unlogged_flag))
+        return;
       changed = TRUE;
     }
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9060,6 +9060,43 @@ def test_volume_dir_entry_list_cache_commits_route_through_appstate_helper() -> 
     assert dir_list.count("AppStateReleaseVolumeDirEntryList(") >= 2
 
 
+def test_volume_logged_state_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    tree_read = Path("src/fs/tree_read.c").read_text(encoding="utf-8")
+    mkdir = Path("src/cmd/mkdir.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryLoggedState(" in header
+    assert 'include "ytnova_appstate_volume.h"' in tree_read
+    assert 'include "ytnova_appstate_volume.h"' in mkdir
+    assert 'include "ytnova_appstate_volume.h"' in dir_ops
+    assert 'include "ytnova_appstate_volume.h"' in panel_anchor
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryLoggedState(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitVolumeGeneration(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.logged_state")'
+    assignments = [
+        "dir_entry->not_scanned = not_scanned ? TRUE : FALSE;",
+        "dir_entry->unlogged_flag = unlogged_flag ? TRUE : FALSE;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    direct_logged_state_write = re.compile(
+        r"->(?:not_scanned|unlogged_flag)\s*=[^=]"
+    )
+    for source in (tree_read, mkdir, dir_ops, panel_anchor):
+        assert not direct_logged_state_write.search(source)
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route directory logged-state ownership through `AppStateCommitDirEntryLoggedState`.
- Replace direct `not_scanned` and `unlogged_flag` writes in tree read, mkdir, directory ops, and panel anchor paths.
- Add AppState guard coverage for the helper boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_logged_state_commits_route_through_appstate_helper` failed before implementation because the helper was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_logged_state_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'volume_logged_state_commits_route_through_appstate_helper or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `make clean && make`
