### PR TITLE
refactor(appstate): project render row math through helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,25 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-focused-window-helper-contract
-Active PR: https://github.com/robkam/ytreenova/pull/366 (draft)
+Current branch: appstate-render-row-projection-helper
+Active PR: https://github.com/robkam/ytreenova/pull/367 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/365 merged at `bc2526a` after green checks.
-- Local `main` and `origin/main` were aligned at `bc2526a` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/366 merged at `773444d` after green checks.
+- Local `main` and `origin/main` were aligned at `773444d` before this branch.
 - The prior topic branch was deleted on merge and pruned locally/remotely.
 
 Current AppState batch:
-- Updates the focused-window compatibility shim contract metadata in `docs/appstate_compat_shims.json` and `src/core/appstate_actions.c` to describe the helper-only boundary now enforced by the runtime.
-- Extends `tests/test_appstate_contract_guard.py` to keep the shim text and source-boundary metadata aligned with the helper-only compatibility carrier.
+- Routes render-derived inactive-panel file viewport/highlight calculations in `src/ui/display.c` through dedicated display helpers instead of inline row-position math.
+- Extends `tests/test_appstate_contract_guard.py` to keep those render-derived row projections on helper functions.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k focused_window_shim_metadata_describes_helper_only_boundary`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or focused_window_compatibility_stays_in_appstate_focus_helpers or render_footer_focus_reads_project_from_panel_state or focus_mirror_projects_through_helper or compatibility_shim_boundaries_fail_closed_before_legacy_writes'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_row_projection_uses_display_helpers`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_display_helpers or focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or render_footer_focus_reads_project_from_panel_state'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/366 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/367 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -471,6 +471,46 @@ static DirEntry *ResolvePanelFileAnchorForRender(ViewContext *ctx,
   return ResolvePanelFileAnchor(panel);
 }
 
+static void ClampRenderFileViewport(const YtreeNovaPanel *panel,
+                                    int *render_start_ptr,
+                                    int *render_cursor_ptr) {
+  int render_start;
+  int render_cursor;
+
+  if (!panel || !render_start_ptr || !render_cursor_ptr)
+    return;
+
+  render_start = *render_start_ptr;
+  render_cursor = *render_cursor_ptr;
+  if (panel->file_count > 0) {
+    if (render_start < 0)
+      render_start = 0;
+    if ((unsigned int)render_start >= panel->file_count)
+      render_start = (int)panel->file_count - 1;
+    if (render_cursor < 0)
+      render_cursor = 0;
+    if ((unsigned int)(render_start + render_cursor) >= panel->file_count) {
+      render_cursor = (int)panel->file_count - 1 - render_start;
+      if (render_cursor < 0)
+        render_cursor = 0;
+    }
+  } else {
+    render_start = 0;
+    render_cursor = 0;
+  }
+
+  *render_start_ptr = render_start;
+  *render_cursor_ptr = render_cursor;
+}
+
+static int ResolveRenderFileHighlight(const YtreeNovaPanel *panel,
+                                      int render_start, int render_cursor) {
+  if (!panel || panel->saved_focus != FOCUS_FILE || panel->file_count == 0)
+    return -1;
+
+  return render_start + render_cursor;
+}
+
 void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
   if (!panel || !panel->vol || !panel->pan_dir_window)
     return;
@@ -548,33 +588,20 @@ void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
       render_start = panel->start_file;
       render_cursor = panel->file_cursor_pos;
     }
-    if (panel->file_count > 0) {
-      if (render_start < 0)
-        render_start = 0;
-      if ((unsigned int)render_start >= panel->file_count)
-        render_start = (int)panel->file_count - 1;
-      if (render_cursor < 0)
-        render_cursor = 0;
-      if ((unsigned int)(render_start + render_cursor) >= panel->file_count) {
-        render_cursor = (int)panel->file_count - 1 - render_start;
-        if (render_cursor < 0)
-          render_cursor = 0;
-      }
-    } else {
-      render_start = 0;
-      render_cursor = 0;
-    }
+    ClampRenderFileViewport(panel, &render_start, &render_cursor);
 
     if (IsPanelSavedBigFileMode(panel) && panel->pan_big_file_window) {
       DEBUG_LOG("RenderInactivePanel:file path='%s' start=%d cursor=%d count=%u",
                 panel->file_selection_dir_path[0] ? panel->file_selection_dir_path
-                                                   : "<none>",
+                                                  : "<none>",
                 render_start, render_cursor, panel->file_count);
       if (panel->pan_dir_window) {
         werase(panel->pan_dir_window);
         wnoutrefresh(panel->pan_dir_window);
       }
-      DisplayFiles(ctx, panel, de, render_start, render_start + render_cursor,
+      DisplayFiles(ctx, panel, de, render_start,
+                   ResolveRenderFileHighlight(panel, render_start,
+                                              render_cursor),
                    0, panel->pan_big_file_window);
       wnoutrefresh(panel->pan_big_file_window);
       return;
@@ -596,9 +623,8 @@ void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
         werase(panel->pan_file_window);
         wnoutrefresh(panel->pan_file_window);
       } else {
-        int file_hilight = -1;
-        if (panel->saved_focus == FOCUS_FILE && panel->file_count > 0)
-          file_hilight = render_start + render_cursor;
+        int file_hilight =
+            ResolveRenderFileHighlight(panel, render_start, render_cursor);
         DisplayFiles(ctx, panel, de, render_start, file_hilight, 0,
                      panel->pan_file_window);
         wnoutrefresh(panel->pan_file_window);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9874,6 +9874,21 @@ def test_focused_window_shim_metadata_describes_helper_only_boundary() -> None:
         assert text in action_registry
 
 
+def test_render_row_projection_uses_display_helpers() -> None:
+    display = Path("src/ui/display.c").read_text(encoding="utf-8")
+
+    assert "static void ClampRenderFileViewport(" in display
+    assert "static int ResolveRenderFileHighlight(" in display
+
+    render_start = display.index("void RenderInactivePanel(")
+    render_end = display.index("\nstatic BOOL IsActivePanelBigFileMode(", render_start)
+    render_body = display[render_start:render_end]
+
+    assert "ClampRenderFileViewport(panel, &render_start, &render_cursor);" in render_body
+    assert "ResolveRenderFileHighlight(panel, render_start, render_cursor)" in render_body
+    assert "render_start + render_cursor" not in render_body
+
+
 def test_split_file_focus_commits_use_appstate_helper() -> None:
     source = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     start = source.index("BOOL SplitTransition_HandleFileWindowAction(")


### PR DESCRIPTION
## Summary
- route render-derived inactive-panel row math through dedicated display helpers
- extend the AppState contract guard to keep those render-row projections on helper functions

## Validation
- red: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_row_projection_uses_display_helpers`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_display_helpers or focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or render_footer_focus_reads_project_from_panel_state'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make`
- `git diff --check`
