### PR TITLE
refactor(appstate): confine focused window compatibility access

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -1,28 +1,29 @@
 # ytreenova AppState continuation checkpoint
 
-Date: 2026-07-06
+Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-focus-mirror-projection
-Active PR: https://github.com/robkam/ytreenova/pull/363 (draft)
+Current branch: appstate-focused-window-boundary
+Active PR: https://github.com/robkam/ytreenova/pull/364 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/362 merged at `a0e68d2` after green checks.
-- Local `main` and `origin/main` are aligned at `a0e68d2` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/363 merged at `a6a2279` after green checks.
+- Local `main` and `origin/main` are aligned at `a6a2279` before this branch.
 - The prior topic branch was deleted on merge and pruned locally/remotely.
 
 Current AppState batch:
-- Routes `AppStateMirrorActivePanelFocus()` in `src/ui/appstate_focus.c` through `AppStateResolveActivePanelFocus()` so compatibility mirror writes reuse the same active-focus projection helper.
-- Extends `tests/test_appstate_contract_guard.py` to keep the focus mirror path on the projection helper.
+- Confines the remaining `ViewContext.focused_window` compatibility carrier in `src/ui/appstate_focus.c` to dedicated compatibility helper functions.
+- Extends `tests/test_appstate_contract_guard.py` to keep raw `ctx->focused_window` access out of other runtime sources and pinned to the AppState focus helper boundary.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focus_mirror_projects_through_helper`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focus_mirror_projects_through_helper or split_panel_switch_traces_project_from_helper or active_panel_focus_decisions_project_from_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focused_window_compatibility_stays_in_appstate_focus_helpers`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focused_window_compatibility_stays_in_appstate_focus_helpers or focus_mirror_projects_through_helper or split_panel_switch_traces_project_from_helper or active_panel_focus_decisions_project_from_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make`
+- CI repair: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_footer_focus_reads_project_from_panel_state or focused_window_compatibility_stays_in_appstate_focus_helpers or focus_mirror_projects_through_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/363 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/364 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/appstate_focus.c
+++ b/src/ui/appstate_focus.c
@@ -10,15 +10,31 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
 
+static ViewFocus ResolveCompatibilityFocusedWindow(const ViewContext *ctx) {
+  if (ctx && (ctx->focused_window == FOCUS_TREE ||
+              ctx->focused_window == FOCUS_FILE))
+    return ctx->focused_window;
+  return FOCUS_TREE;
+}
+
+static BOOL CommitCompatibilityFocusedWindow(ViewContext *ctx,
+                                             const YtreeNovaPanel *panel,
+                                             ViewFocus focus) {
+  if (!ctx || !panel)
+    return FALSE;
+  if (ctx->active != panel)
+    return TRUE;
+
+  ctx->focused_window = focus;
+  return TRUE;
+}
+
 ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx) {
   if (ctx && ctx->active &&
       (ctx->active->saved_focus == FOCUS_TREE ||
        ctx->active->saved_focus == FOCUS_FILE))
     return ctx->active->saved_focus;
-  if (ctx && (ctx->focused_window == FOCUS_TREE ||
-              ctx->focused_window == FOCUS_FILE))
-    return ctx->focused_window;
-  return FOCUS_TREE;
+  return ResolveCompatibilityFocusedWindow(ctx);
 }
 
 BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
@@ -31,8 +47,8 @@ BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
     return FALSE;
 
   panel->saved_focus = focus;
-  if (ctx->active == panel)
-    ctx->focused_window = focus;
+  if (!CommitCompatibilityFocusedWindow(ctx, panel, focus))
+    return FALSE;
   return TRUE;
 }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9591,12 +9591,19 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
     helper_validation = (
         'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'
     )
+    compat_helper_start = focus_helper.index("static BOOL CommitCompatibilityFocusedWindow(")
+    compat_helper_end = focus_helper.index(
+        "\nViewFocus AppStateResolveActivePanelFocus(", compat_helper_start
+    )
+    compat_helper_body = focus_helper[compat_helper_start:compat_helper_end]
+    assert "ctx->focused_window = focus;" in compat_helper_body
+
     commit_start = focus_helper.index("BOOL AppStateCommitPanelFocus(")
     commit_end = focus_helper.index("\nBOOL AppStateCommitPanelFileShape(", commit_start)
     commit_body = focus_helper[commit_start:commit_end]
     assert helper_validation in commit_body
     assert commit_body.index(helper_validation) < commit_body.index(
-        "ctx->focused_window ="
+        "CommitCompatibilityFocusedWindow"
     )
 
     refresh_start = display.index("void RefreshView(")
@@ -9626,12 +9633,17 @@ def test_render_footer_focus_reads_project_from_panel_state() -> None:
         "\nBOOL AppStateCommitVolumeFocusMirror(", helper_start
     )
     helper_body = focus_source[helper_start:helper_end]
+    compat_helper_start = focus_source.index(
+        "static ViewFocus ResolveCompatibilityFocusedWindow("
+    )
+    compat_helper_end = focus_source.index(
+        "\nstatic BOOL CommitCompatibilityFocusedWindow(", compat_helper_start
+    )
+    compat_helper_body = focus_source[compat_helper_start:compat_helper_end]
 
     assert "ctx->active->saved_focus" in helper_body
-    assert "ctx->focused_window" in helper_body
-    assert helper_body.index("ctx->active->saved_focus") < helper_body.index(
-        "ctx->focused_window"
-    )
+    assert "return ResolveCompatibilityFocusedWindow(ctx);" in helper_body
+    assert "ctx->focused_window" in compat_helper_body
 
     for source in [display, error, file_list]:
         assert 'include "ytnova_appstate_focus.h"' in source
@@ -9776,6 +9788,24 @@ def test_focus_mirror_projects_through_helper() -> None:
     mirror_body = focus_source[mirror_start:]
     assert "AppStateResolveActivePanelFocus(ctx)" in mirror_body
     assert "ctx->active->saved_focus" not in mirror_body
+
+
+def test_focused_window_compatibility_stays_in_appstate_focus_helpers() -> None:
+    focus_source = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
+    other_sources = [
+        path
+        for path in Path("src").rglob("*.c")
+        if path.as_posix() != "src/ui/appstate_focus.c"
+    ]
+
+    assert "static ViewFocus ResolveCompatibilityFocusedWindow(" in focus_source
+    assert "static BOOL CommitCompatibilityFocusedWindow(" in focus_source
+    assert "return ResolveCompatibilityFocusedWindow(ctx);" in focus_source
+    assert "if (!CommitCompatibilityFocusedWindow(ctx, panel, focus))" in focus_source
+
+    for path in other_sources:
+        source = path.read_text(encoding="utf-8")
+        assert "ctx->focused_window" not in source, path.as_posix()
 
 
 def test_split_file_focus_commits_use_appstate_helper() -> None:


### PR DESCRIPTION
## Summary
- confine `ViewContext.focused_window` compatibility access to dedicated AppState focus helpers
- extend the AppState contract guard to keep raw focused-window access out of the rest of the runtime

## Validation
- red: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focused_window_compatibility_stays_in_appstate_focus_helpers`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focused_window_compatibility_stays_in_appstate_focus_helpers or focus_mirror_projects_through_helper or split_panel_switch_traces_project_from_helper or active_panel_focus_decisions_project_from_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make`
- `git diff --check`
