### PR TITLE
refactor(appstate): project key dispatch focus from panel state

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,29 +4,27 @@ Date: 2026-07-06
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-layout-focus-projection-helper
-Active PR: https://github.com/robkam/ytreenova/pull/358 (draft)
+Current branch: appstate-key-dispatch-focus-projection
+Active PR: https://github.com/robkam/ytreenova/pull/359 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/357 merged at `e1fed12` after green checks.
-- Local `main` and `origin/main` were at `e1fed12` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/358 merged at `214b2cc` after green checks.
+- Local `main` and `origin/main` were at `214b2cc` before this branch.
 - Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Routes preview-return focus capture in `src/ui/ctrl_file_ops.c` and `src/ui/dir_ops.c` through `AppStateResolveActivePanelFocus()` instead of the legacy `ctx->focused_window` mirror.
-- Routes split-layout preserved-focus handoffs in `src/ui/split_transition.c` through the same projection helper so panel-state focus stays authoritative during split open/close routing.
-- Extends `tests/test_appstate_contract_guard.py` to require preview and split layout focus reads to use the AppState active-focus projection helper.
+- Routes key-dispatch focus decisions in `src/ui/key_engine.c` through `AppStateResolveActivePanelFocus()` instead of direct `ctx->focused_window` reads.
+- Routes file stats-panel focus reads in `src/ui/ctrl_file.c` through the same projection helper so file-versus-directory stats decisions follow panel-local focus state.
+- Extends `tests/test_appstate_contract_guard.py` to require key-dispatch and stats-panel focus reads to use the AppState active-focus projection helper.
+- Bundles the pre-existing tracked `.codex/config.toml` and `docs/ai/WORKFLOW.md` edits into this branch per maintainer instruction.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper'` failed because preview-return and split preserved-focus reads still referenced `ctx->focused_window` directly.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k key_and_stats_focus_reads_project_from_panel_state` failed because `src/ui/key_engine.c` lacked the projection helper include/routing and `src/ui/ctrl_file.c` still read `ctx->focused_window` directly.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `git diff --check`
 
-Local notes:
-- Pre-existing unrelated working-tree changes remain in `.codex/config.toml` and `docs/ai/WORKFLOW.md`; this batch did not modify them.
-
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/358 starting from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/359 starting from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.4-mini"
+model = "gpt-5.4"
 model_reasoning_effort = "high"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -170,16 +170,13 @@ Principle: keep team-shared defaults in repo config and keep user-specific paths
 
 ##### 3.1.0.2 Periodic Codex/AI Tooling Refresh (Recommended)
 
-If you use the Codex/AI workflow, run this checklist periodically from the repository root:
+If you use the Codex/AI workflow, run this update checklist periodically from the repository root:
 
 ```bash
-# Tether (pull + reinstall)
-./scripts/tether-update.sh
-
 # uvx-managed tools: force fresh resolve + latest
 uvx --refresh codex-lb@latest --help
 uvx --refresh --from git+https://github.com/oraios/serena@main serena --help
-uvx --refresh jcodemunch-mcp@latest --help
+uvx --refresh --from git+https://github.com/jgravelle/jcodemunch-mcp.git jcodemunch-mcp --help
 
 # GitHub MCP Docker image (only if you use that MCP server)
 docker pull ghcr.io/github/github-mcp-server:latest
@@ -189,7 +186,7 @@ make mcp-doctor
 # If drift/missing config is reported:
 make mcp-doctor FIX=1
 
-# Optional: refresh pinned helper-script requirements
+cd ~/ytreenova
 source .venv/bin/activate
 pip-compile --upgrade -o scripts/requirements.txt scripts/requirements.in
 ```

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -81,14 +81,16 @@ static YtreeNovaAction FilterPreviewAction(YtreeNovaAction action) {
 void UpdateStatsPanel(ViewContext *ctx, DirEntry *dir_entry,
                       const Statistic *s) {
   FileEntry *fe_ptr = NULL;
+  ViewFocus active_focus;
   BOOL show_file_stats = FALSE;
 
   /* Safety checks */
   if (!ctx || !dir_entry || !s || !ctx->active)
     return;
+  active_focus = AppStateResolveActivePanelFocus(ctx);
 
   /* Check if we're in file window with files available */
-  if (ctx->focused_window == FOCUS_FILE && ctx->active->file_entry_list &&
+  if (active_focus == FOCUS_FILE && ctx->active->file_entry_list &&
       ctx->active->file_count > 0) {
     int file_index = dir_entry->start_file + dir_entry->cursor_pos;
     if (file_index >= 0 && (unsigned int)file_index < ctx->active->file_count) {

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -8,6 +8,7 @@
 
 #include "watcher.h"
 #include "ytnova_appstate_actions.h"
+#include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_render.h"
 #include "ytnova_cmd.h"
 #include "ytnova_ui.h"
@@ -409,8 +410,9 @@ static const DirEntry *GetActiveFileDirEntry(const ViewContext *ctx) {
 
 static BOOL IsGlobalAllVolumesFileView(const ViewContext *ctx) {
   const DirEntry *file_dir_entry = GetActiveFileDirEntry(ctx);
+  ViewFocus active_focus = AppStateResolveActivePanelFocus(ctx);
 
-  if (!ctx || ctx->focused_window != FOCUS_FILE || !file_dir_entry)
+  if (!ctx || active_focus != FOCUS_FILE || !file_dir_entry)
     return FALSE;
 
   return (file_dir_entry->global_flag && file_dir_entry->global_all_volumes)
@@ -426,6 +428,7 @@ int NormalizeViKey(const ViewContext *ctx, int ch) {
 
 YtreeNovaAction GetKeyAction(const ViewContext *ctx, int ch) {
   BOOL vi_keys_enabled = IsViKeysEnabled(ctx);
+  ViewFocus active_focus = AppStateResolveActivePanelFocus(ctx);
   if (!AppStateValidatedDispatchSurface("surface.key-decode-input-dispatch"))
     return ACTION_NONE;
 
@@ -492,7 +495,7 @@ YtreeNovaAction GetKeyAction(const ViewContext *ctx, int ch) {
     /* In vi-key mode, Ctrl-U is reserved for page-up navigation.
      * Use uppercase U as the file-window "untag all" command key.
      */
-    if (vi_keys_enabled && ctx && ctx->focused_window == FOCUS_FILE)
+    if (vi_keys_enabled && ctx && active_focus == FOCUS_FILE)
       return AppStateValidatedKeyAction(ACTION_UNTAG_ALL);
     return AppStateValidatedKeyAction(ACTION_UNTAG);
   case 0x14: /* Ctrl+T */
@@ -538,7 +541,7 @@ YtreeNovaAction GetKeyAction(const ViewContext *ctx, int ch) {
     /* In vi-key mode, Ctrl-D is reserved for page-down navigation.
      * Use uppercase D as the file-window "delete tagged" command key.
      */
-    if (vi_keys_enabled && ctx && ctx->focused_window == FOCUS_FILE)
+    if (vi_keys_enabled && ctx && active_focus == FOCUS_FILE)
       return AppStateValidatedKeyAction(ACTION_CMD_TAGGED_D);
     return AppStateValidatedKeyAction(ACTION_CMD_D);
   case KEY_DC:
@@ -646,17 +649,17 @@ YtreeNovaAction GetKeyAction(const ViewContext *ctx, int ch) {
 
   case 'j':
     if (!vi_keys_enabled && ctx) {
-      if (ctx->focused_window == FOCUS_TREE)
+      if (active_focus == FOCUS_TREE)
         return AppStateValidatedKeyAction(ACTION_COMPARE_DIR);
-      if (ctx->focused_window == FOCUS_FILE)
+      if (active_focus == FOCUS_FILE)
         return AppStateValidatedKeyAction(ACTION_COMPARE_FILE);
     }
     return AppStateValidatedKeyAction(ACTION_NONE);
   case 'J':
     if (ctx) {
-      if (ctx->focused_window == FOCUS_TREE)
+      if (active_focus == FOCUS_TREE)
         return AppStateValidatedKeyAction(ACTION_COMPARE_DIR);
-      if (ctx->focused_window == FOCUS_FILE)
+      if (active_focus == FOCUS_FILE)
         return AppStateValidatedKeyAction(ACTION_COMPARE_FILE);
     }
     return AppStateValidatedKeyAction(ACTION_NONE);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9638,6 +9638,29 @@ def test_render_footer_focus_reads_project_from_panel_state() -> None:
         assert "ctx->focused_window" not in source
 
 
+def test_key_and_stats_focus_reads_project_from_panel_state() -> None:
+    key_engine = Path("src/ui/key_engine.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+
+    assert 'include "ytnova_appstate_focus.h"' in key_engine
+    assert "AppStateResolveActivePanelFocus(ctx)" in key_engine
+    key_action_start = key_engine.index("YtreeNovaAction GetKeyAction(")
+    key_action_end = key_engine.index("\nint WGetch(", key_action_start)
+    key_action_body = key_engine[key_action_start:key_action_end]
+    assert "ViewFocus active_focus = AppStateResolveActivePanelFocus(ctx);" in (
+        key_action_body
+    )
+    assert "ctx->focused_window" not in key_action_body
+
+    stats_start = ctrl_file.index("void UpdateStatsPanel(")
+    stats_end = ctrl_file.index("\nint ChangeFileOwner(", stats_start)
+    stats_body = ctrl_file[stats_start:stats_end]
+    assert "ViewFocus active_focus;" in stats_body
+    assert "active_focus = AppStateResolveActivePanelFocus(ctx);" in stats_body
+    assert "active_focus == FOCUS_FILE" in stats_body
+    assert "ctx->focused_window" not in stats_body
+
+
 def test_split_file_focus_commits_use_appstate_helper() -> None:
     source = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     start = source.index("BOOL SplitTransition_HandleFileWindowAction(")


### PR DESCRIPTION
## Summary
- route key-dispatch file/tree focus decisions through the AppState active-focus projection helper
- route file stats-panel focus reads through the same panel-state projection path
- extend contract guards for key and stats focus reads that must stay off the legacy session mirror

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k key_and_stats_focus_reads_project_from_panel_state`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
