### PR TITLE
refactor(appstate): route tree file lists through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,27 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-tree-read-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/344 (draft)
+Current branch: appstate-tree-file-list-helper
+Active PR: https://github.com/robkam/ytreenova/pull/345 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/343 merged at `45a5b99` after green checks.
-- Local `main` and `origin/main` are at `45a5b99`.
-- The remote branch `appstate-dir-total-payload-helper` was already deleted during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/344 merged at `c7b939b` after green checks.
+- Local `main` and `origin/main` are at `c7b939b`.
+- The remote branch `appstate-tree-read-payload-helper` was deleted during merge cleanup.
 
 Current AppState batch:
-- Adds `AppStateCommitDirEntryAccessDenied` with `volume.payload_cache` owner-field validation.
-- Routes tree-read access-denied state and read-time total payload count updates through AppState volume payload helpers.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` for the tree-read payload helper boundary and direct payload write prevention in `ReadTree`.
+- Adds `AppStateCommitDirEntryFileList` with `volume.payload_cache` owner-field validation.
+- Routes tree-read and rescan directory file-list payload ownership through the helper.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` for direct `dir_entry->file` write prevention in `ReadTree` and `RescanDir`.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_payload_commits_route_through_appstate_helpers` failed because `AppStateCommitDirEntryAccessDenied` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_payload_commits_route_through_appstate_helpers`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_payload_commits_route_through_appstate_helpers or directory_total_payload_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_file_list_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryFileList` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_file_list_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_file_list_commits_route_through_appstate_helper or tree_read_payload_commits_route_through_appstate_helpers or directory_payload_reset_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- `make clean && make` passed with existing warnings.
+- `make clean && make` passed with existing warnings; a newly introduced double-close warning was fixed and the build was rerun.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/344. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/345. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -10,6 +10,7 @@
 
 #include "ytnova_defs.h"
 
+BOOL AppStateCommitDirEntryFileList(DirEntry *dir_entry, FileEntry *file_list);
 BOOL AppStateCommitDirEntryTotalPayload(DirEntry *dir_entry,
                                         unsigned int total_files,
                                         long long total_bytes);

--- a/src/fs/tree_read.c
+++ b/src/fs/tree_read.c
@@ -107,7 +107,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
       n = f->next;
       RemoveFileWithBoundary(ctx, f, s); /* Updates stats and frees memory */
     }
-    dir_entry->file = NULL;
+    if (!AppStateCommitDirEntryFileList(dir_entry, NULL))
+      return (-1);
   }
   if (dir_entry->sub_tree) {
     /* Use UnReadSubTree to recursively free children and decrement stats
@@ -192,7 +193,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
           first_file_entry.next->prev = NULL;
         if (first_dir_entry.next)
           first_dir_entry.next->prev = NULL;
-        dir_entry->file = first_file_entry.next;
+        if (!AppStateCommitDirEntryFileList(dir_entry, first_file_entry.next))
+          return -1;
         dir_entry->sub_tree = first_dir_entry.next;
         return -1;
       } else {
@@ -256,7 +258,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
           first_file_entry.next->prev = NULL;
         if (first_dir_entry.next)
           first_dir_entry.next->prev = NULL;
-        dir_entry->file = first_file_entry.next;
+        if (!AppStateCommitDirEntryFileList(dir_entry, first_file_entry.next))
+          return -1;
         dir_entry->sub_tree = first_dir_entry.next;
         return -1;
       }
@@ -354,7 +357,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
   if (first_dir_entry.next)
     first_dir_entry.next->prev = NULL;
 
-  dir_entry->file = first_file_entry.next;
+  if (!AppStateCommitDirEntryFileList(dir_entry, first_file_entry.next))
+    return -1;
   dir_entry->sub_tree = first_dir_entry.next;
 
   /* Final UI update via callback */
@@ -460,7 +464,8 @@ int RescanDir(ViewContext *ctx, DirEntry *dir_entry, int depth, Statistic *s,
     /* RemoveFile updates stats and frees the entry */
     RemoveFileWithBoundary(ctx, fe_ptr, s);
   }
-  dir_entry->file = NULL;
+  if (!AppStateCommitDirEntryFileList(dir_entry, NULL))
+    return -1;
 
   /*
    * The dir_entry itself still exists and is counted. ReadTree will re-init

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -8,6 +8,16 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_volume.h"
 
+BOOL AppStateCommitDirEntryFileList(DirEntry *dir_entry, FileEntry *file_list) {
+  if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->file = file_list;
+  return TRUE;
+}
+
 BOOL AppStateCommitDirEntryTotalPayload(DirEntry *dir_entry,
                                         unsigned int total_files,
                                         long long total_bytes) {

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9275,6 +9275,39 @@ def test_tree_read_payload_commits_route_through_appstate_helpers() -> None:
     assert read_body.count("AppStateCommitDirEntryTotalPayload(") >= 1
 
 
+def test_tree_read_file_list_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    tree_read = Path("src/fs/tree_read.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryFileList(" in header
+    assert 'include "ytnova_appstate_volume.h"' in tree_read
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryFileList(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitDirEntryTotalPayload(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.payload_cache")'
+    assignment = "dir_entry->file = file_list;"
+
+    assert validation in helper_body
+    assert assignment in helper_body
+    assert helper_body.index(validation) < helper_body.index(assignment)
+
+    read_start = tree_read.index("int ReadTree(")
+    read_body = tree_read[
+        read_start : tree_read.index("\nstatic BOOL", read_start)
+    ]
+    rescan_start = tree_read.index("int RescanDir(")
+    rescan_body = tree_read[rescan_start:]
+    direct_file_list_write = re.compile(r"\bdir_entry->file\s*=(?!=)")
+
+    assert not direct_file_list_write.search(read_body)
+    assert not direct_file_list_write.search(rescan_body)
+    assert tree_read.count("AppStateCommitDirEntryFileList(") >= 5
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a validated AppState helper for directory file-list payload ownership.
- Route tree-read and rescan file-list commits through the helper.
- Guard tree-read file-list payload writes against bypassing the helper boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_file_list_commits_route_through_appstate_helper` failed before implementation because `AppStateCommitDirEntryFileList` was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_file_list_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_file_list_commits_route_through_appstate_helper or tree_read_payload_commits_route_through_appstate_helpers or directory_payload_reset_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
