### PR TITLE
refactor(appstate): route directory total payload through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,29 +4,26 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-matching-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/342 (draft)
+Current branch: appstate-dir-total-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/343 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/341 merged at `69a8e09` after green checks.
-- Local `main` and `origin/main` are at `69a8e09`.
-- The remote branch `appstate-dir-log-flag-helper` was pruned after merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/342 merged after green checks.
+- Local `main` and `origin/main` were at `0eeb7d7` before this branch was created.
 
 Current AppState batch:
-- Adds `AppStateCommitDirEntryMatchingPayload` with `volume.payload_cache` owner-field validation.
-- Routes filter matching payload totals in `src/fs/filter_core.c` through that helper.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the helper boundary and direct matching counter write prevention in filter application.
-- Updates `tests/fuzz/fuzz_filter_core.c` with a harness-local AppState helper stub for the filter-core boundary.
+- Adds `AppStateCommitDirEntryTotalPayload` with `volume.payload_cache` owner-field validation.
+- Routes directory total payload counts in `src/ui/stats.c` through that helper after local aggregation.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the helper boundary and direct total payload write prevention in stats recalculation.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_matching_payload_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryMatchingPayload` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_matching_payload_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_matching_payload_commits_route_through_appstate_helper or directory_log_flag_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_total_payload_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryTotalPayload` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_total_payload_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
-- `make fuzz-filter-core`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/342. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/343. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -10,6 +10,9 @@
 
 #include "ytnova_defs.h"
 
+BOOL AppStateCommitDirEntryTotalPayload(DirEntry *dir_entry,
+                                        unsigned int total_files,
+                                        long long total_bytes);
 BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
                                            unsigned int matching_files,
                                            long long matching_bytes);

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -8,6 +8,19 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_volume.h"
 
+BOOL AppStateCommitDirEntryTotalPayload(DirEntry *dir_entry,
+                                        unsigned int total_files,
+                                        long long total_bytes) {
+  if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->total_files = total_files;
+  dir_entry->total_bytes = total_bytes;
+  return TRUE;
+}
+
 BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
                                            unsigned int matching_files,
                                            long long matching_bytes) {

--- a/src/ui/stats.c
+++ b/src/ui/stats.c
@@ -7,6 +7,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_volume.h"
 #include "ytnova_cmd.h"
 #include "ytnova_ui.h"
 
@@ -74,12 +75,14 @@ static void RecalcLayout(ViewContext *ctx) {
 static void RecalcDir(BOOL hide_dot_files, DirEntry *d, Statistic *s) {
   FileEntry *f;
   DirEntry *sub;
+  unsigned int total_files;
+  long long total_bytes;
 
   /* Apply current filter to this directory */
   ApplyFilter(d, s);
 
-  d->total_files = 0;
-  d->total_bytes = 0;
+  total_files = 0;
+  total_bytes = 0;
   /* matching_files/bytes already updated by ApplyFilter, but we sum them
    * globally below */
 
@@ -87,14 +90,16 @@ static void RecalcDir(BOOL hide_dot_files, DirEntry *d, Statistic *s) {
     if (hide_dot_files && f->name[0] == '.')
       continue;
 
-    d->total_files++;
-    d->total_bytes += f->stat_struct.st_size;
+    total_files++;
+    total_bytes += f->stat_struct.st_size;
 
     if (f->tagged) {
       d->tagged_files++;
       d->tagged_bytes += f->stat_struct.st_size;
     }
   }
+  if (!AppStateCommitDirEntryTotalPayload(d, total_files, total_bytes))
+    return;
 
   sub = d->sub_tree;
   while (sub) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9207,6 +9207,41 @@ def test_directory_matching_payload_commits_route_through_appstate_helper() -> N
     assert "AppStateCommitDirEntryMatchingPayload(" in apply_body
 
 
+def test_directory_total_payload_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    stats = Path("src/ui/stats.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryTotalPayload(" in header
+    assert 'include "ytnova_appstate_volume.h"' in stats
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryTotalPayload(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitDirEntryMatchingPayload(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.payload_cache")'
+    assignments = [
+        "dir_entry->total_files = total_files;",
+        "dir_entry->total_bytes = total_bytes;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    recalc_start = stats.index("static void RecalcDir(BOOL hide_dot_files,")
+    recalc_body = stats[
+        recalc_start : stats.index("\nvoid RecalculateSysStats", recalc_start)
+    ]
+    direct_total_write = re.compile(
+        r"->(?:total_files|total_bytes)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    assert not direct_total_write.search(recalc_body)
+    assert "AppStateCommitDirEntryTotalPayload(" in recalc_body
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a validated AppState helper for directory total payload counts.
- Route stats recalculation through the helper after local aggregation.
- Guard the boundary against direct total payload writes in stats recalculation.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_total_payload_commits_route_through_appstate_helper` failed before implementation because `AppStateCommitDirEntryTotalPayload` was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_total_payload_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q`
