### PR TITLE
refactor(appstate): project render focus from panel state

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -1,30 +1,32 @@
 # ytreenova AppState continuation checkpoint
 
-Date: 2026-07-03
+Date: 2026-07-06
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-mutation-count-payload-helper
-Active PR: https://github.com/robkam/ytreenova/pull/354 (draft)
-Supersession state: maintainer explicitly resumed autonomous AppState work after the prior pause; no active stop condition.
+Current branch: appstate-render-focus-projection-helper
+Active PR: https://github.com/robkam/ytreenova/pull/357 (draft)
+Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/353 merged at `68bb978` after green checks.
-- Local `main` and `origin/main` were at `68bb978` before this branch.
-- Remote branch `appstate-delete-count-payload-helper` was deleted by the merge; local branch cleanup is complete.
+- PR https://github.com/robkam/ytreenova/pull/354 merged before this continuation resumed.
+- Local `main` and `origin/main` were at `64c3328` before this branch.
 - Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Routes copy/move destination total and matching payload increments in `src/cmd/copy.c` and `src/cmd/move.c` through `AppStateCommitDirEntryTotalPayload` and `AppStateCommitDirEntryMatchingPayload`.
-- Keeps existing destination file-entry linking and disk-stat behavior unchanged while removing direct `DirEntry` total/matching payload writes from the migrated mutation paths.
-- Adds guard coverage in `tests/test_appstate_contract_guard.py` to prevent direct total/matching payload writes in the migrated copy/move paths.
+- Adds `AppStateResolveActivePanelFocus()` in `src/ui/appstate_focus.c` and `include/ytnova_appstate_focus.h` so render/footer call sites prefer panel-local `saved_focus` before the legacy `ctx->focused_window` mirror.
+- Routes render/footer focus reads in `src/ui/display.c`, `src/ui/error.c`, and `src/ui/file_list.c` through the projection helper to narrow direct session-mirror reads inside projection-only paths.
+- Extends `tests/test_appstate_contract_guard.py` to lock the new projection helper contract and keep render/footer paths free of raw `ctx->focused_window` reads.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k mutation_count_payload_commits_route_through_appstate_helpers` failed because `src/cmd/copy.c` and `src/cmd/move.c` did not include `ytnova_appstate_volume.h` or route destination total/matching payload writes through AppState helpers.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'mutation_count_payload_commits_route_through_appstate_helpers or delete_count_payload_commits_route_through_appstate_helpers or directory_total_payload_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_footer_focus_reads_project_from_panel_state` failed because the helper declaration/implementation and render/footer call-site routing did not exist.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_footer_focus_reads_project_from_panel_state or compatibility_shim_boundaries_fail_closed_before_legacy_writes or refresh_view_render_reflow_projection_fails_closed_before_render_work'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
+- `git diff --check`
+
+Local notes:
+- Pre-existing unrelated working-tree changes remain in `.codex/config.toml` and `docs/ai/WORKFLOW.md`; this batch did not modify them.
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/354. If checks pass, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/357 starting from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/include/ytnova_appstate_focus.h
+++ b/include/ytnova_appstate_focus.h
@@ -10,6 +10,7 @@
 
 #include "ytnova_defs.h"
 
+ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx);
 BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
                               ViewFocus focus);
 BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view);

--- a/src/ui/appstate_focus.c
+++ b/src/ui/appstate_focus.c
@@ -10,6 +10,17 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
 
+ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx) {
+  if (ctx && ctx->active &&
+      (ctx->active->saved_focus == FOCUS_TREE ||
+       ctx->active->saved_focus == FOCUS_FILE))
+    return ctx->active->saved_focus;
+  if (ctx && (ctx->focused_window == FOCUS_TREE ||
+              ctx->focused_window == FOCUS_FILE))
+    return ctx->focused_window;
+  return FOCUS_TREE;
+}
+
 BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
                               ViewFocus focus) {
   if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -11,6 +11,7 @@
 #include "../../include/ytnova_panel_anchor.h"
 #include "../../include/ytnova_ui.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_layout.h"
 #include "ytnova_appstate_window.h"
 #include <assert.h>
@@ -590,7 +591,8 @@ void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
 
     if (panel->pan_file_window) {
       if (panel->saved_focus != FOCUS_FILE && ctx &&
-          ctx->focused_window == FOCUS_FILE && panel->file_count == 0) {
+          AppStateResolveActivePanelFocus(ctx) == FOCUS_FILE &&
+          panel->file_count == 0) {
         werase(panel->pan_file_window);
         wnoutrefresh(panel->pan_file_window);
       } else {
@@ -733,10 +735,10 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
   {
     char path[PATH_LENGTH + 1];
     DirEntry *path_dir = dir_entry;
+    ViewFocus active_focus = AppStateResolveActivePanelFocus(ctx);
 
-    if (!ctx->preview_mode && dir_entry && ctx->focused_window == FOCUS_FILE &&
-        ctx->active && ctx->active->file_entry_list &&
-        ctx->active->file_count > 0) {
+    if (!ctx->preview_mode && dir_entry && active_focus == FOCUS_FILE &&
+        ctx->active && ctx->active->file_entry_list && ctx->active->file_count > 0) {
       int idx = dir_entry->start_file + dir_entry->cursor_pos;
       if (idx >= 0 && (unsigned int)idx < ctx->active->file_count) {
         FileEntry *fe = ctx->active->file_entry_list[idx].file;
@@ -784,7 +786,7 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
       DrawSplitSeparatorRow(ctx, left_big_mode, right_big_mode);
 
       if (!active_big_mode && ctx->active->pan_dir_window) {
-        BOOL tree_highlight = (ctx->focused_window == FOCUS_TREE);
+        BOOL tree_highlight = (AppStateResolveActivePanelFocus(ctx) == FOCUS_TREE);
         DisplayTree(ctx, ctx->active->vol, ctx->active->pan_dir_window,
                     ctx->active->disp_begin_pos,
                     GetPanelVisibleSelectionIndex(ctx->active),
@@ -800,7 +802,7 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
       } else {
         SwitchToSmallFileWindow(ctx);
         if (ctx->active && ctx->active->pan_dir_window) {
-          BOOL tree_highlight = (ctx->focused_window == FOCUS_TREE);
+          BOOL tree_highlight = (AppStateResolveActivePanelFocus(ctx) == FOCUS_TREE);
           DisplayTree(ctx, ctx->active->vol, ctx->active->pan_dir_window,
                       ctx->active->disp_begin_pos,
                       GetPanelVisibleSelectionIndex(ctx->active),
@@ -816,7 +818,7 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
   if (ctx->preview_mode) {
     DisplayPreviewHelp(ctx);
   } else {
-    if (ctx->focused_window == FOCUS_TREE) {
+    if (AppStateResolveActivePanelFocus(ctx) == FOCUS_TREE) {
       DisplayDirHelp(ctx, dir_entry);
     } else {
       DisplayFileHelp(ctx, dir_entry);

--- a/src/ui/error.c
+++ b/src/ui/error.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "ytnova_appstate_message.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_ui.h"
 
 #include <stdarg.h>
@@ -82,7 +83,7 @@ void UI_ClearStatusLineError(ViewContext *ctx) {
   } else {
     if (ctx->active)
       dir_entry = GetPanelDirEntry(ctx->active);
-    if (ctx->focused_window == FOCUS_TREE)
+    if (AppStateResolveActivePanelFocus(ctx) == FOCUS_TREE)
       DisplayDirHelp(ctx, dir_entry);
     else
       DisplayFileHelp(ctx, dir_entry);

--- a/src/ui/file_list.c
+++ b/src/ui/file_list.c
@@ -6,6 +6,7 @@
  ***************************************************************************/
 
 #include "sort.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
@@ -239,7 +240,7 @@ void DisplayFileWindow(ViewContext *ctx, YtreeNovaPanel *panel,
   (void)AppStateCommitPanelFileViewport(panel, render_start, render_cursor);
 
   highlight_idx = -1;
-  if (ctx->focused_window == FOCUS_FILE)
+  if (AppStateResolveActivePanelFocus(ctx) == FOCUS_FILE)
     highlight_idx = render_start + render_cursor;
 
   DisplayFiles(ctx, panel, dir_entry, render_start, highlight_idx, 0,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9584,8 +9584,11 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     helper_validation = (
         'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'
     )
-    assert helper_validation in focus_helper
-    assert focus_helper.index(helper_validation) < focus_helper.index(
+    commit_start = focus_helper.index("BOOL AppStateCommitPanelFocus(")
+    commit_end = focus_helper.index("\nBOOL AppStateCommitPanelFileShape(", commit_start)
+    commit_body = focus_helper[commit_start:commit_end]
+    assert helper_validation in commit_body
+    assert commit_body.index(helper_validation) < commit_body.index(
         "ctx->focused_window ="
     )
 
@@ -9597,6 +9600,36 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     assert render_validation in refresh_body
     assert refresh_body.index(render_validation) < refresh_body.index("Layout_Recalculate(")
     assert refresh_body.index(render_validation) < refresh_body.index("DisplayTree(")
+
+
+def test_render_footer_focus_reads_project_from_panel_state() -> None:
+    header = Path("include/ytnova_appstate_focus.h").read_text(encoding="utf-8")
+    focus_source = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
+    display = Path("src/ui/display.c").read_text(encoding="utf-8")
+    error = Path("src/ui/error.c").read_text(encoding="utf-8")
+    file_list = Path("src/ui/file_list.c").read_text(encoding="utf-8")
+
+    assert (
+        "ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx);"
+        in header
+    )
+
+    helper_start = focus_source.index("ViewFocus AppStateResolveActivePanelFocus(")
+    helper_end = focus_source.index(
+        "\nBOOL AppStateCommitVolumeFocusMirror(", helper_start
+    )
+    helper_body = focus_source[helper_start:helper_end]
+
+    assert "ctx->active->saved_focus" in helper_body
+    assert "ctx->focused_window" in helper_body
+    assert helper_body.index("ctx->active->saved_focus") < helper_body.index(
+        "ctx->focused_window"
+    )
+
+    for source in [display, error, file_list]:
+        assert 'include "ytnova_appstate_focus.h"' in source
+        assert "AppStateResolveActivePanelFocus(ctx)" in source
+        assert "ctx->focused_window" not in source
 
 
 def test_split_file_focus_commits_use_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- add an AppState active-focus projection helper that prefers panel-local focus state before the legacy session mirror fallback
- route render and footer focus reads through the projection helper in display, error, and file-list paths
- extend the AppState contract guard with render/footer focus projection coverage

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_footer_focus_reads_project_from_panel_state`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_footer_focus_reads_project_from_panel_state or compatibility_shim_boundaries_fail_closed_before_legacy_writes or refresh_view_render_reflow_projection_fails_closed_before_render_work'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
