### PR TITLE
refactor(appstate): remove focused window compatibility carrier

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,28 +4,27 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-file-list-render-helpers
-Active PR: https://github.com/robkam/ytreenova/pull/369 (draft)
+Current branch: appstate-remove-focused-window-carrier
+Active PR: https://github.com/robkam/ytreenova/pull/370 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/368 merged at `ac22ce8` after green checks.
-- Local `main` and `origin/main` were aligned at `ac22ce8` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/369 merged at `9b1bdd8` after green checks.
+- Local `main` and `origin/main` were aligned at `9b1bdd8` before this branch.
 - The prior topic branch was deleted on merge and pruned locally/remotely.
 
 Current AppState batch:
-- Moves render-row clamp/highlight compatibility math into shared AppState render helpers in `src/ui/appstate_render.c` and `include/ytnova_appstate_render.h`.
-- Routes both `src/ui/display.c` and `src/ui/file_list.c` through the shared render helpers so the render-row shim no longer has a display-local runtime boundary.
-- Updates `docs/appstate_compat_shims.json`, `src/core/appstate_actions.c`, and `tests/test_appstate_contract_guard.py` to describe and guard the shared helper boundary.
-- Refreshes the tracked Cline bridge files so the repo-local skill bridge wording matches the linked skill path.
+- Removes the obsolete `ViewContext.focused_window` compatibility carrier from `include/ytnova_defs.h` and `src/ui/appstate_focus.c` now that active-focus reads project from panel-local state.
+- Drops the focused-window shim from `docs/appstate_compat_shims.json`, `src/core/appstate_actions.c`, and `src/core/main.c` so the runtime registry no longer requires the removed carrier.
+- Removes no-longer-needed focused-window shim validation gates from `src/ui/ctrl_dir.c` and `src/ui/ctrl_file.c`.
+- Refreshes `docs/ARCHITECTURE.md` and `tests/test_appstate_contract_guard.py` to guard the carrier removal and keep the remaining render shim coverage intact.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_shared_helpers or render_row_shim_registry_matches_shared_helper_boundary or render_row_shim_metadata_describes_helper_boundary'`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_shared_helpers or render_row_shim_registry_matches_shared_helper_boundary or render_row_shim_metadata_describes_helper_boundary or focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or render_footer_focus_reads_project_from_panel_state'`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'render_row_projection_uses_shared_helpers or render_row_shim_registry_matches_shared_helper_boundary or render_row_shim_metadata_describes_helper_boundary or test_guard_fails_when_runtime_shim_validation_callsite_is_missing or test_guard_fails_when_runtime_shim_validation_moves_outside_source_boundary or focused_window_shim_metadata_describes_helper_only_boundary or focused_window_shim_registry_matches_helper_boundary or render_footer_focus_reads_project_from_panel_state'`
+- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'test_compatibility_shim_boundaries_fail_closed_before_legacy_writes or test_render_footer_focus_reads_project_from_panel_state or test_focused_window_compatibility_carrier_is_removed or test_focused_window_shim_registry_removes_compatibility_carrier or test_focused_window_runtime_no_longer_validates_removed_shim or test_focused_window_shim_metadata_is_removed'`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
 - `make`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/369 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/370 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,7 +145,7 @@ Split-transfer/switch code must classify each field before copying or restoring:
 | **Panel-Local** | `YtreeNovaPanel` | `cursor_pos`, `disp_begin_pos`, `start_file`, `file_cursor_pos`, `file_dir_entry`, `saved_focus`, `saved_big_file_view`, `file_selection_name`, `file_selection_dir_path`, `tagged_paths`, `hide_dot_files` | Active-only commands must not mutate the inactive panel's values. |
 | **Derived / Restore-Mirror** | `ViewContext` mirrors and `Volume` restore breadcrumbs | `saved_tree_index`, `saved_focus` | May shadow panel-local state for compatibility or restore, but must never become the authoritative source of truth when a panel-local copy exists. |
 | **Shared-Topology** | `Volume` (possibly referenced by both panels) | `vol_stats.tree`, `dir_entry_list`, directory expansion/logging topology | Panel code may mirror topology visibility updates, but must re-anchor each panel by identity/path and must not infer panel-local selection by shared index. |
-| **Session-Only** | `ViewContext` session scope | `is_split_screen`, `focused_window`, layout windows, session options other than panel-local visibility state | Session toggles must not be treated as panel-local transfer state; split hand-off code must not use them to overwrite inactive panel-local snapshots. |
+| **Session-Only** | `ViewContext` session scope | `is_split_screen`, layout windows, session options other than panel-local visibility state | Session toggles must not be treated as panel-local transfer state; split hand-off code must not use them to overwrite inactive panel-local snapshots. |
 
 Boundary implementations in `src/ui/dir_ops.c` and `src/ui/ctrl_file_ops.c` reference this map in invariant comments and debug assertions.
 

--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -4,36 +4,6 @@
   "notes": "Compatibility shims document legacy authority paths that may remain during migration. They must be read/write classified and removed when the target transition boundary is live.",
   "shims": [
     {
-      "id": "shim.focused-window-session-flag",
-      "owner": "AppState focus compatibility carrier",
-      "old_authority_path": "ViewContext.focused_window",
-      "read_permission": "Allowed only inside AppState focus compatibility helpers while panel-local focus_shape authority migration remains incomplete.",
-      "write_permission": "Write only from AppState focus compatibility helpers after the active panel focus_shape has been updated.",
-      "write_capability": "write_capable",
-      "invariant_checks": [
-        "invariant.panel-local-focus-restore",
-        "invariant.inactive-panel-frozen"
-      ],
-      "removal_trigger": "AppState focus helpers no longer need a ViewContext.focused_window compatibility fallback.",
-      "target_transition": "transition.keybinding.navigate-tree",
-      "follow_up_task": "Remove the focused-window compatibility carrier once panel-local focus commits fully cover active-focus recovery.",
-      "qa_enforcement": "check_appstate_contract.py validates shim coverage and links it to an existing transition id.",
-      "owner_field_refs": [
-        "panel.focus_shape",
-        "panel.panel_generation"
-      ],
-      "generation_domain_refs": [
-        "generation.panel.local-authority",
-        "shape.panel.focus"
-      ],
-      "diff_harness_refs": [
-        "harness.declared-write-set-diff"
-      ],
-      "source_boundary_refs": [
-        "src/ui/appstate_focus.c"
-      ]
-    },
-    {
       "id": "shim-render-derived-row-position",
       "owner": "AppState render projection helpers",
       "old_authority_path": "disp_begin_pos + cursor_pos render-derived lookup",

--- a/include/ytnova_appstate_focus.h
+++ b/include/ytnova_appstate_focus.h
@@ -1,7 +1,7 @@
 /***************************************************************************
  *
  * ytnova_appstate_focus.h
- * Focus transition commits for AppState compatibility boundaries.
+ * Focus transition commits for AppState panel-local boundaries.
  *
  ***************************************************************************/
 
@@ -11,11 +11,11 @@
 #include "ytnova_defs.h"
 
 ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx);
-BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
+BOOL AppStateCommitPanelFocus(const ViewContext *ctx, YtreeNovaPanel *panel,
                               ViewFocus focus);
 BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view);
 BOOL AppStateCommitDirEntryFileShape(DirEntry *dir_entry, BOOL big_file_view);
 BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus);
-BOOL AppStateMirrorActivePanelFocus(ViewContext *ctx);
+BOOL AppStateMirrorActivePanelFocus(const ViewContext *ctx);
 
 #endif /* YTNOVA_APPSTATE_FOCUS_H */

--- a/include/ytnova_defs.h
+++ b/include/ytnova_defs.h
@@ -972,7 +972,6 @@ typedef struct _ViewContext {
   BOOL clock_print_time;
   int fixed_col_width;
   int refresh_mode;
-  ViewFocus focused_window;
   ViewFocus preview_entry_focus;
   YtreeNovaPanel *preview_return_panel;
   ViewFocus preview_return_focus;

--- a/include/ytnova_panel_anchor.h
+++ b/include/ytnova_panel_anchor.h
@@ -33,7 +33,7 @@ BOOL RestorePanelTreeViewportSnapshot(ViewContext *ctx, YtreeNovaPanel *panel);
 void RememberPanelViewportTop(YtreeNovaPanel *panel);
 void RestorePanelAnchorPath(const struct Volume *vol, YtreeNovaPanel *panel,
                             const char *anchor_path);
-BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
+BOOL DonatePanelState(const ViewContext *ctx, YtreeNovaPanel *dst,
                       const YtreeNovaPanel *src);
 DirEntry *FindDirByPathInTree(DirEntry *entry, const char *path);
 void EnsurePanelAnchorVisible(ViewContext *ctx, const struct Volume *vol,

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2790,30 +2790,15 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceMigrationNotes12,
    sizeof(kAppStateDispatchSurfaceMigrationNotes12) / sizeof(kAppStateDispatchSurfaceMigrationNotes12[0])},
 };
-static const char *const kAppStateCompatibilityShimInvariantChecks1[] = {
-  "invariant.panel-local-focus-restore",
-  "invariant.inactive-panel-frozen",
-};
-
 static const char *const kAppStateCompatibilityShimInvariantChecks2[] = {
   "invariant.render-projection-read-only",
   "invariant.blocked-transition-determinism",
-};
-
-static const char *const kAppStateCompatibilityShimOwnerFieldRefs1[] = {
-  "panel.focus_shape",
-  "panel.panel_generation",
 };
 
 static const char *const kAppStateCompatibilityShimOwnerFieldRefs2[] = {
   "panel.tree_cursor_pos",
   "panel.tree_viewport_origin",
   "panel.file_viewport_origin",
-};
-
-static const char *const kAppStateCompatibilityShimGenerationDomainRefs1[] = {
-  "generation.panel.local-authority",
-  "shape.panel.focus",
 };
 
 static const char *const kAppStateCompatibilityShimGenerationDomainRefs2[] = {
@@ -2823,18 +2808,10 @@ static const char *const kAppStateCompatibilityShimGenerationDomainRefs2[] = {
   "reflow.layout.projection",
 };
 
-static const char *const kAppStateCompatibilityShimDiffHarnessRefs1[] = {
-  "harness.declared-write-set-diff",
-};
-
 static const char *const kAppStateCompatibilityShimDiffHarnessRefs2[] = {
   "harness.render-projection-read-only-diff",
   "harness.generation-mismatch-check",
   "harness.blocked-transition-no-unrelated-mutation",
-};
-
-static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {
-  "src/ui/appstate_focus.c",
 };
 
 static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {
@@ -6283,31 +6260,6 @@ static const AppStateActionCoverageMetadata
 };
 
 static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
-  {"shim.focused-window-session-flag",
-   "AppState focus compatibility carrier",
-   "ViewContext.focused_window",
-   "Allowed only inside AppState focus compatibility helpers while panel-local focus_shape authority migration remains incomplete.",
-   "Write only from AppState focus compatibility helpers after the active panel focus_shape has been updated.",
-   "write_capable",
-   kAppStateCompatibilityShimInvariantChecks1,
-   sizeof(kAppStateCompatibilityShimInvariantChecks1) /
-       sizeof(kAppStateCompatibilityShimInvariantChecks1[0]),
-   kAppStateCompatibilityShimOwnerFieldRefs1,
-   sizeof(kAppStateCompatibilityShimOwnerFieldRefs1) /
-       sizeof(kAppStateCompatibilityShimOwnerFieldRefs1[0]),
-   kAppStateCompatibilityShimGenerationDomainRefs1,
-    sizeof(kAppStateCompatibilityShimGenerationDomainRefs1) /
-        sizeof(kAppStateCompatibilityShimGenerationDomainRefs1[0]),
-    kAppStateCompatibilityShimDiffHarnessRefs1,
-    sizeof(kAppStateCompatibilityShimDiffHarnessRefs1) /
-        sizeof(kAppStateCompatibilityShimDiffHarnessRefs1[0]),
-    kAppStateCompatibilityShimSourceBoundaryRefs1,
-    sizeof(kAppStateCompatibilityShimSourceBoundaryRefs1) /
-        sizeof(kAppStateCompatibilityShimSourceBoundaryRefs1[0]),
-    "AppState focus helpers no longer need a ViewContext.focused_window compatibility fallback.",
-    "transition.keybinding.navigate-tree",
-    "Remove the focused-window compatibility carrier once panel-local focus commits fully cover active-focus recovery.",
-  "check_appstate_contract.py validates shim coverage and links it to an existing transition id."},
   {"shim-render-derived-row-position",
    "AppState render projection helpers",
    "disp_begin_pos + cursor_pos render-derived lookup",

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -236,7 +236,6 @@ static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
 };
 
 static const char *const kAppStateRequiredShimIds[] = {
-  "shim.focused-window-session-flag",
   "shim-render-derived-row-position",
 };
 

--- a/src/ui/appstate_focus.c
+++ b/src/ui/appstate_focus.c
@@ -1,60 +1,34 @@
 /***************************************************************************
  *
  * src/ui/appstate_focus.c
- * Focus transition commits for AppState compatibility boundaries.
+ * Focus transition commits for AppState panel-local boundaries.
  *
  ***************************************************************************/
 
 #define NO_YTNOVA_MACROS
 
-#include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
-
-static ViewFocus ResolveCompatibilityFocusedWindow(const ViewContext *ctx) {
-  if (ctx && (ctx->focused_window == FOCUS_TREE ||
-              ctx->focused_window == FOCUS_FILE))
-    return ctx->focused_window;
-  return FOCUS_TREE;
-}
-
-static BOOL CommitCompatibilityFocusedWindow(ViewContext *ctx,
-                                             const YtreeNovaPanel *panel,
-                                             ViewFocus focus) {
-  if (!ctx || !panel)
-    return FALSE;
-  if (ctx->active != panel)
-    return TRUE;
-
-  ctx->focused_window = focus;
-  return TRUE;
-}
 
 ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx) {
   if (ctx && ctx->active &&
       (ctx->active->saved_focus == FOCUS_TREE ||
        ctx->active->saved_focus == FOCUS_FILE))
     return ctx->active->saved_focus;
-  return ResolveCompatibilityFocusedWindow(ctx);
+  return FOCUS_TREE;
 }
 
-BOOL AppStateCommitPanelFocus(ViewContext *ctx, YtreeNovaPanel *panel,
+BOOL AppStateCommitPanelFocus(const ViewContext *ctx, YtreeNovaPanel *panel,
                               ViewFocus focus) {
-  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
-    return FALSE;
   if (!ctx || !panel)
     return FALSE;
   if (focus != FOCUS_TREE && focus != FOCUS_FILE)
     return FALSE;
 
   panel->saved_focus = focus;
-  if (!CommitCompatibilityFocusedWindow(ctx, panel, focus))
-    return FALSE;
   return TRUE;
 }
 
 BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view) {
-  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
-    return FALSE;
   if (!panel)
     return FALSE;
 
@@ -63,8 +37,6 @@ BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view) {
 }
 
 BOOL AppStateCommitDirEntryFileShape(DirEntry *dir_entry, BOOL big_file_view) {
-  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
-    return FALSE;
   if (!dir_entry)
     return FALSE;
 
@@ -73,8 +45,6 @@ BOOL AppStateCommitDirEntryFileShape(DirEntry *dir_entry, BOOL big_file_view) {
 }
 
 BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus) {
-  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
-    return FALSE;
   if (!volume)
     return FALSE;
   if (focus != FOCUS_TREE && focus != FOCUS_FILE)
@@ -84,7 +54,7 @@ BOOL AppStateCommitVolumeFocusMirror(struct Volume *volume, ViewFocus focus) {
   return TRUE;
 }
 
-BOOL AppStateMirrorActivePanelFocus(ViewContext *ctx) {
+BOOL AppStateMirrorActivePanelFocus(const ViewContext *ctx) {
   if (!ctx || !ctx->active)
     return FALSE;
   return AppStateCommitPanelFocus(ctx, ctx->active,

--- a/src/ui/ctrl_dir.c
+++ b/src/ui/ctrl_dir.c
@@ -464,8 +464,6 @@ static void HandleDirectoryCompare(ViewContext *ctx, DirEntry *source_dir) {
 extern int HandleDirWindow(ViewContext *ctx, const DirEntry *start_dir_entry) {
   if (!AppStateValidatedDispatchSurface("surface.directory-window-action-dispatch"))
     return ESC;
-  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
-    return ESC;
 
   DirEntry *dir_entry, *de_ptr;
   int ch, unput_char;

--- a/src/ui/ctrl_file.c
+++ b/src/ui/ctrl_file.c
@@ -249,8 +249,6 @@ DirEntry *RefreshFileView(ViewContext *ctx, DirEntry *dir_entry) {
 int HandleFileWindow(ViewContext *ctx, DirEntry *dir_entry) {
   if (!AppStateValidatedDispatchSurface("surface.file-window-action-dispatch"))
     return ESC;
-  if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))
-    return ESC;
 
   DEBUG_LOG("HandleFileWindow ENTERED for %s", dir_entry->name);
   FileEntry *fe_ptr;

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -618,7 +618,7 @@ CopyPanelVolumeFileState(const PanelVolumeFileState *src) {
   return head;
 }
 
-BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
+BOOL DonatePanelState(const ViewContext *ctx, YtreeNovaPanel *dst,
                       const YtreeNovaPanel *src) {
   char file_dir_path[PATH_LENGTH + 1];
   BOOL dst_saved_big_file_view;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5362,7 +5362,7 @@ void CapturePanelSelectionAnchor(ViewContext *ctx, YtreeNovaPanel *panel,
   (void)panel;
   (void)dir_entry;
 }
-BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst,
+BOOL DonatePanelState(const ViewContext *ctx, YtreeNovaPanel *dst,
                       const YtreeNovaPanel *src) {
   (void)ctx;
   (void)dst;
@@ -5439,7 +5439,6 @@ static void seed_context(ViewContext *ctx, YtreeNovaPanel *left,
   ctx->left = left;
   ctx->right = right;
   ctx->active = left;
-  ctx->focused_window = FOCUS_TREE;
 }
 
 static int expect_file_split_rejected(void) {
@@ -9554,12 +9553,9 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
 
     assert "shim.viewcontext-hide-dot-files" not in dir_ops
 
-    focus_validation = (
-        'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'
-    )
     dir_start = ctrl_dir.index("HandleDirWindow(")
     dir_body = ctrl_dir[dir_start:]
-    assert focus_validation in dir_body
+    assert 'AppStateValidatedCompatibilityShim("shim.focused-window-session-flag")' not in dir_body
     assert not re.search(r"\bctx->focused_window\s*=[^=]", ctrl_dir)
     assert "AppStateMirrorActivePanelFocus(ctx)" in dir_body
 
@@ -9571,7 +9567,7 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
 
     file_start = ctrl_file.index("int HandleFileWindow(")
     file_body = ctrl_file[file_start:]
-    assert focus_validation in file_body
+    assert 'AppStateValidatedCompatibilityShim("shim.focused-window-session-flag")' not in file_body
     assert not re.search(r"\bctx->focused_window\s*=[^=]", ctrl_file)
     assert "AppStateCommitPanelFocus(ctx, ctx->active, FOCUS_FILE)" in file_body
     assert "if (AppStateResolveActivePanelFocus(ctx) != FOCUS_FILE) {" in file_body
@@ -9588,23 +9584,11 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
         in ctrl_file_ops
     )
 
-    helper_validation = (
-        'if (!AppStateValidatedCompatibilityShim("shim.focused-window-session-flag"))'
-    )
-    compat_helper_start = focus_helper.index("static BOOL CommitCompatibilityFocusedWindow(")
-    compat_helper_end = focus_helper.index(
-        "\nViewFocus AppStateResolveActivePanelFocus(", compat_helper_start
-    )
-    compat_helper_body = focus_helper[compat_helper_start:compat_helper_end]
-    assert "ctx->focused_window = focus;" in compat_helper_body
-
     commit_start = focus_helper.index("BOOL AppStateCommitPanelFocus(")
     commit_end = focus_helper.index("\nBOOL AppStateCommitPanelFileShape(", commit_start)
     commit_body = focus_helper[commit_start:commit_end]
-    assert helper_validation in commit_body
-    assert commit_body.index(helper_validation) < commit_body.index(
-        "CommitCompatibilityFocusedWindow"
-    )
+    assert 'AppStateValidatedCompatibilityShim("shim.focused-window-session-flag")' not in commit_body
+    assert "CommitCompatibilityFocusedWindow" not in commit_body
 
     refresh_start = display.index("void RefreshView(")
     refresh_body = display[refresh_start:]
@@ -9617,6 +9601,7 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
 
 
 def test_render_footer_focus_reads_project_from_panel_state() -> None:
+    defs = Path("include/ytnova_defs.h").read_text(encoding="utf-8")
     header = Path("include/ytnova_appstate_focus.h").read_text(encoding="utf-8")
     focus_source = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
     display = Path("src/ui/display.c").read_text(encoding="utf-8")
@@ -9627,23 +9612,18 @@ def test_render_footer_focus_reads_project_from_panel_state() -> None:
         "ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx);"
         in header
     )
+    assert "ViewFocus focused_window;" not in defs
 
     helper_start = focus_source.index("ViewFocus AppStateResolveActivePanelFocus(")
     helper_end = focus_source.index(
         "\nBOOL AppStateCommitVolumeFocusMirror(", helper_start
     )
     helper_body = focus_source[helper_start:helper_end]
-    compat_helper_start = focus_source.index(
-        "static ViewFocus ResolveCompatibilityFocusedWindow("
-    )
-    compat_helper_end = focus_source.index(
-        "\nstatic BOOL CommitCompatibilityFocusedWindow(", compat_helper_start
-    )
-    compat_helper_body = focus_source[compat_helper_start:compat_helper_end]
 
     assert "ctx->active->saved_focus" in helper_body
-    assert "return ResolveCompatibilityFocusedWindow(ctx);" in helper_body
-    assert "ctx->focused_window" in compat_helper_body
+    assert "return FOCUS_TREE;" in helper_body
+    assert "ResolveCompatibilityFocusedWindow" not in focus_source
+    assert "ctx->focused_window" not in focus_source
 
     for source in [display, error, file_list]:
         assert 'include "ytnova_appstate_focus.h"' in source
@@ -9790,25 +9770,21 @@ def test_focus_mirror_projects_through_helper() -> None:
     assert "ctx->active->saved_focus" not in mirror_body
 
 
-def test_focused_window_compatibility_stays_in_appstate_focus_helpers() -> None:
+def test_focused_window_compatibility_carrier_is_removed() -> None:
     focus_source = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
-    other_sources = [
-        path
-        for path in Path("src").rglob("*.c")
-        if path.as_posix() != "src/ui/appstate_focus.c"
-    ]
+    defs = Path("include/ytnova_defs.h").read_text(encoding="utf-8")
 
-    assert "static ViewFocus ResolveCompatibilityFocusedWindow(" in focus_source
-    assert "static BOOL CommitCompatibilityFocusedWindow(" in focus_source
-    assert "return ResolveCompatibilityFocusedWindow(ctx);" in focus_source
-    assert "if (!CommitCompatibilityFocusedWindow(ctx, panel, focus))" in focus_source
+    assert "ResolveCompatibilityFocusedWindow" not in focus_source
+    assert "CommitCompatibilityFocusedWindow" not in focus_source
+    assert "ctx->focused_window" not in focus_source
+    assert "ViewFocus focused_window;" not in defs
 
-    for path in other_sources:
+    for path in Path("src").rglob("*.c"):
         source = path.read_text(encoding="utf-8")
         assert "ctx->focused_window" not in source, path.as_posix()
 
 
-def test_focused_window_shim_registry_matches_helper_boundary() -> None:
+def test_focused_window_shim_registry_removes_compatibility_carrier() -> None:
     shim_registry = Path("docs/appstate_compat_shims.json").read_text(
         encoding="utf-8"
     )
@@ -9816,62 +9792,41 @@ def test_focused_window_shim_registry_matches_helper_boundary() -> None:
         encoding="utf-8"
     )
 
-    assert '"source_boundary_refs": [' in shim_registry
-    assert '"src/ui/appstate_focus.c"' in shim_registry
-    assert '"src/ui/ctrl_file_ops.c"' not in shim_registry
-    assert '"src/ui/ctrl_file.c"' not in shim_registry
-    assert '"src/ui/ctrl_dir.c"' not in shim_registry
-    assert '"src/ui/dir_ops.c"' not in shim_registry
-    assert '"src/ui/split_transition.c"' not in shim_registry
+    assert "shim.focused-window-session-flag" not in shim_registry
+    assert "AppState focus compatibility carrier" not in shim_registry
+    assert "ViewContext.focused_window" not in shim_registry
+    assert "shim.focused-window-session-flag" not in action_registry
+    assert "AppState focus compatibility carrier" not in action_registry
+    assert "ViewContext.focused_window" not in action_registry
 
-    array_start = action_registry.index(
-        "static const char *const kAppStateCompatibilityShimSourceBoundaryRefs1[] = {"
+
+def test_focused_window_runtime_no_longer_validates_removed_shim() -> None:
+    ctrl_dir = Path("src/ui/ctrl_dir.c").read_text(encoding="utf-8")
+    ctrl_file = Path("src/ui/ctrl_file.c").read_text(encoding="utf-8")
+    focus_source = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
+
+    removed_validation = (
+        'AppStateValidatedCompatibilityShim("shim.focused-window-session-flag")'
     )
-    array_end = action_registry.index("};", array_start)
-    array_body = action_registry[array_start:array_end]
-    assert '"src/ui/appstate_focus.c"' in array_body
-    assert '"src/ui/ctrl_file_ops.c"' not in array_body
-    assert '"src/ui/ctrl_file.c"' not in array_body
-    assert '"src/ui/ctrl_dir.c"' not in array_body
-    assert '"src/ui/dir_ops.c"' not in array_body
-    assert '"src/ui/split_transition.c"' not in array_body
+    for source in [ctrl_dir, ctrl_file, focus_source]:
+        assert removed_validation not in source
 
 
-def test_focused_window_shim_metadata_describes_helper_only_boundary() -> None:
+def test_focused_window_shim_metadata_is_removed() -> None:
     shim_registry = Path("docs/appstate_compat_shims.json").read_text(
         encoding="utf-8"
     )
     action_registry = Path("src/core/appstate_actions.c").read_text(
         encoding="utf-8"
-    )
-
-    owner = "AppState focus compatibility carrier"
-    read_permission = (
-        "Allowed only inside AppState focus compatibility helpers while "
-        "panel-local focus_shape authority migration remains incomplete."
-    )
-    write_permission = (
-        "Write only from AppState focus compatibility helpers after the "
-        "active panel focus_shape has been updated."
-    )
-    removal_trigger = (
-        "AppState focus helpers no longer need a "
-        "ViewContext.focused_window compatibility fallback."
-    )
-    follow_up_task = (
-        "Remove the focused-window compatibility carrier once panel-local "
-        "focus commits fully cover active-focus recovery."
     )
 
     for text in [
-        owner,
-        read_permission,
-        write_permission,
-        removal_trigger,
-        follow_up_task,
+        "AppState focus compatibility carrier",
+        "ViewContext.focused_window",
+        "AppState focus helpers no longer need a ViewContext.focused_window compatibility fallback.",
     ]:
-        assert text in shim_registry
-        assert text in action_registry
+        assert text not in shim_registry
+        assert text not in action_registry
 
 
 def test_render_row_projection_uses_shared_helpers() -> None:
@@ -10040,7 +9995,7 @@ def test_split_seeded_focus_commits_use_appstate_helper() -> None:
     donate_end = panel_anchor.index("\nDirEntry *FindDirByPathInTree(", donate_start)
     donate_body = panel_anchor[donate_start:donate_end]
     assert 'include "ytnova_appstate_focus.h"' in panel_anchor
-    assert "BOOL DonatePanelState(ViewContext *ctx, YtreeNovaPanel *dst" in panel_header
+    assert "BOOL DonatePanelState(const ViewContext *ctx, YtreeNovaPanel *dst" in panel_header
     assert "AppStateCommitPanelFocus(ctx, dst, src->saved_focus)" in donate_body
     assert "AppStateCommitPanelFocus(ctx, dst, FOCUS_FILE)" in donate_body
     assert "AppStateCommitPanelFocus(ctx, dst, FOCUS_TREE)" in donate_body
@@ -10168,10 +10123,7 @@ def test_dir_ops_restore_file_shape_commits_use_appstate_helper() -> None:
         helper_start,
     )
     helper_body = focus_helper[helper_start:helper_end]
-    assert (
-        'AppStateValidatedCompatibilityShim("shim.focused-window-session-flag")'
-        in helper_body
-    )
+    assert 'AppStateValidatedCompatibilityShim("shim.focused-window-session-flag")' not in helper_body
     assert "dir_entry->big_window = big_file_view ? TRUE : FALSE;" in helper_body
 
     restore_start = dir_ops.index("\nDirEntry *RestorePanelFileSelection(")
@@ -10596,40 +10548,40 @@ int main(void) {
     return 19;
 
   invalid_shim =
-      *AppStateCompatibilityShimLookup("shim.focused-window-session-flag");
-  invalid_shim.write_capability = "read_only_projection";
-  if (AppStateValidateCompatibilityShim("shim.focused-window-session-flag",
+      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
+  invalid_shim.write_capability = "write_capable";
+  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
                                         &invalid_shim))
     return 20;
 
   invalid_shim =
-      *AppStateCompatibilityShimLookup("shim.focused-window-session-flag");
+      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
   invalid_shim.invariant_checks = missing_invariant_refs;
   invalid_shim.invariant_check_count = 1;
-  if (AppStateValidateCompatibilityShim("shim.focused-window-session-flag",
+  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
                                         &invalid_shim))
     return 21;
 
   invalid_shim =
-      *AppStateCompatibilityShimLookup("shim.focused-window-session-flag");
+      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
   invalid_shim.generation_domain_refs = missing_generation_domain_refs;
   invalid_shim.generation_domain_ref_count = 1;
-  if (AppStateValidateCompatibilityShim("shim.focused-window-session-flag",
+  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
                                         &invalid_shim))
     return 22;
 
   invalid_shim =
-      *AppStateCompatibilityShimLookup("shim.focused-window-session-flag");
+      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
   invalid_shim.diff_harness_refs = missing_diff_harness_refs;
   invalid_shim.diff_harness_ref_count = 1;
-  if (AppStateValidateCompatibilityShim("shim.focused-window-session-flag",
+  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
                                         &invalid_shim))
     return 23;
 
   invalid_shim =
-      *AppStateCompatibilityShimLookup("shim.focused-window-session-flag");
+      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
   invalid_shim.owner = "";
-  if (AppStateValidateCompatibilityShim("shim.focused-window-session-flag",
+  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
                                         &invalid_shim))
     return 24;
 


### PR DESCRIPTION
## Summary
- remove the obsolete `ViewContext.focused_window` carrier from AppState focus helpers and session state
- drop the focused-window compatibility shim from the runtime registry and required-shim set
- refresh the architecture note and contract guards to prove the carrier is gone while keeping render-shim coverage intact

## Validation
- red proof: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'test_compatibility_shim_boundaries_fail_closed_before_legacy_writes or test_render_footer_focus_reads_project_from_panel_state or test_focused_window_compatibility_carrier_is_removed or test_focused_window_shim_registry_removes_compatibility_carrier or test_focused_window_runtime_no_longer_validates_removed_shim or test_focused_window_shim_metadata_is_removed'`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `make`
- `git diff --check`
