### PR TITLE
refactor(appstate): route delete count payload through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,26 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-delete-tagged-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/352 (draft)
-Supersession state: maintainer resumed autonomous AppState work after a pause; no active stop condition.
+Current branch: appstate-delete-count-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/353 (draft)
+Supersession state: maintainer explicitly resumed autonomous AppState work after the prior pause; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/351 merged at `9727c35` after green checks.
-- Local `main`, `origin/main`, and this branch start at `9727c35`.
-- Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
+- PR https://github.com/robkam/ytreenova/pull/352 merged at `3de334d` after green checks.
+- Local `main` and `origin/main` were at `3de334d` before this branch.
+- Deleted stale local branch `appstate-delete-size-payload-helper`; local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Routes delete-time tagged payload decrements in `src/cmd/delete.c` through `AppStateCommitDirEntryTaggedPayload`.
-- Keeps existing file removal and disk-stat behavior unchanged while removing direct `DirEntry` tagged payload writes from `RemoveFile`.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct tagged payload writes in the migrated delete path.
+- Routes delete-time total and matching payload decrements in `src/cmd/delete.c` through `AppStateCommitDirEntryTotalPayload` and `AppStateCommitDirEntryMatchingPayload`.
+- Keeps existing file removal, disk-stat, and tagged-payload behavior unchanged while removing direct `DirEntry` total/matching payload writes from `RemoveFile`.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct total/matching payload writes in the migrated delete path.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_tagged_payload_commits_route_through_appstate_helper` failed because `src/cmd/delete.c` did not include `ytnova_appstate_volume.h` or route delete tagged payload commits through `AppStateCommitDirEntryTaggedPayload`.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_tagged_payload_commits_route_through_appstate_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'delete_tagged_payload_commits_route_through_appstate_helper or tree_restore_tagged_payload_commits_route_through_appstate_helper or file_tag_payload_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_count_payload_commits_route_through_appstate_helpers` failed because `src/cmd/delete.c` still wrote `DirEntry` total/matching payload fields directly in `RemoveFile`.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'delete_count_payload_commits_route_through_appstate_helpers or delete_tagged_payload_commits_route_through_appstate_helper or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/352. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/353. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/cmd/delete.c
+++ b/src/cmd/delete.c
@@ -115,13 +115,16 @@ int RemoveFile(ViewContext *ctx, FileEntry *fe_ptr, Statistic *s) {
 
   file_size = fe_ptr->stat_struct.st_size;
 
-  de_ptr->total_bytes -= file_size;
-  de_ptr->total_files--;
+  if (!AppStateCommitDirEntryTotalPayload(
+          de_ptr, de_ptr->total_files - 1, de_ptr->total_bytes - file_size))
+    return -1;
   s->disk_total_bytes -= file_size;
   s->disk_total_files--;
   if (fe_ptr->matching) {
-    de_ptr->matching_bytes -= file_size;
-    de_ptr->matching_files--;
+    if (!AppStateCommitDirEntryMatchingPayload(
+            de_ptr, de_ptr->matching_files - 1,
+            de_ptr->matching_bytes - file_size))
+      return -1;
     s->disk_matching_bytes -= file_size;
     s->disk_matching_files--;
   }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9361,6 +9361,24 @@ def test_delete_tagged_payload_commits_route_through_appstate_helper() -> None:
     assert "AppStateCommitDirEntryTaggedPayload(" in remove_body
 
 
+def test_delete_count_payload_commits_route_through_appstate_helpers() -> None:
+    delete = Path("src/cmd/delete.c").read_text(encoding="utf-8")
+
+    assert "ytnova_appstate_volume.h" in delete
+
+    remove_start = delete.index("int RemoveFile(")
+    remove_body = delete[
+        remove_start : delete.index("\nint DeleteTaggedFiles", remove_start)
+    ]
+    direct_count_write = re.compile(
+        r"->(?:total_files|total_bytes|matching_files|matching_bytes)"
+        r"\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    assert not direct_count_write.search(remove_body)
+    assert "AppStateCommitDirEntryTotalPayload(" in remove_body
+    assert "AppStateCommitDirEntryMatchingPayload(" in remove_body
+
+
 def test_directory_total_payload_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- route delete-time total and matching payload decrements through AppState volume helpers
- keep delete file removal, disk-stat updates, and tagged-payload behavior unchanged
- add guard coverage for the migrated delete count payload boundary

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_count_payload_commits_route_through_appstate_helpers` failed before implementation because `RemoveFile` wrote total/matching payload fields directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'delete_count_payload_commits_route_through_appstate_helpers or delete_tagged_payload_commits_route_through_appstate_helper or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
