### PR TITLE
refactor(appstate): route file tag payload through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,27 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-ui-tag-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/349 (draft)
+Current branch: appstate-file-tag-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/350 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/348 merged at `d7a8128` after green checks.
-- Local `main`, `origin/main`, and this branch start at `d7a8128`.
-- Remote branches for the merged stats and tag-state payload helper batches were pruned locally. Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
+- PR https://github.com/robkam/ytreenova/pull/349 merged at `1237fb7` after green checks.
+- Local `main`, `origin/main`, and this branch start at `1237fb7`.
+- The remote branch `appstate-ui-tag-payload-helper` was pruned locally. Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Routes UI directory/file tag payload mutations in `src/ui/dir_tags.c` and `src/ui/file_tags.c` through `AppStateCommitDirEntryTaggedPayload`.
-- Keeps existing per-file tag changes, disk-stat updates, and viewport behavior unchanged while removing direct `DirEntry` tagged payload writes from the migrated UI tag paths.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct tagged payload writes in the migrated UI tag handlers.
+- Routes remaining UI file tag payload writers in `src/ui/ctrl_file_ops.c` and `src/ui/dir_compare.c` through `AppStateCommitDirEntryTaggedPayload`.
+- Keeps existing file tag, compare tagging, disk-stat, and panel tag-state behavior unchanged while removing direct `DirEntry` tagged payload writes from the migrated file-tag paths.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct tagged payload writes in the migrated file tag helpers.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ui_tag_payload_commits_route_through_appstate_helper` failed because `src/ui/dir_tags.c` and `src/ui/file_tags.c` did not include `ytnova_appstate_volume.h` or route tagged payload commits through `AppStateCommitDirEntryTaggedPayload`.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k ui_tag_payload_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_panel_isolation.py -q -k 'ui_tag_payload_commits_route_through_appstate_helper or dir_tag_dir_entry_viewports_commit_through_appstate_helper or split_same_directory_file_tags_are_panel_local_tags'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_tag_payload_commits_route_through_appstate_helper` failed because `src/ui/dir_compare.c` did not include `ytnova_appstate_volume.h` and the file-tag writers did not route tagged payload commits through `AppStateCommitDirEntryTaggedPayload`.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_tag_payload_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_panel_isolation.py tests/test_compare_actions.py -q -k 'file_tag_payload_commits_route_through_appstate_helper or ui_tag_payload_commits_route_through_appstate_helper or file_tags_are_panel_local or compare_tag'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/349. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/350. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -1711,8 +1711,8 @@ static void SetFileTaggedState(YtreeNovaPanel *panel, FileEntry *fe_ptr,
       return;
 
     fe_ptr->tagged = TRUE;
-    de_ptr->tagged_files++;
-    de_ptr->tagged_bytes += file_size;
+    (void)AppStateCommitDirEntryTaggedPayload(
+        de_ptr, de_ptr->tagged_files + 1, de_ptr->tagged_bytes + file_size);
     s->disk_tagged_files++;
     s->disk_tagged_bytes += file_size;
     PanelTags_RecordFileState(panel, fe_ptr, TRUE);
@@ -1723,8 +1723,8 @@ static void SetFileTaggedState(YtreeNovaPanel *panel, FileEntry *fe_ptr,
     return;
 
   fe_ptr->tagged = FALSE;
-  de_ptr->tagged_files--;
-  de_ptr->tagged_bytes -= file_size;
+  (void)AppStateCommitDirEntryTaggedPayload(
+      de_ptr, de_ptr->tagged_files - 1, de_ptr->tagged_bytes - file_size);
   s->disk_tagged_files--;
   s->disk_tagged_bytes -= file_size;
   PanelTags_RecordFileState(panel, fe_ptr, FALSE);

--- a/src/ui/dir_compare.c
+++ b/src/ui/dir_compare.c
@@ -7,6 +7,7 @@
 
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_ui.h"
 #include <errno.h>
 #include <stdlib.h>
@@ -235,8 +236,9 @@ static void TagComparedFile(YtreeNovaPanel *panel, FileEntry *source_file,
   owner_dir = source_file->dir_entry;
   file_size = source_file->stat_struct.st_size;
   source_file->tagged = TRUE;
-  owner_dir->tagged_files++;
-  owner_dir->tagged_bytes += file_size;
+  (void)AppStateCommitDirEntryTaggedPayload(
+      owner_dir, owner_dir->tagged_files + 1,
+      owner_dir->tagged_bytes + file_size);
   stats->disk_tagged_files++;
   stats->disk_tagged_bytes += file_size;
   PanelTags_RecordFileState(panel, source_file, TRUE);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9301,6 +9301,34 @@ def test_ui_tag_payload_commits_route_through_appstate_helper() -> None:
         assert "AppStateCommitDirEntryTaggedPayload(" in tag_body
 
 
+def test_file_tag_payload_commits_route_through_appstate_helper() -> None:
+    ctrl_file_ops = Path("src/ui/ctrl_file_ops.c").read_text(encoding="utf-8")
+    dir_compare = Path("src/ui/dir_compare.c").read_text(encoding="utf-8")
+    direct_tagged_write = re.compile(
+        r"->(?:tagged_files|tagged_bytes)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+
+    assert 'include "ytnova_appstate_volume.h"' in ctrl_file_ops
+    assert 'include "ytnova_appstate_volume.h"' in dir_compare
+
+    tag_bodies = [
+        ctrl_file_ops[
+            ctrl_file_ops.index("static void SetFileTaggedState(") : ctrl_file_ops.index(
+                "\nstatic void SetFileTaggedStateRange"
+            )
+        ],
+        dir_compare[
+            dir_compare.index("static void TagComparedFile(") : dir_compare.index(
+                "\nstatic int BuildRelativeComparePath"
+            )
+        ],
+    ]
+
+    for tag_body in tag_bodies:
+        assert not direct_tagged_write.search(tag_body)
+        assert "AppStateCommitDirEntryTaggedPayload(" in tag_body
+
+
 def test_directory_total_payload_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route file-tag and compared-file tag payload mutations through `AppStateCommitDirEntryTaggedPayload`.
- Preserve existing tag state and disk-stat updates while removing direct tagged payload writes from the migrated handlers.
- Add AppState contract guard coverage for the file-tag mutation paths.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_tag_payload_commits_route_through_appstate_helper` failed before implementation because the compared-file tag path did not include the AppState helper or route tagged payload commits through it.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k file_tag_payload_commits_route_through_appstate_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py tests/test_panel_isolation.py -q -k 'file_tag_payload_commits_route_through_appstate_helper or ui_tag_payload_commits_route_through_appstate_helper or split_same_directory_file_tags_are_panel_local_tags'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
