### PR TITLE
refactor(appstate): remove render projection compatibility shim

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,27 +4,30 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-remove-focused-window-carrier
-Active PR: https://github.com/robkam/ytreenova/pull/370 (draft)
+Current branch: appstate-remove-render-row-shim
+Active PR: https://github.com/robkam/ytreenova/pull/371 (draft)
 Supersession state: no active stop or pause condition.
 
 Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/369 merged at `9b1bdd8` after green checks.
-- Local `main` and `origin/main` were aligned at `9b1bdd8` before this branch.
+- PR https://github.com/robkam/ytreenova/pull/370 merged at `aef1b36` after green checks.
+- Local `main` and `origin/main` were aligned at `aef1b36` before this branch.
 - The prior topic branch was deleted on merge and pruned locally/remotely.
 
 Current AppState batch:
-- Removes the obsolete `ViewContext.focused_window` compatibility carrier from `include/ytnova_defs.h` and `src/ui/appstate_focus.c` now that active-focus reads project from panel-local state.
-- Drops the focused-window shim from `docs/appstate_compat_shims.json`, `src/core/appstate_actions.c`, and `src/core/main.c` so the runtime registry no longer requires the removed carrier.
-- Removes no-longer-needed focused-window shim validation gates from `src/ui/ctrl_dir.c` and `src/ui/ctrl_file.c`.
-- Refreshes `docs/ARCHITECTURE.md` and `tests/test_appstate_contract_guard.py` to guard the carrier removal and keep the remaining render shim coverage intact.
+- Removes the last render-row compatibility shim from `docs/appstate_compat_shims.json`, `src/core/appstate_actions.c`, and `src/core/main.c` so the AppState contract no longer carries an empty runtime shim boundary.
+- Narrows render projection helpers in `include/ytnova_appstate_render.h`, `src/ui/appstate_render.c`, `src/ui/display.c`, and `src/ui/file_list.c` to explicit `file_count` inputs instead of panel-derived shim validation.
+- Teaches `scripts/check_appstate_contract.py` and `tests/test_appstate_contract_guard.py` that the compatibility shim registry can now be empty while still validating the remaining registry/runtime boundaries.
+- Syncs the tracked AI workflow bridge files for portable local defaults and tracked recovery checkpoint handling.
 
 Local validation:
-- Red proof before implementation: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'test_compatibility_shim_boundaries_fail_closed_before_legacy_writes or test_render_footer_focus_reads_project_from_panel_state or test_focused_window_compatibility_carrier_is_removed or test_focused_window_shim_registry_removes_compatibility_carrier or test_focused_window_runtime_no_longer_validates_removed_shim or test_focused_window_shim_metadata_is_removed'`
 - `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
 - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
+- `source .venv/bin/activate && pytest tests/test_project_ai_config_guard.py -q`
+- `python3 scripts/check_project_ai_config.py`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'test_render_projection_runtime_uses_no_compatibility_shim or test_runtime_shim_startup_requires_documented_shim_ids or test_runtime_registry_boundary_validation_requires_registered_metadata'`
+- `cppcheck --enable=all --inconclusive --force --std=c99 -I include --error-exitcode=1 --suppressions-list=.cppcheck-suppressions.txt src/core/appstate_actions.c src/core/main.c`
 - `make`
 - `git diff --check`
 
 Next action:
-- Follow the CI wait rule for PR https://github.com/robkam/ytreenova/pull/370 from the latest push that includes this checkpoint. If checks go green, mark ready when allowed, merge after branch protection/review requirements are satisfied, clean up branch state, update this checkpoint, then continue the next AppState batch unless superseded.
+- PR https://github.com/robkam/ytreenova/pull/371 failed the `Full local-equivalent QA gate (qa-all)` on `cppcheck` style findings caused by the zero-shim registry scaffolding. Amend the branch with the shim-count fix, push, then restart the CI wait rule from the new push time before checking status again.

--- a/.cline/skills.cline
+++ b/.cline/skills.cline
@@ -1,0 +1,27 @@
+# YtreeNova skill bridge
+
+Use this file only as a lightweight Cline bridge.
+The canonical skill content lives in `.ai/skills/*/SKILL.md`.
+
+## Persona defaults
+
+- `architect` -> `.ai/skills/architect-planning/SKILL.md`
+- `developer` -> `.ai/skills/developer-implementation/SKILL.md`
+- `code_auditor` -> `.ai/skills/code-auditor-gate/SKILL.md`
+- `tester` -> `.ai/skills/tester-regression-design/SKILL.md`
+- `greybeard` -> `.ai/skills/greybeard-meta-guidance/SKILL.md`
+
+## Cross-cutting auto-load
+
+- bugfix -> `.ai/skills/bugfix-red-green-proof/SKILL.md`
+- feature-sized or PR work -> `.ai/skills/full-audit-gate-c/SKILL.md`
+- PR review or conflict triage -> `.ai/skills/pr-gate-review/SKILL.md`
+- QA failure remediation -> `.ai/skills/qa-root-cause-remediation/SKILL.md`
+- PTY or `pexpect` debugging -> `.ai/skills/pty-pexpect-debug/SKILL.md`
+- ncurses rendering changes -> `.ai/skills/ncurses-render-safety/SKILL.md`
+- keybinding or help/menu key changes -> `.ai/skills/keybinding-collision-check/SKILL.md`
+- manpage or usage doc sync -> `.ai/skills/manpage-sync/SKILL.md`
+- UI workflow or menu-depth design -> `.ai/skills/ui-economy-navigation/SKILL.md`
+- UI prompt-chain or offender audit -> `.ai/skills/ui-flow-offender-audit/SKILL.md`
+- code-quality audit or cleanup -> `.ai/skills/code-quality/SKILL.md`
+- prose de-slop or AI-writing-tell work -> `.ai/skills/ai-writing-tells/SKILL.md`

--- a/.clinerules/01-ytreenova.md
+++ b/.clinerules/01-ytreenova.md
@@ -19,7 +19,7 @@ In Cline, treat those files as authoritative even when they mention Codex-specif
 
 ## Persona routing
 
-Choose the working role by user intent, then load the matching project skill through the `.cline/skills` bridge:
+Choose the working role by user intent, then load the matching project skill through `.cline/skills.cline`:
 
 - `architect` -> `architect-planning`
 - `developer` -> `developer-implementation`
@@ -51,6 +51,7 @@ Also load the matching project skill when the task calls for it:
 - Never have two active agents edit the same file at the same time.
 - Separate concurrent work by task, file set, or worktree.
 - For this repo, prefer the documented architect -> developer -> code_auditor loop over ad hoc parallel editing.
+- When the maintainer is using tracked recovery context, keep `.agent/handoffs/prompt.1.txt` current with the active unit and treat older prompt/report files as transient unless explicitly preserved.
 
 ## Validation and execution
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,7 +2,7 @@ model = "gpt-5.4"
 model_reasoning_effort = "high"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
-model_instructions_file = "/home/rob/ytreenova/.ai/codex.md"
+model_instructions_file = ".ai/codex.md"
 
 [mcp_servers.serena]
 command = "uvx"

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -211,7 +211,9 @@ make qa-fuzz
     *   atomic and independently verifiable,
     *   not fragmented into trivial micro-steps,
     *   executed one work item at a time.
-3.  Prompt/report artifacts used for handoff are workflow artifacts and MUST NOT be committed.
+3.  Handoff artifacts are split into:
+    *   tracked recovery checkpoint: keep `.agent/handoffs/prompt.1.txt` current and commit it with the active unit when the maintainer is using tracked recovery context,
+    *   transient prompt/report scratch artifacts: do not commit them unless the maintainer explicitly asks to preserve them.
 
 #### 3.1.2 Mission Definition Pass (Stateless Planning)
 
@@ -297,7 +299,7 @@ make qa-fuzz
 2.  Integrate branch to `main` using fast-forward only.
 3.  For any bug or task, mark final status (Fixed/Completed) in the commit that is fast-forwarded to main; before that, status must stay non-final (Confirmed/In Progress).
 4.  Delete temporary feature branch locally and on remote after merge.
-5.  Verify workflow artifacts are not committed.
+5.  Verify only the intended tracked recovery checkpoint is committed; stale transient handoff artifacts must stay out of the change.
 6.  Manual mode is default: one-unit-at-a-time architect -> developer -> auditor handoff.
 
 #### 3.1.8 Practical Prompt-Template Finish Flow (Consecutive Role Order)
@@ -310,7 +312,7 @@ Use this when wrapping up a PROMPT_TEMPLATE-driven mission and returning the rep
     *   Manually exercise the changed behavior.
 2.  **Maintainer -> Architect/AI:** If manual checks find issues, report failures; architect dispatches a new developer/auditor unit and repeats the loop until manual checks are green.
 3.  **Architect/AI:** Clean stale task artifacts from the finished mission (prompt/report/temp workflow files).
-    *   Required before final commit: remove stale handoff artifacts from `.agent/handoffs/` (for example `prompt.<id>.*.txt`, `report.<id>.*.txt`, and any consumed prompt/report files) unless the maintainer explicitly asks to keep them.
+    *   Required before final commit: keep `.agent/handoffs/prompt.1.txt` current when tracked recovery is in use, and remove or leave untracked stale transient handoff artifacts from `.agent/handoffs/` (for example consumed `prompt.<id>.*.txt` and `report.<id>.*.txt` files) unless the maintainer explicitly asks to keep them.
 4.  **Architect/AI:** Run quick local checks only (build + targeted smoke/tests for touched scope).
 5.  **Architect/AI:** Stage intended changes only (exclude unrelated local edits and workflow artifacts).
 6.  **Architect/AI:** Suggest a Conventional Commit subject and request maintainer commit-message approval.

--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -2,41 +2,5 @@
   "schema_version": 1,
   "contract": "AppState compatibility shim registry",
   "notes": "Compatibility shims document legacy authority paths that may remain during migration. They must be read/write classified and removed when the target transition boundary is live.",
-  "shims": [
-    {
-      "id": "shim-render-derived-row-position",
-      "owner": "AppState render projection helpers",
-      "old_authority_path": "disp_begin_pos + cursor_pos render-derived lookup",
-      "read_permission": "Allowed only inside AppState render projection helpers or bounds-correction code after identity restore has run.",
-      "write_permission": "Never write authoritative selection from AppState render projection helper calculations.",
-      "write_capability": "read_only_projection",
-      "invariant_checks": [
-        "invariant.render-projection-read-only",
-        "invariant.blocked-transition-determinism"
-      ],
-      "removal_trigger": "AppState render projection helpers accept explicit projection inputs and no longer inspect restore authority fields directly.",
-      "target_transition": "transition.render-reflow.project-state",
-      "follow_up_task": "Remove render-derived row compatibility helpers once render callers carry explicit projection state.",
-      "qa_enforcement": "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage.",
-      "owner_field_refs": [
-        "panel.tree_cursor_pos",
-        "panel.tree_viewport_origin",
-        "panel.file_viewport_origin"
-      ],
-      "generation_domain_refs": [
-        "generation.panel.local-authority",
-        "identity.directory.stable-key",
-        "identity.file.stable-key",
-        "reflow.layout.projection"
-      ],
-      "diff_harness_refs": [
-        "harness.render-projection-read-only-diff",
-        "harness.generation-mismatch-check",
-        "harness.blocked-transition-no-unrelated-mutation"
-      ],
-      "source_boundary_refs": [
-        "src/ui/appstate_render.c"
-      ]
-    }
-  ]
+  "shims": []
 }

--- a/include/ytnova_appstate_render.h
+++ b/include/ytnova_appstate_render.h
@@ -13,10 +13,10 @@
 BOOL AppStateCommitResizeRequest(ViewContext *ctx, BOOL resize_request);
 BOOL AppStateMarkResizeRequest(ViewContext *ctx);
 BOOL AppStateClearResizeRequest(ViewContext *ctx);
-void AppStateClampRenderFileViewport(const YtreeNovaPanel *panel,
+void AppStateClampRenderFileViewport(unsigned int file_count,
                                      int *render_start_ptr,
                                      int *render_cursor_ptr);
-int AppStateResolveRenderFileHighlight(const YtreeNovaPanel *panel,
+int AppStateResolveRenderFileHighlight(unsigned int file_count,
                                        int render_start, int render_cursor);
 
 #endif /* YTNOVA_APPSTATE_RENDER_H */

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -2128,6 +2128,14 @@ def _parse_runtime_shim_registry(
         re.S,
     )
     if match is None:
+        null_match = re.search(
+            r"static\s+const\s+AppStateCompatibilityShimMetadata\s+\*const\s+"
+            r"kAppStateCompatibilityShims\s*=\s*NULL\s*;",
+            source,
+            re.S,
+        )
+        if null_match is not None:
+            return [], failures
         return [], [f"{runtime_path}: failed to find runtime compatibility shim registry"]
 
     records: list[dict[str, Any]] = []
@@ -2218,9 +2226,6 @@ def _parse_runtime_shim_registry(
                 "qa_enforcement": row_match.group("qa_enforcement"),
             }
         )
-
-    if not records:
-        failures.append(f"{runtime_path}: runtime compatibility shim registry must not be empty")
     return records, failures
 
 
@@ -7655,8 +7660,8 @@ def validate_contract(
         shims = []
     else:
         shims = shims_doc.get("shims")
-        if not isinstance(shims, list) or not shims:
-            failures.append(f"{shims_path}: shims must be a non-empty list")
+        if not isinstance(shims, list):
+            failures.append(f"{shims_path}: shims must be a list")
             shims = []
 
     shim_ids: set[str] = set()

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -2790,34 +2790,6 @@ static const AppStateDispatchSurfaceMetadata kAppStateDispatchSurfaces[] = {
    kAppStateDispatchSurfaceMigrationNotes12,
    sizeof(kAppStateDispatchSurfaceMigrationNotes12) / sizeof(kAppStateDispatchSurfaceMigrationNotes12[0])},
 };
-static const char *const kAppStateCompatibilityShimInvariantChecks2[] = {
-  "invariant.render-projection-read-only",
-  "invariant.blocked-transition-determinism",
-};
-
-static const char *const kAppStateCompatibilityShimOwnerFieldRefs2[] = {
-  "panel.tree_cursor_pos",
-  "panel.tree_viewport_origin",
-  "panel.file_viewport_origin",
-};
-
-static const char *const kAppStateCompatibilityShimGenerationDomainRefs2[] = {
-  "generation.panel.local-authority",
-  "identity.directory.stable-key",
-  "identity.file.stable-key",
-  "reflow.layout.projection",
-};
-
-static const char *const kAppStateCompatibilityShimDiffHarnessRefs2[] = {
-  "harness.render-projection-read-only-diff",
-  "harness.generation-mismatch-check",
-  "harness.blocked-transition-no-unrelated-mutation",
-};
-
-static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {
-    "src/ui/appstate_render.c",
-};
-
 static const char *const kAppStateInvariantProtectedFields0[] = {
   "ctx.active",
   "panel.volume_key",
@@ -6260,31 +6232,7 @@ static const AppStateActionCoverageMetadata
 };
 
 static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
-  {"shim-render-derived-row-position",
-   "AppState render projection helpers",
-   "disp_begin_pos + cursor_pos render-derived lookup",
-   "Allowed only inside AppState render projection helpers or bounds-correction code after identity restore has run.",
-   "Never write authoritative selection from AppState render projection helper calculations.",
-   "read_only_projection",
-   kAppStateCompatibilityShimInvariantChecks2,
-   sizeof(kAppStateCompatibilityShimInvariantChecks2) /
-       sizeof(kAppStateCompatibilityShimInvariantChecks2[0]),
-   kAppStateCompatibilityShimOwnerFieldRefs2,
-   sizeof(kAppStateCompatibilityShimOwnerFieldRefs2) /
-       sizeof(kAppStateCompatibilityShimOwnerFieldRefs2[0]),
-   kAppStateCompatibilityShimGenerationDomainRefs2,
-    sizeof(kAppStateCompatibilityShimGenerationDomainRefs2) /
-        sizeof(kAppStateCompatibilityShimGenerationDomainRefs2[0]),
-    kAppStateCompatibilityShimDiffHarnessRefs2,
-    sizeof(kAppStateCompatibilityShimDiffHarnessRefs2) /
-        sizeof(kAppStateCompatibilityShimDiffHarnessRefs2[0]),
-    kAppStateCompatibilityShimSourceBoundaryRefs2,
-    sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2) /
-        sizeof(kAppStateCompatibilityShimSourceBoundaryRefs2[0]),
-   "AppState render projection helpers accept explicit projection inputs and no longer inspect restore authority fields directly.",
-   "transition.render-reflow.project-state",
-   "Remove render-derived row compatibility helpers once render callers carry explicit projection state.",
-   "check_appstate_contract.py requires render shims to declare no-write authority and target transition linkage."},
+    {0},
 };
 
 static int AppStateValidateActionCoverage(
@@ -6320,8 +6268,11 @@ size_t AppStateDispatchSurfaceCount(void) {
 }
 
 size_t AppStateCompatibilityShimCount(void) {
-  return sizeof(kAppStateCompatibilityShims) /
-         sizeof(kAppStateCompatibilityShims[0]);
+  size_t count = 0;
+
+  while (kAppStateCompatibilityShims[count].id != NULL)
+    count++;
+  return count;
 }
 
 size_t AppStateInvariantCount(void) {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -236,7 +236,7 @@ static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
 };
 
 static const char *const kAppStateRequiredShimIds[] = {
-  "shim-render-derived-row-position",
+  NULL,
 };
 
 static const char *const kAppStateRequiredInvariantIds[] = {
@@ -1668,10 +1668,17 @@ static int AppStateCompatibilityShimDiffHarnessCoversGenerationDomain(
   return 0;
 }
 
+static size_t AppStateRequiredShimIdCount(void) {
+  size_t count = 0;
+
+  while (kAppStateRequiredShimIds[count] != NULL)
+    count++;
+  return count;
+}
+
 static int AppStateCompatibilityShimsReady(void) {
   size_t index;
-  size_t required_shim_id_count =
-      sizeof(kAppStateRequiredShimIds) / sizeof(kAppStateRequiredShimIds[0]);
+  size_t required_shim_id_count = AppStateRequiredShimIdCount();
 
   if (AppStateCompatibilityShimCount() != required_shim_id_count)
     return 0;

--- a/src/ui/appstate_render.c
+++ b/src/ui/appstate_render.c
@@ -26,28 +26,26 @@ BOOL AppStateClearResizeRequest(ViewContext *ctx) {
   return AppStateCommitResizeRequest(ctx, FALSE);
 }
 
-void AppStateClampRenderFileViewport(const YtreeNovaPanel *panel,
+void AppStateClampRenderFileViewport(unsigned int file_count,
                                      int *render_start_ptr,
                                      int *render_cursor_ptr) {
   int render_start;
   int render_cursor;
 
-  if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
-    return;
-  if (!panel || !render_start_ptr || !render_cursor_ptr)
+  if (!render_start_ptr || !render_cursor_ptr)
     return;
 
   render_start = *render_start_ptr;
   render_cursor = *render_cursor_ptr;
-  if (panel->file_count > 0) {
+  if (file_count > 0) {
     if (render_start < 0)
       render_start = 0;
-    if ((unsigned int)render_start >= panel->file_count)
-      render_start = (int)panel->file_count - 1;
+    if ((unsigned int)render_start >= file_count)
+      render_start = (int)file_count - 1;
     if (render_cursor < 0)
       render_cursor = 0;
-    if ((unsigned int)(render_start + render_cursor) >= panel->file_count) {
-      render_cursor = (int)panel->file_count - 1 - render_start;
+    if ((unsigned int)(render_start + render_cursor) >= file_count) {
+      render_cursor = (int)file_count - 1 - render_start;
       if (render_cursor < 0)
         render_cursor = 0;
     }
@@ -60,11 +58,9 @@ void AppStateClampRenderFileViewport(const YtreeNovaPanel *panel,
   *render_cursor_ptr = render_cursor;
 }
 
-int AppStateResolveRenderFileHighlight(const YtreeNovaPanel *panel,
+int AppStateResolveRenderFileHighlight(unsigned int file_count,
                                        int render_start, int render_cursor) {
-  if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
-    return -1;
-  if (!panel || panel->file_count == 0)
+  if (file_count == 0)
     return -1;
 
   return render_start + render_cursor;

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -549,14 +549,15 @@ void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
       render_start = panel->start_file;
       render_cursor = panel->file_cursor_pos;
     }
-    AppStateClampRenderFileViewport(panel, &render_start, &render_cursor);
+    AppStateClampRenderFileViewport(panel->file_count, &render_start,
+                                    &render_cursor);
 
     if (IsPanelSavedBigFileMode(panel) && panel->pan_big_file_window) {
       int file_hilight = -1;
 
       if (panel->saved_focus == FOCUS_FILE) {
         file_hilight =
-            AppStateResolveRenderFileHighlight(panel, render_start,
+            AppStateResolveRenderFileHighlight(panel->file_count, render_start,
                                                render_cursor);
       }
       DEBUG_LOG("RenderInactivePanel:file path='%s' start=%d cursor=%d count=%u",
@@ -593,7 +594,7 @@ void RenderInactivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
 
         if (panel->saved_focus == FOCUS_FILE) {
           file_hilight =
-              AppStateResolveRenderFileHighlight(panel, render_start,
+              AppStateResolveRenderFileHighlight(panel->file_count, render_start,
                                                  render_cursor);
         }
         DisplayFiles(ctx, panel, de, render_start, file_hilight, 0,
@@ -681,8 +682,6 @@ void RefreshView(ViewContext *ctx, DirEntry *dir_entry) {
   if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))
     return;
   if (!AppStateValidatedEvent("event.render-reflow"))
-    return;
-  if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
     return;
 
   const Statistic *s = &ctx->active->vol->vol_stats;

--- a/src/ui/file_list.c
+++ b/src/ui/file_list.c
@@ -218,7 +218,8 @@ void DisplayFileWindow(ViewContext *ctx, YtreeNovaPanel *panel,
     int original_start = render_start;
     int original_cursor = render_cursor;
 
-    AppStateClampRenderFileViewport(panel, &render_start, &render_cursor);
+    AppStateClampRenderFileViewport(panel->file_count, &render_start,
+                                    &render_cursor);
     if (original_start != render_start || original_cursor != render_cursor) {
       DEBUG_LOG("DisplayFileWindow:clamp start=%d->%d cursor=%d->%d count=%u",
                 original_start, render_start, original_cursor, render_cursor,
@@ -228,7 +229,8 @@ void DisplayFileWindow(ViewContext *ctx, YtreeNovaPanel *panel,
 
   (void)AppStateCommitPanelFileViewport(panel, render_start, render_cursor);
 
-  highlight_idx = AppStateResolveRenderFileHighlight(panel, render_start,
+  highlight_idx = AppStateResolveRenderFileHighlight(panel->file_count,
+                                                     render_start,
                                                      render_cursor);
   if (AppStateResolveActivePanelFocus(ctx) != FOCUS_FILE)
     highlight_idx = -1;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9592,12 +9592,8 @@ def test_compatibility_shim_boundaries_fail_closed_before_legacy_writes() -> Non
 
     refresh_start = display.index("void RefreshView(")
     refresh_body = display[refresh_start:]
-    render_validation = (
-        'if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))'
-    )
-    assert render_validation in refresh_body
-    assert refresh_body.index(render_validation) < refresh_body.index("Layout_Recalculate(")
-    assert refresh_body.index(render_validation) < refresh_body.index("DisplayTree(")
+    render_validation = 'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")'
+    assert render_validation not in refresh_body
 
 
 def test_render_footer_focus_reads_project_from_panel_state() -> None:
@@ -9834,32 +9830,39 @@ def test_render_row_projection_uses_shared_helpers() -> None:
     display = Path("src/ui/display.c").read_text(encoding="utf-8")
     file_list = Path("src/ui/file_list.c").read_text(encoding="utf-8")
 
-    assert "void AppStateClampRenderFileViewport(" in render_helpers
-    assert "int AppStateResolveRenderFileHighlight(" in render_helpers
+    assert "void AppStateClampRenderFileViewport(unsigned int file_count," in (
+        render_helpers
+    )
+    assert "int AppStateResolveRenderFileHighlight(unsigned int file_count," in (
+        render_helpers
+    )
+    assert 'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")' not in render_helpers
 
     render_start = display.index("void RenderInactivePanel(")
     render_end = display.index("\nstatic BOOL IsActivePanelBigFileMode(", render_start)
     render_body = display[render_start:render_end]
 
     assert (
-        "AppStateClampRenderFileViewport(panel, &render_start, &render_cursor);"
+        "AppStateClampRenderFileViewport(panel->file_count, &render_start,"
         in render_body
     )
-    assert "AppStateResolveRenderFileHighlight(panel, render_start" in render_body
+    assert "AppStateResolveRenderFileHighlight(panel->file_count, render_start" in (
+        render_body
+    )
     assert "render_start + render_cursor" not in render_body
 
     file_start = file_list.index("void DisplayFileWindow(")
     file_body = file_list[file_start:]
 
     assert (
-        "AppStateClampRenderFileViewport(panel, &render_start, &render_cursor);"
+        "AppStateClampRenderFileViewport(panel->file_count, &render_start,"
         in file_body
     )
-    assert "AppStateResolveRenderFileHighlight(panel, render_start" in file_body
+    assert "AppStateResolveRenderFileHighlight(panel->file_count," in file_body
     assert "render_start + render_cursor" not in file_body
 
 
-def test_render_row_shim_registry_matches_shared_helper_boundary() -> None:
+def test_render_row_shim_registry_is_removed() -> None:
     shim_registry = Path("docs/appstate_compat_shims.json").read_text(
         encoding="utf-8"
     )
@@ -9867,56 +9870,26 @@ def test_render_row_shim_registry_matches_shared_helper_boundary() -> None:
         encoding="utf-8"
     )
 
-    assert '"source_boundary_refs": [' in shim_registry
-    assert '"src/ui/appstate_render.c"' in shim_registry
-    assert '"src/ui/display.c"' not in shim_registry
-    assert '"src/ui/file_list.c"' not in shim_registry
-
-    array_start = action_registry.index(
-        "static const char *const kAppStateCompatibilityShimSourceBoundaryRefs2[] = {"
-    )
-    array_end = action_registry.index("};", array_start)
-    array_body = action_registry[array_start:array_end]
-    assert '"src/ui/appstate_render.c"' in array_body
-    assert '"src/ui/display.c"' not in array_body
-    assert '"src/ui/file_list.c"' not in array_body
+    assert '"shims": []' in shim_registry
+    assert "shim-render-derived-row-position" not in shim_registry
+    assert "shim-render-derived-row-position" not in action_registry
 
 
-def test_render_row_shim_metadata_describes_helper_boundary() -> None:
+def test_render_row_shim_metadata_is_removed() -> None:
     shim_registry = Path("docs/appstate_compat_shims.json").read_text(
         encoding="utf-8"
     )
     action_registry = Path("src/core/appstate_actions.c").read_text(
         encoding="utf-8"
-    )
-
-    owner = "AppState render projection helpers"
-    read_permission = (
-        "Allowed only inside AppState render projection helpers or "
-        "bounds-correction code after identity restore has run."
-    )
-    write_permission = (
-        "Never write authoritative selection from AppState render projection "
-        "helper calculations."
-    )
-    removal_trigger = (
-        "AppState render projection helpers accept explicit projection inputs "
-        "and no longer inspect restore authority fields directly."
-    )
-    follow_up_task = (
-        "Remove render-derived row compatibility helpers once render callers "
-        "carry explicit projection state."
     )
 
     for text in [
-        owner,
-        read_permission,
-        write_permission,
-        removal_trigger,
-        follow_up_task,
+        "AppState render projection helpers",
+        "disp_begin_pos + cursor_pos render-derived lookup",
+        "Remove render-derived row compatibility helpers once render callers carry explicit projection state.",
     ]:
-        assert text in shim_registry
-        assert text in action_registry
+        assert text not in shim_registry
+        assert text not in action_registry
 
 
 def test_split_file_focus_commits_use_appstate_helper() -> None:
@@ -10463,15 +10436,8 @@ int main(void) {
   AppStateGenerationDomainMetadata invalid_generation_domain;
   AppStateDiffHarnessMetadata invalid_diff_harness;
   AppStateTransitionSequenceMetadata invalid_sequence;
-  AppStateCompatibilityShimMetadata invalid_shim;
   static const char *const missing_invariant_refs[] = {
       "invariant.__ytnova_missing__",
-  };
-  static const char *const missing_generation_domain_refs[] = {
-      "generation.__ytnova_missing__",
-  };
-  static const char *const missing_diff_harness_refs[] = {
-      "harness.__ytnova_missing__",
   };
 
   if (!AppStateValidatedTransition("transition.keybinding.navigate-tree"))
@@ -10486,7 +10452,7 @@ int main(void) {
     return 5;
   if (!AppStateValidatedTransitionSequence("sequence.split-toggle-f8"))
     return 6;
-  if (!AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
+  if (AppStateCompatibilityShimCount() != 0)
     return 7;
 
   if (AppStateValidatedTransition(NULL))
@@ -10547,42 +10513,15 @@ int main(void) {
                                          &invalid_sequence))
     return 19;
 
-  invalid_shim =
-      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
-  invalid_shim.write_capability = "write_capable";
-  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
-                                        &invalid_shim))
+  if (AppStateCompatibilityShimCount() != 0)
     return 20;
-
-  invalid_shim =
-      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
-  invalid_shim.invariant_checks = missing_invariant_refs;
-  invalid_shim.invariant_check_count = 1;
-  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
-                                        &invalid_shim))
+  if (AppStateCompatibilityShimAt(0) != NULL)
     return 21;
-
-  invalid_shim =
-      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
-  invalid_shim.generation_domain_refs = missing_generation_domain_refs;
-  invalid_shim.generation_domain_ref_count = 1;
-  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
-                                        &invalid_shim))
+  if (AppStateCompatibilityShimLookup("shim-render-derived-row-position") != NULL)
     return 22;
-
-  invalid_shim =
-      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
-  invalid_shim.diff_harness_refs = missing_diff_harness_refs;
-  invalid_shim.diff_harness_ref_count = 1;
-  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
-                                        &invalid_shim))
+  if (AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
     return 23;
-
-  invalid_shim =
-      *AppStateCompatibilityShimLookup("shim-render-derived-row-position");
-  invalid_shim.owner = "";
-  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position",
-                                        &invalid_shim))
+  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position", NULL))
     return 24;
 
   return 0;
@@ -11866,87 +11805,16 @@ def test_guard_fails_when_runtime_event_validation_moves_outside_source_boundary
     )
 
 
-def test_guard_fails_when_runtime_shim_validation_callsite_is_missing(
-    tmp_path: Path,
-) -> None:
-    shutil.copytree(REPO_ROOT / "src", tmp_path / "src")
-    source_path = tmp_path / "src" / "ui" / "appstate_render.c"
-    original = source_path.read_text(encoding="utf-8")
-    mutated = original.replace(
-        'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")',
-        'AppStateValidatedCompatibilityShim("shim-render-derived-row-position-missing")',
-    )
-    assert mutated != original
-    source_path.write_text(mutated, encoding="utf-8")
+def test_render_projection_runtime_uses_no_compatibility_shim() -> None:
+    main_source = Path("src/core/main.c").read_text(encoding="utf-8")
+    display_source = Path("src/ui/display.c").read_text(encoding="utf-8")
+    render_source = Path("src/ui/appstate_render.c").read_text(encoding="utf-8")
 
-    failures = guard.validate_contract(
-        guard.DEFAULT_TRANSITIONS,
-        guard.DEFAULT_SHIMS,
-        guard.DEFAULT_ACTION_COVERAGE,
-        guard.DEFAULT_ACTION_HEADER,
-        guard.DEFAULT_EVENT_COVERAGE,
-        guard.DEFAULT_OWNER_FIELDS,
-        guard.DEFAULT_DISPATCH_SURFACES,
-        guard.DEFAULT_INVARIANTS,
-        guard.DEFAULT_GENERATION_DOMAINS,
-        guard.DEFAULT_DIFF_HARNESS,
-        guard.DEFAULT_TRANSITION_SEQUENCES,
-        guard.DEFAULT_ACTION_RUNTIME,
-        repository_root=tmp_path,
-    )
-
-    assert any(
-        "shim-render-derived-row-position" in failure
-        and "missing runtime validation callsite" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_validation_moves_outside_source_boundary(
-    tmp_path: Path,
-) -> None:
-    shutil.copytree(REPO_ROOT / "src", tmp_path / "src")
-    source_path = tmp_path / "src" / "ui" / "appstate_render.c"
-    original = source_path.read_text(encoding="utf-8")
-    mutated = original.replace(
-        'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")',
-        'AppStateValidatedCompatibilityShim("shim-render-derived-row-position-missing")',
-    )
-    assert mutated != original
-    source_path.write_text(mutated, encoding="utf-8")
-
-    unrelated_source_path = tmp_path / "src" / "core" / "main.c"
-    unrelated_original = unrelated_source_path.read_text(encoding="utf-8")
-    injected = unrelated_original.replace(
-        "int main(int argc, char **argv) {",
-        'int main(int argc, char **argv) {\n  (void)AppStateValidatedCompatibilityShim("shim-render-derived-row-position");',
-        1,
-    )
-    assert injected != unrelated_original
-    unrelated_source_path.write_text(injected, encoding="utf-8")
-
-    failures = guard.validate_contract(
-        guard.DEFAULT_TRANSITIONS,
-        guard.DEFAULT_SHIMS,
-        guard.DEFAULT_ACTION_COVERAGE,
-        guard.DEFAULT_ACTION_HEADER,
-        guard.DEFAULT_EVENT_COVERAGE,
-        guard.DEFAULT_OWNER_FIELDS,
-        guard.DEFAULT_DISPATCH_SURFACES,
-        guard.DEFAULT_INVARIANTS,
-        guard.DEFAULT_GENERATION_DOMAINS,
-        guard.DEFAULT_DIFF_HARNESS,
-        guard.DEFAULT_TRANSITION_SEQUENCES,
-        guard.DEFAULT_ACTION_RUNTIME,
-        repository_root=tmp_path,
-    )
-
-    assert any(
-        "shim-render-derived-row-position" in failure
-        and "src/ui/appstate_render.c" in failure
-        and "missing runtime validation callsite" in failure
-        for failure in failures
-    )
+    assert "static const char *const kAppStateRequiredShimIds[] = {" in main_source
+    assert "NULL," in main_source
+    assert "AppStateRequiredShimIdCount(void)" in main_source
+    assert 'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")' not in display_source
+    assert 'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")' not in render_source
 
 
 def test_guard_fails_on_malformed_dispatch_surface_entry_symbol_or_path(
@@ -17630,15 +17498,18 @@ def test_runtime_shim_startup_requires_documented_shim_ids() -> None:
         source,
         re.S,
     )
-
     assert shim_failures == []
     assert required_table is not None
-    table_ids, table_failures = guard._parse_string_initializer_array(
-        required_table.group("body"),
-        "kAppStateRequiredShimIds",
-    )
-    assert table_failures == []
-    assert set(table_ids) == required_ids
+    if required_ids:
+        table_ids, table_failures = guard._parse_string_initializer_array(
+            required_table.group("body"),
+            "kAppStateRequiredShimIds",
+        )
+        assert table_failures == []
+        assert set(table_ids) == required_ids
+    else:
+        assert "NULL" in required_table.group("body")
+        assert "AppStateRequiredShimIdCount(void)" in source
     assert re.search(
         r"AppStateCompatibilityShimLookup\(\s*"
         r"kAppStateRequiredShimIds\[index\]\s*\)",


### PR DESCRIPTION
## Summary
- remove the final render-row compatibility shim from the AppState registry and startup contract checks
- pass explicit file-count projection inputs through the shared render helpers and drop runtime shim validation
- allow an empty shim registry in the contract guards while keeping the tracked recovery and local AI bridge defaults in sync

## Validation
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_project_ai_config_guard.py -q`
- `python3 scripts/check_project_ai_config.py`
- `make`
- `git diff --check`