### PR TITLE
refactor(appstate): route directory payload reset through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,22 +4,27 @@ Date: 2026-07-02
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-volume-logged-state-helper
-Active PR: https://github.com/robkam/ytreenova/pull/339 (draft)
-Supersession state: maintainer explicitly resumed autonomous AppState work after the prior idle-boundary stop checkpoint.
+Current branch: appstate-dir-payload-reset-helper
+Active PR: https://github.com/robkam/ytreenova/pull/340 (draft)
+Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
+
+Recently merged AppState batch:
+- PR https://github.com/robkam/ytreenova/pull/339 merged at `0d1986a` after green checks.
+- Local `main` and `origin/main` are at `0d1986a`.
+- The remote branch `appstate-volume-logged-state-helper` was pruned after merge cleanup.
 
 Current AppState batch:
-- Routes directory logged-state commits (`DirEntry.not_scanned` and `DirEntry.unlogged_flag`) through `AppStateCommitDirEntryLoggedState` with `volume.logged_state` owner-field validation.
-- Covered direct logged-state writes in `src/fs/tree_read.c`, `src/cmd/mkdir.c`, `src/ui/dir_ops.c`, and `src/ui/panel_anchor.c`.
-- Added guard coverage in `tests/test_appstate_contract_guard.py` to keep those runtime boundaries helper-routed.
+- Adds `AppStateResetDirEntryPayloadCache` with `volume.payload_cache` owner-field validation.
+- Routes directory payload reset initialization in `src/fs/tree_read.c` and `src/cmd/mkdir.c` through that helper.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the helper boundary and reset call sites.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_logged_state_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryLoggedState` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k volume_logged_state_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'volume_logged_state_commits_route_through_appstate_helper or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_payload_reset_commits_route_through_appstate_helper` failed because `AppStateResetDirEntryPayloadCache` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_payload_reset_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_payload_reset_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - `make clean && make` passed with existing warnings.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/339. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/340. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -10,6 +10,7 @@
 
 #include "ytnova_defs.h"
 
+BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry);
 BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
                                        BOOL unlogged_flag);
 BOOL AppStateCommitVolumeGeneration(struct Volume *volume);

--- a/src/cmd/mkdir.c
+++ b/src/cmd/mkdir.c
@@ -162,18 +162,13 @@ static DirEntry *MakeDirEntry(const ViewContext *ctx, YtreeNovaPanel *panel,
     /* FIX: Added +1 to allocation for null terminator */
     den_ptr = (DirEntry *)xcalloc(1, sizeof(DirEntry) + strlen(dir_name) + 1);
 
-    den_ptr->file = NULL;
     den_ptr->next = NULL;
     den_ptr->prev = NULL;
     den_ptr->sub_tree = NULL;
-    den_ptr->total_bytes = 0L;
-    den_ptr->matching_bytes = 0L;
-    den_ptr->tagged_bytes = 0L;
-    den_ptr->total_files = 0;
-    den_ptr->matching_files = 0;
-    den_ptr->tagged_files = 0;
-    den_ptr->access_denied = FALSE;
-    den_ptr->log_flag = FALSE;
+    if (!AppStateResetDirEntryPayloadCache(den_ptr)) {
+      free(den_ptr);
+      return NULL;
+    }
     if (!AppStateCommitDirEntryFileViewport(den_ptr, 0, 0) ||
         !AppStateCommitDirEntryGlobalFilter(den_ptr, FALSE, FALSE) ||
         !AppStateCommitDirEntryTaggedFilter(den_ptr, FALSE) ||

--- a/src/fs/tree_read.c
+++ b/src/fs/tree_read.c
@@ -119,20 +119,13 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
   /* Initialize dir_entry */
   /*--------------------------*/
 
-  dir_entry->file = NULL;
   /*
     dir_entry->next           = NULL;
     dir_entry->prev           = NULL;
   */
   dir_entry->sub_tree = NULL;
-  dir_entry->total_bytes = 0L;
-  dir_entry->matching_bytes = 0L;
-  dir_entry->tagged_bytes = 0L;
-  dir_entry->total_files = 0;
-  dir_entry->matching_files = 0;
-  dir_entry->tagged_files = 0;
-  dir_entry->access_denied = FALSE;
-  dir_entry->log_flag = FALSE;
+  if (!AppStateResetDirEntryPayloadCache(dir_entry))
+    return (-1);
   if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, 0) ||
       !AppStateCommitDirEntryGlobalFilter(dir_entry, FALSE, FALSE) ||
       !AppStateCommitDirEntryTaggedFilter(dir_entry, FALSE) ||

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -8,6 +8,24 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_volume.h"
 
+BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry) {
+  if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->file = NULL;
+  dir_entry->total_bytes = 0L;
+  dir_entry->matching_bytes = 0L;
+  dir_entry->tagged_bytes = 0L;
+  dir_entry->total_files = 0;
+  dir_entry->matching_files = 0;
+  dir_entry->tagged_files = 0;
+  dir_entry->access_denied = FALSE;
+  dir_entry->log_flag = FALSE;
+  return TRUE;
+}
+
 BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
                                        BOOL unlogged_flag) {
   if (!AppStateValidatedOwnerField("volume.logged_state"))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9097,6 +9097,56 @@ def test_volume_logged_state_commits_route_through_appstate_helper() -> None:
         assert not direct_logged_state_write.search(source)
 
 
+def test_directory_payload_reset_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    tree_read = Path("src/fs/tree_read.c").read_text(encoding="utf-8")
+    mkdir = Path("src/cmd/mkdir.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateResetDirEntryPayloadCache(" in header
+    assert 'include "ytnova_appstate_volume.h"' in tree_read
+    assert 'include "ytnova_appstate_volume.h"' in mkdir
+
+    helper_start = helper.index("BOOL AppStateResetDirEntryPayloadCache(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitDirEntryLoggedState(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.payload_cache")'
+    assignments = [
+        "dir_entry->file = NULL;",
+        "dir_entry->total_bytes = 0L;",
+        "dir_entry->matching_bytes = 0L;",
+        "dir_entry->tagged_bytes = 0L;",
+        "dir_entry->total_files = 0;",
+        "dir_entry->matching_files = 0;",
+        "dir_entry->tagged_files = 0;",
+        "dir_entry->access_denied = FALSE;",
+        "dir_entry->log_flag = FALSE;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    reset_write = re.compile(
+        r"->(?:file|total_bytes|matching_bytes|tagged_bytes|total_files|"
+        r"matching_files|tagged_files|access_denied|log_flag)\s*=[^=]"
+    )
+    tree_start = tree_read.index("/* Initialize dir_entry */")
+    tree_end = tree_read.index("if (S_ISBLK", tree_start)
+    tree_init_body = tree_read[tree_start:tree_end]
+    mkdir_start = mkdir.index("den_ptr = (DirEntry *)xcalloc")
+    mkdir_end = mkdir.index("den_ptr->up_tree = father_dir_entry;", mkdir_start)
+    mkdir_init_body = mkdir[mkdir_start:mkdir_end]
+
+    assert not reset_write.search(tree_init_body)
+    assert not reset_write.search(mkdir_init_body)
+    assert "AppStateResetDirEntryPayloadCache(dir_entry)" in tree_init_body
+    assert "AppStateResetDirEntryPayloadCache(den_ptr)" in mkdir_init_body
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState helper for directory payload-cache reset state.
- Route tree-read and mkdir directory payload reset initialization through the helper.
- Add guard coverage for the payload reset boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_payload_reset_commits_route_through_appstate_helper` failed before implementation because the helper was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_payload_reset_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_payload_reset_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
