### PR TITLE
refactor(appstate): route stats tagged payload through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,27 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-tree-child-list-helper
-Active PR: https://github.com/robkam/ytreenova/pull/346 (draft)
+Current branch: appstate-stats-tagged-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/347 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/345 merged at `b8f1d57` after green checks.
-- Local `main` and `origin/main` are at `b8f1d57`.
-- The remote branch `appstate-tree-file-list-helper` was deleted during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/346 merged at `feebd3c` after green checks.
+- Local `main` and `origin/main` are at `feebd3c`.
+- The remote branch `appstate-tree-child-list-helper` was deleted during merge cleanup.
 
 Current AppState batch:
-- Adds `AppStateCommitDirEntrySubTree` with `volume.dir_tree` owner-field validation.
-- Routes tree-read, unread, and rescan child-directory topology link updates through the helper.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` for direct `dir_entry->sub_tree` write prevention in `src/fs/tree_read.c`.
+- Adds `AppStateCommitDirEntryTaggedPayload` with `volume.payload_cache` owner-field validation.
+- Routes stats recalculation tagged payload totals through the helper while preserving existing accumulated tagged-count semantics.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` for direct tagged payload write prevention in stats recalculation.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_child_list_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntrySubTree` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_read_child_list_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'tree_read_child_list_commits_route_through_appstate_helper or tree_read_file_list_commits_route_through_appstate_helper or tree_read_payload_commits_route_through_appstate_helpers'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_tagged_payload_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryTaggedPayload` was missing.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_tagged_payload_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q -k 'directory_tagged_payload_commits_route_through_appstate_helper or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or stats'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/346. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/347. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_volume.h
+++ b/include/ytnova_appstate_volume.h
@@ -17,6 +17,9 @@ BOOL AppStateCommitDirEntryTotalPayload(DirEntry *dir_entry,
 BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
                                            unsigned int matching_files,
                                            long long matching_bytes);
+BOOL AppStateCommitDirEntryTaggedPayload(DirEntry *dir_entry,
+                                         unsigned int tagged_files,
+                                         long long tagged_bytes);
 BOOL AppStateCommitDirEntryAccessDenied(DirEntry *dir_entry,
                                         BOOL access_denied);
 BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry);

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -44,6 +44,19 @@ BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
   return TRUE;
 }
 
+BOOL AppStateCommitDirEntryTaggedPayload(DirEntry *dir_entry,
+                                         unsigned int tagged_files,
+                                         long long tagged_bytes) {
+  if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!dir_entry)
+    return FALSE;
+
+  dir_entry->tagged_files = tagged_files;
+  dir_entry->tagged_bytes = tagged_bytes;
+  return TRUE;
+}
+
 BOOL AppStateCommitDirEntryAccessDenied(DirEntry *dir_entry,
                                         BOOL access_denied) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))

--- a/src/ui/stats.c
+++ b/src/ui/stats.c
@@ -76,13 +76,17 @@ static void RecalcDir(BOOL hide_dot_files, DirEntry *d, Statistic *s) {
   FileEntry *f;
   DirEntry *sub;
   unsigned int total_files;
+  unsigned int tagged_files;
   long long total_bytes;
+  long long tagged_bytes;
 
   /* Apply current filter to this directory */
   ApplyFilter(d, s);
 
   total_files = 0;
   total_bytes = 0;
+  tagged_files = d->tagged_files;
+  tagged_bytes = d->tagged_bytes;
   /* matching_files/bytes already updated by ApplyFilter, but we sum them
    * globally below */
 
@@ -94,11 +98,13 @@ static void RecalcDir(BOOL hide_dot_files, DirEntry *d, Statistic *s) {
     total_bytes += f->stat_struct.st_size;
 
     if (f->tagged) {
-      d->tagged_files++;
-      d->tagged_bytes += f->stat_struct.st_size;
+      tagged_files++;
+      tagged_bytes += f->stat_struct.st_size;
     }
   }
   if (!AppStateCommitDirEntryTotalPayload(d, total_files, total_bytes))
+    return;
+  if (!AppStateCommitDirEntryTaggedPayload(d, tagged_files, tagged_bytes))
     return;
 
   sub = d->sub_tree;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9207,6 +9207,41 @@ def test_directory_matching_payload_commits_route_through_appstate_helper() -> N
     assert "AppStateCommitDirEntryMatchingPayload(" in apply_body
 
 
+def test_directory_tagged_payload_commits_route_through_appstate_helper() -> None:
+    header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
+    helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    stats = Path("src/ui/stats.c").read_text(encoding="utf-8")
+
+    assert "BOOL AppStateCommitDirEntryTaggedPayload(" in header
+    assert 'include "ytnova_appstate_volume.h"' in stats
+
+    helper_start = helper.index("BOOL AppStateCommitDirEntryTaggedPayload(")
+    helper_end = helper.index(
+        "\nBOOL AppStateCommitDirEntryAccessDenied(", helper_start
+    )
+    helper_body = helper[helper_start:helper_end]
+    validation = 'AppStateValidatedOwnerField("volume.payload_cache")'
+    assignments = [
+        "dir_entry->tagged_files = tagged_files;",
+        "dir_entry->tagged_bytes = tagged_bytes;",
+    ]
+
+    assert validation in helper_body
+    for assignment in assignments:
+        assert assignment in helper_body
+        assert helper_body.index(validation) < helper_body.index(assignment)
+
+    recalc_start = stats.index("static void RecalcDir(BOOL hide_dot_files,")
+    recalc_body = stats[
+        recalc_start : stats.index("\nvoid RecalculateSysStats", recalc_start)
+    ]
+    direct_tagged_write = re.compile(
+        r"->(?:tagged_files|tagged_bytes)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    assert not direct_tagged_write.search(recalc_body)
+    assert "AppStateCommitDirEntryTaggedPayload(" in recalc_body
+
+
 def test_directory_total_payload_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a validated AppState helper for directory tagged payload totals.
- Route stats recalculation tagged payload totals through the helper.
- Guard stats tagged payload writes against bypassing the helper boundary.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_tagged_payload_commits_route_through_appstate_helper` failed before implementation because `AppStateCommitDirEntryTaggedPayload` was missing.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_tagged_payload_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q -k 'directory_tagged_payload_commits_route_through_appstate_helper or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or stats'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
