### PR TITLE
refactor(appstate): route mutation count payload through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,27 @@ Date: 2026-07-03
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-delete-count-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/353 (draft)
+Current branch: appstate-mutation-count-payload-helper
+Active PR: https://github.com/robkam/ytreenova/pull/354 (draft)
 Supersession state: maintainer explicitly resumed autonomous AppState work after the prior pause; no active stop condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/352 merged at `3de334d` after green checks.
-- Local `main` and `origin/main` were at `3de334d` before this branch.
-- Deleted stale local branch `appstate-delete-size-payload-helper`; local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
+- PR https://github.com/robkam/ytreenova/pull/353 merged at `68bb978` after green checks.
+- Local `main` and `origin/main` were at `68bb978` before this branch.
+- Remote branch `appstate-delete-count-payload-helper` was deleted by the merge; local branch cleanup is complete.
+- Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Routes delete-time total and matching payload decrements in `src/cmd/delete.c` through `AppStateCommitDirEntryTotalPayload` and `AppStateCommitDirEntryMatchingPayload`.
-- Keeps existing file removal, disk-stat, and tagged-payload behavior unchanged while removing direct `DirEntry` total/matching payload writes from `RemoveFile`.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct total/matching payload writes in the migrated delete path.
+- Routes copy/move destination total and matching payload increments in `src/cmd/copy.c` and `src/cmd/move.c` through `AppStateCommitDirEntryTotalPayload` and `AppStateCommitDirEntryMatchingPayload`.
+- Keeps existing destination file-entry linking and disk-stat behavior unchanged while removing direct `DirEntry` total/matching payload writes from the migrated mutation paths.
+- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct total/matching payload writes in the migrated copy/move paths.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k delete_count_payload_commits_route_through_appstate_helpers` failed because `src/cmd/delete.c` still wrote `DirEntry` total/matching payload fields directly in `RemoveFile`.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'delete_count_payload_commits_route_through_appstate_helpers or delete_tagged_payload_commits_route_through_appstate_helper or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k mutation_count_payload_commits_route_through_appstate_helpers` failed because `src/cmd/copy.c` and `src/cmd/move.c` did not include `ytnova_appstate_volume.h` or route destination total/matching payload writes through AppState helpers.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'mutation_count_payload_commits_route_through_appstate_helpers or delete_count_payload_commits_route_through_appstate_helpers or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/353. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/354. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/cmd/copy.c
+++ b/src/cmd/copy.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_cmd.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_fs.h"
 #include <errno.h>
 #include <stdio.h>
@@ -526,8 +527,11 @@ int CopyFile(ViewContext *ctx, Statistic *statistic_ptr, FileEntry *fe_ptr,
       file_size = stat_struct.st_size;
 
       /* Update Total Stats using target_stats if available */
-      dest_dir_entry->total_bytes += file_size;
-      dest_dir_entry->total_files++;
+      if (!AppStateCommitDirEntryTotalPayload(
+              dest_dir_entry, dest_dir_entry->total_files + 1,
+              dest_dir_entry->total_bytes + file_size)) {
+        ESCAPE;
+      }
 
       if (target_stats) {
         target_stats->disk_total_bytes += file_size;
@@ -559,8 +563,12 @@ int CopyFile(ViewContext *ctx, Statistic *statistic_ptr, FileEntry *fe_ptr,
 
       /* Update Matching Stats */
       if (fen_ptr->matching) {
-        dest_dir_entry->matching_bytes += file_size;
-        dest_dir_entry->matching_files++;
+        if (!AppStateCommitDirEntryMatchingPayload(
+                dest_dir_entry, dest_dir_entry->matching_files + 1,
+                dest_dir_entry->matching_bytes + file_size)) {
+          free(fen_ptr);
+          ESCAPE;
+        }
         if (target_stats) {
           target_stats->disk_matching_bytes += file_size;
           target_stats->disk_matching_files++;

--- a/src/cmd/move.c
+++ b/src/cmd/move.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_cmd.h"
+#include "ytnova_appstate_volume.h"
 #include "ytnova_fs.h"
 #include <errno.h>
 #include <stdio.h>
@@ -223,8 +224,11 @@ int MoveFile(ViewContext *ctx, FileEntry *fe_ptr, const char *to_file,
       file_size = stat_struct.st_size;
 
       /* Update Total Stats for TARGET volume */
-      dest_dir_entry->total_bytes += file_size;
-      dest_dir_entry->total_files++;
+      if (!AppStateCommitDirEntryTotalPayload(
+              dest_dir_entry, dest_dir_entry->total_files + 1,
+              dest_dir_entry->total_bytes + file_size)) {
+        ESCAPE;
+      }
 
       if (target_stats_ptr) {
         target_stats_ptr->disk_total_bytes += file_size;
@@ -253,8 +257,12 @@ int MoveFile(ViewContext *ctx, FileEntry *fe_ptr, const char *to_file,
 
       /* Update Matching Stats for TARGET volume */
       if (fen_ptr->matching) {
-        dest_dir_entry->matching_bytes += file_size;
-        dest_dir_entry->matching_files++;
+        if (!AppStateCommitDirEntryMatchingPayload(
+                dest_dir_entry, dest_dir_entry->matching_files + 1,
+                dest_dir_entry->matching_bytes + file_size)) {
+          free(fen_ptr);
+          ESCAPE;
+        }
         if (target_stats_ptr) {
           target_stats_ptr->disk_matching_bytes += file_size;
           target_stats_ptr->disk_matching_files++;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9379,6 +9379,30 @@ def test_delete_count_payload_commits_route_through_appstate_helpers() -> None:
     assert "AppStateCommitDirEntryMatchingPayload(" in remove_body
 
 
+def test_mutation_count_payload_commits_route_through_appstate_helpers() -> None:
+    direct_count_write = re.compile(
+        r"->(?:total_files|total_bytes|matching_files|matching_bytes)"
+        r"\s*(?:[+*/%-]?=|\+\+|--)"
+    )
+    migrated_functions = [
+        ("src/cmd/copy.c", "int CopyFile(", "\nint CopyFileContent("),
+        ("src/cmd/move.c", "int MoveFile(", "\nstatic int Move("),
+    ]
+
+    for path, start_marker, end_marker in migrated_functions:
+        source = Path(path).read_text(encoding="utf-8")
+
+        assert "ytnova_appstate_volume.h" in source
+
+        function_start = source.index(start_marker)
+        function_body = source[
+            function_start : source.index(end_marker, function_start)
+        ]
+        assert not direct_count_write.search(function_body)
+        assert "AppStateCommitDirEntryTotalPayload(" in function_body
+        assert "AppStateCommitDirEntryMatchingPayload(" in function_body
+
+
 def test_directory_total_payload_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- route copy and move destination total/matching payload increments through AppState volume helpers
- keep destination file-entry linking and disk-stat behavior unchanged
- add guard coverage for the migrated mutation count payload boundaries

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k mutation_count_payload_commits_route_through_appstate_helpers` failed before implementation because copy/move still wrote destination payload fields directly.
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'mutation_count_payload_commits_route_through_appstate_helpers or delete_count_payload_commits_route_through_appstate_helpers or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
