### PR TITLE
refactor(appstate): route directory log flag through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -1,30 +1,30 @@
 # ytreenova AppState continuation checkpoint
 
-Date: 2026-07-02
+Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-payload-reset-helper
-Active PR: https://github.com/robkam/ytreenova/pull/340 (draft)
+Current branch: appstate-dir-log-flag-helper
+Active PR: https://github.com/robkam/ytreenova/pull/341 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/339 merged at `0d1986a` after green checks.
-- Local `main` and `origin/main` are at `0d1986a`.
-- The remote branch `appstate-volume-logged-state-helper` was pruned after merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/340 merged at `100f3a1` after green checks.
+- Local `main` and `origin/main` are at `100f3a1`.
+- The remote branch `appstate-dir-payload-reset-helper` was pruned after merge cleanup.
 
 Current AppState batch:
-- Adds `AppStateResetDirEntryPayloadCache` with `volume.payload_cache` owner-field validation.
-- Routes directory payload reset initialization in `src/fs/tree_read.c` and `src/cmd/mkdir.c` through that helper.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the helper boundary and reset call sites.
+- Adds `AppStateCommitDirEntryLogFlag` with `volume.payload_cache` owner-field validation.
+- Routes directory log-flag commits in `src/ui/dir_ops.c` and `src/ui/ctrl_file_ops.c` through that helper.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the helper boundary and direct log-flag write prevention in those files.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_payload_reset_commits_route_through_appstate_helper` failed because `AppStateResetDirEntryPayloadCache` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_payload_reset_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_payload_reset_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_log_flag_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryLogFlag` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_log_flag_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_log_flag_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/340. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/341. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -11,6 +11,7 @@
 #include "ytnova_defs.h"
 
 BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry);
+BOOL AppStateCommitDirEntryLogFlag(DirEntry *dir_entry, BOOL log_flag);
 BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
                                        BOOL unlogged_flag);
 BOOL AppStateCommitVolumeGeneration(struct Volume *volume);

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -26,6 +26,16 @@ BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry) {
   return TRUE;
 }
 
+BOOL AppStateCommitDirEntryLogFlag(DirEntry *dir_entry, BOOL log_flag) {
+  if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->log_flag = log_flag ? TRUE : FALSE;
+  return TRUE;
+}
+
 BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
                                        BOOL unlogged_flag) {
   if (!AppStateValidatedOwnerField("volume.logged_state"))

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -14,6 +14,7 @@
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_session.h"
 #include "ytnova_appstate_visibility.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_appstate_window.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
@@ -1083,7 +1084,8 @@ BOOL handle_file_window_misc_dispatch_action(
     if (ctx->view_mode == DISK_MODE || ctx->view_mode == USER_MODE) {
       (void)GetFileNamePath(fe_ptr, new_log_path);
       if (!GetNewLogPath(ctx, ctx->active, new_log_path)) {
-        dir_entry->log_flag = TRUE;
+        if (!AppStateCommitDirEntryLogFlag(dir_entry, TRUE))
+          return FALSE;
         if (LogDisk(ctx, ctx->active, new_log_path) == 0) {
           dir_entry = GetPanelDirEntry(ctx->active);
           if (!dir_entry) {

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1137,7 +1137,8 @@ void HandleShowAll(ViewContext *ctx, BOOL tagged_only, BOOL all_volumes,
   if (visible_count > 0) {
     int result;
     if (dir_entry->log_flag) {
-      dir_entry->log_flag = FALSE;
+      if (!AppStateCommitDirEntryLogFlag(dir_entry, FALSE))
+        return;
     } else {
       if (!AppStateCommitDirEntryFileShape(dir_entry, TRUE))
         return;
@@ -1182,7 +1183,8 @@ void HandleShowAll(ViewContext *ctx, BOOL tagged_only, BOOL all_volumes,
         return;
     }
   } else {
-    dir_entry->log_flag = FALSE;
+    if (!AppStateCommitDirEntryLogFlag(dir_entry, FALSE))
+      return;
   }
   *need_dsp_help = TRUE;
   return;
@@ -1224,7 +1226,8 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
 
   if (dir_entry->matching_files) {
     if (dir_entry->log_flag) {
-      dir_entry->log_flag = FALSE;
+      if (!AppStateCommitDirEntryLogFlag(dir_entry, FALSE))
+        return;
     } else {
       BOOL big_file_view;
 
@@ -1317,7 +1320,8 @@ void HandleSwitchWindow(ViewContext *ctx, DirEntry *dir_entry,
     DisplayAvailBytes(ctx, s);
     *need_dsp_help = TRUE;
   } else {
-    dir_entry->log_flag = FALSE;
+    if (!AppStateCommitDirEntryLogFlag(dir_entry, FALSE))
+      return;
   }
   return;
 }
@@ -2095,7 +2099,8 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
     /* 2a. Restore critical flags destroyed by ReadTree */
     if (!AppStateCommitDirEntryFileShape(entry, saved_big_window))
       return entry;
-    entry->log_flag = saved_log_flag;
+    if (!AppStateCommitDirEntryLogFlag(entry, saved_log_flag))
+      return entry;
     if (!AppStateCommitDirEntryGlobalFilter(entry, saved_global_flag,
                                             saved_global_all_volumes))
       return entry;
@@ -2183,7 +2188,8 @@ DirEntry *RefreshTreeSafe(ViewContext *ctx, YtreeNovaPanel *p, DirEntry *entry) 
     /* Restore flags for Archive mode too, as RescanDir/ReadTree clears them */
     if (!AppStateCommitDirEntryFileShape(entry, saved_big_window))
       return entry;
-    entry->log_flag = saved_log_flag;
+    if (!AppStateCommitDirEntryLogFlag(entry, saved_log_flag))
+      return entry;
     if (!AppStateCommitDirEntryGlobalFilter(entry, saved_global_flag,
                                             saved_global_all_volumes))
       return entry;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9147,6 +9147,35 @@ def test_directory_payload_reset_commits_route_through_appstate_helper() -> None
     assert "AppStateResetDirEntryPayloadCache(den_ptr)" in mkdir_init_body
 
 
+def test_directory_log_flag_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryLogFlag(" in header
+    assert 'include "ytnova_appstate_volume.h"' in dir_ops
+    assert 'include "ytnova_appstate_volume.h"' in ctrl_file_ops
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryLogFlag(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitDirEntryLoggedState(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.payload_cache")'
+    assignment = "dir_entry->log_flag = log_flag ? TRUE : FALSE;"
+
+    assert validation in helper_body
+    assert assignment in helper_body
+    assert helper_body.index(validation) < helper_body.index(assignment)
+
+    direct_log_flag_write = re.compile(r"->log_flag\s*=[^=]")
+    assert not direct_log_flag_write.search(dir_ops)
+    assert not direct_log_flag_write.search(ctrl_file_ops)
+    assert dir_ops.count("AppStateCommitDirEntryLogFlag(") >= 6
+    assert ctrl_file_ops.count("AppStateCommitDirEntryLogFlag(") >= 1
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState helper for directory log-flag updates.
- Route directory and file controller log-flag writes through the helper.
- Add guard coverage for the log-flag boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_log_flag_commits_route_through_appstate_helper` failed before implementation because the helper was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_log_flag_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_log_flag_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
