### PR TITLE
refactor(appstate): route tree child lists through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,27 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-tree-file-list-helper
-Active PR: https://github.com/robkam/ytreenova/pull/345 (draft)
+Current branch: appstate-tree-child-list-helper
+Active PR: https://github.com/robkam/ytreenova/pull/346 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/344 merged at `c7b939b` after green checks.
-- Local `main` and `origin/main` are at `c7b939b`.
-- The remote branch `appstate-tree-read-payload-helper` was deleted during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/345 merged at `b8f1d57` after green checks.
+- Local `main` and `origin/main` are at `b8f1d57`.
+- The remote branch `appstate-tree-file-list-helper` was deleted during merge cleanup.
 
 Current AppState batch:
-- Adds `AppStateCommitDirEntryFileList` with `volume.payload_cache` owner-field validation.
-- Routes tree-read and rescan directory file-list payload ownership through the helper.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` for direct `dir_entry->file` write prevention in `ReadTree` and `RescanDir`.
+- Adds `AppStateCommitDirEntrySubTree` with `volume.dir_tree` owner-field validation.
+- Routes tree-read, unread, and rescan child-directory topology link updates through the helper.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` for direct `dir_entry->sub_tree` write prevention in `src/fs/tree_read.c`.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_file_list_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryFileList` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_file_list_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_file_list_commits_route_through_appstate_helper or tree_read_payload_commits_route_through_appstate_helpers or directory_payload_reset_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_child_list_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntrySubTree` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_child_list_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_child_list_commits_route_through_appstate_helper or tree_read_file_list_commits_route_through_appstate_helper or tree_read_payload_commits_route_through_appstate_helpers'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- `make clean && make` passed with existing warnings; a newly introduced double-close warning was fixed and the build was rerun.
+- `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/345. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/346. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -23,6 +23,7 @@ BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry);
 BOOL AppStateCommitDirEntryLogFlag(DirEntry *dir_entry, BOOL log_flag);
 BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
                                        BOOL unlogged_flag);
+BOOL AppStateCommitDirEntrySubTree(DirEntry *dir_entry, DirEntry *sub_tree);
 BOOL AppStateCommitVolumeGeneration(struct Volume *volume);
 BOOL AppStateCommitVolumeDirEntryList(struct Volume *volume,
                                       DirEntryList *dir_entry_list,

--- a/src/fs/tree_read.c
+++ b/src/fs/tree_read.c
@@ -114,7 +114,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
     /* Use UnReadSubTree to recursively free children and decrement stats
      * correctly */
     UnReadSubTree(ctx, dir_entry->sub_tree, s);
-    dir_entry->sub_tree = NULL;
+    if (!AppStateCommitDirEntrySubTree(dir_entry, NULL))
+      return (-1);
   }
 
   /* Initialize dir_entry */
@@ -124,7 +125,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
     dir_entry->next           = NULL;
     dir_entry->prev           = NULL;
   */
-  dir_entry->sub_tree = NULL;
+  if (!AppStateCommitDirEntrySubTree(dir_entry, NULL))
+    return (-1);
   if (!AppStateResetDirEntryPayloadCache(dir_entry))
     return (-1);
   if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, 0) ||
@@ -195,7 +197,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
           first_dir_entry.next->prev = NULL;
         if (!AppStateCommitDirEntryFileList(dir_entry, first_file_entry.next))
           return -1;
-        dir_entry->sub_tree = first_dir_entry.next;
+        if (!AppStateCommitDirEntrySubTree(dir_entry, first_dir_entry.next))
+          return -1;
         return -1;
       } else {
         ClearPromptLineWithBoundary(ctx);
@@ -260,7 +263,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
           first_dir_entry.next->prev = NULL;
         if (!AppStateCommitDirEntryFileList(dir_entry, first_file_entry.next))
           return -1;
-        dir_entry->sub_tree = first_dir_entry.next;
+        if (!AppStateCommitDirEntrySubTree(dir_entry, first_dir_entry.next))
+          return -1;
         return -1;
       }
 
@@ -359,7 +363,8 @@ int ReadTree(ViewContext *ctx, DirEntry *dir_entry, char *path, int depth,
 
   if (!AppStateCommitDirEntryFileList(dir_entry, first_file_entry.next))
     return -1;
-  dir_entry->sub_tree = first_dir_entry.next;
+  if (!AppStateCommitDirEntrySubTree(dir_entry, first_dir_entry.next))
+    return -1;
 
   /* Final UI update via callback */
   if (cb)
@@ -396,7 +401,8 @@ void UnReadTree(ViewContext *ctx, DirEntry *dir_entry, Statistic *s) {
     }
     if (dir_entry->sub_tree) {
       UnReadSubTree(ctx, dir_entry->sub_tree, s);
-      dir_entry->sub_tree = NULL;
+      if (!AppStateCommitDirEntrySubTree(dir_entry, NULL))
+        return;
     }
     if (!AppStateCommitDirEntryLoggedState(dir_entry, TRUE, TRUE))
       return;
@@ -455,7 +461,8 @@ int RescanDir(ViewContext *ctx, DirEntry *dir_entry, int depth, Statistic *s,
   /* Unlink and free all child directories recursively, updating stats. */
   if (dir_entry->sub_tree) {
     UnReadSubTree(ctx, dir_entry->sub_tree, s);
-    dir_entry->sub_tree = NULL;
+    if (!AppStateCommitDirEntrySubTree(dir_entry, NULL))
+      return -1;
   }
 
   /* Unlink and free all files, updating stats. */

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -95,6 +95,16 @@ BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
   return TRUE;
 }
 
+BOOL AppStateCommitDirEntrySubTree(DirEntry *dir_entry, DirEntry *sub_tree) {
+  if (!AppStateValidatedOwnerField("volume.dir_tree"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->sub_tree = sub_tree;
+  return TRUE;
+}
+
 BOOL AppStateCommitVolumeGeneration(struct Volume *volume) {
   if (!AppStateValidatedOwnerField("volume.volume_generation"))
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9308,6 +9308,31 @@ def test_tree_read_file_list_commits_route_through_appstate_helper() -> None:
     assert tree_read.count("AppStateCommitDirEntryFileList(") >= 5
 
 
+def test_tree_read_child_list_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    tree_read = Path("src/fs/tree_read.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntrySubTree(" in header
+    assert 'include "ytnova_appstate_volume.h"' in tree_read
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntrySubTree(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitVolumeGeneration(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.dir_tree")'
+    assignment = "dir_entry->sub_tree = sub_tree;"
+
+    assert validation in helper_body
+    assert assignment in helper_body
+    assert helper_body.index(validation) < helper_body.index(assignment)
+
+    direct_child_list_write = re.compile(r"\bdir_entry->sub_tree\s*=(?!=)")
+    assert not direct_child_list_write.search(tree_read)
+    assert tree_read.count("AppStateCommitDirEntrySubTree(") >= 7
+
+
 def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> None:
     dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
     ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a validated AppState helper for directory child-list topology links.
- Route tree-read, unread, and rescan child-directory link commits through the helper.
- Guard tree topology writes against bypassing the helper boundary in `src/fs/tree_read.c`.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_child_list_commits_route_through_appstate_helper` failed before implementation because `AppStateCommitDirEntrySubTree` was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_child_list_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_child_list_commits_route_through_appstate_helper or tree_read_file_list_commits_route_through_appstate_helper or tree_read_payload_commits_route_through_appstate_helpers'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
