### PR TITLE
refactor(appstate): project layout focus from panel state

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,23 +4,23 @@ Date: 2026-07-06
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-render-focus-projection-helper
-Active PR: https://github.com/robkam/ytreenova/pull/357 (draft)
+Current branch: appstate-layout-focus-projection-helper
+Active PR: https://github.com/robkam/ytreenova/pull/358 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/354 merged before this continuation resumed.
-- Local `main` and `origin/main` were at `64c3328` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/357 merged at `e1fed12` after green checks.
+- Local `main` and `origin/main` were at `e1fed12` before this branch.
 - Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Adds `AppStateResolveActivePanelFocus()` in `src/ui/appstate_focus.c` and `include/ytnova_appstate_focus.h` so render/footer call sites prefer panel-local `saved_focus` before the legacy `ctx->focused_window` mirror.
-- Routes render/footer focus reads in `src/ui/display.c`, `src/ui/error.c`, and `src/ui/file_list.c` through the projection helper to narrow direct session-mirror reads inside projection-only paths.
-- Extends `tests/test_appstate_contract_guard.py` to lock the new projection helper contract and keep render/footer paths free of raw `ctx->focused_window` reads.
+- Routes preview-return focus capture in `src/ui/ctrl_file_ops.c` and `src/ui/dir_ops.c` through `AppStateResolveActivePanelFocus()` instead of the legacy `ctx->focused_window` mirror.
+- Routes split-layout preserved-focus handoffs in `src/ui/split_transition.c` through the same projection helper so panel-state focus stays authoritative during split open/close routing.
+- Extends `tests/test_appstate_contract_guard.py` to require preview and split layout focus reads to use the AppState active-focus projection helper.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_footer_focus_reads_project_from_panel_state` failed because the helper declaration/implementation and render/footer call-site routing did not exist.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_footer_focus_reads_project_from_panel_state or compatibility_shim_boundaries_fail_closed_before_legacy_writes or refresh_view_render_reflow_projection_fails_closed_before_render_work'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper'` failed because preview-return and split preserved-focus reads still referenced `ctx->focused_window` directly.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `git diff --check`
@@ -29,4 +29,4 @@ Local notes:
 - Pre-existing unrelated working-tree changes remain in `.codex/config.toml` and `docs/ai/WORKFLOW.md`; this batch did not modify them.
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/357 starting from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/358 starting from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -283,7 +283,8 @@ BOOL handle_file_window_preview_action(
   switch (action) {
   case ACTION_VIEW_PREVIEW:
     if (!ctx->preview_mode) {
-      if (!AppStateCommitPreviewReturn(ctx, ctx->active, ctx->focused_window))
+      if (!AppStateCommitPreviewReturn(ctx, ctx->active,
+                                       AppStateResolveActivePanelFocus(ctx)))
         return FALSE;
     }
 

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1573,7 +1573,8 @@ HandleDirWindowPanelAction(ViewContext *ctx, YtreeNovaAction action,
   case ACTION_VIEW_PREVIEW: {
     const YtreeNovaPanel *saved_panel = ctx->active;
 
-    if (!AppStateCommitPreviewReturn(ctx, ctx->active, ctx->focused_window))
+    if (!AppStateCommitPreviewReturn(ctx, ctx->active,
+                                     AppStateResolveActivePanelFocus(ctx)))
       return DIR_WINDOW_DISPATCH_RETURN_ESC;
     if (!AppStateCommitPreviewMode(ctx, TRUE))
       return DIR_WINDOW_DISPATCH_RETURN_ESC;

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -279,7 +279,7 @@ BOOL SplitTransition_HandleFileWindowAction(ViewContext *ctx, YtreeNovaAction ac
 
     {
       BOOL closing_split = ctx->is_split_screen;
-      ViewFocus preserved_focus = ctx->focused_window;
+      ViewFocus preserved_focus = AppStateResolveActivePanelFocus(ctx);
       BOOL donate_active_state =
           closing_split && ctx->active == ctx->right && ctx->left &&
           ctx->right && preserved_focus == FOCUS_FILE;
@@ -499,7 +499,7 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
           ctx->right ? ctx->right->panel_generation : 0U;
       char left_file_selection_name[PATH_LENGTH + 1];
       char left_file_selection_dir_path[PATH_LENGTH + 1];
-      ViewFocus preserved_focus = ctx->focused_window;
+      ViewFocus preserved_focus = AppStateResolveActivePanelFocus(ctx);
 
       left_file_selection_name[0] = '\0';
       left_file_selection_dir_path[0] = '\0';
@@ -692,7 +692,7 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         return TRUE;
       }
       *need_dsp_help_ptr = TRUE;
-      if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
+      if (AppStateResolveActivePanelFocus(ctx) == FOCUS_FILE && *dir_entry_ptr &&
           PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
         *unput_char_ptr = CR;
       }
@@ -766,7 +766,7 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       return TRUE;
     }
     *need_dsp_help_ptr = TRUE;
-    if (ctx->focused_window == FOCUS_FILE && *dir_entry_ptr &&
+    if (AppStateResolveActivePanelFocus(ctx) == FOCUS_FILE && *dir_entry_ptr &&
         PanelHasVisibleFiles(ctx, ctx->active, *dir_entry_ptr)) {
       *unput_char_ptr = CR;
     }

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7297,12 +7297,18 @@ def test_preview_modal_state_routes_through_appstate_helper() -> None:
 
     assert "AppStateCommitPreviewMode(ctx, FALSE)" in init_source
     assert "AppStateCommitPreviewMode(ctx, FALSE)" in ctrl_dir
-    assert "AppStateCommitPreviewReturn(ctx, ctx->active, ctx->focused_window)" in (
-        ctrl_file_ops
+    assert 'include "ytnova_appstate_focus.h"' in ctrl_file_ops
+    assert re.search(
+        r"AppStateCommitPreviewReturn\(\s*ctx,\s*ctx->active,\s*"
+        r"AppStateResolveActivePanelFocus\(ctx\)\s*\)",
+        ctrl_file_ops,
     )
     assert "AppStateCommitPreviewMode(ctx, !ctx->preview_mode)" in ctrl_file_ops
-    assert "AppStateCommitPreviewReturn(ctx, ctx->active, ctx->focused_window)" in (
-        dir_ops
+    assert 'include "ytnova_appstate_focus.h"' in dir_ops
+    assert re.search(
+        r"AppStateCommitPreviewReturn\(\s*ctx,\s*ctx->active,\s*"
+        r"AppStateResolveActivePanelFocus\(ctx\)\s*\)",
+        dir_ops,
     )
     assert "AppStateCommitPreviewEntryFocus(ctx, FOCUS_TREE)" in dir_ops
 
@@ -9640,6 +9646,8 @@ def test_split_file_focus_commits_use_appstate_helper() -> None:
 
     assert 'include "ytnova_appstate_focus.h"' in source
     assert not re.search(r"\bctx->focused_window\s*=[^=]", body)
+    assert "ViewFocus preserved_focus = AppStateResolveActivePanelFocus(ctx);" in body
+    assert "ctx->focused_window" not in body
     assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)" in body
     assert "AppStateCommitPanelFocus(ctx, ctx->active, preserved_focus)" in body
     assert "AppStateMirrorActivePanelFocus(ctx)" in body
@@ -9652,6 +9660,8 @@ def test_split_directory_focus_commits_use_appstate_helper() -> None:
 
     assert 'include "ytnova_appstate_focus.h"' in source
     assert not re.search(r"\bctx->focused_window\s*=[^=]", body)
+    assert "ViewFocus preserved_focus = AppStateResolveActivePanelFocus(ctx);" in body
+    assert "ctx->focused_window" not in body
     assert "AppStateCommitPanelFocus(ctx, ctx->active, preserved_focus)" in body
     assert body.count("AppStateMirrorActivePanelFocus(ctx)") >= 2
 


### PR DESCRIPTION
## Summary
- route preview return focus capture through the AppState active-focus projection helper
- preserve split layout focus handoffs through panel-state projection instead of the legacy session mirror
- extend contract guards for preview and split layout focus projection reads

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper'`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
