### PR TITLE
docs(ai): clarify canonical code quality audit terms

### DIFF
--- a/.ai/skills/code-auditor-gate/SKILL.md
+++ b/.ai/skills/code-auditor-gate/SKILL.md
@@ -10,14 +10,45 @@ Use this skill when the active persona is `code_auditor`.
 ## Review Workflow
 
 1. Read changed files and relevant architecture/spec docs.
-2. Check correctness, memory safety, portability, and maintainability.
-3. Validate architecture invariants (ownership, isolation, redraw control).
+2. Check correctness, memory safety, portability, maintainability, and performance regressions in interactive flows.
+3. Validate architecture invariants and conceptual integrity (ownership, isolation, redraw control, architecture conformance).
 4. Run the mandatory Security Checklist before finalizing findings.
 5. Validate source comment quality: invariants/rationale are documented where needed, and no stale or change-diary comments remain.
 6. Validate documentation signal quality: new guidance appears in the most relevant canonical location, with no redundant AI/process broadcast across unrelated sections.
 7. Validate UX economy for interactive flows (common-path depth, prompt chaining, fast path).
 8. Produce findings first, ordered by severity.
 9. End with explicit gate status and residual risks.
+
+## Conceptual Integrity / Architecture Conformance Lens
+
+When reviewing, explicitly look for canonical whole-system failure modes:
+
+- conceptual integrity loss: the codebase no longer feels like one coherent design
+- architectural drift: implementation no longer matches the documented design
+- architectural erosion: architectural constraints are actively violated
+- shotgun surgery: one logical change forces scattered edits across many files
+- duplicate or parallel implementations: old and new paths survive side by side
+- divergent sibling semantics: similar features implement the same concept differently without a documented reason
+- half-migrated replacements: old code remains reachable, inert, or only partially retired
+- event-loop nondeterminism: user-visible behavior changes under resize, watcher, or bursty input conditions
+- signal-safety violations: complex logic, I/O, or ncurses calls in signal handlers
+
+Required review questions:
+
+- Is there exactly one authoritative implementation for each durable behavior?
+- Does the implementation still conform to the intended architecture and documented invariants?
+- Are any surviving alternatives intentional transition paths, or accidental leftovers?
+- Do similar code paths still express the same concept in the same way?
+- Would a maintainer understand the system as a coherent whole, or as stitched-together fragments?
+- Does the change avoid introducing avoidable blocking, redraw lag, or input-latency regressions?
+- Does the change preserve single-threaded event-loop determinism and signal-safety boundaries?
+
+When this lens finds a problem, identify:
+
+- the surviving duplicate, drift, or erosion point,
+- whether it is dead, transitional, or still user-reachable,
+- the architectural or conceptual-integrity breakage it causes,
+- and the single durable owner or consolidation path.
 
 ## Security Checklist (Mandatory)
 

--- a/.ai/skills/code-quality/SKILL.md
+++ b/.ai/skills/code-quality/SKILL.md
@@ -71,6 +71,29 @@ Review rule:
 
 ## Comprehensive ytnova-Specific Smell Checklist
 
+### 0) Conceptual Integrity and Architecture Conformance
+
+- Treat the codebase as one integrated product, not a pile of locally correct patches.
+- Check whether the implementation still conforms to the intended architecture, not just whether each edited file works in isolation.
+- Look for architectural drift when the code no longer matches the documented design, and architectural erosion when the implementation violates architectural constraints.
+- Look for shotgun surgery when one logical change forces scattered edits across many files.
+- Look for duplicate or parallel implementations that survive after a refactor, migration, or feature replacement.
+- Look for sibling features that implement the same concept with divergent semantics, naming, ordering, polarity, or ownership.
+- Look for half-migrated replacements where old code remains reachable, inert, or only partially retired.
+
+Audit questions:
+- Is there exactly one authoritative implementation for each durable behavior?
+- Does the implementation still conform to the intended architecture and documented invariants?
+- Are any surviving alternatives intentionally transitional, or are they accidental leftovers?
+- Do similar code paths still express the same concept in the same way?
+- Would a maintainer understand the system as a coherent whole, or as stitched-together fragments?
+
+Required response when this smell is found:
+- Name the surviving duplicate, drift, or erosion point.
+- State whether it is dead, transitional, or still user-reachable.
+- Explain the architectural or conceptual-integrity breakage it causes.
+- Recommend the single durable owner or consolidation path.
+
 ### 1) Architecture and Module Boundaries
 
 - Logic for non-controller concerns placed in `src/ui/ctrl_*.c` instead of dedicated modules.
@@ -98,7 +121,14 @@ Review rule:
 - Missing validation at boundary points (user input, filesystem responses, command arguments).
 - Retries or recovery branches that hide deterministic failures.
 
-### 4) UI/TUI Flow and Interaction Economy
+### 4) Performance and Event-Loop Determinism
+
+- Performance regressions in interactive flows, especially input latency, redraw lag, and avoidable blocking.
+- Event-loop nondeterminism that changes user-visible behavior under resize, watcher, or bursty input conditions.
+- Signal-safety violations that introduce complex logic, I/O, or ncurses calls into signal handlers.
+- Blocking work on the main loop when a non-blocking or deferred path is already the established architecture.
+
+### 5) UI/TUI Flow and Interaction Economy
 
 - Common path requires more than one submenu before result.
 - Prompt chains that can be collapsed into one prompt with defaults/toggles.
@@ -107,7 +137,7 @@ Review rule:
 - Redraw/update behavior that causes flicker or stale panel state.
 - UX confirmation friction on non-destructive common-path operations.
 
-### 5) API, Data Shape, and Logic Clarity
+### 6) API, Data Shape, and Logic Clarity
 
 - Long parameter lists suggesting data clumps.
 - Flag-heavy function signatures (`bool do_x, bool do_y`) indicating mixed responsibilities.
@@ -116,7 +146,7 @@ Review rule:
 - Message-chain style calls that expose internal object structure.
 - Magic numbers/strings hiding domain meaning.
 
-### 6) Complexity and Readability
+### 7) Complexity and Readability
 
 - Functions with multiple abstraction levels mixed together.
 - Functions with deep conditional nesting or high branching complexity.
@@ -125,7 +155,7 @@ Review rule:
 - Wrong abstraction smell: generic helper gains branch flags per new callsite.
 - Dead code, unreachable branches, or stale fallback logic.
 
-### 7) Tests, QA Signals, and Regression Risk
+### 8) Tests, QA Signals, and Regression Risk
 
 - Missing regression tests for bugfixes.
 - Tests added only after fix, without fail-first proof.
@@ -134,7 +164,7 @@ Review rule:
 - Local suppressions/skips/xfails used to bypass root-cause remediation.
 - Changed behavior without corresponding spec/test updates.
 
-### 8) Documentation and Comment Hygiene
+### 9) Documentation and Comment Hygiene
 
 - Stale comments that no longer match behavior.
 - Change-diary comments in source files.

--- a/docs/ai/CODE_QUALITY.md
+++ b/docs/ai/CODE_QUALITY.md
@@ -11,6 +11,21 @@ This doc is for AI-assisted sessions (architect/developer/code-auditor) when pro
 
 It is not runtime code and not read by the compiler; it guides how AI work is requested and executed.
 
+## Canonical Audit Frame
+
+The code-quality skill checks for the canonical failure modes behind “looks fine locally, but not as a whole”:
+
+- conceptual integrity
+- architectural drift
+- architectural erosion
+- architecture conformance failures
+- shotgun surgery
+- duplicate or parallel implementations
+- performance regressions in interactive flows
+- event-loop nondeterminism and signal-safety violations
+
+When invoking `code-quality`, ask it to verify that the implementation still forms one coherent system rather than a set of independently edited fragments.
+
 ## Canonical Blueprint Location
 
 This file is a concise prompt/entry guide.
@@ -36,6 +51,13 @@ Before code edits, enforce:
 - root-cause QA remediation (no bypass/suppressions)
 - UX economy gate for interactive flows
 - focused validation during iteration
+- conceptual integrity check
+- architecture conformance check
+- drift/erosion check
+- shotgun-surgery check
+- duplicate/parallel implementation check
+- performance regression check
+- event-loop determinism / signal-safety check
 Then report/implement only approved P0-P1 issues.
 ```
 


### PR DESCRIPTION
## Summary
- Align `code-quality` and `code-auditor-gate` with canonical whole-system review terms:
  conceptual integrity, architectural drift/erosion, architecture conformance, shotgun surgery,
  and duplicate/parallel implementations.
- Add explicit coverage for performance regressions and event-loop determinism / signal safety.
- Update `docs/ai/CODE_QUALITY.md` to point prompts at the same canonical audit frame.

## Validation
- Reviewed the diff for:
  - `.ai/skills/code-quality/SKILL.md`
  - `.ai/skills/code-auditor-gate/SKILL.md`
  - `docs/ai/CODE_QUALITY.md`
