### PR TITLE
refactor(appstate): route tag state payload through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,26 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-stats-tagged-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/347 (draft)
+Current branch: appstate-tag-state-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/348 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/346 merged at `feebd3c` after green checks.
-- Local `main` and `origin/main` are at `feebd3c`.
-- The remote branch `appstate-tree-child-list-helper` was deleted during merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/347 merged at `0c42f0b` after green checks.
+- Local `main`, `origin/main`, and this branch start at `0c42f0b`.
 
 Current AppState batch:
-- Adds `AppStateCommitDirEntryTaggedPayload` with `volume.payload_cache` owner-field validation.
-- Routes stats recalculation tagged payload totals through the helper while preserving existing accumulated tagged-count semantics.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` for direct tagged payload write prevention in stats recalculation.
+- Routes tag-state restore tagged payload totals through `AppStateCommitDirEntryTaggedPayload`.
+- Keeps per-file tag restoration and statistics accumulation behavior unchanged while moving `DirEntry` tagged payload writes behind the AppState helper.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct tagged payload writes in `ApplyPanelTagsToDir`.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_tagged_payload_commits_route_through_appstate_helper` failed because `AppStateCommitDirEntryTaggedPayload` was missing.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k directory_tagged_payload_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q -k 'directory_tagged_payload_commits_route_through_appstate_helper or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or stats'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tag_state_tagged_payload_commits_route_through_appstate_helper` failed because `src/ui/tag_state.c` did not include `ytnova_appstate_volume.h` and did not call `AppStateCommitDirEntryTaggedPayload`.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tag_state_tagged_payload_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q -k 'tag_state_tagged_payload_commits_route_through_appstate_helper or directory_tagged_payload_commits_route_through_appstate_helper or stats'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/347. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/348. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/tag_state.c
+++ b/src/ui/tag_state.c
@@ -1,3 +1,4 @@
+#include "ytnova_appstate_volume.h"
 #include "ytnova_fs.h"
 #include "ytnova_ui.h"
 #include <stdlib.h>
@@ -150,21 +151,25 @@ void PanelTags_RecordFileState(YtreeNovaPanel *panel, FileEntry *file_entry,
 static void ApplyPanelTagsToDir(const YtreeNovaPanel *panel, DirEntry *dir_entry,
                                 Statistic *stats) {
   FileEntry *file_entry;
+  unsigned int tagged_files;
+  long long tagged_bytes;
 
   if (!panel || !dir_entry || !stats)
     return;
 
-  dir_entry->tagged_files = 0;
-  dir_entry->tagged_bytes = 0;
+  tagged_files = 0;
+  tagged_bytes = 0;
   for (file_entry = dir_entry->file; file_entry; file_entry = file_entry->next) {
     file_entry->tagged = PanelTags_FileIsTagged(panel, file_entry);
     if (file_entry->tagged) {
-      dir_entry->tagged_files++;
-      dir_entry->tagged_bytes += file_entry->stat_struct.st_size;
+      tagged_files++;
+      tagged_bytes += file_entry->stat_struct.st_size;
       stats->disk_tagged_files++;
       stats->disk_tagged_bytes += file_entry->stat_struct.st_size;
     }
   }
+  (void)AppStateCommitDirEntryTaggedPayload(dir_entry, tagged_files,
+                                            tagged_bytes);
 }
 
 static void ApplyPanelTagsToTree(YtreeNovaPanel *panel, DirEntry *dir_entry,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9242,6 +9242,24 @@ def test_directory_tagged_payload_commits_route_through_appstate_helper() -> Non
     assert "AppStateCommitDirEntryTaggedPayload(" in recalc_body
 
 
+def test_tag_state_tagged_payload_commits_route_through_appstate_helper() -> None:
+    tag_state = Path("src/ui/tag_state.c").read_text(encoding="utf-8")
+
+    assert 'include "ytnova_appstate_volume.h"' in tag_state
+
+    apply_start = tag_state.index("static void ApplyPanelTagsToDir(")
+    apply_body = tag_state[
+        apply_start : tag_state.index(
+            "\nstatic void ApplyPanelTagsToTree", apply_start
+        )
+    ]
+    direct_tagged_write = re.compile(
+        r"->(?:tagged_files|tagged_bytes)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    assert not direct_tagged_write.search(apply_body)
+    assert "AppStateCommitDirEntryTaggedPayload(" in apply_body
+
+
 def test_directory_total_payload_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route tag-state directory tagged payload restore through `AppStateCommitDirEntryTaggedPayload`.
- Keep file tag restore and stats accumulation unchanged while removing direct tagged payload writes from `ApplyPanelTagsToDir`.
- Add AppState contract guard coverage for the tag-state restore path.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tag_state_tagged_payload_commits_route_through_appstate_helper` failed before implementation because the tag-state restore path did not include the AppState helper or route tagged payload commits through it.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tag_state_tagged_payload_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q -k 'tag_state_tagged_payload_commits_route_through_appstate_helper or directory_tagged_payload_commits_route_through_appstate_helper or stats'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
