### PR TITLE
refactor(appstate): route delete tagged payload through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,27 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-filter-tag-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/351 (draft)
-Supersession state: maintainer explicitly resumed autonomous AppState work; no active stop condition.
+Current branch: appstate-delete-tagged-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/352 (draft)
+Supersession state: maintainer resumed autonomous AppState work after a pause; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/350 merged at `6f7fe6b` after green checks.
-- Local `main`, `origin/main`, and this branch start at `6f7fe6b`.
+- PR https://github.com/robkam/ytreenova/pull/351 merged at `9727c35` after green checks.
+- Local `main`, `origin/main`, and this branch start at `9727c35`.
 - Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Routes restored tree tagged payload totals in `src/fs/tree_utils.c` through `AppStateCommitDirEntryTaggedPayload`.
-- Keeps existing tag restoration and disk-stat accumulation behavior unchanged while removing direct `DirEntry` tagged payload writes from `RestoreTreeState`.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct tagged payload writes in the tree restore path.
+- Routes delete-time tagged payload decrements in `src/cmd/delete.c` through `AppStateCommitDirEntryTaggedPayload`.
+- Keeps existing file removal and disk-stat behavior unchanged while removing direct `DirEntry` tagged payload writes from `RemoveFile`.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct tagged payload writes in the migrated delete path.
 
 Local validation:
-- Red proof before implementation: `source /home/rob/ytreenova/.venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_restore_tagged_payload_commits_route_through_appstate_helper` failed in a temporary clean worktree because `src/fs/tree_utils.c` did not include `ytnova_appstate_volume.h` or call `AppStateCommitDirEntryTaggedPayload`.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k tree_restore_tagged_payload_commits_route_through_appstate_helper`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_tagged_payload_commits_route_through_appstate_helper` failed because `src/cmd/delete.c` did not include `ytnova_appstate_volume.h` or route delete tagged payload commits through `AppStateCommitDirEntryTaggedPayload`.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_tagged_payload_commits_route_through_appstate_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'delete_tagged_payload_commits_route_through_appstate_helper or tree_restore_tagged_payload_commits_route_through_appstate_helper or file_tag_payload_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/351. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/352. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/cmd/delete.c
+++ b/src/cmd/delete.c
@@ -9,6 +9,7 @@
 #include "../../include/ytnova.h"
 #endif
 
+#include "../../include/ytnova_appstate_volume.h"
 #include "../../include/ytnova_cmd.h"
 #include "../../include/ytnova_fs.h"
 #include <errno.h>
@@ -125,8 +126,8 @@ int RemoveFile(ViewContext *ctx, FileEntry *fe_ptr, Statistic *s) {
     s->disk_matching_files--;
   }
   if (fe_ptr->tagged) {
-    de_ptr->tagged_bytes -= file_size;
-    de_ptr->tagged_files--;
+    (void)AppStateCommitDirEntryTaggedPayload(
+        de_ptr, de_ptr->tagged_files - 1, de_ptr->tagged_bytes - file_size);
     s->disk_tagged_bytes -= file_size;
     s->disk_tagged_files--;
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9345,6 +9345,22 @@ def test_tree_restore_tagged_payload_commits_route_through_appstate_helper() -> 
     assert "AppStateCommitDirEntryTaggedPayload(" in restore_body
 
 
+def test_delete_tagged_payload_commits_route_through_appstate_helper() -> None:
+    delete = Path("src/cmd/delete.c").read_text(encoding="utf-8")
+
+    assert "ytnova_appstate_volume.h" in delete
+
+    remove_start = delete.index("int RemoveFile(")
+    remove_body = delete[
+        remove_start : delete.index("\nint DeleteTaggedFiles", remove_start)
+    ]
+    direct_tagged_write = re.compile(
+        r"->(?:tagged_files|tagged_bytes)\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    assert not direct_tagged_write.search(remove_body)
+    assert "AppStateCommitDirEntryTaggedPayload(" in remove_body
+
+
 def test_directory_total_payload_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Route delete-time tagged payload updates through `AppStateCommitDirEntryTaggedPayload`.
- Preserve file removal, disk-stat, and list relink behavior while removing direct tagged payload writes from `RemoveFile`.
- Add AppState contract guard coverage for the delete removal tagged payload path.

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_tagged_payload_commits_route_through_appstate_helper` failed before implementation because `src/cmd/delete.c` did not include the AppState helper or route tagged payload commits through it.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_tagged_payload_commits_route_through_appstate_helper`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
