### PR TITLE
chore(appstate): describe render shim helper contract

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,25 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-render-row-projection-helper
-Active PR: https://github.com/robkam/ytreenova/pull/367 (draft)
+Current branch: appstate-render-shim-helper-contract
+Active PR: https://github.com/robkam/ytreenova/pull/368 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/366 merged at `773444d` after green checks.
-- Local `main` and `origin/main` were aligned at `773444d` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/367 merged at `c4cca50` after green checks.
+- Local `main` and `origin/main` were aligned at `c4cca50` before this branch.
 - The prior topic branch was deleted on merge and pruned locally/remotely.
 
 Current AppState batch:
-- Routes render-derived inactive-panel file viewport/highlight calculations in `src/ui/display.c` through dedicated display helpers instead of inline row-position math.
-- Extends `tests/test_appstate_contract_guard.py` to keep those render-derived row projections on helper functions.
+- Updates the render-derived row compatibility shim contract metadata in `docs/appstate_compat_shims.json` and `src/core/appstate_actions.c` to describe the helper-only display boundary now enforced by `src/ui/display.c`.
+- Extends `tests/test_appstate_contract_guard.py` to keep the render-row shim text aligned with the display helper boundary.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_row_projection_uses_display_helpers`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_display_helpers or focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or render_footer_focus_reads_project_from_panel_state'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_row_shim_metadata_describes_helper_boundary`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_shim_metadata_describes_helper_boundary or render_row_projection_uses_display_helpers or focused_window_shim_metadata_describes_helper_only_boundary or render_footer_focus_reads_project_from_panel_state'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/367 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/368 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -35,18 +35,18 @@
     },
     {
       "id": "shim-render-derived-row-position",
-      "owner": "Render projection temporary",
+      "owner": "Display render projection helpers",
       "old_authority_path": "disp_begin_pos + cursor_pos render-derived lookup",
-      "read_permission": "Allowed only inside render projection or bounds-correction code after identity restore has run.",
-      "write_permission": "Never write authoritative selection from this calculation.",
+      "read_permission": "Allowed only inside display render projection helpers or bounds-correction code after identity restore has run.",
+      "write_permission": "Never write authoritative selection from display render projection helper calculations.",
       "write_capability": "read_only_projection",
       "invariant_checks": [
         "invariant.render-projection-read-only",
         "invariant.blocked-transition-determinism"
       ],
-      "removal_trigger": "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
+      "removal_trigger": "Display render projection helpers accept explicit projection inputs and no longer inspect restore authority fields directly.",
       "target_transition": "transition.render-reflow.project-state",
-      "follow_up_task": "Audit render/reflow call sites for projection-only behavior during runtime migration.",
+      "follow_up_task": "Remove render-derived row compatibility helpers once render callers carry explicit projection state.",
       "qa_enforcement": "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage.",
       "owner_field_refs": [
         "panel.tree_cursor_pos",

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6307,12 +6307,12 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
     "AppState focus helpers no longer need a ViewContext.focused_window compatibility fallback.",
     "transition.keybinding.navigate-tree",
     "Remove the focused-window compatibility carrier once panel-local focus commits fully cover active-focus recovery.",
-   "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
+  "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
   {"shim-render-derived-row-position",
-   "Render projection temporary",
+   "Display render projection helpers",
    "disp_begin_pos + cursor_pos render-derived lookup",
-   "Allowed only inside render projection or bounds-correction code after identity restore has run.",
-   "Never write authoritative selection from this calculation.",
+   "Allowed only inside display render projection helpers or bounds-correction code after identity restore has run.",
+   "Never write authoritative selection from display render projection helper calculations.",
    "read_only_projection",
    kAppStateCompatibilityShimInvariantChecks2,
    sizeof(kAppStateCompatibilityShimInvariantChecks2) /
@@ -6329,9 +6329,9 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
     kAppStateCompatibilityShimSourceBoundaryRefs2,
     sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2) /
         sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2[0]),
-    "Render paths accept explicit projection inputs and no longer inspect restore authority fields directly.",
-    "transition.render-reflow.project-state",
-    "Audit render/reflow call sites for projection-only behavior during runtime migration.",
+   "Display render projection helpers accept explicit projection inputs and no longer inspect restore authority fields directly.",
+   "transition.render-reflow.project-state",
+   "Remove render-derived row compatibility helpers once render callers carry explicit projection state.",
    "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage."},
 };
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9889,6 +9889,43 @@ def test_render_row_projection_uses_display_helpers() -> None:
     assert "render_start + render_cursor" not in render_body
 
 
+def test_render_row_shim_metadata_describes_helper_boundary() -> None:
+    shim_registry = Path("docs/appstate_compat_shims.json").read_text(
+        encoding="utf-8"
+    )
+    action_registry = Path("src/core/appstate_actions.c").read_text(
+        encoding="utf-8"
+    )
+
+    owner = "Display render projection helpers"
+    read_permission = (
+        "Allowed only inside display render projection helpers or "
+        "bounds-correction code after identity restore has run."
+    )
+    write_permission = (
+        "Never write authoritative selection from display render projection "
+        "helper calculations."
+    )
+    removal_trigger = (
+        "Display render projection helpers accept explicit projection inputs "
+        "and no longer inspect restore authority fields directly."
+    )
+    follow_up_task = (
+        "Remove render-derived row compatibility helpers once render callers "
+        "carry explicit projection state."
+    )
+
+    for text in [
+        owner,
+        read_permission,
+        write_permission,
+        removal_trigger,
+        follow_up_task,
+    ]:
+        assert text in shim_registry
+        assert text in action_registry
+
+
 def test_split_file_focus_commits_use_appstate_helper() -> None:
     source = Path("src/ui/split_transition.c").read_text(encoding="utf-8")
     start = source.index("BOOL SplitTransition_HandleFileWindowAction(")


### PR DESCRIPTION
## Summary
- update the render-derived row compatibility shim contract to describe the helper-only display boundary
- extend the AppState contract guard to keep the render-row shim metadata aligned with that helper boundary

## Validation
- red: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_row_shim_metadata_describes_helper_boundary`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_shim_metadata_describes_helper_boundary or render_row_projection_uses_display_helpers or focused_window_shim_metadata_describes_helper_only_boundary or render_footer_focus_reads_project_from_panel_state'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make`
- `git diff --check`
