### PR TITLE
refactor(appstate): share render row projection helpers

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,25 +4,28 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-render-shim-helper-contract
-Active PR: https://github.com/robkam/ytreenova/pull/368 (draft)
+Current branch: appstate-file-list-render-helpers
+Active PR: https://github.com/robkam/ytreenova/pull/369 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/367 merged at `c4cca50` after green checks.
-- Local `main` and `origin/main` were aligned at `c4cca50` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/368 merged at `ac22ce8` after green checks.
+- Local `main` and `origin/main` were aligned at `ac22ce8` before this branch.
 - The prior topic branch was deleted on merge and pruned locally/remotely.
 
 Current AppState batch:
-- Updates the render-derived row compatibility shim contract metadata in `docs/appstate_compat_shims.json` and `src/core/appstate_actions.c` to describe the helper-only display boundary now enforced by `src/ui/display.c`.
-- Extends `tests/test_appstate_contract_guard.py` to keep the render-row shim text aligned with the display helper boundary.
+- Moves render-row clamp/highlight compatibility math into shared AppState render helpers in `src/ui/appstate_render.c` and `include/ytnova_appstate_render.h`.
+- Routes both `src/ui/display.c` and `src/ui/file_list.c` through the shared render helpers so the render-row shim no longer has a display-local runtime boundary.
+- Updates `docs/appstate_compat_shims.json`, `src/core/appstate_actions.c`, and `tests/test_appstate_contract_guard.py` to describe and guard the shared helper boundary.
+- Refreshes the tracked Cline bridge files so the repo-local skill bridge wording matches the linked skill path.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k render_row_shim_metadata_describes_helper_boundary`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_shim_metadata_describes_helper_boundary or render_row_projection_uses_display_helpers or focused_window_shim_metadata_describes_helper_only_boundary or render_footer_focus_reads_project_from_panel_state'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_shared_helpers or render_row_shim_registry_matches_shared_helper_boundary or render_row_shim_metadata_describes_helper_boundary'`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_shared_helpers or render_row_shim_registry_matches_shared_helper_boundary or render_row_shim_metadata_describes_helper_boundary or focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or render_footer_focus_reads_project_from_panel_state'`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_shared_helpers or render_row_shim_registry_matches_shared_helper_boundary or render_row_shim_metadata_describes_helper_boundary or test_guard_fails_when_runtime_shim_validation_callsite_is_missing or test_guard_fails_when_runtime_shim_validation_moves_outside_source_boundary or focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or render_footer_focus_reads_project_from_panel_state'`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/368 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/369 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/.cline/skills
+++ b/.cline/skills
@@ -1,1 +1,1 @@
-../.ai/skills
+../.ai/skills/

--- a/.clinerules/01-ytreenova.md
+++ b/.clinerules/01-ytreenova.md
@@ -19,7 +19,7 @@ In Cline, treat those files as authoritative even when they mention Codex-specif
 
 ## Persona routing
 
-Choose the working role by user intent, then load the matching project skill from `.cline/skills/`:
+Choose the working role by user intent, then load the matching project skill through the `.cline/skills` bridge:
 
 - `architect` -> `architect-planning`
 - `developer` -> `developer-implementation`

--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -35,16 +35,16 @@
     },
     {
       "id": "shim-render-derived-row-position",
-      "owner": "Display render projection helpers",
+      "owner": "AppState render projection helpers",
       "old_authority_path": "disp_begin_pos + cursor_pos render-derived lookup",
-      "read_permission": "Allowed only inside display render projection helpers or bounds-correction code after identity restore has run.",
-      "write_permission": "Never write authoritative selection from display render projection helper calculations.",
+      "read_permission": "Allowed only inside AppState render projection helpers or bounds-correction code after identity restore has run.",
+      "write_permission": "Never write authoritative selection from AppState render projection helper calculations.",
       "write_capability": "read_only_projection",
       "invariant_checks": [
         "invariant.render-projection-read-only",
         "invariant.blocked-transition-determinism"
       ],
-      "removal_trigger": "Display render projection helpers accept explicit projection inputs and no longer inspect restore authority fields directly.",
+      "removal_trigger": "AppState render projection helpers accept explicit projection inputs and no longer inspect restore authority fields directly.",
       "target_transition": "transition.render-reflow.project-state",
       "follow_up_task": "Remove render-derived row compatibility helpers once render callers carry explicit projection state.",
       "qa_enforcement": "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage.",
@@ -65,7 +65,7 @@
         "harness.blocked-transition-no-unrelated-mutation"
       ],
       "source_boundary_refs": [
-        "src/ui/display.c"
+        "src/ui/appstate_render.c"
       ]
     }
   ]

--- a/include/ytnova_appstate_render.h
+++ b/include/ytnova_appstate_render.h
@@ -1,7 +1,7 @@
 /***************************************************************************
  *
  * ytnova_appstate_render.h
- * Render-invalidation transition commits for AppState boundaries.
+ * Render transition commits and projection helpers for AppState boundaries.
  *
  ***************************************************************************/
 
@@ -13,5 +13,10 @@
 BOOL AppStateCommitResizeRequest(ViewContext *ctx, BOOL resize_request);
 BOOL AppStateMarkResizeRequest(ViewContext *ctx);
 BOOL AppStateClearResizeRequest(ViewContext *ctx);
+void AppStateClampRenderFileViewport(const YtreeNovaPanel *panel,
+                                     int *render_start_ptr,
+                                     int *render_cursor_ptr);
+int AppStateResolveRenderFileHighlight(const YtreeNovaPanel *panel,
+                                       int render_start, int render_cursor);
 
 #endif /* YTNOVA_APPSTATE_RENDER_H */

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2838,7 +2838,7 @@ static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {
 };
 
 static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {
-  "src/ui/display.c",
+    "src/ui/appstate_render.c",
 };
 
 static const char *const kAppStateInvariantProtectedFields0[] = {
@@ -6309,10 +6309,10 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
     "Remove the focused-window compatibility carrier once panel-local focus commits fully cover active-focus recovery.",
   "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
   {"shim-render-derived-row-position",
-   "Display render projection helpers",
+   "AppState render projection helpers",
    "disp_begin_pos + cursor_pos render-derived lookup",
-   "Allowed only inside display render projection helpers or bounds-correction code after identity restore has run.",
-   "Never write authoritative selection from display render projection helper calculations.",
+   "Allowed only inside AppState render projection helpers or bounds-correction code after identity restore has run.",
+   "Never write authoritative selection from AppState render projection helper calculations.",
    "read_only_projection",
    kAppStateCompatibilityShimInvariantChecks2,
    sizeof(kAppStateCompatibilityShimInvariantChecks2) /
@@ -6329,7 +6329,7 @@ static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
     kAppStateCompatibilityShimSourceBoundaryRefs2,
     sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2) /
         sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2[0]),
-   "Display render projection helpers accept explicit projection inputs and no longer inspect restore authority fields directly.",
+   "AppState render projection helpers accept explicit projection inputs and no longer inspect restore authority fields directly.",
    "transition.render-reflow.project-state",
    "Remove render-derived row compatibility helpers once render callers carry explicit projection state.",
    "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage."},

--- a/src/ui/appstate_render.c
+++ b/src/ui/appstate_render.c
@@ -1,7 +1,7 @@
 /***************************************************************************
  *
  * src/ui/appstate_render.c
- * Render-invalidation transition commits for AppState boundaries.
+ * Render transition commits and projection helpers for AppState boundaries.
  *
  ***************************************************************************/
 
@@ -24,4 +24,48 @@ BOOL AppStateMarkResizeRequest(ViewContext *ctx) {
 
 BOOL AppStateClearResizeRequest(ViewContext *ctx) {
   return AppStateCommitResizeRequest(ctx, FALSE);
+}
+
+void AppStateClampRenderFileViewport(const YtreeNovaPanel *panel,
+                                     int *render_start_ptr,
+                                     int *render_cursor_ptr) {
+  int render_start;
+  int render_cursor;
+
+  if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
+    return;
+  if (!panel || !render_start_ptr || !render_cursor_ptr)
+    return;
+
+  render_start = *render_start_ptr;
+  render_cursor = *render_cursor_ptr;
+  if (panel->file_count > 0) {
+    if (render_start < 0)
+      render_start = 0;
+    if ((unsigned int)render_start >= panel->file_count)
+      render_start = (int)panel->file_count - 1;
+    if (render_cursor < 0)
+      render_cursor = 0;
+    if ((unsigned int)(render_start + render_cursor) >= panel->file_count) {
+      render_cursor = (int)panel->file_count - 1 - render_start;
+      if (render_cursor < 0)
+        render_cursor = 0;
+    }
+  } else {
+    render_start = 0;
+    render_cursor = 0;
+  }
+
+  *render_start_ptr = render_start;
+  *render_cursor_ptr = render_cursor;
+}
+
+int AppStateResolveRenderFileHighlight(const YtreeNovaPanel *panel,
+                                       int render_start, int render_cursor) {
+  if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
+    return -1;
+  if (!panel || panel->file_count == 0)
+    return -1;
+
+  return render_start + render_cursor;
 }

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -13,6 +13,7 @@
 #include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_layout.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_appstate_window.h"
 #include <assert.h>
 
@@ -471,46 +472,6 @@ static DirEntry *ResolvePanelFileAnchorForRender(ViewContext *ctx,
   return ResolvePanelFileAnchor(panel);
 }
 
-static void ClampRenderFileViewport(const YtreeNovaPanel *panel,
-                                    int *render_start_ptr,
-                                    int *render_cursor_ptr) {
-  int render_start;
-  int render_cursor;
-
-  if (!panel || !render_start_ptr || !render_cursor_ptr)
-    return;
-
-  render_start = *render_start_ptr;
-  render_cursor = *render_cursor_ptr;
-  if (panel->file_count > 0) {
-    if (render_start < 0)
-      render_start = 0;
-    if ((unsigned int)render_start >= panel->file_count)
-      render_start = (int)panel->file_count - 1;
-    if (render_cursor < 0)
-      render_cursor = 0;
-    if ((unsigned int)(render_start + render_cursor) >= panel->file_count) {
-      render_cursor = (int)panel->file_count - 1 - render_start;
-      if (render_cursor < 0)
-        render_cursor = 0;
-    }
-  } else {
-    render_start = 0;
-    render_cursor = 0;
-  }
-
-  *render_start_ptr = render_start;
-  *render_cursor_ptr = render_cursor;
-}
-
-static int ResolveRenderFileHighlight(const YtreeNovaPanel *panel,
-                                      int render_start, int render_cursor) {
-  if (!panel || panel->saved_focus != FOCUS_FILE || panel->file_count == 0)
-    return -1;
-
-  return render_start + render_cursor;
-}
-
 void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
   if (!panel || !panel->vol || !panel->pan_dir_window)
     return;
@@ -588,9 +549,16 @@ void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
       render_start = panel->start_file;
       render_cursor = panel->file_cursor_pos;
     }
-    ClampRenderFileViewport(panel, &render_start, &render_cursor);
+    AppStateClampRenderFileViewport(panel, &render_start, &render_cursor);
 
     if (IsPanelSavedBigFileMode(panel) && panel->pan_big_file_window) {
+      int file_hilight = -1;
+
+      if (panel->saved_focus == FOCUS_FILE) {
+        file_hilight =
+            AppStateResolveRenderFileHighlight(panel, render_start,
+                                               render_cursor);
+      }
       DEBUG_LOG("RenderInactivePanel:file path='%s' start=%d cursor=%d count=%u",
                 panel->file_selection_dir_path[0] ? panel->file_selection_dir_path
                                                   : "<none>",
@@ -599,10 +567,8 @@ void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
         werase(panel->pan_dir_window);
         wnoutrefresh(panel->pan_dir_window);
       }
-      DisplayFiles(ctx, panel, de, render_start,
-                   ResolveRenderFileHighlight(panel, render_start,
-                                              render_cursor),
-                   0, panel->pan_big_file_window);
+      DisplayFiles(ctx, panel, de, render_start, file_hilight, 0,
+                   panel->pan_big_file_window);
       wnoutrefresh(panel->pan_big_file_window);
       return;
     }
@@ -623,8 +589,13 @@ void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
         werase(panel->pan_file_window);
         wnoutrefresh(panel->pan_file_window);
       } else {
-        int file_hilight =
-            ResolveRenderFileHighlight(panel, render_start, render_cursor);
+        int file_hilight = -1;
+
+        if (panel->saved_focus == FOCUS_FILE) {
+          file_hilight =
+              AppStateResolveRenderFileHighlight(panel, render_start,
+                                                 render_cursor);
+        }
         DisplayFiles(ctx, panel, de, render_start, file_hilight, 0,
                      panel->pan_file_window);
         wnoutrefresh(panel->pan_file_window);

--- a/src/ui/file_list.c
+++ b/src/ui/file_list.c
@@ -8,6 +8,7 @@
 #include "sort.h"
 #include "ytnova_appstate_focus.h"
 #include "ytnova_appstate_panel.h"
+#include "ytnova_appstate_render.h"
 #include "ytnova_cmd.h"
 #include "ytnova_fs.h"
 #include "ytnova_ui.h"
@@ -213,23 +214,11 @@ void DisplayFileWindow(ViewContext *ctx, YtreeNovaPanel *panel,
     render_start = dir_entry->start_file;
     render_cursor = dir_entry->cursor_pos;
   }
-  if (panel->file_count == 0) {
-    render_start = 0;
-    render_cursor = 0;
-  } else {
+  {
     int original_start = render_start;
     int original_cursor = render_cursor;
-    if (render_start < 0)
-      render_start = 0;
-    if ((unsigned int)render_start >= panel->file_count)
-      render_start = (int)panel->file_count - 1;
-    if (render_cursor < 0)
-      render_cursor = 0;
-    if ((unsigned int)(render_start + render_cursor) >= panel->file_count) {
-      render_cursor = (int)panel->file_count - 1 - render_start;
-      if (render_cursor < 0)
-        render_cursor = 0;
-    }
+
+    AppStateClampRenderFileViewport(panel, &render_start, &render_cursor);
     if (original_start != render_start || original_cursor != render_cursor) {
       DEBUG_LOG("DisplayFileWindow:clamp start=%d->%d cursor=%d->%d count=%u",
                 original_start, render_start, original_cursor, render_cursor,
@@ -239,9 +228,10 @@ void DisplayFileWindow(ViewContext *ctx, YtreeNovaPanel *panel,
 
   (void)AppStateCommitPanelFileViewport(panel, render_start, render_cursor);
 
-  highlight_idx = -1;
-  if (AppStateResolveActivePanelFocus(ctx) == FOCUS_FILE)
-    highlight_idx = render_start + render_cursor;
+  highlight_idx = AppStateResolveRenderFileHighlight(panel, render_start,
+                                                     render_cursor);
+  if (AppStateResolveActivePanelFocus(ctx) != FOCUS_FILE)
+    highlight_idx = -1;
 
   DisplayFiles(ctx, panel, dir_entry, render_start, highlight_idx, 0,
                panel->pan_file_window);

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9874,19 +9874,57 @@ def test_focused_window_shim_metadata_describes_helper_only_boundary() -> None:
         assert text in action_registry
 
 
-def test_render_row_projection_uses_display_helpers() -> None:
+def test_render_row_projection_uses_shared_helpers() -> None:
+    render_helpers = Path("src/ui/appstate_render.c").read_text(encoding="utf-8")
     display = Path("src/ui/display.c").read_text(encoding="utf-8")
+    file_list = Path("src/ui/file_list.c").read_text(encoding="utf-8")
 
-    assert "static void ClampRenderFileViewport(" in display
-    assert "static int ResolveRenderFileHighlight(" in display
+    assert "void AppStateClampRenderFileViewport(" in render_helpers
+    assert "int AppStateResolveRenderFileHighlight(" in render_helpers
 
     render_start = display.index("void RenderInactivePanel(")
     render_end = display.index("\nstatic BOOL IsActivePanelBigFileMode(", render_start)
     render_body = display[render_start:render_end]
 
-    assert "ClampRenderFileViewport(panel, &render_start, &render_cursor);" in render_body
-    assert "ResolveRenderFileHighlight(panel, render_start, render_cursor)" in render_body
+    assert (
+        "AppStateClampRenderFileViewport(panel, &render_start, &render_cursor);"
+        in render_body
+    )
+    assert "AppStateResolveRenderFileHighlight(panel, render_start" in render_body
     assert "render_start + render_cursor" not in render_body
+
+    file_start = file_list.index("void DisplayFileWindow(")
+    file_body = file_list[file_start:]
+
+    assert (
+        "AppStateClampRenderFileViewport(panel, &render_start, &render_cursor);"
+        in file_body
+    )
+    assert "AppStateResolveRenderFileHighlight(panel, render_start" in file_body
+    assert "render_start + render_cursor" not in file_body
+
+
+def test_render_row_shim_registry_matches_shared_helper_boundary() -> None:
+    shim_registry = Path("docs/appstate_compat_shims.json").read_text(
+        encoding="utf-8"
+    )
+    action_registry = Path("src/core/appstate_actions.c").read_text(
+        encoding="utf-8"
+    )
+
+    assert '"source_boundary_refs": [' in shim_registry
+    assert '"src/ui/appstate_render.c"' in shim_registry
+    assert '"src/ui/display.c"' not in shim_registry
+    assert '"src/ui/file_list.c"' not in shim_registry
+
+    array_start = action_registry.index(
+        "static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {"
+    )
+    array_end = action_registry.index("};", array_start)
+    array_body = action_registry[array_start:array_end]
+    assert '"src/ui/appstate_render.c"' in array_body
+    assert '"src/ui/display.c"' not in array_body
+    assert '"src/ui/file_list.c"' not in array_body
 
 
 def test_render_row_shim_metadata_describes_helper_boundary() -> None:
@@ -9897,17 +9935,17 @@ def test_render_row_shim_metadata_describes_helper_boundary() -> None:
         encoding="utf-8"
     )
 
-    owner = "Display render projection helpers"
+    owner = "AppState render projection helpers"
     read_permission = (
-        "Allowed only inside display render projection helpers or "
+        "Allowed only inside AppState render projection helpers or "
         "bounds-correction code after identity restore has run."
     )
     write_permission = (
-        "Never write authoritative selection from display render projection "
+        "Never write authoritative selection from AppState render projection "
         "helper calculations."
     )
     removal_trigger = (
-        "Display render projection helpers accept explicit projection inputs "
+        "AppState render projection helpers accept explicit projection inputs "
         "and no longer inspect restore authority fields directly."
     )
     follow_up_task = (
@@ -11880,12 +11918,11 @@ def test_guard_fails_when_runtime_shim_validation_callsite_is_missing(
     tmp_path: Path,
 ) -> None:
     shutil.copytree(REPO_ROOT / "src", tmp_path / "src")
-    source_path = tmp_path / "src" / "ui" / "display.c"
+    source_path = tmp_path / "src" / "ui" / "appstate_render.c"
     original = source_path.read_text(encoding="utf-8")
     mutated = original.replace(
         'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")',
         'AppStateValidatedCompatibilityShim("shim-render-derived-row-position-missing")',
-        1,
     )
     assert mutated != original
     source_path.write_text(mutated, encoding="utf-8")
@@ -11917,12 +11954,11 @@ def test_guard_fails_when_runtime_shim_validation_moves_outside_source_boundary(
     tmp_path: Path,
 ) -> None:
     shutil.copytree(REPO_ROOT / "src", tmp_path / "src")
-    source_path = tmp_path / "src" / "ui" / "display.c"
+    source_path = tmp_path / "src" / "ui" / "appstate_render.c"
     original = source_path.read_text(encoding="utf-8")
     mutated = original.replace(
         'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")',
         'AppStateValidatedCompatibilityShim("shim-render-derived-row-position-missing")',
-        1,
     )
     assert mutated != original
     source_path.write_text(mutated, encoding="utf-8")
@@ -11955,7 +11991,7 @@ def test_guard_fails_when_runtime_shim_validation_moves_outside_source_boundary(
 
     assert any(
         "shim-render-derived-row-position" in failure
-        and "src/ui/display.c" in failure
+        and "src/ui/appstate_render.c" in failure
         and "missing runtime validation callsite" in failure
         for failure in failures
     )


### PR DESCRIPTION
## Summary
- move render-row clamp/highlight projection helpers into `src/ui/appstate_render.c`
- route `src/ui/display.c` and `src/ui/file_list.c` through the shared AppState render helper boundary
- align render shim registry metadata and contract guards with the shared helper contract

## Validation
- red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_shared_helpers or render_row_shim_registry_matches_shared_helper_boundary or render_row_shim_metadata_describes_helper_boundary'`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_shared_helpers or render_row_shim_registry_matches_shared_helper_boundary or render_row_shim_metadata_describes_helper_boundary or focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or render_footer_focus_reads_project_from_panel_state'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make`
- `git diff --check`
