### PR TITLE
chore(appstate): describe focused-window helper shim contract

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,25 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-focused-window-registry-boundary
-Active PR: https://github.com/robkam/ytreenova/pull/365 (draft)
+Current branch: appstate-focused-window-helper-contract
+Active PR: https://github.com/robkam/ytreenova/pull/366 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/364 merged at `b768388` after green checks.
-- Local `main` and `origin/main` were aligned at `b768388` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/365 merged at `bc2526a` after green checks.
+- Local `main` and `origin/main` were aligned at `bc2526a` before this branch.
 - The prior topic branch was deleted on merge and pruned locally/remotely.
 
 Current AppState batch:
-- Narrows the focused-window compatibility shim registry in `docs/appstate_compat_shims.json` and `src/core/appstate_actions.c` to the helper-only boundary now enforced in `src/ui/appstate_focus.c`.
-- Extends `tests/test_appstate_contract_guard.py` to keep the focused-window shim metadata aligned with the helper-only runtime boundary.
+- Updates the focused-window compatibility shim contract metadata in `docs/appstate_compat_shims.json` and `src/core/appstate_actions.c` to describe the helper-only boundary now enforced by the runtime.
+- Extends `tests/test_appstate_contract_guard.py` to keep the shim text and source-boundary metadata aligned with the helper-only compatibility carrier.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focused_window_shim_registry_matches_helper_boundary`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focused_window_shim_registry_matches_helper_boundary or focused_window_compatibility_stays_in_appstate_focus_helpers or render_footer_focus_reads_project_from_panel_state or focus_mirror_projects_through_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focused_window_shim_metadata_describes_helper_only_boundary`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or focused_window_compatibility_stays_in_appstate_focus_helpers or render_footer_focus_reads_project_from_panel_state or focus_mirror_projects_through_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/365 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/366 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -5,18 +5,18 @@
   "shims": [
     {
       "id": "shim.focused-window-session-flag",
-      "owner": "ViewContext session routing",
+      "owner": "AppState focus compatibility carrier",
       "old_authority_path": "ViewContext.focused_window",
-      "read_permission": "Allowed for layout routing and footer context selection while AppState focus_shape migration is incomplete.",
-      "write_permission": "Write only from transition commit after the active panel focus_shape has been updated.",
+      "read_permission": "Allowed only inside AppState focus compatibility helpers while panel-local focus_shape authority migration remains incomplete.",
+      "write_permission": "Write only from AppState focus compatibility helpers after the active panel focus_shape has been updated.",
       "write_capability": "write_capable",
       "invariant_checks": [
         "invariant.panel-local-focus-restore",
         "invariant.inactive-panel-frozen"
       ],
-      "removal_trigger": "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
+      "removal_trigger": "AppState focus helpers no longer need a ViewContext.focused_window compatibility fallback.",
       "target_transition": "transition.keybinding.navigate-tree",
-      "follow_up_task": "Move focus-shape authority from session mirrors into panel-local transition records.",
+      "follow_up_task": "Remove the focused-window compatibility carrier once panel-local focus commits fully cover active-focus recovery.",
       "qa_enforcement": "check_appstate_contract.py validates shim coverage and links it to an existing transition id.",
       "owner_field_refs": [
         "panel.focus_shape",

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6284,10 +6284,10 @@ static const AppStateActionCoverageMetadata
 
 static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
   {"shim.focused-window-session-flag",
-   "ViewContext session routing",
+   "AppState focus compatibility carrier",
    "ViewContext.focused_window",
-   "Allowed for layout routing and footer context selection while AppState focus_shape migration is incomplete.",
-   "Write only from transition commit after the active panel focus_shape has been updated.",
+   "Allowed only inside AppState focus compatibility helpers while panel-local focus_shape authority migration remains incomplete.",
+   "Write only from AppState focus compatibility helpers after the active panel focus_shape has been updated.",
    "write_capable",
    kAppStateCompatibilityShimInvariantChecks1,
    sizeof(kAppStateCompatibilityShimInvariantChecks1) /
@@ -6304,9 +6304,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
     kAppStateCompatibilityShimSourceBoundaryRefs1,
     sizeof(kAppStateCompatibilityShimSourceBoundaryRefs1) /
         sizeof(kAppStateCompatibilityShimSourceBoundaryRefs1[0]),
-    "All Enter, Tab, and F8 paths route through the canonical AppState transition entry point.",
+    "AppState focus helpers no longer need a ViewContext.focused_window compatibility fallback.",
     "transition.keybinding.navigate-tree",
-    "Move focus-shape authority from session mirrors into panel-local transition records.",
+    "Remove the focused-window compatibility carrier once panel-local focus commits fully cover active-focus recovery.",
    "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
   {"shim-render-derived-row-position",
    "Render projection temporary",

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9837,6 +9837,43 @@ def test_focused_window_shim_registry_matches_helper_boundary() -> None:
     assert '"src/ui/split_transition.c"' not in array_body
 
 
+def test_focused_window_shim_metadata_describes_helper_only_boundary() -> None:
+    shim_registry = Path("docs/appstate_compat_shims.json").read_text(
+        encoding="utf-8"
+    )
+    action_registry = Path("src/core/appstate_actions.c").read_text(
+        encoding="utf-8"
+    )
+
+    owner = "AppState focus compatibility carrier"
+    read_permission = (
+        "Allowed only inside AppState focus compatibility helpers while "
+        "panel-local focus_shape authority migration remains incomplete."
+    )
+    write_permission = (
+        "Write only from AppState focus compatibility helpers after the "
+        "active panel focus_shape has been updated."
+    )
+    removal_trigger = (
+        "AppState focus helpers no longer need a "
+        "ViewContext.focused_window compatibility fallback."
+    )
+    follow_up_task = (
+        "Remove the focused-window compatibility carrier once panel-local "
+        "focus commits fully cover active-focus recovery."
+    )
+
+    for text in [
+        owner,
+        read_permission,
+        write_permission,
+        removal_trigger,
+        follow_up_task,
+    ]:
+        assert text in shim_registry
+        assert text in action_registry
+
+
 def test_split_file_focus_commits_use_appstate_helper() -> None:
     source = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     start = source.index("BOOL SplitTransition_HandleFileWindowAction(")


### PR DESCRIPTION
## Summary
- update the focused-window compatibility shim contract to describe the helper-only runtime boundary
- extend the AppState contract guard to keep the shim metadata aligned with that helper boundary

## Validation
- red: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focused_window_shim_metadata_describes_helper_only_boundary`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or focused_window_compatibility_stays_in_appstate_focus_helpers or render_footer_focus_reads_project_from_panel_state or focus_mirror_projects_through_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make`
- `git diff --check`
