### PR TITLE
refactor(appstate): drop dead compatibility shim runtime surface

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,30 +4,21 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-remove-render-row-shim
-Active PR: https://github.com/robkam/ytreenova/pull/371 (draft)
+Current branch: appstate-remove-shim-runtime-support
+Active PR: https://github.com/robkam/ytreenova/pull/372
 Supersession state: no active stop or pause condition.
 
-Recently merged AppState batch:
-- PR https://github.com/robkam/ytreenova/pull/370 merged at `aef1b36` after green checks.
-- Local `main` and `origin/main` were aligned at `aef1b36` before this branch.
-- The prior topic branch was deleted on merge and pruned locally/remotely.
-
 Current AppState batch:
-- Removes the last render-row compatibility shim from `docs/appstate_compat_shims.json`, `src/core/appstate_actions.c`, and `src/core/main.c` so the AppState contract no longer carries an empty runtime shim boundary.
-- Narrows render projection helpers in `include/ytnova_appstate_render.h`, `src/ui/appstate_render.c`, `src/ui/display.c`, and `src/ui/file_list.c` to explicit `file_count` inputs instead of panel-derived shim validation.
-- Teaches `scripts/check_appstate_contract.py` and `tests/test_appstate_contract_guard.py` that the compatibility shim registry can now be empty while still validating the remaining registry/runtime boundaries.
-- Syncs the tracked AI workflow bridge files for portable local defaults and tracked recovery checkpoint handling.
+- Remove dead compatibility shim runtime support now that `docs/appstate_compat_shims.json` is empty and no runtime shim validation callsites remain.
+- Runtime/header removal is implemented in `include/ytnova_appstate_actions.h`, `src/core/appstate_actions.c`, and `src/core/main.c`.
+- The contract guard no longer parses or validates a runtime shim registry, and the matching tests/fixtures were trimmed in `scripts/check_appstate_contract.py` and `tests/test_appstate_contract_guard.py`.
+- The render reflow path no longer gates on shim validation in `src/ui/display.c`.
 
 Local validation:
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q`
-- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- `source .venv/bin/activate && pytest tests/test_project_ai_config_guard.py -q`
-- `python3 scripts/check_project_ai_config.py`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -q -k 'test_render_projection_runtime_uses_no_compatibility_shim or test_runtime_shim_startup_requires_documented_shim_ids or test_runtime_registry_boundary_validation_requires_registered_metadata'`
-- `cppcheck --enable=all --inconclusive --force --std=c99 -I include --error-exitcode=1 --suppressions-list=.cppcheck-suppressions.txt src/core/appstate_actions.c src/core/main.c`
 - `make`
-- `git diff --check`
+- `python3 scripts/check_appstate_contract.py`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'shim or runtime_registry_boundary_validation_requires_registered_metadata or render_projection_runtime_uses_no_compatibility_shim'`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'test_runtime_generation_domain_ref_readiness_uses_coverage_transitions or shim or runtime_registry_boundary_validation_requires_registered_metadata or render_projection_runtime_uses_no_compatibility_shim'`
 
 Next action:
-- PR https://github.com/robkam/ytreenova/pull/371 failed the `Full local-equivalent QA gate (qa-all)` on `cppcheck` style findings caused by the zero-shim registry scaffolding. Amend the branch with the shim-count fix, push, then restart the CI wait rule from the new push time before checking status again.
+- Push the amended PR fix for the coverage guard helper-slice failure, restart the CI wait clock, then follow the CI wait rule until mergeable.

--- a/.ai/skills.cline
+++ b/.ai/skills.cline
@@ -1,0 +1,4 @@
+Discovery stub for repo-local skills.
+
+Canonical skill procedures live under `.ai/skills/*/SKILL.md`.
+Load behavior and precedence are defined in `.ai/shared.md`.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,6 +2,8 @@ model = "gpt-5.4"
 model_reasoning_effort = "high"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
+# Repo-shared defaults only; keep user-specific auth/session state in the
+# user-local Codex config.
 model_instructions_file = ".ai/codex.md"
 
 [mcp_servers.serena]

--- a/01-ytreenova.md
+++ b/01-ytreenova.md
@@ -1,0 +1,5 @@
+# YtreeNova quick context
+
+- Canonical repo instructions: `AGENTS.md`, `.ai/codex.md`, `.ai/shared.md`
+- Core references: `docs/ARCHITECTURE.md`, `docs/SPECIFICATION.md`, `docs/ROADMAP.md`
+- Generated usage docs: edit `etc/ytnova.1.md`, not `docs/USAGE.md`

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -214,6 +214,7 @@ make qa-fuzz
 3.  Handoff artifacts are split into:
     *   tracked recovery checkpoint: keep `.agent/handoffs/prompt.1.txt` current and commit it with the active unit when the maintainer is using tracked recovery context,
     *   transient prompt/report scratch artifacts: do not commit them unless the maintainer explicitly asks to preserve them.
+4.  When tracked recovery context is active, refresh the committed checkpoint before the branch's first push and again after merge/cleanup so the next autonomous resume starts from current branch and PR state.
 
 #### 3.1.2 Mission Definition Pass (Stateless Planning)
 

--- a/include/ytnova_appstate_actions.h
+++ b/include/ytnova_appstate_actions.h
@@ -106,29 +106,6 @@ typedef struct {
 } AppStateDispatchSurfaceMetadata;
 
 typedef struct {
-  const char *id;
-  const char *owner;
-  const char *old_authority_path;
-  const char *read_permission;
-  const char *write_permission;
-  const char *write_capability;
-  const char *const *invariant_checks;
-  size_t invariant_check_count;
-  const char *const *owner_field_refs;
-  size_t owner_field_ref_count;
-  const char *const *generation_domain_refs;
-  size_t generation_domain_ref_count;
-  const char *const *diff_harness_refs;
-  size_t diff_harness_ref_count;
-  const char *const *source_boundary_refs;
-  size_t source_boundary_ref_count;
-  const char *removal_trigger;
-  const char *target_transition;
-  const char *follow_up_task;
-  const char *qa_enforcement;
-} AppStateCompatibilityShimMetadata;
-
-typedef struct {
   const char *invariant_id;
   const char *category;
   const char *owner_region;
@@ -270,12 +247,6 @@ AppStateDispatchSurfaceLookup(const char *surface_id);
 int AppStateValidatedDispatchSurface(const char *surface_id);
 const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index);
 size_t AppStateDispatchSurfaceCount(void);
-const AppStateCompatibilityShimMetadata *
-AppStateCompatibilityShimLookup(const char *shim_id);
-int AppStateValidatedCompatibilityShim(const char *shim_id);
-const AppStateCompatibilityShimMetadata *
-AppStateCompatibilityShimAt(size_t index);
-size_t AppStateCompatibilityShimCount(void);
 const AppStateInvariantMetadata *
 AppStateInvariantLookup(const char *invariant_id);
 int AppStateValidatedInvariant(const char *invariant_id);

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -396,9 +396,6 @@ DISPATCH_SURFACE_CALLSITE_RE = re.compile(
     r'AppStateValidatedDispatchSurface\s*\(\s*"([^"]+)"\s*\)'
 )
 EVENT_CALLSITE_RE = re.compile(r'AppStateValidatedEvent\s*\(\s*"([^"]+)"\s*\)')
-SHIM_CALLSITE_RE = re.compile(
-    r'AppStateValidatedCompatibilityShim\s*\(\s*"([^"]+)"\s*\)'
-)
 KEY_ACTION_CALLSITE_RE = re.compile(r"\bAppStateValidatedKeyAction\s*\(")
 DECODED_ACTION_DISPATCH_SURFACE_CATEGORIES = {
     "key_decode_input_dispatch",
@@ -2033,202 +2030,6 @@ def _parse_runtime_transition_sequence_registry(
         )
     return records, failures
 
-def _parse_runtime_shim_registry(
-    runtime_path: Path,
-) -> tuple[list[dict[str, Any]], list[str]]:
-    try:
-        source = runtime_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        return [], [f"{runtime_path}: failed to read: {exc}"]
-
-    invariant_tables: dict[str, list[str]] = {}
-    owner_ref_tables: dict[str, list[str]] = {}
-    generation_domain_ref_tables: dict[str, list[str]] = {}
-    diff_harness_ref_tables: dict[str, list[str]] = {}
-    source_boundary_ref_tables: dict[str, list[str]] = {}
-    failures: list[str] = []
-    invariant_re = re.compile(
-        r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateCompatibilityShimInvariantChecks[0-9]+)\[\]\s*=\s*\{"
-        r"(?P<body>.*?)\};",
-        re.S,
-    )
-    for invariant_match in invariant_re.finditer(source):
-        table_name = invariant_match.group(1)
-        values, array_failures = _parse_string_initializer_array(
-            invariant_match.group("body"),
-            table_name,
-        )
-        invariant_tables[table_name] = values
-        failures.extend(array_failures)
-
-    owner_ref_re = re.compile(
-        r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateCompatibilityShimOwnerFieldRefs[0-9]+)\[\]\s*=\s*\{"
-        r"(?P<body>.*?)\};",
-        re.S,
-    )
-    for owner_ref_match in owner_ref_re.finditer(source):
-        table_name = owner_ref_match.group(1)
-        values, array_failures = _parse_string_initializer_array(
-            owner_ref_match.group("body"),
-            table_name,
-        )
-        owner_ref_tables[table_name] = values
-        failures.extend(array_failures)
-
-    generation_domain_ref_re = re.compile(
-        r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateCompatibilityShimGenerationDomainRefs[0-9]+)\[\]\s*=\s*\{"
-        r"(?P<body>.*?)\};",
-        re.S,
-    )
-    for generation_domain_ref_match in generation_domain_ref_re.finditer(source):
-        table_name = generation_domain_ref_match.group(1)
-        values, array_failures = _parse_string_initializer_array(
-            generation_domain_ref_match.group("body"),
-            table_name,
-        )
-        generation_domain_ref_tables[table_name] = values
-        failures.extend(array_failures)
-
-    diff_harness_ref_re = re.compile(
-        r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateCompatibilityShimDiffHarnessRefs[0-9]+)\[\]\s*=\s*\{"
-        r"(?P<body>.*?)\};",
-        re.S,
-    )
-    for diff_harness_ref_match in diff_harness_ref_re.finditer(source):
-        table_name = diff_harness_ref_match.group(1)
-        values, array_failures = _parse_string_initializer_array(
-            diff_harness_ref_match.group("body"),
-            table_name,
-        )
-        diff_harness_ref_tables[table_name] = values
-        failures.extend(array_failures)
-
-    source_boundary_ref_re = re.compile(
-        r"static\s+const\s+char\s+\*const\s+"
-        r"(kAppStateCompatibilityShimSourceBoundaryRefs[0-9]+)\[\]\s*=\s*\{"
-        r"(?P<body>.*?)\};",
-        re.S,
-    )
-    for source_boundary_ref_match in source_boundary_ref_re.finditer(source):
-        table_name = source_boundary_ref_match.group(1)
-        values, array_failures = _parse_string_initializer_array(
-            source_boundary_ref_match.group("body"),
-            table_name,
-        )
-        source_boundary_ref_tables[table_name] = values
-        failures.extend(array_failures)
-
-    match = re.search(
-        r"kAppStateCompatibilityShims\s*\[\]\s*=\s*\{(?P<body>.*?)\};",
-        source,
-        re.S,
-    )
-    if match is None:
-        null_match = re.search(
-            r"static\s+const\s+AppStateCompatibilityShimMetadata\s+\*const\s+"
-            r"kAppStateCompatibilityShims\s*=\s*NULL\s*;",
-            source,
-            re.S,
-        )
-        if null_match is not None:
-            return [], failures
-        return [], [f"{runtime_path}: failed to find runtime compatibility shim registry"]
-
-    records: list[dict[str, Any]] = []
-    row_re = re.compile(
-        r"\{\s*\"(?P<id>[^\"]*)\"\s*,\s*\"(?P<owner>[^\"]*)\"\s*,"
-        r"\s*\"(?P<old_authority_path>[^\"]*)\"\s*,"
-        r"\s*\"(?P<read_permission>[^\"]*)\"\s*,"
-        r"\s*\"(?P<write_permission>[^\"]*)\"\s*,"
-        r"\s*\"(?P<write_capability>[^\"]*)\"\s*,"
-        r"\s*(?P<invariants>kAppStateCompatibilityShimInvariantChecks[0-9]+)\s*,"
-        r"\s*sizeof\((?P=invariants)\)\s*/"
-        r"\s*sizeof\((?P=invariants)\[0\]\)\s*,"
-        r"\s*(?P<owner_refs>kAppStateCompatibilityShimOwnerFieldRefs[0-9]+)\s*,"
-        r"\s*sizeof\((?P=owner_refs)\)\s*/"
-        r"\s*sizeof\((?P=owner_refs)\[0\]\)\s*,"
-        r"\s*(?P<generation_refs>kAppStateCompatibilityShimGenerationDomainRefs[0-9]+)\s*,"
-        r"\s*sizeof\((?P=generation_refs)\)\s*/"
-        r"\s*sizeof\((?P=generation_refs)\[0\]\)\s*,"
-        r"\s*(?P<diff_refs>kAppStateCompatibilityShimDiffHarnessRefs[0-9]+)\s*,"
-        r"\s*sizeof\((?P=diff_refs)\)\s*/"
-        r"\s*sizeof\((?P=diff_refs)\[0\]\)\s*,"
-        r"\s*(?P<source_boundary_refs>kAppStateCompatibilityShimSourceBoundaryRefs[0-9]+)\s*,"
-        r"\s*sizeof\((?P=source_boundary_refs)\)\s*/"
-        r"\s*sizeof\((?P=source_boundary_refs)\[0\]\)\s*,"
-        r"\s*\"(?P<removal_trigger>[^\"]*)\"\s*,"
-        r"\s*\"(?P<target_transition>[^\"]*)\"\s*,"
-        r"\s*\"(?P<follow_up_task>[^\"]*)\"\s*,"
-        r"\s*\"(?P<qa_enforcement>[^\"]*)\"\s*\}",
-        re.S,
-    )
-    for index, row_match in enumerate(row_re.finditer(match.group("body"))):
-        invariant_table_name = row_match.group("invariants")
-        invariant_checks = invariant_tables.get(invariant_table_name)
-        if invariant_checks is None:
-            failures.append(
-                f"runtime_shim[{index}]: unknown invariant-check table: {invariant_table_name}"
-            )
-            invariant_checks = []
-        owner_ref_table_name = row_match.group("owner_refs")
-        owner_field_refs = owner_ref_tables.get(owner_ref_table_name)
-        if owner_field_refs is None:
-            failures.append(
-                f"runtime_shim[{index}]: unknown owner-field-ref table: {owner_ref_table_name}"
-            )
-            owner_field_refs = []
-        generation_ref_table_name = row_match.group("generation_refs")
-        generation_domain_refs = generation_domain_ref_tables.get(
-            generation_ref_table_name
-        )
-        if generation_domain_refs is None:
-            failures.append(
-                f"runtime_shim[{index}]: unknown generation-domain-ref table: {generation_ref_table_name}"
-            )
-            generation_domain_refs = []
-        diff_ref_table_name = row_match.group("diff_refs")
-        diff_harness_refs = diff_harness_ref_tables.get(diff_ref_table_name)
-        if diff_harness_refs is None:
-            failures.append(
-                f"runtime_shim[{index}]: unknown diff-harness-ref table: {diff_ref_table_name}"
-            )
-            diff_harness_refs = []
-        source_boundary_ref_table_name = row_match.group("source_boundary_refs")
-        source_boundary_refs = source_boundary_ref_tables.get(
-            source_boundary_ref_table_name
-        )
-        if source_boundary_refs is None:
-            failures.append(
-                f"runtime_shim[{index}]: unknown source-boundary-ref table: "
-                f"{source_boundary_ref_table_name}"
-            )
-            source_boundary_refs = []
-        records.append(
-            {
-                "id": row_match.group("id"),
-                "owner": row_match.group("owner"),
-                "old_authority_path": row_match.group("old_authority_path"),
-                "read_permission": row_match.group("read_permission"),
-                "write_permission": row_match.group("write_permission"),
-                "write_capability": row_match.group("write_capability"),
-                "invariant_checks": invariant_checks,
-                "owner_field_refs": owner_field_refs,
-                "generation_domain_refs": generation_domain_refs,
-                "diff_harness_refs": diff_harness_refs,
-                "source_boundary_refs": source_boundary_refs,
-                "removal_trigger": row_match.group("removal_trigger"),
-                "target_transition": row_match.group("target_transition"),
-                "follow_up_task": row_match.group("follow_up_task"),
-                "qa_enforcement": row_match.group("qa_enforcement"),
-            }
-        )
-    return records, failures
-
-
 def _validate_runtime_action_lookup(
     *,
     runtime_records: list[dict[str, str]],
@@ -3476,162 +3277,6 @@ def _validate_runtime_diff_harness_registry(
     if missing_ids:
         failures.append(
             f"{runtime_path}: runtime diff harness registry missing harness id(s): "
-            + ", ".join(missing_ids)
-        )
-
-    return failures
-
-
-def _validate_runtime_shim_registry(
-    *,
-    runtime_records: list[dict[str, Any]],
-    runtime_path: Path,
-    shim_records: list[Any],
-    runtime_transition_ids: dict[str, dict[str, Any]],
-    runtime_owner_fields: set[str],
-    runtime_invariant_ids: set[str],
-    runtime_invariant_transition_ids: dict[str, set[str]],
-    runtime_generation_domain_owner_fields: dict[str, str],
-    runtime_diff_harness_ids: set[str],
-    runtime_diff_harness_transition_ids: dict[str, set[str]],
-    runtime_diff_harness_owner_field_refs: dict[str, set[str]],
-    runtime_diff_harness_invariant_ids: dict[str, set[str]],
-    runtime_diff_harness_generation_domain_ids: dict[str, set[str]],
-) -> list[str]:
-    failures: list[str] = []
-    expected_shims = {
-        record["id"]: record
-        for record in shim_records
-        if isinstance(record, dict)
-        and isinstance(record.get("id"), str)
-        and record["id"].strip()
-    }
-    expected_ids = set(expected_shims)
-    covered_ids: set[str] = set()
-
-    for index, record in enumerate(runtime_records):
-        label = f"runtime_shim[{index}]"
-        runtime_id = record["id"]
-        if runtime_id in covered_ids:
-            failures.append(f"{label}: duplicate runtime shim id: {runtime_id}")
-        covered_ids.add(runtime_id)
-
-        shim_record = expected_shims.get(runtime_id)
-        if shim_record is None:
-            failures.append(f"{label}: id does not match a shim id: {runtime_id}")
-        else:
-            for field in (
-                "owner",
-                "old_authority_path",
-                "read_permission",
-                "write_permission",
-                "write_capability",
-                "invariant_checks",
-                "owner_field_refs",
-                "generation_domain_refs",
-                "diff_harness_refs",
-                "source_boundary_refs",
-                "removal_trigger",
-                "target_transition",
-                "follow_up_task",
-                "qa_enforcement",
-            ):
-                if record.get(field) != shim_record.get(field):
-                    failures.append(
-                        f"{label}: runtime {field} does not match shim "
-                        f"{runtime_id}: {record.get(field)}"
-                    )
-
-        failures.extend(_validate_shim_write_capability(record, label))
-
-        invariant_checks = record.get("invariant_checks")
-        if not isinstance(invariant_checks, list) or not invariant_checks:
-            failures.append(f"{label}: invariant_checks must be non-empty")
-        else:
-            failures.extend(
-                _validate_invariant_check_refs(
-                    invariant_checks=invariant_checks,
-                    runtime_invariant_ids=runtime_invariant_ids,
-                    label=label,
-                )
-            )
-
-        target_transition = record.get("target_transition")
-        if (
-            isinstance(target_transition, str)
-            and target_transition.strip()
-            and target_transition not in runtime_transition_ids
-        ):
-            failures.append(
-                f"{label}: target_transition does not match runtime transition "
-                f"registry: {target_transition}"
-            )
-        failures.extend(
-            _validate_shim_owner_field_refs(
-                record=record,
-                registered_fields=runtime_owner_fields,
-                transition_ids=runtime_transition_ids,
-                label=label,
-                registry_label="runtime owner field registry",
-            )
-        )
-        failures.extend(
-            _validate_invariant_transition_alignment(
-                invariant_refs=invariant_checks,
-                transition_id=target_transition,
-                invariant_transition_ids=runtime_invariant_transition_ids,
-                label=label,
-                invariant_field="invariant_checks",
-                transition_field="target_transition",
-            )
-        )
-        failures.extend(
-            _validate_each_shim_invariant_covers_transition(
-                invariant_refs=invariant_checks,
-                transition_id=target_transition,
-                invariant_transition_ids=runtime_invariant_transition_ids,
-                label=label,
-            )
-        )
-        failures.extend(
-            _validate_shim_generation_domain_refs(
-                record=record,
-                generation_domain_owner_fields=runtime_generation_domain_owner_fields,
-                label=label,
-                registry_label="runtime generation domain registry",
-            )
-        )
-        failures.extend(
-            _validate_shim_diff_harness_refs(
-                refs=record.get("diff_harness_refs"),
-                diff_harness_ids=runtime_diff_harness_ids,
-                label=label,
-            )
-        )
-        failures.extend(
-            _validate_shim_diff_harness_transition_coverage(
-                diff_harness_refs=record.get("diff_harness_refs"),
-                transition_id=target_transition,
-                diff_harness_transition_ids=runtime_diff_harness_transition_ids,
-                label=label,
-            )
-        )
-        failures.extend(
-            _validate_shim_diff_harness_union_coverage(
-                record=record,
-                diff_harness_owner_field_refs=runtime_diff_harness_owner_field_refs,
-                diff_harness_invariant_ids=runtime_diff_harness_invariant_ids,
-                diff_harness_generation_domain_ids=(
-                    runtime_diff_harness_generation_domain_ids
-                ),
-                label=label,
-            )
-        )
-
-    missing_ids = sorted(expected_ids - covered_ids)
-    if missing_ids:
-        failures.append(
-            f"{runtime_path}: runtime compatibility shim registry missing shim id(s): "
             + ", ".join(missing_ids)
         )
 
@@ -4918,12 +4563,6 @@ def _runtime_dispatch_surface_callsites_by_id(
     )
 
 
-def _runtime_shim_callsites_by_id(
-    source_root: Path,
-) -> tuple[dict[str, set[str]], list[str]]:
-    return _runtime_validation_callsites_by_id(source_root, SHIM_CALLSITE_RE)
-
-
 def _validate_runtime_dispatch_surface_callsites(
     *,
     runtime_records: list[dict[str, Any]],
@@ -5084,61 +4723,6 @@ def _validate_runtime_event_callsites(
         if not event_found:
             failures.append(
                 f"{', '.join(source_paths)}: {event_id}: missing runtime validation callsite"
-            )
-    return failures
-
-
-def _validate_runtime_shim_callsites(
-    *,
-    runtime_records: list[dict[str, Any]],
-    repository_root: Path,
-    action_runtime_path: Path,
-) -> list[str]:
-    if (
-        action_runtime_path.parent.name != "core"
-        or action_runtime_path.parent.parent.name != "src"
-    ):
-        return []
-    failures: list[str] = []
-    for record in runtime_records:
-        if not isinstance(record, dict):
-            continue
-        shim_id = record.get("id")
-        source_boundary_refs = record.get("source_boundary_refs")
-        if not isinstance(shim_id, str) or not shim_id.strip():
-            continue
-        if not isinstance(source_boundary_refs, list):
-            continue
-
-        source_paths: list[str] = []
-        seen_paths: set[str] = set()
-        for source_path in source_boundary_refs:
-            if (
-                not isinstance(source_path, str)
-                or not source_path.strip()
-                or source_path in seen_paths
-            ):
-                continue
-            source_paths.append(source_path)
-            seen_paths.add(source_path)
-        if not source_paths:
-            continue
-
-        shim_found = False
-        for source_path in source_paths:
-            source_file = repository_root / source_path
-            callsite_ids, read_failures = _runtime_validation_callsite_ids_in_file(
-                source_file, SHIM_CALLSITE_RE
-            )
-            failures.extend(read_failures)
-            if read_failures:
-                continue
-            if shim_id in callsite_ids:
-                shim_found = True
-                break
-        if not shim_found:
-            failures.append(
-                f"{', '.join(source_paths)}: {shim_id}: missing runtime validation callsite"
             )
     return failures
 
@@ -7342,9 +6926,6 @@ def validate_contract(
     runtime_dispatch_surface_records, runtime_dispatch_surface_failures = (
         _parse_runtime_dispatch_surface_registry(action_runtime_path)
     )
-    runtime_shim_records, runtime_shim_failures = _parse_runtime_shim_registry(
-        action_runtime_path
-    )
     runtime_invariant_records, runtime_invariant_failures = (
         _parse_runtime_invariant_registry(action_runtime_path)
     )
@@ -7374,7 +6955,6 @@ def validate_contract(
     failures.extend(runtime_transition_failures)
     failures.extend(runtime_owner_field_failures)
     failures.extend(runtime_dispatch_surface_failures)
-    failures.extend(runtime_shim_failures)
     failures.extend(runtime_invariant_failures)
     failures.extend(runtime_generation_domain_failures)
     failures.extend(runtime_diff_harness_failures)
@@ -7384,7 +6964,6 @@ def validate_contract(
 
     for doc, path, runtime_records in (
         (transitions_doc, transitions_path, runtime_transition_records),
-        (shims_doc, shims_path, runtime_shim_records),
         (action_coverage_doc, action_coverage_path, runtime_action_coverage_records),
         (event_coverage_doc, event_coverage_path, runtime_event_coverage_records),
         (owner_fields_doc, owner_fields_path, runtime_owner_field_records),
@@ -7764,44 +7343,6 @@ def validate_contract(
                 repository_root=repository_root,
             )
         )
-    failures.extend(
-        _validate_runtime_shim_registry(
-            runtime_records=runtime_shim_records,
-            runtime_path=action_runtime_path,
-            shim_records=shims,
-            runtime_transition_ids={
-                record["id"]: record for record in runtime_transition_records
-            },
-            runtime_owner_fields={
-                record["field"] for record in runtime_owner_field_records
-            },
-            runtime_invariant_ids=runtime_invariant_ids,
-            runtime_invariant_transition_ids=_invariant_transition_ids_by_invariant(
-                runtime_invariant_records
-            ),
-            runtime_generation_domain_owner_fields=runtime_generation_domain_owner_fields,
-            runtime_diff_harness_ids={
-                record["harness_id"] for record in runtime_diff_harness_records
-            },
-            runtime_diff_harness_transition_ids=runtime_diff_harness_transition_ids,
-            runtime_diff_harness_owner_field_refs=(
-                runtime_diff_harness_owner_field_refs_by_harness
-            ),
-            runtime_diff_harness_invariant_ids=(
-                runtime_diff_harness_invariant_ids_by_harness
-            ),
-            runtime_diff_harness_generation_domain_ids=(
-                runtime_diff_harness_generation_domain_ids_by_harness
-            ),
-        )
-    )
-    failures.extend(
-        _validate_runtime_shim_callsites(
-            runtime_records=runtime_shim_records,
-            repository_root=repository_root,
-            action_runtime_path=action_runtime_path,
-        )
-    )
 
     if not isinstance(action_coverage_doc, dict):
         failures.append(f"{action_coverage_path}: top-level value must be an object")

--- a/src/core/appstate_actions.c
+++ b/src/core/appstate_actions.c
@@ -6231,10 +6231,6 @@ static const AppStateActionCoverageMetadata
    sizeof(kAppStateActionCoverageMigrationNotes3) / sizeof(kAppStateActionCoverageMigrationNotes3[0])},
 };
 
-static const AppStateCompatibilityShimMetadata kAppStateCompatibilityShims[] = {
-    {0},
-};
-
 static int AppStateValidateActionCoverage(
     YtreeNovaAction action, const AppStateActionCoverageMetadata *coverage);
 static int AppStateLookupIdMatches(const char *candidate,
@@ -6242,7 +6238,6 @@ static int AppStateLookupIdMatches(const char *candidate,
 int AppStateValidatedEvent(const char *event_id);
 int AppStateValidatedTransition(const char *transition_id);
 int AppStateValidatedDispatchSurface(const char *surface_id);
-int AppStateValidatedCompatibilityShim(const char *shim_id);
 int AppStateValidatedInvariant(const char *invariant_id);
 int AppStateValidatedOwnerField(const char *field);
 int AppStateValidatedTransitionSequence(const char *scenario_id);
@@ -6265,14 +6260,6 @@ size_t AppStateTransitionCount(void) {
 
 size_t AppStateDispatchSurfaceCount(void) {
   return sizeof(kAppStateDispatchSurfaces) / sizeof(kAppStateDispatchSurfaces[0]);
-}
-
-size_t AppStateCompatibilityShimCount(void) {
-  size_t count = 0;
-
-  while (kAppStateCompatibilityShims[count].id != NULL)
-    count++;
-  return count;
 }
 
 size_t AppStateInvariantCount(void) {
@@ -6382,17 +6369,6 @@ const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index) {
   return &kAppStateDispatchSurfaces[index];
 }
 
-const AppStateCompatibilityShimMetadata *
-AppStateCompatibilityShimAt(size_t index) {
-  if (index >= AppStateCompatibilityShimCount())
-    return NULL;
-
-  if (!AppStateValidatedCompatibilityShim(kAppStateCompatibilityShims[index].id))
-    return NULL;
-
-  return &kAppStateCompatibilityShims[index];
-}
-
 const AppStateInvariantMetadata *AppStateInvariantAt(size_t index) {
   if (index >= AppStateInvariantCount())
     return NULL;
@@ -6493,22 +6469,6 @@ AppStateDispatchSurfaceLookup(const char *surface_id) {
     if (AppStateLookupIdMatches(kAppStateDispatchSurfaces[index].surface_id,
                                 surface_id))
       return &kAppStateDispatchSurfaces[index];
-  }
-
-  return NULL;
-}
-
-const AppStateCompatibilityShimMetadata *
-AppStateCompatibilityShimLookup(const char *shim_id) {
-  size_t index;
-
-  if (shim_id == NULL || shim_id[0] == '\0')
-    return NULL;
-
-  for (index = 0; index < AppStateCompatibilityShimCount(); index++) {
-    if (AppStateLookupIdMatches(kAppStateCompatibilityShims[index].id,
-                                shim_id))
-      return &kAppStateCompatibilityShims[index];
   }
 
   return NULL;
@@ -7498,159 +7458,6 @@ static int AppStateValidateDispatchSurface(
 int AppStateValidatedDispatchSurface(const char *surface_id) {
   return AppStateValidateDispatchSurface(
       surface_id, AppStateDispatchSurfaceLookup(surface_id));
-}
-
-static int AppStateStringListHasDuplicate(const char *const *values,
-                                          size_t value_count) {
-  size_t index;
-
-  if (!AppStateNonEmptyStringList(values, value_count))
-    return 1;
-
-  for (index = 0; index < value_count; index++) {
-    if (AppStateStringListContains(values, index, values[index]))
-      return 1;
-  }
-
-  return 0;
-}
-
-static int AppStateCompatibilityShimWriteCapabilityKnown(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  if (metadata == NULL || !AppStateNonEmptyString(metadata->write_capability))
-    return 0;
-
-  return strcmp(metadata->write_capability, "write_capable") == 0 ||
-         strcmp(metadata->write_capability, "read_only_projection") == 0 ||
-         strcmp(metadata->write_capability, "no_write") == 0;
-}
-
-static int AppStateCompatibilityShimWriteCapable(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  return metadata != NULL && AppStateNonEmptyString(metadata->write_capability) &&
-         strcmp(metadata->write_capability, "write_capable") == 0;
-}
-
-static int AppStateCompatibilityShimReadOnlyProjection(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  return metadata != NULL && AppStateNonEmptyString(metadata->write_capability) &&
-         strcmp(metadata->write_capability, "read_only_projection") == 0;
-}
-
-static int AppStateCompatibilityShimInvariantRefsReady(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  size_t index;
-
-  if (metadata == NULL ||
-      !AppStateNonEmptyStringList(metadata->invariant_checks,
-                                  metadata->invariant_check_count) ||
-      AppStateStringListHasDuplicate(metadata->invariant_checks,
-                                     metadata->invariant_check_count))
-    return 0;
-
-  for (index = 0; index < metadata->invariant_check_count; index++) {
-    if (!AppStateValidatedInvariant(metadata->invariant_checks[index]))
-      return 0;
-  }
-
-  return 1;
-}
-
-static int AppStateCompatibilityShimGenerationDomainRefsReady(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  size_t index;
-
-  if (metadata == NULL ||
-      !AppStateNonEmptyStringList(metadata->generation_domain_refs,
-                                  metadata->generation_domain_ref_count) ||
-      AppStateStringListHasDuplicate(metadata->generation_domain_refs,
-                                     metadata->generation_domain_ref_count))
-    return 0;
-
-  for (index = 0; index < metadata->generation_domain_ref_count; index++) {
-    if (!AppStateValidatedGenerationDomain(
-            metadata->generation_domain_refs[index]))
-      return 0;
-  }
-
-  return 1;
-}
-
-static int AppStateCompatibilityShimDiffHarnessRefsReady(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  size_t index;
-
-  if (metadata == NULL ||
-      !AppStateNonEmptyStringList(metadata->diff_harness_refs,
-                                  metadata->diff_harness_ref_count) ||
-      AppStateStringListHasDuplicate(metadata->diff_harness_refs,
-                                     metadata->diff_harness_ref_count))
-    return 0;
-
-  for (index = 0; index < metadata->diff_harness_ref_count; index++) {
-    if (!AppStateValidatedDiffHarness(metadata->diff_harness_refs[index]))
-      return 0;
-  }
-
-  return 1;
-}
-
-static int AppStateValidateCompatibilityShim(
-    const char *shim_id, const AppStateCompatibilityShimMetadata *metadata) {
-  const AppStateTransitionMetadata *transition;
-  size_t owner_field_index;
-
-  if (!AppStateNonEmptyString(shim_id))
-    return 0;
-  if (metadata == NULL || !AppStateNonEmptyString(metadata->id) ||
-      strcmp(metadata->id, shim_id))
-    return 0;
-  if (!AppStateNonEmptyString(metadata->owner) ||
-      !AppStateNonEmptyString(metadata->old_authority_path) ||
-      !AppStateNonEmptyString(metadata->read_permission) ||
-      !AppStateNonEmptyString(metadata->write_permission) ||
-      !AppStateCompatibilityShimWriteCapabilityKnown(metadata) ||
-      !AppStateNonEmptyString(metadata->removal_trigger) ||
-      !AppStateNonEmptyString(metadata->target_transition) ||
-      !AppStateNonEmptyString(metadata->follow_up_task) ||
-      !AppStateNonEmptyString(metadata->qa_enforcement))
-    return 0;
-  transition = AppStateTransitionLookup(metadata->target_transition);
-  if (!AppStateValidateTransition(metadata->target_transition, transition))
-    return 0;
-  if (!AppStateCompatibilityShimInvariantRefsReady(metadata))
-    return 0;
-  if (!AppStateTransitionFieldsRegistered(metadata->owner_field_refs,
-                                          metadata->owner_field_ref_count))
-    return 0;
-  if (AppStateStringListHasDuplicate(metadata->owner_field_refs,
-                                     metadata->owner_field_ref_count))
-    return 0;
-  if (!AppStateCompatibilityShimGenerationDomainRefsReady(metadata))
-    return 0;
-  if (!AppStateCompatibilityShimDiffHarnessRefsReady(metadata))
-    return 0;
-
-  for (owner_field_index = 0;
-       owner_field_index < metadata->owner_field_ref_count;
-       owner_field_index++) {
-    int field_in_transition = AppStateStringListContains(
-        transition->declared_write_set, transition->declared_write_set_count,
-        metadata->owner_field_refs[owner_field_index]);
-
-    if (AppStateCompatibilityShimWriteCapable(metadata) && !field_in_transition)
-      return 0;
-    if (AppStateCompatibilityShimReadOnlyProjection(metadata) &&
-        field_in_transition)
-      return 0;
-  }
-
-  return 1;
-}
-
-int AppStateValidatedCompatibilityShim(const char *shim_id) {
-  return AppStateValidateCompatibilityShim(
-      shim_id, AppStateCompatibilityShimLookup(shim_id));
 }
 
 const AppStateEventCoverageMetadata *

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -235,10 +235,6 @@ static const char *const kAppStateRequiredDispatchSurfaceIds[] = {
   "surface.panel-anchor-rebind",
 };
 
-static const char *const kAppStateRequiredShimIds[] = {
-  NULL,
-};
-
 static const char *const kAppStateRequiredInvariantIds[] = {
   "invariant.inactive-panel-frozen",
   "invariant.render-projection-read-only",
@@ -357,6 +353,15 @@ AppStateActionCoverageIdLookup(const char *action_id) {
 
   return NULL;
 }
+
+static int
+AppStateInvariantRefsReady(const char *const *refs, size_t ref_count,
+                           const char *transition_id,
+                           const char *const *declared_write_set,
+                           size_t declared_write_set_count);
+static int
+AppStateGenerationDomainRefsReady(const char *const *refs, size_t ref_count,
+                                  const char *transition_id);
 
 static int AppStateFallbackPreconditionValid(const char *precondition) {
   if (precondition == NULL)
@@ -1477,342 +1482,6 @@ static int AppStateInvariantRegistryReady(void) {
   return 1;
 }
 
-static int AppStateCompatibilityShimWriteCapable(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  return metadata != NULL && metadata->write_capability != NULL &&
-         strcmp(metadata->write_capability, "write_capable") == 0;
-}
-
-static int AppStateCompatibilityShimReadOnlyProjection(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  return metadata != NULL && metadata->write_capability != NULL &&
-         strcmp(metadata->write_capability, "read_only_projection") == 0;
-}
-
-static int AppStateCompatibilityShimWriteCapabilityKnown(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  if (metadata == NULL || !NonEmptyString(metadata->write_capability))
-    return 0;
-
-  return strcmp(metadata->write_capability, "write_capable") == 0 ||
-         strcmp(metadata->write_capability, "read_only_projection") == 0 ||
-         strcmp(metadata->write_capability, "no_write") == 0;
-}
-
-static int AppStateCompatibilityShimInvariantCoversTransition(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  size_t invariant_index;
-
-  if (metadata == NULL || !NonEmptyString(metadata->target_transition) ||
-      !NonEmptyStringList(metadata->invariant_checks,
-                          metadata->invariant_check_count))
-    return 0;
-
-  for (invariant_index = 0; invariant_index < metadata->invariant_check_count;
-       invariant_index++) {
-    const AppStateInvariantMetadata *invariant =
-        AppStateInvariantLookup(metadata->invariant_checks[invariant_index]);
-
-    if (invariant == NULL || invariant->transition_ids == NULL)
-      return 0;
-    if (!StringListContains(invariant->transition_ids,
-                            invariant->transition_id_count,
-                            metadata->target_transition))
-      return 0;
-  }
-
-  return 1;
-}
-
-static int AppStateGenerationOwnerFieldRegistered(const char *owner_field) {
-  size_t domain_index;
-
-  if (!NonEmptyString(owner_field))
-    return 0;
-
-  for (domain_index = 0; domain_index < AppStateGenerationDomainCount();
-       domain_index++) {
-    const AppStateGenerationDomainMetadata *domain =
-        AppStateGenerationDomainAt(domain_index);
-
-    if (domain == NULL || !NonEmptyString(domain->generation_owner_field))
-      return 0;
-    if (strcmp(domain->generation_owner_field, owner_field) == 0)
-      return 1;
-  }
-
-  return 0;
-}
-
-static int AppStateCompatibilityShimGenerationDomainCoversOwnerField(
-    const AppStateCompatibilityShimMetadata *metadata,
-    const char *owner_field) {
-  size_t ref_index;
-
-  if (metadata == NULL || !NonEmptyString(owner_field) ||
-      metadata->generation_domain_refs == NULL)
-    return 0;
-
-  for (ref_index = 0; ref_index < metadata->generation_domain_ref_count;
-       ref_index++) {
-    const AppStateGenerationDomainMetadata *domain =
-        AppStateGenerationDomainLookup(
-            metadata->generation_domain_refs[ref_index]);
-
-    if (domain == NULL || !NonEmptyString(domain->generation_owner_field))
-      return 0;
-    if (strcmp(domain->generation_owner_field, owner_field) == 0)
-      return 1;
-  }
-
-  return 0;
-}
-
-static int AppStateCompatibilityShimDiffHarnessCoversTransition(
-    const AppStateCompatibilityShimMetadata *metadata) {
-  size_t ref_index;
-
-  if (metadata == NULL || !NonEmptyString(metadata->target_transition) ||
-      !NonEmptyStringList(metadata->diff_harness_refs,
-                          metadata->diff_harness_ref_count))
-    return 0;
-
-  for (ref_index = 0; ref_index < metadata->diff_harness_ref_count;
-       ref_index++) {
-    const AppStateDiffHarnessMetadata *harness =
-        AppStateDiffHarnessLookup(metadata->diff_harness_refs[ref_index]);
-
-    if (harness == NULL || harness->transition_ids == NULL)
-      return 0;
-    if (StringListContains(harness->transition_ids,
-                           harness->transition_id_count,
-                           metadata->target_transition))
-      return 1;
-  }
-
-  return 0;
-}
-
-static int AppStateCompatibilityShimDiffHarnessCoversOwnerField(
-    const AppStateCompatibilityShimMetadata *metadata,
-    const char *owner_field) {
-  size_t ref_index;
-
-  if (metadata == NULL || !NonEmptyString(owner_field) ||
-      !NonEmptyStringList(metadata->diff_harness_refs,
-                          metadata->diff_harness_ref_count))
-    return 0;
-
-  for (ref_index = 0; ref_index < metadata->diff_harness_ref_count;
-       ref_index++) {
-    const AppStateDiffHarnessMetadata *harness =
-        AppStateDiffHarnessLookup(metadata->diff_harness_refs[ref_index]);
-
-    if (harness == NULL || harness->owner_field_refs == NULL)
-      return 0;
-    if (StringListContains(harness->owner_field_refs,
-                           harness->owner_field_ref_count, owner_field))
-      return 1;
-  }
-
-  return 0;
-}
-
-static int AppStateCompatibilityShimDiffHarnessCoversInvariant(
-    const AppStateCompatibilityShimMetadata *metadata,
-    const char *invariant_id) {
-  size_t ref_index;
-
-  if (metadata == NULL || !NonEmptyString(invariant_id) ||
-      !NonEmptyStringList(metadata->diff_harness_refs,
-                          metadata->diff_harness_ref_count))
-    return 0;
-
-  for (ref_index = 0; ref_index < metadata->diff_harness_ref_count;
-       ref_index++) {
-    const AppStateDiffHarnessMetadata *harness =
-        AppStateDiffHarnessLookup(metadata->diff_harness_refs[ref_index]);
-
-    if (harness == NULL || harness->invariant_ids == NULL)
-      return 0;
-    if (StringListContains(harness->invariant_ids,
-                           harness->invariant_id_count, invariant_id))
-      return 1;
-  }
-
-  return 0;
-}
-
-static int AppStateCompatibilityShimDiffHarnessCoversGenerationDomain(
-    const AppStateCompatibilityShimMetadata *metadata,
-    const char *domain_id) {
-  size_t ref_index;
-
-  if (metadata == NULL || !NonEmptyString(domain_id) ||
-      !NonEmptyStringList(metadata->diff_harness_refs,
-                          metadata->diff_harness_ref_count))
-    return 0;
-
-  for (ref_index = 0; ref_index < metadata->diff_harness_ref_count;
-       ref_index++) {
-    const AppStateDiffHarnessMetadata *harness =
-        AppStateDiffHarnessLookup(metadata->diff_harness_refs[ref_index]);
-
-    if (harness == NULL || harness->generation_domain_ids == NULL)
-      return 0;
-    if (StringListContains(harness->generation_domain_ids,
-                           harness->generation_domain_id_count, domain_id))
-      return 1;
-  }
-
-  return 0;
-}
-
-static size_t AppStateRequiredShimIdCount(void) {
-  size_t count = 0;
-
-  while (kAppStateRequiredShimIds[count] != NULL)
-    count++;
-  return count;
-}
-
-static int AppStateCompatibilityShimsReady(void) {
-  size_t index;
-  size_t required_shim_id_count = AppStateRequiredShimIdCount();
-
-  if (AppStateCompatibilityShimCount() != required_shim_id_count)
-    return 0;
-
-  for (index = 0; index < AppStateCompatibilityShimCount(); index++) {
-    const AppStateCompatibilityShimMetadata *metadata =
-        AppStateCompatibilityShimAt(index);
-    size_t invariant_index;
-    size_t diff_index;
-    size_t generation_index;
-    size_t previous_index;
-    size_t ref_index;
-    const AppStateTransitionMetadata *transition;
-
-    if (metadata == NULL || !NonEmptyString(metadata->id) ||
-        !NonEmptyString(metadata->owner) ||
-        !NonEmptyString(metadata->old_authority_path) ||
-        !NonEmptyString(metadata->read_permission) ||
-        !NonEmptyString(metadata->write_permission) ||
-        !AppStateCompatibilityShimWriteCapabilityKnown(metadata) ||
-        metadata->invariant_checks == NULL ||
-        metadata->invariant_check_count == 0 ||
-        !NonEmptyStringList(metadata->owner_field_refs,
-                            metadata->owner_field_ref_count) ||
-        !NonEmptyStringList(metadata->generation_domain_refs,
-                            metadata->generation_domain_ref_count) ||
-        !NonEmptyStringList(metadata->diff_harness_refs,
-                            metadata->diff_harness_ref_count) ||
-        !NonEmptyStringList(metadata->source_boundary_refs,
-                            metadata->source_boundary_ref_count) ||
-        !NonEmptyString(metadata->removal_trigger) ||
-        !NonEmptyString(metadata->target_transition) ||
-        !NonEmptyString(metadata->follow_up_task) ||
-        !NonEmptyString(metadata->qa_enforcement))
-      return 0;
-    if (AppStateCompatibilityShimLookup(metadata->id) != metadata)
-      return 0;
-    if (AppStateTransitionLookup(metadata->target_transition) == NULL)
-      return 0;
-    transition = AppStateTransitionLookup(metadata->target_transition);
-
-    for (previous_index = 0; previous_index < index; previous_index++) {
-      const AppStateCompatibilityShimMetadata *previous =
-          AppStateCompatibilityShimAt(previous_index);
-
-      if (previous == NULL || strcmp(previous->id, metadata->id) == 0)
-        return 0;
-    }
-
-    for (invariant_index = 0;
-         invariant_index < metadata->invariant_check_count; invariant_index++) {
-      if (!NonEmptyString(metadata->invariant_checks[invariant_index]))
-        return 0;
-      if (AppStateInvariantLookup(metadata->invariant_checks[invariant_index]) ==
-          NULL)
-        return 0;
-      if (!AppStateCompatibilityShimDiffHarnessCoversInvariant(
-              metadata, metadata->invariant_checks[invariant_index]))
-        return 0;
-    }
-    for (diff_index = 0; diff_index < metadata->diff_harness_ref_count;
-         diff_index++) {
-      if (AppStateDiffHarnessLookup(metadata->diff_harness_refs[diff_index]) ==
-          NULL)
-        return 0;
-      if (StringListContains(metadata->diff_harness_refs, diff_index,
-                             metadata->diff_harness_refs[diff_index]))
-        return 0;
-    }
-    for (generation_index = 0;
-         generation_index < metadata->generation_domain_ref_count;
-         generation_index++) {
-      if (AppStateGenerationDomainLookup(
-              metadata->generation_domain_refs[generation_index]) == NULL)
-        return 0;
-      if (StringListContains(metadata->generation_domain_refs, generation_index,
-                             metadata->generation_domain_refs[generation_index]))
-        return 0;
-      if (!AppStateCompatibilityShimDiffHarnessCoversGenerationDomain(
-              metadata, metadata->generation_domain_refs[generation_index]))
-        return 0;
-    }
-    for (ref_index = 0; ref_index < metadata->owner_field_ref_count;
-         ref_index++) {
-      if (AppStateOwnerFieldLookup(metadata->owner_field_refs[ref_index]) ==
-          NULL)
-        return 0;
-      if (StringListContains(metadata->owner_field_refs, ref_index,
-                             metadata->owner_field_refs[ref_index]))
-        return 0;
-      if (AppStateCompatibilityShimWriteCapable(metadata) &&
-          !StringListContains(transition->declared_write_set,
-                              transition->declared_write_set_count,
-                              metadata->owner_field_refs[ref_index]))
-        return 0;
-      if (AppStateCompatibilityShimReadOnlyProjection(metadata) &&
-          StringListContains(transition->declared_write_set,
-                             transition->declared_write_set_count,
-                             metadata->owner_field_refs[ref_index]))
-        return 0;
-      if (AppStateCompatibilityShimWriteCapable(metadata) &&
-          AppStateGenerationOwnerFieldRegistered(
-              metadata->owner_field_refs[ref_index]) &&
-          !AppStateCompatibilityShimGenerationDomainCoversOwnerField(
-              metadata, metadata->owner_field_refs[ref_index]))
-        return 0;
-      if (!AppStateCompatibilityShimDiffHarnessCoversOwnerField(
-              metadata, metadata->owner_field_refs[ref_index]))
-        return 0;
-    }
-    if (!AppStateCompatibilityShimInvariantCoversTransition(metadata))
-      return 0;
-    if (!AppStateCompatibilityShimDiffHarnessCoversTransition(metadata))
-      return 0;
-  }
-
-  for (index = 0; index < required_shim_id_count; index++) {
-    if (AppStateCompatibilityShimLookup(kAppStateRequiredShimIds[index]) ==
-        NULL)
-      return 0;
-  }
-
-  if (AppStateCompatibilityShimAt(AppStateCompatibilityShimCount()) != NULL)
-    return 0;
-  if (AppStateCompatibilityShimLookup(NULL) != NULL)
-    return 0;
-  if (AppStateCompatibilityShimLookup("") != NULL)
-    return 0;
-  if (AppStateCompatibilityShimLookup("shim.__ytnova_unknown__") != NULL)
-    return 0;
-
-  return 1;
-}
-
 static int AppStateInvariantRefsReady(const char *const *refs, size_t ref_count,
                                       const char *transition_id,
                                       const char *const *declared_write_set,
@@ -1846,8 +1515,8 @@ static int AppStateInvariantRefsReady(const char *const *refs, size_t ref_count,
   }
 
   for (write_index = 0; write_index < declared_write_set_count; write_index++) {
-    if (!AppStateTransitionWriteHasInvariantCoverage(transition_id,
-                                                     declared_write_set[write_index]))
+    if (!AppStateTransitionWriteHasInvariantCoverage(
+            transition_id, declared_write_set[write_index]))
       return 0;
     for (ref_index = 0; ref_index < ref_count; ref_index++) {
       if (AppStateInvariantProtectsField(refs[ref_index],
@@ -2641,7 +2310,6 @@ int main(int argc, char **argv) {
       !AppStateGenerationDomainsReady() ||
       !AppStateDispatchSurfacesReady() ||
       !AppStateInvariantRegistryReady() ||
-      !AppStateCompatibilityShimsReady() ||
       !AppStateDiffHarnessRegistryReady() ||
       !AppStateTransitionSequencesReady() ||
       !AppStateActionCoverageReady() ||

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -772,7 +772,6 @@ def _write_fixture(
     runtime_events: list[dict[str, object]] | None = None,
     runtime_transitions: list[dict[str, object]] | None = None,
     runtime_dispatch_surfaces: list[dict[str, object]] | None = None,
-    runtime_shims: list[dict[str, object]] | None = None,
     runtime_invariants: list[dict[str, object]] | None = None,
     runtime_owner_fields: list[dict[str, object]] | None = None,
     runtime_generation_domains: list[dict[str, object]] | None = None,
@@ -882,9 +881,6 @@ def _write_fixture(
                 if dispatch_surfaces is not None
                 else _complete_dispatch_surfaces()
             ),
-            runtime_shims
-            if runtime_shims is not None
-            else (shims if shims is not None else [_shim()]),
             runtime_invariants
             if runtime_invariants is not None
             else (invariants if invariants is not None else _complete_invariants()),
@@ -945,7 +941,6 @@ def _runtime_source(
     transitions: list[dict[str, object]],
     owner_fields: list[dict[str, object]],
     dispatch_surfaces: list[dict[str, object]],
-    shims: list[dict[str, object]],
     invariants: list[dict[str, object]],
     generation_domains: list[dict[str, object]],
     diff_harness_checks: list[dict[str, object]],
@@ -1318,95 +1313,6 @@ def _runtime_source(
             f"sizeof({sequence_refs_table}[0]), "
             f"{notes_table}, sizeof({notes_table}) / sizeof({notes_table}[0])}},"
         )
-    shim_invariants = []
-    shim_owner_field_refs = []
-    shim_generation_domain_refs = []
-    shim_diff_harness_refs = []
-    shim_source_boundary_refs = []
-    shim_rows = []
-    for index, record in enumerate(shims):
-        invariant_checks = record.get("invariant_checks")
-        if not isinstance(invariant_checks, list):
-            invariant_checks = []
-        invariant_rows = "\n".join(
-            f'  "{check}",' for check in invariant_checks if isinstance(check, str)
-        )
-        shim_invariants.append(
-            "static const char *const kAppStateCompatibilityShimInvariantChecks"
-            f"{index}[] = {{\n{invariant_rows}\n}};\n"
-        )
-        owner_field_refs = record.get("owner_field_refs")
-        if not isinstance(owner_field_refs, list):
-            owner_field_refs = []
-        owner_ref_rows = "\n".join(
-            f'  "{field}",' for field in owner_field_refs if isinstance(field, str)
-        )
-        shim_owner_field_refs.append(
-            "static const char *const kAppStateCompatibilityShimOwnerFieldRefs"
-            f"{index}[] = {{\n{owner_ref_rows}\n}};\n"
-        )
-        generation_domain_refs = record.get("generation_domain_refs")
-        if not isinstance(generation_domain_refs, list):
-            generation_domain_refs = []
-        generation_ref_rows = "\n".join(
-            f'  "{domain_id}",'
-            for domain_id in generation_domain_refs
-            if isinstance(domain_id, str)
-        )
-        shim_generation_domain_refs.append(
-            "static const char *const kAppStateCompatibilityShimGenerationDomainRefs"
-            f"{index}[] = {{\n{generation_ref_rows}\n}};\n"
-        )
-        diff_harness_refs = record.get("diff_harness_refs")
-        if not isinstance(diff_harness_refs, list):
-            diff_harness_refs = []
-        diff_ref_rows = "\n".join(
-            f'  "{harness_id}",'
-            for harness_id in diff_harness_refs
-            if isinstance(harness_id, str)
-        )
-        shim_diff_harness_refs.append(
-            "static const char *const kAppStateCompatibilityShimDiffHarnessRefs"
-            f"{index}[] = {{\n{diff_ref_rows}\n}};\n"
-        )
-        source_boundary_refs = record.get("source_boundary_refs")
-        if not isinstance(source_boundary_refs, list):
-            source_boundary_refs = []
-        source_boundary_ref_rows = "\n".join(
-            f'  "{source_path}",'
-            for source_path in source_boundary_refs
-            if isinstance(source_path, str)
-        )
-        shim_source_boundary_refs.append(
-            "static const char *const kAppStateCompatibilityShimSourceBoundaryRefs"
-            f"{index}[] = {{\n{source_boundary_ref_rows}\n}};\n"
-        )
-        shim_rows.append(
-            f'  {{"{record.get("id", "")}", "{record.get("owner", "")}", '
-            f'"{record.get("old_authority_path", "")}", '
-            f'"{record.get("read_permission", "")}", '
-            f'"{record.get("write_permission", "")}", '
-            f'"{record.get("write_capability", "")}", '
-            f"kAppStateCompatibilityShimInvariantChecks{index}, "
-            f"sizeof(kAppStateCompatibilityShimInvariantChecks{index}) / "
-            f"sizeof(kAppStateCompatibilityShimInvariantChecks{index}[0]), "
-            f"kAppStateCompatibilityShimOwnerFieldRefs{index}, "
-            f"sizeof(kAppStateCompatibilityShimOwnerFieldRefs{index}) / "
-            f"sizeof(kAppStateCompatibilityShimOwnerFieldRefs{index}[0]), "
-            f"kAppStateCompatibilityShimGenerationDomainRefs{index}, "
-            f"sizeof(kAppStateCompatibilityShimGenerationDomainRefs{index}) / "
-            f"sizeof(kAppStateCompatibilityShimGenerationDomainRefs{index}[0]), "
-            f"kAppStateCompatibilityShimDiffHarnessRefs{index}, "
-            f"sizeof(kAppStateCompatibilityShimDiffHarnessRefs{index}) / "
-            f"sizeof(kAppStateCompatibilityShimDiffHarnessRefs{index}[0]), "
-            f"kAppStateCompatibilityShimSourceBoundaryRefs{index}, "
-            f"sizeof(kAppStateCompatibilityShimSourceBoundaryRefs{index}) / "
-            f"sizeof(kAppStateCompatibilityShimSourceBoundaryRefs{index}[0]), "
-            f'"{record.get("removal_trigger", "")}", '
-            f'"{record.get("target_transition", "")}", '
-            f'"{record.get("follow_up_task", "")}", '
-            f'"{record.get("qa_enforcement", "")}"}},'
-        )
     invariant_arrays = []
     invariant_rows = []
     invariant_list_fields = (
@@ -1717,11 +1623,6 @@ def _runtime_source(
         + "".join(event_coverage_arrays)
         + "".join(owner_field_arrays)
         + "".join(dispatch_surface_arrays)
-        + "".join(shim_invariants)
-        + "".join(shim_owner_field_refs)
-        + "".join(shim_generation_domain_refs)
-        + "".join(shim_diff_harness_refs)
-        + "".join(shim_source_boundary_refs)
         + "".join(invariant_arrays)
         + "".join(generation_domain_arrays)
         + "".join(diff_harness_arrays)
@@ -1734,10 +1635,6 @@ def _runtime_source(
         "static const AppStateDispatchSurfaceMetadata "
         "kAppStateDispatchSurfaces[] = {\n"
         + "\n".join(dispatch_surface_rows)
-        + "\n};\n"
-        "static const AppStateCompatibilityShimMetadata "
-        "kAppStateCompatibilityShims[] = {\n"
-        + "\n".join(shim_rows)
         + "\n};\n"
         "static const AppStateGenerationDomainMetadata "
         "kAppStateGenerationDomains[] = {\n"
@@ -5180,7 +5077,7 @@ int main(void) {
   if (!AppStateValidatedDispatchSurface("surface.command-completion-dispatch"))
     return 8;
   if (!AppStateValidatedDispatchSurface("surface.watcher-live-refresh"))
-    return 15;
+    return 14;
   if (!AppStateValidatedDispatchSurface("surface.render-reflow-projection"))
     return 9;
   if (!AppStateValidatedDispatchSurface("surface.volume-menu-selection"))
@@ -5192,9 +5089,9 @@ int main(void) {
   if (!AppStateValidatedDispatchSurface("surface.directory-window-action-dispatch"))
     return 13;
   if (!AppStateValidatedDispatchSurface("surface.panel-anchor-rebind"))
-    return 14;
+    return 13;
   if (!AppStateValidatedDispatchSurface("surface.filesystem-mutation-result"))
-    return 16;
+    return 15;
   if (AppStateValidatedDispatchSurface(NULL))
     return 3;
   if (AppStateValidatedDispatchSurface(""))
@@ -5221,7 +5118,7 @@ int main(void) {
   blank_source_path.source_path = "";
   if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
                                       &blank_source_path))
-    return 17;
+    return 16;
 
   unknown_allowed_write =
       *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
@@ -5229,7 +5126,7 @@ int main(void) {
   unknown_allowed_write.allowed_direct_write_count = 1;
   if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
                                       &unknown_allowed_write))
-    return 18;
+    return 17;
 
   outside_allowed_write =
       *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
@@ -5237,7 +5134,7 @@ int main(void) {
   outside_allowed_write.allowed_direct_write_count = 1;
   if (AppStateValidateDispatchSurface("surface.key-decode-input-dispatch",
                                       &outside_allowed_write))
-    return 19;
+    return 18;
 
   missing_sequences =
       *AppStateDispatchSurfaceLookup("surface.key-decode-input-dispatch");
@@ -5895,27 +5792,30 @@ def test_refresh_tree_safe_fails_closed_before_tree_refresh_work() -> None:
         assert event_return_idx < body.index(call, event_return_idx)
 
 
-def test_appstate_shim_lookup_fails_closed_through_runtime_metadata() -> None:
+def test_appstate_runtime_no_longer_exposes_shim_registry_support() -> None:
     header = Path("include/ytnova_appstate_actions.h").read_text(encoding="utf-8")
     source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
-    validation = "int AppStateValidatedCompatibilityShim(const char *shim_id)"
-    body_start = source.index("static int AppStateValidateCompatibilityShim(")
-    body_end = source.index("\nconst AppStateEventCoverageMetadata", body_start)
-    body = source[body_start:body_end]
+    startup = Path("src/core/main.c").read_text(encoding="utf-8")
+    guard_source = Path("scripts/check_appstate_contract.py").read_text(
+        encoding="utf-8"
+    )
 
-    assert validation in header
-    assert "static int AppStateValidateCompatibilityShim(" in source
-    assert "AppStateCompatibilityShimLookup(shim_id)" in body
-    assert "AppStateTransitionLookup(metadata->target_transition)" in body
-    assert "AppStateValidateTransition(metadata->target_transition, transition)" in body
-    assert "AppStateCompatibilityShimWriteCapabilityKnown(metadata)" in body
-    assert "AppStateCompatibilityShimInvariantRefsReady(metadata)" in body
-    assert "AppStateCompatibilityShimGenerationDomainRefsReady(metadata)" in body
-    assert "AppStateCompatibilityShimDiffHarnessRefsReady(metadata)" in body
-    assert "AppStateCompatibilityShimReadOnlyProjection(metadata)" in body
-    assert "AppStateTransitionFieldsRegistered(metadata->owner_field_refs" in body
-    assert "strcmp(metadata->id, shim_id)" in body
+    for removed in [
+        "AppStateCompatibilityShimMetadata",
+        "AppStateCompatibilityShimLookup(",
+        "AppStateCompatibilityShimAt(",
+        "AppStateCompatibilityShimCount(",
+        "AppStateValidatedCompatibilityShim(",
+        "AppStateValidateCompatibilityShim(",
+    ]:
+        assert removed not in header
+        assert removed not in source
 
+    assert "AppStateCompatibilityShimsReady(" not in startup
+    assert "kAppStateRequiredShimIds" not in startup
+    assert "_parse_runtime_shim_registry(" not in guard_source
+    assert "_validate_runtime_shim_registry(" not in guard_source
+    assert "_validate_runtime_shim_callsites(" not in guard_source
 
 def test_volume_tree_runtime_breadcrumb_fields_are_retired() -> None:
     volume_defs = Path("include/ytnova_defs.h").read_text(encoding="utf-8")
@@ -10452,21 +10352,19 @@ int main(void) {
     return 5;
   if (!AppStateValidatedTransitionSequence("sequence.split-toggle-f8"))
     return 6;
-  if (AppStateCompatibilityShimCount() != 0)
-    return 7;
 
   if (AppStateValidatedTransition(NULL))
-    return 8;
+    return 7;
   if (AppStateValidatedOwnerField(""))
-    return 9;
+    return 8;
   if (AppStateValidatedInvariant("invariant.__ytnova_missing__"))
-    return 10;
+    return 9;
   if (AppStateValidatedGenerationDomain("generation.__ytnova_missing__"))
-    return 11;
+    return 10;
   if (AppStateValidatedDiffHarness("harness.__ytnova_missing__"))
-    return 12;
+    return 11;
   if (AppStateValidatedTransitionSequence("sequence.__ytnova_missing__"))
-    return 13;
+    return 12;
 
   invalid_transition =
       *AppStateTransitionLookup("transition.keybinding.navigate-tree");
@@ -10512,17 +10410,6 @@ int main(void) {
   if (AppStateValidateTransitionSequence("sequence.split-toggle-f8",
                                          &invalid_sequence))
     return 19;
-
-  if (AppStateCompatibilityShimCount() != 0)
-    return 20;
-  if (AppStateCompatibilityShimAt(0) != NULL)
-    return 21;
-  if (AppStateCompatibilityShimLookup("shim-render-derived-row-position") != NULL)
-    return 22;
-  if (AppStateValidatedCompatibilityShim("shim-render-derived-row-position"))
-    return 23;
-  if (AppStateValidateCompatibilityShim("shim-render-derived-row-position", NULL))
-    return 24;
 
   return 0;
 }
@@ -11810,9 +11697,8 @@ def test_render_projection_runtime_uses_no_compatibility_shim() -> None:
     display_source = Path("src/ui/display.c").read_text(encoding="utf-8")
     render_source = Path("src/ui/appstate_render.c").read_text(encoding="utf-8")
 
-    assert "static const char *const kAppStateRequiredShimIds[] = {" in main_source
-    assert "NULL," in main_source
-    assert "AppStateRequiredShimIdCount(void)" in main_source
+    assert "AppStateCompatibilityShimsReady(" not in main_source
+    assert "kAppStateRequiredShimIds" not in main_source
     assert 'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")' not in display_source
     assert 'AppStateValidatedCompatibilityShim("shim-render-derived-row-position")' not in render_source
 
@@ -13657,353 +13543,6 @@ def test_guard_allows_read_only_projection_shim_owner_field_outside_write_set(
     )
 
 
-def test_guard_fails_when_runtime_shim_metadata_drifts(tmp_path: Path) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim()]
-    runtime_shims[0]["owner"] = "different owner"
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "runtime owner does not match shim" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_owner_field_refs_drift(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim(owner_field_refs=["panel.tree_selection_key"])]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "runtime owner_field_refs does not match shim" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_generation_domain_refs_drift(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [
-        _shim(generation_domain_refs=["domain.panel_generation", "domain.volume_generation"])
-    ]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "runtime generation_domain_refs does not match shim" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_diff_harness_refs_drift(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [
-        _shim(
-            diff_harness_refs=[
-                "harness.transition_before_after_snapshot",
-                "harness.declared_write_set_diff",
-            ]
-        )
-    ]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "runtime diff_harness_refs does not match shim" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_diff_harness_refs_are_missing(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim()]
-    runtime_shims[0].pop("diff_harness_refs")
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "diff_harness_refs must be non-empty" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_diff_harness_ref_is_unknown(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim(diff_harness_refs=["harness.unknown"])]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "diff_harness_refs references unknown diff harness id" in failure
-        and "harness.unknown" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_diff_harness_ref_is_duplicated(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [
-        _shim(
-            diff_harness_refs=[
-                "harness.transition_before_after_snapshot",
-                "harness.transition_before_after_snapshot",
-            ]
-        )
-    ]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "duplicate diff_harness_refs[1]" in failure
-        and "harness.transition_before_after_snapshot" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_diff_harness_lacks_target_transition(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_diff_harness_checks = _complete_diff_harness_checks()
-    for harness in runtime_diff_harness_checks:
-        harness["transition_ids"] = ["transition.render_reflow"]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_diff_harness_checks=runtime_diff_harness_checks,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "diff_harness_refs must include at least one diff harness covering"
-        in failure
-        and "transition.keybinding" in failure
-        for failure in failures
-    )
-
-
-@pytest.mark.parametrize(
-    ("field", "replacement", "expected_ref"),
-    (
-        ("owner_field_refs", ["panel.tree_selection_key"], "field"),
-        (
-            "invariant_ids",
-            ["invariant.blocked_transition_determinism"],
-            "invariant.inactive_panel_frozen",
-        ),
-        ("generation_domain_ids", ["domain.volume_generation"], "domain.panel_generation"),
-    ),
-)
-def test_guard_fails_when_runtime_shim_diff_harness_union_lacks_declared_coverage(
-    tmp_path: Path,
-    field: str,
-    replacement: list[str],
-    expected_ref: str,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_diff_harness_checks = _complete_diff_harness_checks()
-    for harness in runtime_diff_harness_checks:
-        if harness["harness_id"] == "harness.transition_before_after_snapshot":
-            harness[field] = replacement
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_diff_harness_checks=runtime_diff_harness_checks,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "lacks referenced diff_harness_refs coverage" in failure
-        and expected_ref in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_generation_domain_refs_are_missing(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim()]
-    runtime_shims[0].pop("generation_domain_refs")
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "generation_domain_refs must be non-empty" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_generation_domain_ref_is_unknown(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim(generation_domain_refs=["domain.unknown"])]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "generation_domain_refs does not match runtime generation domain registry"
-        in failure
-        and "domain.unknown" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_generation_domain_ref_is_duplicated(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [
-        _shim(
-            generation_domain_refs=[
-                "domain.panel_generation",
-                "domain.panel_generation",
-            ]
-        )
-    ]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "duplicate generation_domain_refs[1]" in failure
-        and "domain.panel_generation" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_generation_owner_ref_lacks_matching_domain(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    transitions[0]["declared_write_set"] = ["field", "panel.panel_generation"]
-    owner_fields = _complete_owner_fields() + [_owner_field("panel.panel_generation")]
-    generation_domains = _complete_generation_domains()
-    generation_domains[0]["generation_owner_field"] = "panel.panel_generation"
-    generation_domains[0]["identity_fields"] = ["panel.panel_generation"]
-    runtime_shims = [
-        _shim(
-            owner_field_refs=["panel.panel_generation"],
-            generation_domain_refs=["domain.volume_generation"],
-        )
-    ]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        owner_fields=owner_fields,
-        generation_domains=generation_domains,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "generation_domain_refs must include a domain whose "
-        "generation_owner_field is panel.panel_generation" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_owner_field_ref_is_unknown(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim(owner_field_refs=["field.unknown"])]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "owner_field_refs does not match runtime owner field registry"
-        in failure
-        and "field.unknown" in failure
-        for failure in failures
-    )
-
-
 def test_guard_fails_when_read_only_projection_shim_owner_field_is_in_write_set(
     tmp_path: Path,
 ) -> None:
@@ -14023,345 +13562,6 @@ def test_guard_fails_when_read_only_projection_shim_owner_field_is_in_write_set(
         for failure in failures
     )
 
-
-def test_guard_fails_when_runtime_shim_write_capability_is_missing(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim()]
-    runtime_shims[0]["write_capability"] = ""
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "write_capability must be one of" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_write_capability_is_unknown(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim()]
-    runtime_shims[0]["write_capability"] = "sometimes"
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "write_capability must be one of" in failure
-        and "sometimes" in failure
-        for failure in failures
-    )
-
-
-@pytest.mark.parametrize(
-    "write_permission",
-    (
-        "Do not write stale mirror directly; write only from transition commit after canonical state changes.",
-        "No write should happen before transition commit; write the compatibility mirror after canonical state changes.",
-        "Never write before canonical state changes; write during the transition commit.",
-        "Read-only before commit; write the compatibility mirror after canonical state changes.",
-    ),
-)
-def test_guard_runtime_treats_explicit_write_capability_as_authoritative_over_prose(
-    tmp_path: Path, write_permission: str
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim(owner_field_refs=["panel.tree_selection_key"])]
-    runtime_shims[0]["write_permission"] = write_permission
-    runtime_shims[0]["write_capability"] = "write_capable"
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "owner_field_refs must be declared by target_transition write set"
-        in failure
-        and "panel.tree_selection_key" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_write_capable_shim_owner_field_is_outside_write_set(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim(owner_field_refs=["panel.tree_selection_key"])]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "owner_field_refs must be declared by target_transition write set"
-        in failure
-        and "panel.tree_selection_key" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_read_only_projection_owner_field_is_in_write_set(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim()]
-    runtime_shims[0]["write_permission"] = (
-        "Read-only projection for render calculations."
-    )
-    runtime_shims[0]["write_capability"] = "read_only_projection"
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "read_only_projection owner_field_refs must stay outside "
-        "target_transition write set" in failure
-        and "field" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_id_is_missing(tmp_path: Path) -> None:
-    transitions = _complete_transitions()
-    second_shim = _shim()
-    second_shim["id"] = "shim.second"
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        shims=[_shim(), second_shim],
-        runtime_shims=[_shim()],
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime compatibility shim registry missing shim id" in failure
-        and "shim.second" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_id_is_extra(tmp_path: Path) -> None:
-    transitions = _complete_transitions()
-    extra_shim = _shim()
-    extra_shim["id"] = "shim.extra"
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=[_shim(), extra_shim],
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[1]" in failure
-        and "id does not match a shim id" in failure
-        and "shim.extra" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_target_transition_drifts(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim(target_transition="transition.render_reflow")]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "runtime target_transition does not match shim" in failure
-        and "transition.render_reflow" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_invariant_checks_do_not_cover_target_transition(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim(target_transition="transition.render_reflow")]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and (
-            "invariant_checks must include at least one invariant covering "
-            "target_transition transition.render_reflow"
-        )
-        in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_each_runtime_shim_invariant_check_lacks_generation_target_coverage(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim()]
-    runtime_shims[0]["invariant_checks"] = [
-        "invariant.inactive_panel_frozen",
-        "invariant.render_projection_read_only",
-    ]
-    invariants = _complete_invariants()
-    for invariant in invariants:
-        if invariant["invariant_id"] == "invariant.render_projection_read_only":
-            invariant["transition_ids"] = ["transition.render_reflow"]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-        invariants=invariants,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "invariant_checks[1] must cover target_transition transition.keybinding"
-        in failure
-        and "invariant.render_projection_read_only" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_invariant_checks_are_missing(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_shims = [_shim()]
-    runtime_shims[0]["invariant_checks"] = []
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_shims=runtime_shims,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "invariant_checks must be non-empty" in failure
-        for failure in failures
-    )
-
-
-def test_guard_preserves_runtime_shim_invariant_array_parse_failures(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    paths = _write_fixture(tmp_path, transitions=transitions)
-    runtime_path = paths[-1]
-    source = runtime_path.read_text(encoding="utf-8")
-    runtime_path.write_text(
-        source.replace(
-            'static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {\n'
-            '  "invariant.inactive_panel_frozen",',
-            "static const char *const kAppStateCompatibilityShimInvariantChecks0[] = {\n"
-            "  NULL,",
-            1,
-        ),
-        encoding="utf-8",
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "kAppStateCompatibilityShimInvariantChecks0[0]" in failure
-        and "malformed string literal entry" in failure
-        and "NULL" in failure
-        for failure in failures
-    )
-
-
-def test_guard_preserves_runtime_shim_generation_domain_array_parse_failures(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    paths = _write_fixture(tmp_path, transitions=transitions)
-    runtime_path = paths[-1]
-    source = runtime_path.read_text(encoding="utf-8")
-    runtime_path.write_text(
-        source.replace(
-            'static const char *const kAppStateCompatibilityShimGenerationDomainRefs0[] = {\n'
-            '  "domain.panel_generation",',
-            "static const char *const kAppStateCompatibilityShimGenerationDomainRefs0[] = {\n"
-            "  NULL,",
-            1,
-        ),
-        encoding="utf-8",
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "kAppStateCompatibilityShimGenerationDomainRefs0[0]" in failure
-        and "malformed string literal entry" in failure
-        and "NULL" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_runtime_shim_target_transition_is_not_runtime_registered(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    runtime_transitions = [
-        record for record in transitions if record["id"] != "transition.keybinding"
-    ]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        runtime_transitions=runtime_transitions,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "runtime_shim[0]" in failure
-        and "target_transition does not match runtime transition registry" in failure
-        and "transition.keybinding" in failure
-        for failure in failures
-    )
 
 def test_guard_fails_when_runtime_invariant_metadata_drifts(tmp_path: Path) -> None:
     transitions = _complete_transitions()
@@ -17300,224 +16500,6 @@ def test_runtime_invariant_startup_requires_documented_invariant_ids() -> None:
     )
 
 
-def test_runtime_shim_startup_checks_fail_closed() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-
-    assert (
-        "AppStateCompatibilityShimAt(AppStateCompatibilityShimCount()) != NULL"
-        in source
-    )
-    assert (
-        'AppStateCompatibilityShimLookup("shim.__ytnova_unknown__") != NULL'
-        in source
-    )
-    assert "AppStateCompatibilityShimCount() != required_shim_id_count" in source
-    assert "previous_index < index" in source
-    assert "strcmp(previous->id, metadata->id) == 0" in source
-    assert "!AppStateCompatibilityShimsReady()" in source
-
-
-def test_runtime_shim_startup_validates_invariant_checks_against_registry() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-
-    assert re.search(
-        r"for \(invariant_index = 0;\s*"
-        r"invariant_index < metadata->invariant_check_count;\s*"
-        r"invariant_index\+\+\) \{\s*"
-        r"if \(!NonEmptyString\(metadata->invariant_checks\[invariant_index\]\)\)\s*"
-        r"return 0;\s*"
-        r"if \(AppStateInvariantLookup\("
-        r"metadata->invariant_checks\[invariant_index\]\)\s*==\s*NULL\)\s*"
-        r"return 0;",
-        source,
-        re.S,
-    )
-
-
-def test_runtime_shim_startup_requires_invariant_to_cover_target_transition() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-    helper_start = source.index(
-        "static int AppStateCompatibilityShimInvariantCoversTransition("
-    )
-    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
-    action_start = source.index("static int AppStateActionTransitionsReady(void)")
-    helper_body = source[helper_start:ready_start]
-    ready_body = source[ready_start:action_start]
-
-    assert "metadata->target_transition" in helper_body
-    assert (
-        "AppStateInvariantLookup(metadata->invariant_checks[invariant_index])"
-        in helper_body
-    )
-    assert "invariant->transition_ids" in helper_body
-    assert "invariant->transition_id_count" in helper_body
-    assert "!StringListContains(invariant->transition_ids" in helper_body
-    assert "!AppStateCompatibilityShimInvariantCoversTransition(metadata)" in ready_body
-
-
-def test_runtime_shim_startup_requires_owner_field_refs() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
-    action_start = source.index("static int AppStateActionTransitionsReady(void)")
-    ready_body = source[ready_start:action_start]
-
-    assert "metadata->owner_field_refs" in ready_body
-    assert "metadata->owner_field_ref_count" in ready_body
-    assert "AppStateOwnerFieldLookup(metadata->owner_field_refs[ref_index])" in ready_body
-    assert re.search(
-        r"StringListContains\(metadata->owner_field_refs,\s*"
-        r"ref_index,\s*metadata->owner_field_refs\[ref_index\]\)",
-        ready_body,
-        re.S,
-    )
-
-
-def test_runtime_shim_startup_requires_generation_domain_refs() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
-    action_start = source.index("static int AppStateActionTransitionsReady(void)")
-    ready_body = source[ready_start:action_start]
-
-    assert "metadata->generation_domain_refs" in ready_body
-    assert "metadata->generation_domain_ref_count" in ready_body
-    assert "AppStateGenerationDomainLookup(" in ready_body
-    assert re.search(
-        r"StringListContains\(metadata->generation_domain_refs,\s*"
-        r"generation_index,\s*"
-        r"metadata->generation_domain_refs\[generation_index\]\)",
-        ready_body,
-        re.S,
-    )
-
-
-def test_runtime_shim_startup_requires_diff_harness_refs() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
-    action_start = source.index("static int AppStateActionTransitionsReady(void)")
-    ready_body = source[ready_start:action_start]
-
-    assert "metadata->diff_harness_refs" in ready_body
-    assert "metadata->diff_harness_ref_count" in ready_body
-    assert "AppStateDiffHarnessLookup(metadata->diff_harness_refs[diff_index])" in ready_body
-    assert re.search(
-        r"StringListContains\(metadata->diff_harness_refs,\s*"
-        r"diff_index,\s*metadata->diff_harness_refs\[diff_index\]\)",
-        ready_body,
-        re.S,
-    )
-
-
-def test_runtime_shim_startup_requires_diff_harness_union_coverage() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-    helper_start = source.index(
-        "static int AppStateCompatibilityShimDiffHarnessCoversTransition("
-    )
-    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
-    action_start = source.index("static int AppStateActionTransitionsReady(void)")
-    helper_body = source[helper_start:ready_start]
-    ready_body = source[ready_start:action_start]
-
-    assert "AppStateCompatibilityShimDiffHarnessCoversOwnerField(" in helper_body
-    assert "AppStateCompatibilityShimDiffHarnessCoversInvariant(" in helper_body
-    assert (
-        "AppStateCompatibilityShimDiffHarnessCoversGenerationDomain("
-        in helper_body
-    )
-    assert "harness->transition_ids" in helper_body
-    assert "harness->owner_field_refs" in helper_body
-    assert "harness->invariant_ids" in helper_body
-    assert "harness->generation_domain_ids" in helper_body
-    assert "AppStateCompatibilityShimDiffHarnessCoversTransition(metadata)" in ready_body
-    assert "AppStateCompatibilityShimDiffHarnessCoversOwnerField(" in ready_body
-    assert "AppStateCompatibilityShimDiffHarnessCoversInvariant(" in ready_body
-    assert (
-        "AppStateCompatibilityShimDiffHarnessCoversGenerationDomain("
-        in ready_body
-    )
-
-
-def test_runtime_shim_startup_requires_generation_owner_refs_to_match_domains() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-    owner_helper_start = source.index(
-        "static int AppStateGenerationOwnerFieldRegistered("
-    )
-    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
-    action_start = source.index("static int AppStateActionTransitionsReady(void)")
-    helper_body = source[owner_helper_start:ready_start]
-    ready_body = source[ready_start:action_start]
-
-    assert "AppStateGenerationDomainAt(domain_index)" in helper_body
-    assert "domain->generation_owner_field" in helper_body
-    assert "AppStateCompatibilityShimGenerationDomainCoversOwnerField(" in helper_body
-    assert "AppStateGenerationDomainLookup(" in helper_body
-    assert "metadata->generation_domain_refs[ref_index]" in helper_body
-    assert "AppStateGenerationOwnerFieldRegistered(" in ready_body
-    assert "AppStateCompatibilityShimGenerationDomainCoversOwnerField(" in ready_body
-
-
-def test_runtime_shim_startup_requires_write_refs_to_match_target_write_set() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-    helper_start = source.index("static int AppStateCompatibilityShimWriteCapable(")
-    invariant_start = source.index(
-        "static int AppStateCompatibilityShimInvariantCoversTransition("
-    )
-    ready_start = source.index("static int AppStateCompatibilityShimsReady(void)")
-    action_start = source.index("static int AppStateActionTransitionsReady(void)")
-    helper_body = source[helper_start:invariant_start]
-    ready_body = source[ready_start:action_start]
-
-    assert "metadata->write_capability" in helper_body
-    assert 'strcmp(metadata->write_capability, "write_capable") == 0' in helper_body
-    assert "strstr" not in helper_body
-    assert "write_permission" not in helper_body
-    assert "AppStateCompatibilityShimWriteCapabilityKnown(metadata)" in ready_body
-    assert '"read_only_projection"' in helper_body
-    assert '"no_write"' in helper_body
-    assert "const AppStateTransitionMetadata *transition" in ready_body
-    assert re.search(
-        r"AppStateCompatibilityShimWriteCapable\(metadata\).*?"
-        r"!StringListContains\(transition->declared_write_set,\s*"
-        r"transition->declared_write_set_count,\s*"
-        r"metadata->owner_field_refs\[ref_index\]\)",
-        ready_body,
-        re.S,
-    )
-
-
-def test_runtime_shim_startup_requires_documented_shim_ids() -> None:
-    source = Path("src/core/main.c").read_text(encoding="utf-8")
-    shim_doc, shim_failures = guard._load_json(guard.DEFAULT_SHIMS)
-    required_ids = guard._collect_string_ids(
-        shim_doc,
-        collection_key="shims",
-        id_field="id",
-    )
-    required_table = re.search(
-        r"static\s+const\s+char\s+\*const\s+"
-        r"kAppStateRequiredShimIds\[\]\s*=\s*\{(?P<body>.*?)\};",
-        source,
-        re.S,
-    )
-    assert shim_failures == []
-    assert required_table is not None
-    if required_ids:
-        table_ids, table_failures = guard._parse_string_initializer_array(
-            required_table.group("body"),
-            "kAppStateRequiredShimIds",
-        )
-        assert table_failures == []
-        assert set(table_ids) == required_ids
-    else:
-        assert "NULL" in required_table.group("body")
-        assert "AppStateRequiredShimIdCount(void)" in source
-    assert re.search(
-        r"AppStateCompatibilityShimLookup\(\s*"
-        r"kAppStateRequiredShimIds\[index\]\s*\)",
-        source,
-        re.S,
-    )
-
-
 def test_runtime_diff_harness_startup_checks_fail_closed() -> None:
     source = Path("src/core/main.c").read_text(encoding="utf-8")
 
@@ -17773,8 +16755,7 @@ def test_appstate_dispatch_surface_accessor_fails_closed_on_invalid_metadata() -
         "const AppStateDispatchSurfaceMetadata *AppStateDispatchSurfaceAt(size_t index)"
     )
     next_accessor_start = source.index(
-        "const AppStateCompatibilityShimMetadata *\n"
-        "AppStateCompatibilityShimAt(size_t index)"
+        "const AppStateInvariantMetadata *AppStateInvariantAt(size_t index)"
     )
     accessor_body = source[accessor_start:next_accessor_start]
 
@@ -17782,27 +16763,6 @@ def test_appstate_dispatch_surface_accessor_fails_closed_on_invalid_metadata() -
     assert re.search(
         r"if \(!AppStateValidatedDispatchSurface\(\s*"
         r"kAppStateDispatchSurfaces\[index\]\.surface_id\s*"
-        r"\)\)\s*return NULL;",
-        accessor_body,
-        re.S,
-    )
-
-
-def test_appstate_shim_accessor_fails_closed_on_invalid_metadata() -> None:
-    source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
-    accessor_start = source.index(
-        "const AppStateCompatibilityShimMetadata *\n"
-        "AppStateCompatibilityShimAt(size_t index)"
-    )
-    next_accessor_start = source.index(
-        "const AppStateInvariantMetadata *AppStateInvariantAt(size_t index)"
-    )
-    accessor_body = source[accessor_start:next_accessor_start]
-
-    assert "index >= AppStateCompatibilityShimCount()" in accessor_body
-    assert re.search(
-        r"if \(!AppStateValidatedCompatibilityShim\(\s*"
-        r"kAppStateCompatibilityShims\[index\]\.id\s*"
         r"\)\)\s*return NULL;",
         accessor_body,
         re.S,
@@ -17856,10 +16816,6 @@ def test_appstate_string_lookup_boundaries_fail_closed_on_invalid_registry_keys(
         "AppStateDispatchSurfaceLookup": (
             "kAppStateDispatchSurfaces[index].surface_id",
             "surface_id",
-        ),
-        "AppStateCompatibilityShimLookup": (
-            "kAppStateCompatibilityShims[index].id",
-            "shim_id",
         ),
         "AppStateInvariantLookup": (
             "kAppStateInvariants[index].invariant_id",


### PR DESCRIPTION
## Summary
- remove the empty compatibility shim runtime surface from AppState headers, startup checks, and render reflow gating
- stop the contract guard from parsing runtime shim metadata or shim validation callsites
- trim contract-guard tests so the removed shim runtime surface stays gone

## Validation
- Red proof is encoded in the targeted contract-guard cases that assert the removed shim runtime surface stays absent.
- `make`
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'shim or runtime_registry_boundary_validation_requires_registered_metadata or render_projection_runtime_uses_no_compatibility_shim'`
