### PR TITLE
refactor(appstate): project split focus traces through helper

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,25 @@ Date: 2026-07-06
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-active-focus-projection
-Active PR: https://github.com/robkam/ytreenova/pull/361 (draft)
+Current branch: appstate-split-focus-trace-projection
+Active PR: https://github.com/robkam/ytreenova/pull/362 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/360 merged at `d63bd73` after green checks.
-- Local `main` and `origin/main` were cleaned up after the merge.
-- Remote stale AppState focus branches were pruned during post-merge cleanup.
+- PR https://github.com/robkam/ytreenova/pull/361 merged at `cbebf61` after green checks.
+- Local `main` and `origin/main` are aligned at `cbebf61` before this branch.
+- The prior topic branch was deleted on merge and pruned locally/remotely.
 
 Current AppState batch:
-- Routes remaining active-panel focus decisions in `src/ui/ctrl_dir.c`, `src/ui/ctrl_file.c`, `src/ui/dir_ops.c`, `src/ui/display.c`, and `src/ui/split_transition.c` through `AppStateResolveActivePanelFocus()` instead of reading `ctx->active->saved_focus` directly.
-- Extends `tests/test_appstate_contract_guard.py` to keep those active-panel focus decisions on the projection helper.
+- Routes split-panel post-toggle active-focus traces in `src/ui/split_transition.c` through `AppStateResolveActivePanelFocus()` instead of logging `ctx->active->saved_focus` directly.
+- Extends `tests/test_appstate_contract_guard.py` to keep those split-panel trace reads on the projection helper.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k active_panel_focus_decisions_project_from_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'active_panel_focus_decisions_project_from_helper or focus_debug_traces_project_from_panel_state or key_and_stats_focus_reads_project_from_panel_state or preview_modal_state_routes_through_appstate_helper or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k split_panel_switch_traces_project_from_helper`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'split_panel_switch_traces_project_from_helper or focus_debug_traces_project_from_panel_state or active_panel_focus_decisions_project_from_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- `make clean && make`
-- CI repair: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'compatibility_shim_boundaries_fail_closed_before_legacy_writes or active_panel_focus_decisions_project_from_helper'`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'compatibility_shim_boundaries_fail_closed_before_legacy_writes or active_panel_focus_decisions_project_from_helper or focus_debug_traces_project_from_panel_state or key_and_stats_focus_reads_project_from_panel_state or split_file_focus_commits_use_appstate_helper or split_directory_focus_commits_use_appstate_helper or render_footer_focus_reads_project_from_panel_state'`
+- `make`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/361 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/362 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/split_transition.c
+++ b/src/ui/split_transition.c
@@ -638,7 +638,7 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
       *s_ptr = &ctx->active->vol->vol_stats;
       PanelTags_ApplyToTree(ctx, ctx->active);
       DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",
-                ctx->active->saved_focus);
+                AppStateResolveActivePanelFocus(ctx));
 
       if (ctx->active->vol->total_dirs > 0) {
         if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=
@@ -713,7 +713,7 @@ BOOL SplitTransition_HandleDirWindowAction(ViewContext *ctx, YtreeNovaAction act
     *s_ptr = &ctx->active->vol->vol_stats;
     PanelTags_ApplyToTree(ctx, ctx->active);
     DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",
-              ctx->active->saved_focus);
+              AppStateResolveActivePanelFocus(ctx));
 
     if (ctx->active->vol->total_dirs > 0) {
       if (ctx->active->disp_begin_pos + ctx->active->cursor_pos >=

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9747,6 +9747,28 @@ def test_active_panel_focus_decisions_project_from_helper() -> None:
     assert "ctx->active->saved_focus" not in split_file_body
 
 
+def test_split_panel_switch_traces_project_from_helper() -> None:
+    split_transition = Path("src/ui/split_transition.c").read_text(
+        encoding="utf-8"
+    )
+
+    dir_start = split_transition.index("BOOL SplitTransition_HandleDirWindowAction(")
+    dir_body = split_transition[dir_start:]
+    assert "AppStateResolveActivePanelFocus(ctx)" in dir_body
+    assert (
+        'DEBUG_LOG("DirPanelAction:switch:post_toggle active_saved_focus=%d",'
+        in dir_body
+    )
+    assert (
+        "DEBUG_LOG(\"DirPanelAction:switch:post_toggle active_saved_focus=%d\",\n"
+        "                ctx->active->saved_focus);"
+    ) not in dir_body
+    assert (
+        "DEBUG_LOG(\"DirPanelAction:switch:post_toggle active_saved_focus=%d\",\n"
+        "              ctx->active->saved_focus);"
+    ) not in dir_body
+
+
 def test_split_file_focus_commits_use_appstate_helper() -> None:
     source = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     start = source.index("BOOL SplitTransition_HandleFileWindowAction(")


### PR DESCRIPTION
## Summary
- route split-panel post-toggle focus traces through `AppStateResolveActivePanelFocus()`
- extend the AppState contract guard to keep those split-panel traces on the helper path

## Validation
- red: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k split_panel_switch_traces_project_from_helper`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'split_panel_switch_traces_project_from_helper or focus_debug_traces_project_from_panel_state or active_panel_focus_decisions_project_from_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make`
- `git diff --check`
