### PR TITLE
refactor(appstate): route tree read payload through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,27 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-dir-total-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/343 (draft)
+Current branch: appstate-tree-read-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/344 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/342 merged after green checks.
-- Local `main` and `origin/main` were at `0eeb7d7` before this branch was created.
+- PR https://github.com/robkam/ytreenova/pull/343 merged at `45a5b99` after green checks.
+- Local `main` and `origin/main` are at `45a5b99`.
+- The remote branch `appstate-dir-total-payload-helper` was already deleted during merge cleanup.
 
 Current AppState batch:
-- Adds `AppStateCommitDirEntryTotalPayload` with `volume.payload_cache` owner-field validation.
-- Routes directory total payload counts in `src/ui/stats.c` through that helper after local aggregation.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the helper boundary and direct total payload write prevention in stats recalculation.
+- Adds `AppStateCommitDirEntryAccessDenied` with `volume.payload_cache` owner-field validation.
+- Routes tree-read access-denied state and read-time total payload count updates through AppState volume payload helpers.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the tree-read payload helper boundary and direct payload write prevention in `ReadTree`.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_total_payload_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryTotalPayload` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_total_payload_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_payload_commits_route_through_appstate_helpers` failed because `AppStateCommitDirEntryAccessDenied` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_payload_commits_route_through_appstate_helpers`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_payload_commits_route_through_appstate_helpers or directory_total_payload_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/343. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/344. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -16,6 +16,8 @@ BOOL AppStateCommitDirEntryTotalPayload(DirEntry *dir_entry,
 BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
                                            unsigned int matching_files,
                                            long long matching_bytes);
+BOOL AppStateCommitDirEntryAccessDenied(DirEntry *dir_entry,
+                                        BOOL access_denied);
 BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry);
 BOOL AppStateCommitDirEntryLogFlag(DirEntry *dir_entry, BOOL log_flag);
 BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,

--- a/src/fs/tree_read.c
+++ b/src/fs/tree_read.c
@@ -157,7 +157,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
 
   /* Silently skip unreadable or missing directories */
   if ((dir = opendir(path)) == NULL) {
-    dir_entry->access_denied = TRUE;
+    if (!AppStateCommitDirEntryAccessDenied(dir_entry, TRUE))
+      return (-1);
     return 0;
   }
 
@@ -335,8 +336,12 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
       fes_ptr->next = fen_ptr;
       fen_ptr->prev = fes_ptr;
       fes_ptr = fen_ptr;
-      dir_entry->total_files++;
-      dir_entry->total_bytes += stat_struct.st_size;
+      if (!AppStateCommitDirEntryTotalPayload(
+              dir_entry, dir_entry->total_files + 1,
+              dir_entry->total_bytes + stat_struct.st_size)) {
+        (void)closedir(dir);
+        return -1;
+      }
       s->disk_total_files++;
       s->disk_total_bytes += stat_struct.st_size;
     }

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -34,6 +34,17 @@ BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
   return TRUE;
 }
 
+BOOL AppStateCommitDirEntryAccessDenied(DirEntry *dir_entry,
+                                        BOOL access_denied) {
+  if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->access_denied = access_denied ? TRUE : FALSE;
+  return TRUE;
+}
+
 BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9242,6 +9242,39 @@ def test_directory_total_payload_commits_route_through_appstate_helper() -> None
     assert "AppStateCommitDirEntryTotalPayload(" in recalc_body
 
 
+def test_tree_read_payload_commits_route_through_appstate_helpers() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    tree_read = Path("src/fs/tree_read.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryAccessDenied(" in header
+    assert 'include "ytnova_appstate_volume.h"' in tree_read
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryAccessDenied(")
+    helper_end = helper.index(
+        "\nBOOL AppStateResetDirEntryPayloadCache(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.payload_cache")'
+    assignment = "dir_entry->access_denied = access_denied ? TRUE : FALSE;"
+
+    assert validation in helper_body
+    assert assignment in helper_body
+    assert helper_body.index(validation) < helper_body.index(assignment)
+
+    read_start = tree_read.index("int ReadTree(")
+    read_body = tree_read[
+        read_start : tree_read.index("\nstatic BOOL", read_start)
+    ]
+    direct_payload_write = re.compile(
+        r"->(?:access_denied|total_files|total_bytes)\s*"
+        r"(?:[+*/%-]?=|\+\+|--)"
+    )
+    assert not direct_payload_write.search(read_body)
+    assert "AppStateCommitDirEntryAccessDenied(dir_entry, TRUE)" in read_body
+    assert read_body.count("AppStateCommitDirEntryTotalPayload(") >= 1
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a validated AppState helper for directory access-denied payload state.
- Route tree-read access-denied state and read-time total payload counts through AppState helpers.
- Guard tree-read payload writes against bypassing the helper boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_payload_commits_route_through_appstate_helpers` failed before implementation because `AppStateCommitDirEntryAccessDenied` was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_payload_commits_route_through_appstate_helpers`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_payload_commits_route_through_appstate_helpers or directory_total_payload_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
