### PR TITLE
refactor(appstate): project active-panel focus guards through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,27 @@ Date: 2026-07-06
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-focus-debug-projection
-Active PR: https://github.com/robkam/ytreenova/pull/360 (draft)
+Current branch: appstate-active-focus-projection
+Active PR: https://github.com/robkam/ytreenova/pull/361 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/359 merged at `d58942b` after green checks.
-- Local `main` and `origin/main` were at `d58942b` before this branch.
-- Local branch `task-60` is still attached to worktree `/home/rob/nova60` and was not deleted.
+- PR https://github.com/robkam/ytreenova/pull/360 merged at `d63bd73` after green checks.
+- Local `main` and `origin/main` were cleaned up after the merge.
+- Remote stale AppState focus branches were pruned during post-merge cleanup.
 
 Current AppState batch:
-- Routes remaining split/directory focus debug reads in `src/ui/dir_ops.c`, `src/ui/split_transition.c`, and `src/ui/panel_anchor.c` through `AppStateResolveActivePanelFocus()` instead of direct `ctx->focused_window` reads.
-- Extends `tests/test_appstate_contract_guard.py` to require those focus debug traces to stay on the AppState active-focus projection helper.
+- Routes remaining active-panel focus decisions in `src/ui/ctrl_dir.c`, `src/ui/ctrl_file.c`, `src/ui/dir_ops.c`, `src/ui/display.c`, and `src/ui/split_transition.c` through `AppStateResolveActivePanelFocus()` instead of reading `ctx->active->saved_focus` directly.
+- Extends `tests/test_appstate_contract_guard.py` to keep those active-panel focus decisions on the projection helper.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focus_debug_traces_project_from_panel_state` failed because the debug helpers still logged `ctx->focused_window` directly.
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focus_debug_traces_project_from_panel_state or key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k active_panel_focus_decisions_project_from_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'active_panel_focus_decisions_project_from_helper or focus_debug_traces_project_from_panel_state or key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- `make clean && make` passed with existing warnings.
+- `make clean && make`
+- CI repair: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'compatibility_shim_boundaries_fail_closed_before_legacy_writes or active_panel_focus_decisions_project_from_helper'`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'compatibility_shim_boundaries_fail_closed_before_legacy_writes or active_panel_focus_decisions_project_from_helper or focus_debug_traces_project_from_panel_state or key_and_stats_focus_reads_project_from_panel_state or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/360 starting from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/361 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -632,45 +632,50 @@ extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
     }
   }
 
-  if (!dir_entry->log_flag) {
-    if (ctx->active && ctx->active->saved_focus == FOCUS_FILE) {
-      int file_start = dir_entry->start_file;
-      int file_cursor = dir_entry->cursor_pos;
+  {
+    BOOL active_focus_is_file =
+        (AppStateResolveActivePanelFocus(ctx) == FOCUS_FILE);
 
-      if (ctx->active->file_dir_entry == dir_entry) {
-        file_start = ctx->active->start_file;
-        file_cursor = ctx->active->file_cursor_pos;
+    if (!dir_entry->log_flag) {
+      if (ctx->active && active_focus_is_file) {
+        int file_start = dir_entry->start_file;
+        int file_cursor = dir_entry->cursor_pos;
+
+        if (ctx->active->file_dir_entry == dir_entry) {
+          file_start = ctx->active->start_file;
+          file_cursor = ctx->active->file_cursor_pos;
+        }
+        if (file_start < 0)
+          file_start = 0;
+        if (file_cursor < 0 && dir_entry->total_files > 0)
+          file_cursor = 0;
+
+        if (!AppStateCommitDirEntryFileViewport(dir_entry, file_start,
+                                                file_cursor))
+          return ESC;
+        if (!AppStateCommitPanelFileAnchor(ctx->active, dir_entry))
+          return ESC;
+        (void)AppStateCommitPanelFileViewport(ctx->active,
+                                              dir_entry->start_file,
+                                              dir_entry->cursor_pos);
+        BuildFileEntryList(ctx, ctx->active);
+      } else {
+        if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, -1))
+          return ESC;
       }
-      if (file_start < 0)
-        file_start = 0;
-      if (file_cursor < 0 && dir_entry->total_files > 0)
-        file_cursor = 0;
-
-      if (!AppStateCommitDirEntryFileViewport(dir_entry, file_start,
-                                              file_cursor))
-        return ESC;
-      if (!AppStateCommitPanelFileAnchor(ctx->active, dir_entry))
-        return ESC;
-      (void)AppStateCommitPanelFileViewport(ctx->active, dir_entry->start_file,
-                                            dir_entry->cursor_pos);
-      BuildFileEntryList(ctx, ctx->active);
-    } else {
-      if (!AppStateCommitDirEntryFileViewport(dir_entry, 0, -1))
-        return ESC;
     }
-  }
+    RefreshView(ctx, dir_entry);
 
-  RefreshView(ctx, dir_entry);
-
-  if (dir_entry->log_flag) {
-    if ((dir_entry->global_flag) || (dir_entry->tagged_flag)) {
-      unput_char = 'S';
-    } else {
+    if (dir_entry->log_flag) {
+      if ((dir_entry->global_flag) || (dir_entry->tagged_flag)) {
+        unput_char = 'S';
+      } else {
+        unput_char = CR;
+      }
+    } else if (ctx->active && active_focus_is_file &&
+               ctx->active->file_count > 0 && dir_entry->total_files > 0) {
       unput_char = CR;
     }
-  } else if (ctx->active && ctx->active->saved_focus == FOCUS_FILE &&
-             ctx->active->file_count > 0 && dir_entry->total_files > 0) {
-    unput_char = CR;
   }
   do {
     /* Detect Global Volume Change (Split Brain Fix) */

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -706,7 +706,7 @@ int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
     }
 
     if (switched_panel && ctx->active != owner_panel) {
-      if (ctx->active->saved_focus != FOCUS_FILE) {
+      if (AppStateResolveActivePanelFocus(ctx) != FOCUS_FILE) {
         switched_to_tree_panel = TRUE;
         action = ACTION_ESCAPE;
         goto file_window_done;

--- a/src/ui/dir_ops.c
+++ b/src/ui/dir_ops.c
@@ -1779,7 +1779,7 @@ HandleDirWindowEnterAction(ViewContext *ctx, DirEntry **dir_entry_ptr,
     return DIR_WINDOW_DISPATCH_RETURN_ESC;
 
   *dir_entry_ptr = ResolveActiveDirEntry(ctx, *s_ptr);
-  if (ctx->active->saved_focus == FOCUS_FILE &&
+  if (AppStateResolveActivePanelFocus(ctx) == FOCUS_FILE &&
       ctx->active->file_selection_dir_path[0] != '\0') {
     RestorePanelAnchorPath(ctx->active->vol, ctx->active,
                            ctx->active->file_selection_dir_path);

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -615,7 +615,7 @@ static BOOL IsActivePanelBigFileMode(const ViewContext *ctx,
   if (!dir_entry)
     return FALSE;
 
-  if (!ctx->active || ctx->active->saved_focus != FOCUS_FILE)
+  if (!ctx->active || AppStateResolveActivePanelFocus(ctx) != FOCUS_FILE)
     return FALSE;
 
   return (ctx->active->saved_big_file_view || dir_entry->global_flag ||

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -582,7 +582,7 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
         if (preserve_left_file_state && !donate_active_state &&
             !AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE))
           return FALSE;
-        if (ctx->active->saved_focus == FOCUS_FILE) {
+        if (AppStateResolveActivePanelFocus(ctx) == FOCUS_FILE) {
           if (ctx->active->file_selection_dir_path[0] != '\0') {
             /*
              * Re-anchor the surviving panel to its saved file-selection path

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9574,7 +9574,8 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     assert focus_validation in file_body
     assert not re.search(r"\bctx->focused_window\s*=[^=]", ctrl_file)
     assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)" in file_body
-    assert "if (ctx->active->saved_focus != FOCUS_FILE) {" in file_body
+    assert "if (AppStateResolveActivePanelFocus(ctx) != FOCUS_FILE) {" in file_body
+    assert "ctx->active->saved_focus != FOCUS_FILE" not in file_body
     assert "if (ctx->focused_window != FOCUS_FILE) {" not in file_body
 
     assert not re.search(r"\bctx->focused_window\s*=[^=]", dir_ops)
@@ -9697,6 +9698,53 @@ def test_focus_debug_traces_project_from_panel_state() -> None:
     panel_trace_body = panel_anchor[panel_trace_start:]
     assert "AppStateResolveActivePanelFocus(ctx)" in panel_trace_body
     assert "ctx->focused_window" not in panel_trace_body
+
+
+def test_active_panel_focus_decisions_project_from_helper() -> None:
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    dir_ops = Path("src/ui/dir_ops.c").read_text(encoding="utf-8")
+    display = Path("src/ui/display.c").read_text(encoding="utf-8")
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
+
+    for source in [ctrl_dir, ctrl_file, dir_ops, display, split_transition]:
+        assert 'include "ytnova_appstate_focus.h"' in source
+
+    dir_start = ctrl_dir.index("extern int HandleDirWindow(")
+    dir_body = ctrl_dir[dir_start:]
+    assert "AppStateResolveActivePanelFocus(ctx)" in dir_body
+    assert "ctx->active->saved_focus" not in dir_body
+
+    file_start = ctrl_file.index("int HandleFileWindow(")
+    file_body = ctrl_file[file_start:]
+    assert "AppStateResolveActivePanelFocus(ctx)" in file_body
+    assert "ctx->active->saved_focus" not in file_body
+
+    switch_start = dir_ops.index("HandleDirWindowEnterAction(")
+    switch_end = dir_ops.index(
+        "\nDirWindowDispatchResult\nHandleDirWindowVolumeAction(", switch_start
+    )
+    switch_body = dir_ops[switch_start:switch_end]
+    assert "AppStateResolveActivePanelFocus(ctx)" in switch_body
+    assert "ctx->active->saved_focus" not in switch_body
+
+    mode_start = display.index("static BOOL IsActivePanelBigFileMode(")
+    mode_end = display.index("\nstatic BOOL IsPanelSavedBigFileMode(", mode_start)
+    mode_body = display[mode_start:mode_end]
+    assert "AppStateResolveActivePanelFocus(ctx)" in mode_body
+    assert "ctx->active->saved_focus" not in mode_body
+
+    split_file_start = split_transition.index(
+        "BOOL SplitTransition_HandleFileWindowAction("
+    )
+    split_dir_start = split_transition.index(
+        "\nBOOL SplitTransition_HandleDirWindowAction(", split_file_start
+    )
+    split_file_body = split_transition[split_file_start:split_dir_start]
+    assert "AppStateResolveActivePanelFocus(ctx)" in split_file_body
+    assert "ctx->active->saved_focus" not in split_file_body
 
 
 def test_split_file_focus_commits_use_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- route remaining active-panel focus decisions through `AppStateResolveActivePanelFocus()`
- cover the helper path in the AppState contract guard for dir/file handoffs and big-file projection checks

## Validation
- red: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k active_panel_focus_decisions_project_from_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'active_panel_focus_decisions_project_from_helper or focus_debug_traces_project_from_panel_state or key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
