### PR TITLE
refactor(appstate): project focus debug traces from panel state

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,25 @@ Date: 2026-07-06
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-key-dispatch-focus-projection
-Active PR: https://github.com/robkam/ytreenova/pull/359 (draft)
+Current branch: appstate-focus-debug-projection
+Active PR: https://github.com/robkam/ytreenova/pull/360 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/358 merged at `214b2cc` after green checks.
-- Local `main` and `origin/main` were at `214b2cc` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/359 merged at `d58942b` after green checks.
+- Local `main` and `origin/main` were at `d58942b` before this branch.
 - Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
 
 Current AppState batch:
-- Routes key-dispatch focus decisions in `src/ui/key_engine.c` through `AppStateResolveActivePanelFocus()` instead of direct `ctx->focused_window` reads.
-- Routes file stats-panel focus reads in `src/ui/ctrl_file.c` through the same projection helper so file-versus-directory stats decisions follow panel-local focus state.
-- Extends `tests/test_appstate_contract_guard.py` to require key-dispatch and stats-panel focus reads to use the AppState active-focus projection helper.
-- Bundles the pre-existing tracked `.codex/config.toml` and `docs/ai/WORKFLOW.md` edits into this branch per maintainer instruction.
+- Routes remaining split/directory focus debug reads in `src/ui/dir_ops.c`, `src/ui/split_transition.c`, and `src/ui/panel_anchor.c` through `AppStateResolveActivePanelFocus()` instead of direct `ctx->focused_window` reads.
+- Extends `tests/test_appstate_contract_guard.py` to require those focus debug traces to stay on the AppState active-focus projection helper.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k key_and_stats_focus_reads_project_from_panel_state` failed because `src/ui/key_engine.c` lacked the projection helper include/routing and `src/ui/ctrl_file.c` still read `ctx->focused_window` directly.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focus_debug_traces_project_from_panel_state` failed because the debug helpers still logged `ctx->focused_window` directly.
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focus_debug_traces_project_from_panel_state or key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make clean && make` passed with existing warnings.
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/359 starting from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/360 starting from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -116,6 +116,7 @@ static void DebugLogPanelState(const char *label, const YtreeNovaPanel *panel) {
 
 static void DebugLogSplitState(const char *label, const ViewContext *ctx) {
   const char *active_side = "?";
+  int focused = -1;
 
   if (!ctx) {
     DEBUG_LOG("SPLIT[%s] <null>", label ? label : "?");
@@ -126,9 +127,10 @@ static void DebugLogSplitState(const char *label, const ViewContext *ctx) {
     active_side = "LEFT";
   else if (ctx->active == ctx->right)
     active_side = "RIGHT";
+  focused = (int)AppStateResolveActivePanelFocus(ctx);
 
   DEBUG_LOG("SPLIT[%s] is_split=%d active=%s focused=%d", label ? label : "?",
-            ctx->is_split_screen, active_side, ctx->focused_window);
+            ctx->is_split_screen, active_side, focused);
   DebugLogPanelState("LEFT", ctx->left);
   DebugLogPanelState("RIGHT", ctx->right);
 }

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -852,6 +852,7 @@ void DebugLogDirLoopState(const char *label, const ViewContext *ctx,
                           int unput_char) {
   char dir_path[PATH_LENGTH + 1];
   const char *active_side = "?";
+  int focused = -1;
 
   dir_path[0] = '\0';
   if (dir_entry) {
@@ -863,12 +864,13 @@ void DebugLogDirLoopState(const char *label, const ViewContext *ctx,
       active_side = "LEFT";
     else if (ctx->active == ctx->right)
       active_side = "RIGHT";
+    focused = (int)AppStateResolveActivePanelFocus(ctx);
   }
 
   DEBUG_LOG("DirLoop[%s] ch=%d action=%d unput=%d active=%s focus=%d "
             "left(d=%d c=%d sf=%d fc=%d) right(d=%d c=%d sf=%d fc=%d) dir='%s'",
             label ? label : "?", ch, (int)action, unput_char, active_side,
-            ctx ? (int)ctx->focused_window : -1,
+            focused,
             (ctx && ctx->left) ? ctx->left->disp_begin_pos : -1,
             (ctx && ctx->left) ? ctx->left->cursor_pos : -1,
             (ctx && ctx->left) ? ctx->left->start_file : -1,

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -199,18 +199,19 @@ static void SplitTransitionDebugLogFilePanelState(const char *label,
 static void SplitTransitionDebugLogFileState(const char *label,
                                              const ViewContext *ctx) {
   const char *active_side = "?";
+  int focused = -1;
 
   if (ctx && ctx->active) {
     if (ctx->active == ctx->left)
       active_side = "LEFT";
     else if (ctx->active == ctx->right)
       active_side = "RIGHT";
+    focused = (int)AppStateResolveActivePanelFocus(ctx);
   }
 
   DEBUG_LOG("FILE_SPLIT[%s] is_split=%d active=%s focused=%d",
             label ? label : "?",
-            ctx ? (int)ctx->is_split_screen : -1, active_side,
-            ctx ? (int)ctx->focused_window : -1);
+            ctx ? (int)ctx->is_split_screen : -1, active_side, focused);
   if (ctx) {
     SplitTransitionDebugLogFilePanelState("LEFT", ctx->left);
     SplitTransitionDebugLogFilePanelState("RIGHT", ctx->right);
@@ -220,17 +221,18 @@ static void SplitTransitionDebugLogFileState(const char *label,
 static void SplitTransitionDebugLogDirState(const char *label,
                                             const ViewContext *ctx) {
   const char *active_side = "?";
+  int focused = -1;
 
   if (ctx && ctx->active) {
     if (ctx->active == ctx->left)
       active_side = "LEFT";
     else if (ctx->active == ctx->right)
       active_side = "RIGHT";
+    focused = (int)AppStateResolveActivePanelFocus(ctx);
   }
 
   DEBUG_LOG("SPLIT[%s] is_split=%d active=%s focused=%d", label ? label : "?",
-            ctx ? (int)ctx->is_split_screen : -1, active_side,
-            ctx ? (int)ctx->focused_window : -1);
+            ctx ? (int)ctx->is_split_screen : -1, active_side, focused);
 }
 
 static BOOL PanelHasVisibleFiles(ViewContext *ctx, YtreeNovaPanel *panel,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9661,6 +9661,44 @@ def test_key_and_stats_focus_reads_project_from_panel_state() -> None:
     assert "ctx->focused_window" not in stats_body
 
 
+def test_focus_debug_traces_project_from_panel_state() -> None:
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
+    panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
+
+    dir_debug_start = dir_ops.index("static void DebugLogSplitState(")
+    dir_debug_end = dir_ops.index("\nvoid HandlePlus(", dir_debug_start)
+    dir_debug_body = dir_ops[dir_debug_start:dir_debug_end]
+    assert "AppStateResolveActivePanelFocus(ctx)" in dir_debug_body
+    assert "ctx->focused_window" not in dir_debug_body
+
+    split_file_debug_start = split_transition.index(
+        "static void SplitTransitionDebugLogFileState("
+    )
+    split_dir_debug_start = split_transition.index(
+        "\nstatic void SplitTransitionDebugLogDirState(", split_file_debug_start
+    )
+    split_dir_debug_end = split_transition.index(
+        "\nstatic BOOL PanelHasVisibleFiles(", split_dir_debug_start
+    )
+    split_file_debug_body = split_transition[
+        split_file_debug_start:split_dir_debug_start
+    ]
+    split_dir_debug_body = split_transition[
+        split_dir_debug_start:split_dir_debug_end
+    ]
+    for body in [split_file_debug_body, split_dir_debug_body]:
+        assert "AppStateResolveActivePanelFocus(ctx)" in body
+        assert "ctx->focused_window" not in body
+
+    panel_trace_start = panel_anchor.index("void DebugLogDirLoopState(")
+    panel_trace_body = panel_anchor[panel_trace_start:]
+    assert "AppStateResolveActivePanelFocus(ctx)" in panel_trace_body
+    assert "ctx->focused_window" not in panel_trace_body
+
+
 def test_split_file_focus_commits_use_appstate_helper() -> None:
     source = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     start = source.index("BOOL SplitTransition_HandleFileWindowAction(")


### PR DESCRIPTION
## Summary
- route remaining split and directory focus debug traces through the AppState active-focus projection helper
- keep panel trace logging aligned with panel-local focus state instead of the legacy session mirror
- extend contract guards for focus debug traces that must stay off the legacy session mirror

## Validation
- Red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focus_debug_traces_project_from_panel_state`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focus_debug_traces_project_from_panel_state or key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
