### PR TITLE
refactor(appstate): route ui tag payload through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,27 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-tag-state-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/348 (draft)
+Current branch: appstate-ui-tag-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/349 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/347 merged at `0c42f0b` after green checks.
-- Local `main`, `origin/main`, and this branch start at `0c42f0b`.
+- PR https://github.com/robkam/ytreenova/pull/348 merged at `d7a8128` after green checks.
+- Local `main`, `origin/main`, and this branch start at `d7a8128`.
+- Remote branches for the merged stats and tag-state payload helper batches were pruned locally. Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Routes tag-state restore tagged payload totals through `AppStateCommitDirEntryTaggedPayload`.
-- Keeps per-file tag restoration and statistics accumulation behavior unchanged while moving `DirEntry` tagged payload writes behind the AppState helper.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct tagged payload writes in `ApplyPanelTagsToDir`.
+- Routes UI directory/file tag payload mutations in `src/ui/dir_tags.c` and `src/ui/file_tags.c` through `AppStateCommitDirEntryTaggedPayload`.
+- Keeps existing per-file tag changes, disk-stat updates, and viewport behavior unchanged while removing direct `DirEntry` tagged payload writes from the migrated UI tag paths.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct tagged payload writes in the migrated UI tag handlers.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tag_state_tagged_payload_commits_route_through_appstate_helper` failed because `src/ui/tag_state.c` did not include `ytnova_appstate_volume.h` and did not call `AppStateCommitDirEntryTaggedPayload`.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tag_state_tagged_payload_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_stats_panel.py -q -k 'tag_state_tagged_payload_commits_route_through_appstate_helper or directory_tagged_payload_commits_route_through_appstate_helper or stats'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ui_tag_payload_commits_route_through_appstate_helper` failed because `src/ui/dir_tags.c` and `src/ui/file_tags.c` did not include `ytnova_appstate_volume.h` or route tagged payload commits through `AppStateCommitDirEntryTaggedPayload`.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ui_tag_payload_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_panel_isolation.py -q -k 'ui_tag_payload_commits_route_through_appstate_helper or dir_tag_dir_entry_viewports_commit_through_appstate_helper or split_same_directory_file_tags_are_panel_local_tags'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/348. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/349. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/dir_tags.c
+++ b/src/ui/dir_tags.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_appstate_panel.h"
 #include "ytnova_appstate_visibility.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_ui.h"
 
 void HandleTagDir(ViewContext *ctx, DirEntry *dir_entry, BOOL value,
@@ -22,13 +23,15 @@ void HandleTagDir(ViewContext *ctx, DirEntry *dir_entry, BOOL value,
     if ((fe_ptr->matching) && (fe_ptr->tagged != value)) {
       fe_ptr->tagged = value;
       if (value) {
-        dir_entry->tagged_files++;
-        dir_entry->tagged_bytes += fe_ptr->stat_struct.st_size;
+        (void)AppStateCommitDirEntryTaggedPayload(
+            dir_entry, dir_entry->tagged_files + 1,
+            dir_entry->tagged_bytes + fe_ptr->stat_struct.st_size);
         s->disk_tagged_files++;
         s->disk_tagged_bytes += fe_ptr->stat_struct.st_size;
       } else {
-        dir_entry->tagged_files--;
-        dir_entry->tagged_bytes -= fe_ptr->stat_struct.st_size;
+        (void)AppStateCommitDirEntryTaggedPayload(
+            dir_entry, dir_entry->tagged_files - 1,
+            dir_entry->tagged_bytes - fe_ptr->stat_struct.st_size);
         s->disk_tagged_files--;
         s->disk_tagged_bytes -= fe_ptr->stat_struct.st_size;
       }
@@ -58,14 +61,16 @@ void HandleTagAllDirs(ViewContext *ctx, struct Volume *vol, DirEntry *dir_entry,
       if ((fe_ptr->matching) && (fe_ptr->tagged != value)) {
         if (value) {
           fe_ptr->tagged = value;
-          dir_entry->tagged_files++;
-          dir_entry->tagged_bytes += fe_ptr->stat_struct.st_size;
+          (void)AppStateCommitDirEntryTaggedPayload(
+              dir_entry, dir_entry->tagged_files + 1,
+              dir_entry->tagged_bytes + fe_ptr->stat_struct.st_size);
           s->disk_tagged_files++;
           s->disk_tagged_bytes += fe_ptr->stat_struct.st_size;
         } else {
           fe_ptr->tagged = value;
-          dir_entry->tagged_files--;
-          dir_entry->tagged_bytes -= fe_ptr->stat_struct.st_size;
+          (void)AppStateCommitDirEntryTaggedPayload(
+              dir_entry, dir_entry->tagged_files - 1,
+              dir_entry->tagged_bytes - fe_ptr->stat_struct.st_size);
           s->disk_tagged_files--;
           s->disk_tagged_bytes -= fe_ptr->stat_struct.st_size;
         }
@@ -95,13 +100,15 @@ static void HandleInvertDirTags(ViewContext *ctx, DirEntry *dir_entry,
 
     fe_ptr->tagged = !fe_ptr->tagged;
     if (fe_ptr->tagged) {
-      dir_entry->tagged_files++;
-      dir_entry->tagged_bytes += fe_ptr->stat_struct.st_size;
+      (void)AppStateCommitDirEntryTaggedPayload(
+          dir_entry, dir_entry->tagged_files + 1,
+          dir_entry->tagged_bytes + fe_ptr->stat_struct.st_size);
       s->disk_tagged_files++;
       s->disk_tagged_bytes += fe_ptr->stat_struct.st_size;
     } else {
-      dir_entry->tagged_files--;
-      dir_entry->tagged_bytes -= fe_ptr->stat_struct.st_size;
+      (void)AppStateCommitDirEntryTaggedPayload(
+          dir_entry, dir_entry->tagged_files - 1,
+          dir_entry->tagged_bytes - fe_ptr->stat_struct.st_size);
       s->disk_tagged_files--;
       s->disk_tagged_bytes -= fe_ptr->stat_struct.st_size;
     }

--- a/src/ui/file_tags.c
+++ b/src/ui/file_tags.c
@@ -5,6 +5,7 @@
  *
  ***************************************************************************/
 
+#include "ytnova_appstate_volume.h"
 #include "ytnova_cmd.h"
 #include "ytnova_ui.h"
 
@@ -136,8 +137,9 @@ void FileTags_SilentTagWalkTaggedFiles(ViewContext *ctx,
       if (result != 0) {
         fe_ptr->tagged = FALSE;
         /* Update Stats */
-        fe_ptr->dir_entry->tagged_files--;
-        fe_ptr->dir_entry->tagged_bytes -= fe_ptr->stat_struct.st_size;
+        (void)AppStateCommitDirEntryTaggedPayload(
+            fe_ptr->dir_entry, fe_ptr->dir_entry->tagged_files - 1,
+            fe_ptr->dir_entry->tagged_bytes - fe_ptr->stat_struct.st_size);
         ctx->active->vol->vol_stats.disk_tagged_files--;
         ctx->active->vol->vol_stats.disk_tagged_bytes -=
             fe_ptr->stat_struct.st_size;
@@ -278,10 +280,14 @@ void FileTags_HandleInvertTags(ViewContext *ctx, DirEntry *dir_entry,
       fe->tagged = !fe->tagged;
       if (fe->tagged) {
         s->disk_tagged_files++;
-        dir_entry->tagged_files++;
+        (void)AppStateCommitDirEntryTaggedPayload(
+            dir_entry, dir_entry->tagged_files + 1,
+            dir_entry->tagged_bytes);
       } else {
         s->disk_tagged_files--;
-        dir_entry->tagged_files--;
+        (void)AppStateCommitDirEntryTaggedPayload(
+            dir_entry, dir_entry->tagged_files - 1,
+            dir_entry->tagged_bytes);
       }
       PanelTags_RecordFileState(ctx->active, fe, fe->tagged);
     }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9260,6 +9260,47 @@ def test_tag_state_tagged_payload_commits_route_through_appstate_helper() -> Non
     assert "AppStateCommitDirEntryTaggedPayload(" in apply_body
 
 
+def test_ui_tag_payload_commits_route_through_appstate_helper() -> None:
+    dir_tags = Path("src/ui/dir_tags.c").read_text(encoding="utf-8")
+    file_tags = Path("src/ui/file_tags.c").read_text(encoding="utf-8")
+    direct_tagged_write = re.compile(
+        r"->(?:tagged_files|tagged_bytes)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    assert 'include "ytnova_appstate_volume.h"' in dir_tags
+    assert 'include "ytnova_appstate_volume.h"' in file_tags
+
+    dir_tag_bodies = [
+        dir_tags[
+            dir_tags.index("void HandleTagDir(") : dir_tags.index(
+                "\nvoid HandleTagAllDirs"
+            )
+        ],
+        dir_tags[
+            dir_tags.index("void HandleTagAllDirs(") : dir_tags.index(
+                "\nstatic void HandleInvertDirTags"
+            )
+        ],
+        dir_tags[
+            dir_tags.index("static void HandleInvertDirTags(") : dir_tags.index(
+                "\nstatic void HandleDirTaggedOnlyToggle"
+            )
+        ],
+    ]
+    file_tag_bodies = [
+        file_tags[
+            file_tags.index("void FileTags_SilentTagWalkTaggedFiles(") : file_tags.index(
+                "\nBOOL FileTags_IsMatchingTaggedFiles"
+            )
+        ],
+        file_tags[file_tags.index("void FileTags_HandleInvertTags(") :],
+    ]
+
+    for tag_body in dir_tag_bodies + file_tag_bodies:
+        assert not direct_tagged_write.search(tag_body)
+        assert "AppStateCommitDirEntryTaggedPayload(" in tag_body
+
+
 def test_directory_total_payload_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route directory and file tag payload mutations through `AppStateCommitDirEntryTaggedPayload`.
- Preserve existing file tag, disk-stat, and viewport behavior while removing direct tagged payload writes from the migrated UI handlers.
- Add AppState contract guard coverage for the UI tag mutation paths.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ui_tag_payload_commits_route_through_appstate_helper` failed before implementation because the UI tag paths did not include the AppState helper or route tagged payload commits through it.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ui_tag_payload_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_panel_isolation.py -q -k 'ui_tag_payload_commits_route_through_appstate_helper or dir_tag_dir_entry_viewports_commit_through_appstate_helper or split_same_directory_file_tags_are_panel_local_tags'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
