### PR TITLE
refactor(appstate): route directory matching payload through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,29 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-log-flag-helper
-Active PR: https://github.com/robkam/ytreenova/pull/341 (draft)
+Current branch: appstate-dir-matching-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/342 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/340 merged at `100f3a1` after green checks.
-- Local `main` and `origin/main` are at `100f3a1`.
-- The remote branch `appstate-dir-payload-reset-helper` was pruned after merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/341 merged at `69a8e09` after green checks.
+- Local `main` and `origin/main` are at `69a8e09`.
+- The remote branch `appstate-dir-log-flag-helper` was pruned after merge cleanup.
 
 Current AppState batch:
-- Adds `AppStateCommitDirEntryLogFlag` with `volume.payload_cache` owner-field validation.
-- Routes directory log-flag commits in `src/ui/dir_ops.c` and `src/ui/ctrl_file_ops.c` through that helper.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the helper boundary and direct log-flag write prevention in those files.
+- Adds `AppStateCommitDirEntryMatchingPayload` with `volume.payload_cache` owner-field validation.
+- Routes filter matching payload totals in `src/fs/filter_core.c` through that helper.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the helper boundary and direct matching counter write prevention in filter application.
+- Updates `tests/fuzz/fuzz_filter_core.c` with a harness-local AppState helper stub for the filter-core boundary.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_log_flag_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryLogFlag` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_log_flag_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_log_flag_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_matching_payload_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryMatchingPayload` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_matching_payload_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_matching_payload_commits_route_through_appstate_helper or directory_log_flag_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
+- `make fuzz-filter-core`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/341. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/342. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -10,6 +10,9 @@
 
 #include "ytnova_defs.h"
 
+BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
+                                           unsigned int matching_files,
+                                           long long matching_bytes);
 BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry);
 BOOL AppStateCommitDirEntryLogFlag(DirEntry *dir_entry, BOOL log_flag);
 BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,

--- a/src/fs/filter_core.c
+++ b/src/fs/filter_core.c
@@ -5,6 +5,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_volume.h"
 #include "ytnova_fs.h"
 #include <ctype.h>
 #include <fnmatch.h>
@@ -72,18 +73,22 @@ BOOL FsMatchFilter(FileEntry *fe, const Statistic *s) {
 
 void FsApplyFilter(DirEntry *dir_entry, const Statistic *s) {
   FileEntry *fe;
+  unsigned int matching_files;
+  long long matching_bytes;
 
   if (!dir_entry || !s)
     return;
 
-  dir_entry->matching_files = 0;
-  dir_entry->matching_bytes = 0;
+  matching_files = 0;
+  matching_bytes = 0;
 
   for (fe = dir_entry->file; fe; fe = fe->next) {
     fe->matching = FsMatchFilter(fe, s);
     if (fe->matching) {
-      dir_entry->matching_files++;
-      dir_entry->matching_bytes += fe->stat_struct.st_size;
+      matching_files++;
+      matching_bytes += fe->stat_struct.st_size;
     }
   }
+  (void)AppStateCommitDirEntryMatchingPayload(dir_entry, matching_files,
+                                              matching_bytes);
 }

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -8,6 +8,19 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_volume.h"
 
+BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
+                                           unsigned int matching_files,
+                                           long long matching_bytes) {
+  if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->matching_files = matching_files;
+  dir_entry->matching_bytes = matching_bytes;
+  return TRUE;
+}
+
 BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
     return FALSE;

--- a/tests/fuzz/fuzz_filter_core.c
+++ b/tests/fuzz/fuzz_filter_core.c
@@ -6,6 +6,17 @@
 #include <stdlib.h>
 #include <string.h>
 
+BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
+                                           unsigned int matching_files,
+                                           long long matching_bytes) {
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->matching_files = matching_files;
+  dir_entry->matching_bytes = matching_bytes;
+  return TRUE;
+}
+
 static FileEntry *AllocFileEntry(const char *name) {
   size_t name_len = strlen(name);
   FileEntry *file_entry =

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9176,6 +9176,37 @@ def test_directory_log_flag_commits_route_through_appstate_helper() -> None:
     assert ctrl_file_ops.count("AppStateCommitDirEntryLogFlag(") >= 1
 
 
+def test_directory_matching_payload_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    filter_core = Path("src/fs/filter_core.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryMatchingPayload(" in header
+    assert 'include "ytnova_appstate_volume.h"' in filter_core
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryMatchingPayload(")
+    helper_end = helper.index("\nBOOL AppStateResetDirEntryPayloadCache(", helper_start)
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.payload_cache")'
+    assignments = [
+        "dir_entry->matching_files = matching_files;",
+        "dir_entry->matching_bytes = matching_bytes;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    apply_start = filter_core.index("void FsApplyFilter(")
+    apply_body = filter_core[apply_start:]
+    direct_matching_write = re.compile(
+        r"->(?:matching_files|matching_bytes)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    assert not direct_matching_write.search(apply_body)
+    assert "AppStateCommitDirEntryMatchingPayload(" in apply_body
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add an AppState helper for directory matching payload totals.
- Route filter application matching counters through the helper.
- Add guard coverage for the matching payload boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_matching_payload_commits_route_through_appstate_helper` failed before implementation because the helper was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_matching_payload_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_matching_payload_commits_route_through_appstate_helper or directory_log_flag_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
