### PR TITLE
refactor(appstate): retire the empty compatibility shim registry

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,21 +4,26 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-remove-shim-runtime-support
-Active PR: https://github.com/robkam/ytreenova/pull/372
+Current branch: appstate-drop-empty-compat-shim-registry
+Active PR: https://github.com/robkam/ytreenova/pull/373
 Supersession state: no active stop or pause condition.
 
 Current AppState batch:
-- Remove dead compatibility shim runtime support now that `docs/appstate_compat_shims.json` is empty and no runtime shim validation callsites remain.
-- Runtime/header removal is implemented in `include/ytnova_appstate_actions.h`, `src/core/appstate_actions.c`, and `src/core/main.c`.
-- The contract guard no longer parses or validates a runtime shim registry, and the matching tests/fixtures were trimmed in `scripts/check_appstate_contract.py` and `tests/test_appstate_contract_guard.py`.
-- The render reflow path no longer gates on shim validation in `src/ui/display.c`.
+- Remove the now-empty AppState compatibility-shim registry from the formal contract guard surface.
+- Delete `docs/appstate_compat_shims.json`, drop the guard CLI/validation paths that still loaded shim metadata, and trim the matching contract-guard fixture/tests.
+- Update architecture/spec references so the current contract treats legacy alternate authority as a defect instead of a documented shim registry path.
+
+Current repair state:
+- PR #373 first went red on `Full coverage baseline gate` because `validate_contract(...)` stopped running action-coverage and event-coverage validation after the shim-registry removal edits.
+- After that repair, the rerun exposed one remaining stale guard test that still indexed the removed shim slot inside `_write_fixture(...)` path tuples.
+- The local fixes now restore the missing action/event coverage guard passes, keep shim-registry support removed, and make the runtime-backed notes test target named fixture paths instead of brittle tuple offsets.
 
 Local validation:
-- `make`
+- `python3 -m py_compile scripts/check_appstate_contract.py tests/test_appstate_contract_guard.py`
 - `python3 scripts/check_appstate_contract.py`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'shim or runtime_registry_boundary_validation_requires_registered_metadata or render_projection_runtime_uses_no_compatibility_shim'`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'test_runtime_generation_domain_ref_readiness_uses_coverage_transitions or shim or runtime_registry_boundary_validation_requires_registered_metadata or render_projection_runtime_uses_no_compatibility_shim'`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'runtime_action_lookup_mismatches_action_coverage or runtime_action_coverage_is_missing_enum_action or runtime_event_coverage_owner_does_not_match_transition or event_coverage_dispatch_surface_refs_are_invalid or coverage_diff_harness_refs_are_invalid'`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'runtime_backed_registry_notes_reject_stale_non_runtime_wording'`
+- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'current_repository_appstate_contract_passes or guard_passes_complete_temporary_fixtures or appstate_runtime_no_longer_exposes_shim_registry_support or volume_tree_runtime_breadcrumb_fields_are_retired or visibility_session_mirror_is_retired or focused_window_runtime_no_longer_validates_removed_shim or render_row_projection_uses_shared_helpers or render_projection_runtime_uses_no_compatibility_shim or guard_fails_on_duplicate_transition_ids or guard_fails_on_empty_required_list_fields or guard_fails_on_non_list_required_list_fields or runtime_dispatch_surface_validation_callsite_is_missing or runtime_dispatch_surface_validation_moves_outside_source_boundary or runtime_event_validation_callsite_is_missing or runtime_event_validation_moves_outside_source_boundary or runtime_action_lookup_mismatches_action_coverage or runtime_action_coverage_is_missing_enum_action or runtime_event_coverage_owner_does_not_match_transition or event_coverage_dispatch_surface_refs_are_invalid or coverage_diff_harness_refs_are_invalid or runtime_backed_registry_notes_reject_stale_non_runtime_wording'`
 
 Next action:
-- Push the amended PR fix for the coverage guard helper-slice failure, restart the CI wait clock, then follow the CI wait rule until mergeable.
+- Stage the repaired guard/test/handoff state, amend the branch commit, push with lease, then restart the CI wait clock and wait 15 minutes before the first compact PR status check.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,7 +213,7 @@ Generation metadata is part of transition correctness:
 
 Rendering is projection only. Render/reflow paths may compute temporary row positions and clipped viewports from settled `AppState`, but those temporary values are discarded after drawing. A renderer must not choose a new tree/file selection, overwrite a saved viewport, or synthesize focus shape from visible rows. If projection cannot be computed safely, rendering must degrade or skip while leaving authoritative state intact.
 
-Compatibility shims are temporary migration debt, not alternate authority. Each shim must be recorded in `docs/appstate_compat_shims.json` with an owner, legacy authority path, read permission, write permission, invariant checks, removal trigger, target transition, follow-up task, and QA enforcement. Shim writes are allowed only when synchronizing from the future authoritative owner during a transition commit; shim reads must not outrank stable path keys, generation checks, or panel-local state.
+Compatibility shims are retired from the current AppState contract. Any legacy mirror or alternate authority path is a defect that must be removed rather than documented as an accepted AppState boundary.
 
 ### 4.3 Inter-Panel Operations (The Directional Rule)
 *   **Targeting:** Copy and Move operations occur directionally: **Source (Active Panel) to Destination (Inactive Panel)**.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -26,7 +26,7 @@ This section states the intended contract. Where current behavior differs, the c
 
 The architectural state model that backs this contract is described in `docs/ARCHITECTURE.md` as the per-window / per-panel UI state record and its ownership rules.
 
-The formal AppState transition contract is defined in `docs/ARCHITECTURE.md` §4.2.3 and backed by the machine-readable registries `docs/appstate_transition_matrix.json` and `docs/appstate_compat_shims.json`. This specification states user-visible behavior; transition ownership, write-set, generation, blocked-transition, render-projection, and compatibility-shim metadata belong to the architecture contract and must not be duplicated here.
+The formal AppState transition contract is defined in `docs/ARCHITECTURE.md` §4.2.3 and backed by the machine-readable AppState registries under `docs/appstate*.json`. This specification states user-visible behavior; transition ownership, write-set, generation, blocked-transition, render-projection, and related contract metadata belong to the architecture contract and must not be duplicated here.
 
 ### 2.1 Input Semantics
 

--- a/docs/appstate_compat_shims.json
+++ b/docs/appstate_compat_shims.json
@@ -1,6 +1,0 @@
-{
-  "schema_version": 1,
-  "contract": "AppState compatibility shim registry",
-  "notes": "Compatibility shims document legacy authority paths that may remain during migration. They must be read/write classified and removed when the target transition boundary is live.",
-  "shims": []
-}

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the documented AppState transition and compatibility-shim registries."""
+"""Validate the documented AppState transition registries."""
 
 from __future__ import annotations
 
@@ -11,7 +11,6 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_TRANSITIONS = REPO_ROOT / "docs" / "appstate_transition_matrix.json"
-DEFAULT_SHIMS = REPO_ROOT / "docs" / "appstate_compat_shims.json"
 DEFAULT_ACTION_COVERAGE = REPO_ROOT / "docs" / "appstate_action_coverage.json"
 DEFAULT_EVENT_COVERAGE = REPO_ROOT / "docs" / "appstate_event_coverage.json"
 DEFAULT_OWNER_FIELDS = REPO_ROOT / "docs" / "appstate_owner_fields.json"
@@ -60,24 +59,6 @@ REQUIRED_TRANSITION_FIELDS = {
     "render_invalidation",
     "boundary_status",
     "notes_follow_up",
-}
-
-REQUIRED_SHIM_FIELDS = {
-    "id",
-    "owner",
-    "old_authority_path",
-    "read_permission",
-    "write_permission",
-    "write_capability",
-    "invariant_checks",
-    "owner_field_refs",
-    "generation_domain_refs",
-    "diff_harness_refs",
-    "source_boundary_refs",
-    "removal_trigger",
-    "target_transition",
-    "follow_up_task",
-    "qa_enforcement",
 }
 
 REQUIRED_ACTION_FIELDS = {
@@ -335,17 +316,6 @@ EVENT_LIST_FIELDS = LIST_FIELDS | {
     "generation_domain_refs",
     "diff_harness_refs",
     "invariant_refs",
-}
-SHIM_LIST_FIELDS = LIST_FIELDS | {
-    "owner_field_refs",
-    "generation_domain_refs",
-    "diff_harness_refs",
-    "source_boundary_refs",
-}
-VALID_SHIM_WRITE_CAPABILITIES = {
-    "write_capable",
-    "read_only_projection",
-    "no_write",
 }
 VALID_BOUNDARY_STATUSES = {
     "covered_by_transition_record",
@@ -3315,23 +3285,6 @@ def _validate_required_string_list(
     return failures
 
 
-def _validate_shim_write_capability(record: dict[str, Any], label: str) -> list[str]:
-    value = record.get("write_capability")
-    if isinstance(value, str) and value in VALID_SHIM_WRITE_CAPABILITIES:
-        return []
-
-    allowed = ", ".join(sorted(VALID_SHIM_WRITE_CAPABILITIES))
-    return [f"{label}: write_capability must be one of {allowed}: {value}"]
-
-
-def _shim_write_capable(write_capability: Any) -> bool:
-    return write_capability == "write_capable"
-
-
-def _shim_read_only_projection(write_capability: Any) -> bool:
-    return write_capability == "read_only_projection"
-
-
 def _validate_owner_field_ref_list(
     *,
     refs: Any,
@@ -3364,213 +3317,6 @@ def _validate_owner_field_ref_list(
             failures.append(
                 f"{label}: owner_field_refs does not match {registry_label}: {ref}"
             )
-
-    return failures
-
-
-def _validate_shim_owner_field_refs(
-    *,
-    record: dict[str, Any],
-    registered_fields: set[str],
-    transition_ids: dict[str, dict[str, Any]],
-    label: str,
-    registry_label: str,
-) -> list[str]:
-    failures = _validate_owner_field_ref_list(
-        refs=record.get("owner_field_refs"),
-        registered_fields=registered_fields,
-        label=label,
-        registry_label=registry_label,
-    )
-    if failures:
-        return failures
-
-    target_transition = record.get("target_transition")
-    transition = (
-        transition_ids.get(target_transition)
-        if isinstance(target_transition, str)
-        else None
-    )
-    if transition is None:
-        return failures
-
-    declared_write_set = transition.get("declared_write_set")
-    if not isinstance(declared_write_set, list):
-        return failures
-    declared_writes = {
-        field
-        for field in declared_write_set
-        if isinstance(field, str) and field.strip()
-    }
-    owner_refs = record.get("owner_field_refs")
-    assert isinstance(owner_refs, list)
-    write_capability = record.get("write_capability")
-    for owner_ref in owner_refs:
-        if _shim_write_capable(write_capability) and owner_ref not in declared_writes:
-            failures.append(
-                f"{label}: owner_field_refs must be declared by "
-                f"target_transition write set {target_transition}: {owner_ref}"
-            )
-        if (
-            _shim_read_only_projection(write_capability)
-            and owner_ref in declared_writes
-        ):
-            failures.append(
-                f"{label}: read_only_projection owner_field_refs must stay "
-                f"outside target_transition write set {target_transition}: "
-                f"{owner_ref}"
-            )
-
-    return failures
-
-
-def _validate_shim_generation_domain_refs(
-    *,
-    record: dict[str, Any],
-    generation_domain_owner_fields: dict[str, str],
-    label: str,
-    registry_label: str,
-) -> list[str]:
-    failures = _validate_list_field(
-        value=record.get("generation_domain_refs"),
-        label=label,
-        field="generation_domain_refs",
-    )
-    if failures:
-        return failures
-
-    generation_domain_refs = record.get("generation_domain_refs")
-    owner_field_refs = record.get("owner_field_refs")
-    assert isinstance(generation_domain_refs, list)
-    seen: set[str] = set()
-    covered_generation_owner_fields: set[str] = set()
-    for index, ref in enumerate(generation_domain_refs):
-        assert isinstance(ref, str)
-        if ref in seen:
-            failures.append(f"{label}: duplicate generation_domain_refs[{index}]: {ref}")
-        seen.add(ref)
-        generation_owner_field = generation_domain_owner_fields.get(ref)
-        if generation_owner_field is None:
-            failures.append(
-                f"{label}: generation_domain_refs does not match {registry_label}: {ref}"
-            )
-        else:
-            covered_generation_owner_fields.add(generation_owner_field)
-
-    if (
-        _shim_write_capable(record.get("write_capability"))
-        and isinstance(owner_field_refs, list)
-        and not failures
-    ):
-        known_generation_owner_fields = set(generation_domain_owner_fields.values())
-        for owner_ref in owner_field_refs:
-            if (
-                isinstance(owner_ref, str)
-                and owner_ref in known_generation_owner_fields
-                and owner_ref not in covered_generation_owner_fields
-            ):
-                failures.append(
-                    f"{label}: generation_domain_refs must include a domain "
-                    f"whose generation_owner_field is {owner_ref}"
-                )
-
-    return failures
-
-
-def _validate_shim_diff_harness_refs(
-    *,
-    refs: Any,
-    diff_harness_ids: set[str],
-    label: str,
-) -> list[str]:
-    failures = _validate_list_field(
-        value=refs,
-        label=label,
-        field="diff_harness_refs",
-    )
-    if failures:
-        return failures
-
-    seen: set[str] = set()
-    assert isinstance(refs, list)
-    for index, ref in enumerate(refs):
-        assert isinstance(ref, str)
-        if ref in seen:
-            failures.append(f"{label}: duplicate diff_harness_refs[{index}]: {ref}")
-        seen.add(ref)
-        if ref not in diff_harness_ids:
-            failures.append(
-                f"{label}: diff_harness_refs references unknown diff harness id: {ref}"
-            )
-
-    return failures
-
-
-def _validate_shim_diff_harness_transition_coverage(
-    *,
-    diff_harness_refs: Any,
-    transition_id: Any,
-    diff_harness_transition_ids: dict[str, set[str]],
-    label: str,
-) -> list[str]:
-    if not isinstance(transition_id, str) or not transition_id.strip():
-        return []
-    if not isinstance(diff_harness_refs, list):
-        return []
-
-    for harness_id in diff_harness_refs:
-        if not isinstance(harness_id, str) or not harness_id.strip():
-            continue
-        if transition_id in diff_harness_transition_ids.get(harness_id, set()):
-            return []
-
-    return [
-        f"{label}: diff_harness_refs must include at least one diff harness "
-        f"covering target_transition {transition_id}"
-    ]
-
-
-def _validate_shim_diff_harness_union_coverage(
-    *,
-    record: dict[str, Any],
-    diff_harness_owner_field_refs: dict[str, set[str]],
-    diff_harness_invariant_ids: dict[str, set[str]],
-    diff_harness_generation_domain_ids: dict[str, set[str]],
-    label: str,
-) -> list[str]:
-    diff_harness_refs = record.get("diff_harness_refs")
-    if not isinstance(diff_harness_refs, list):
-        return []
-
-    covered_owner_fields: set[str] = set()
-    covered_invariants: set[str] = set()
-    covered_generation_domains: set[str] = set()
-    for harness_id in diff_harness_refs:
-        if not isinstance(harness_id, str) or not harness_id.strip():
-            continue
-        covered_owner_fields.update(diff_harness_owner_field_refs.get(harness_id, set()))
-        covered_invariants.update(diff_harness_invariant_ids.get(harness_id, set()))
-        covered_generation_domains.update(
-            diff_harness_generation_domain_ids.get(harness_id, set())
-        )
-
-    failures: list[str] = []
-    for field_name, covered_refs in (
-        ("owner_field_refs", covered_owner_fields),
-        ("invariant_checks", covered_invariants),
-        ("generation_domain_refs", covered_generation_domains),
-    ):
-        refs = record.get(field_name)
-        if not isinstance(refs, list):
-            continue
-        for index, ref in enumerate(refs):
-            if not isinstance(ref, str) or not ref.strip():
-                continue
-            if ref not in covered_refs:
-                failures.append(
-                    f"{label}: {field_name}[{index}] lacks referenced "
-                    f"diff_harness_refs coverage: {ref}"
-                )
 
     return failures
 
@@ -3646,29 +3392,6 @@ def _validate_coverage_diff_harness_refs(
     return failures
 
 
-def _validate_each_shim_invariant_covers_transition(
-    *,
-    invariant_refs: Any,
-    transition_id: Any,
-    invariant_transition_ids: dict[str, set[str]],
-    label: str,
-) -> list[str]:
-    if not isinstance(transition_id, str) or not transition_id.strip():
-        return []
-    if not isinstance(invariant_refs, list):
-        return []
-
-    failures: list[str] = []
-    for index, invariant_ref in enumerate(invariant_refs):
-        if not isinstance(invariant_ref, str) or not invariant_ref.strip():
-            continue
-        if transition_id not in invariant_transition_ids.get(invariant_ref, set()):
-            failures.append(
-                f"{label}: invariant_checks[{index}] must cover "
-                f"target_transition {transition_id}: {invariant_ref}"
-            )
-
-    return failures
 
 
 def _validate_owner_fields(
@@ -6876,7 +6599,6 @@ def _validate_runtime_transition_sequence_registry(
 
 def validate_contract(
     transitions_path: Path,
-    shims_path: Path,
     action_coverage_path: Path,
     actions_header_path: Path,
     event_coverage_path: Path = DEFAULT_EVENT_COVERAGE,
@@ -6892,7 +6614,6 @@ def validate_contract(
 ) -> list[str]:
     failures: list[str] = []
     transitions_doc, transition_load_failures = _load_json(transitions_path)
-    shims_doc, shim_load_failures = _load_json(shims_path)
     action_coverage_doc, action_coverage_load_failures = _load_json(action_coverage_path)
     event_coverage_doc, event_coverage_load_failures = _load_json(event_coverage_path)
     owner_fields_doc, owner_fields_load_failures = _load_json(owner_fields_path)
@@ -6939,7 +6660,6 @@ def validate_contract(
         _parse_runtime_transition_sequence_registry(action_runtime_path)
     )
     failures.extend(transition_load_failures)
-    failures.extend(shim_load_failures)
     failures.extend(action_coverage_load_failures)
     failures.extend(event_coverage_load_failures)
     failures.extend(owner_fields_load_failures)
@@ -7233,117 +6953,6 @@ def validate_contract(
             "generation_domain_ids",
         )
     )
-
-    if not isinstance(shims_doc, dict):
-        failures.append(f"{shims_path}: top-level value must be an object")
-        shims = []
-    else:
-        shims = shims_doc.get("shims")
-        if not isinstance(shims, list):
-            failures.append(f"{shims_path}: shims must be a list")
-            shims = []
-
-    shim_ids: set[str] = set()
-    for index, record in enumerate(shims):
-        label = f"shim[{index}]"
-        failures.extend(
-            _validate_required_fields(
-                record=record,
-                required_fields=REQUIRED_SHIM_FIELDS,
-                list_fields=SHIM_LIST_FIELDS,
-                label=label,
-            )
-        )
-        if not isinstance(record, dict):
-            continue
-        shim_id = record.get("id")
-        if isinstance(shim_id, str) and shim_id.strip():
-            if shim_id in shim_ids:
-                failures.append(f"{label}: duplicate id: {shim_id}")
-            shim_ids.add(shim_id)
-        target_transition = record.get("target_transition")
-        if isinstance(target_transition, str) and target_transition.strip():
-            if target_transition not in transition_ids:
-                failures.append(
-                    f"{label}: target_transition does not match a transition id: {target_transition}"
-                )
-        failures.extend(_validate_shim_write_capability(record, label))
-        failures.extend(
-            _validate_invariant_check_refs(
-                invariant_checks=record.get("invariant_checks"),
-                runtime_invariant_ids=runtime_invariant_ids,
-                label=label,
-            )
-        )
-        failures.extend(
-            _validate_invariant_transition_alignment(
-                invariant_refs=record.get("invariant_checks"),
-                transition_id=target_transition,
-                invariant_transition_ids=invariant_transition_ids,
-                label=label,
-                invariant_field="invariant_checks",
-                transition_field="target_transition",
-            )
-        )
-        failures.extend(
-            _validate_each_shim_invariant_covers_transition(
-                invariant_refs=record.get("invariant_checks"),
-                transition_id=target_transition,
-                invariant_transition_ids=invariant_transition_ids,
-                label=label,
-            )
-        )
-        failures.extend(
-            _validate_shim_owner_field_refs(
-                record=record,
-                registered_fields=registered_owner_fields,
-                transition_ids=transition_ids,
-                label=label,
-                registry_label="owner-field registry",
-            )
-        )
-        failures.extend(
-            _validate_shim_generation_domain_refs(
-                record=record,
-                generation_domain_owner_fields=generation_domain_owner_fields,
-                label=label,
-                registry_label="generation-domain registry",
-            )
-        )
-        failures.extend(
-            _validate_shim_diff_harness_refs(
-                refs=record.get("diff_harness_refs"),
-                diff_harness_ids=diff_harness_ids,
-                label=label,
-            )
-        )
-        failures.extend(
-            _validate_shim_diff_harness_transition_coverage(
-                diff_harness_refs=record.get("diff_harness_refs"),
-                transition_id=target_transition,
-                diff_harness_transition_ids=diff_harness_transition_ids,
-                label=label,
-            )
-        )
-        failures.extend(
-            _validate_shim_diff_harness_union_coverage(
-                record=record,
-                diff_harness_owner_field_refs=diff_harness_owner_field_refs_by_harness,
-                diff_harness_invariant_ids=diff_harness_invariant_ids_by_harness,
-                diff_harness_generation_domain_ids=(
-                    diff_harness_generation_domain_ids_by_harness
-                ),
-                label=label,
-            )
-        )
-        failures.extend(
-            _validate_source_boundary_refs(
-                record.get("source_boundary_refs"),
-                label=label,
-                repository_root=repository_root,
-            )
-        )
-
     if not isinstance(action_coverage_doc, dict):
         failures.append(f"{action_coverage_path}: top-level value must be an object")
         action_records = []
@@ -7358,7 +6967,6 @@ def validate_contract(
         dispatch_surface_records = dispatch_surfaces_doc["dispatch_surfaces"]
     else:
         dispatch_surface_records = []
-
     expected_actions = set(enum_actions)
     covered_actions: set[str] = set()
     action_coverage_by_action: dict[str, dict[str, Any]] = {}
@@ -7616,6 +7224,7 @@ def validate_contract(
             action_runtime_path=action_runtime_path,
         )
     )
+
     failures.extend(
         _validate_dispatch_surfaces(
             dispatch_surfaces_doc=dispatch_surfaces_doc,
@@ -7800,6 +7409,18 @@ def validate_contract(
         collection_key="actions",
         id_field="action",
     )
+    if isinstance(action_coverage_doc, dict) and isinstance(
+        action_coverage_doc.get("actions"), list
+    ):
+        action_coverage_by_action = {
+            record["action"]: record
+            for record in action_coverage_doc["actions"]
+            if isinstance(record, dict)
+            and isinstance(record.get("action"), str)
+            and record["action"].strip()
+        }
+    else:
+        action_coverage_by_action = {}
     event_ids = _collect_string_ids(
         event_coverage_doc,
         collection_key="events",
@@ -7888,7 +7509,6 @@ def validate_contract(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--transitions", type=Path, default=DEFAULT_TRANSITIONS)
-    parser.add_argument("--shims", type=Path, default=DEFAULT_SHIMS)
     parser.add_argument("--action-coverage", type=Path, default=DEFAULT_ACTION_COVERAGE)
     parser.add_argument("--event-coverage", type=Path, default=DEFAULT_EVENT_COVERAGE)
     parser.add_argument("--owner-fields", type=Path, default=DEFAULT_OWNER_FIELDS)
@@ -7909,7 +7529,6 @@ def main() -> int:
 
     failures = validate_contract(
         args.transitions,
-        args.shims,
         args.action_coverage,
         args.actions_header,
         args.event_coverage,

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -87,11 +87,6 @@ REQUIRED_LIST_FIELD_CASES = [
         "diff_harness_ids",
         "transition_sequence[0].step[0]",
     ),
-    ("shim", "invariant_checks", "shim[0]"),
-    ("shim", "owner_field_refs", "shim[0]"),
-    ("shim", "generation_domain_refs", "shim[0]"),
-    ("shim", "diff_harness_refs", "shim[0]"),
-    ("shim", "migration_notes", "shim[0]"),
 ]
 
 
@@ -125,31 +120,6 @@ def _transition(category: str, transition_id: str | None = None) -> dict[str, ob
     }
 
 
-def _shim(
-    target_transition: str = "transition.keybinding",
-    owner_field_refs: list[str] | None = None,
-    generation_domain_refs: list[str] | None = None,
-    diff_harness_refs: list[str] | None = None,
-    source_boundary_refs: list[str] | None = None,
-) -> dict[str, object]:
-    return {
-        "id": "shim.test",
-        "owner": "owner",
-        "old_authority_path": "legacy.path",
-        "read_permission": "read",
-        "write_permission": "write",
-        "write_capability": "write_capable",
-        "invariant_checks": ["invariant.inactive_panel_frozen"],
-        "owner_field_refs": owner_field_refs or ["field"],
-        "generation_domain_refs": generation_domain_refs or ["domain.panel_generation"],
-        "diff_harness_refs": diff_harness_refs
-        or ["harness.transition_before_after_snapshot"],
-        "source_boundary_refs": source_boundary_refs or ["src/ui/display.c"],
-        "removal_trigger": "trigger",
-        "target_transition": target_transition,
-        "follow_up_task": "task",
-        "qa_enforcement": "guard",
-    }
 
 
 def _action(
@@ -756,7 +726,6 @@ def _write_fixture(
     tmp_path: Path,
     *,
     transitions: list[dict[str, object]],
-    shims: list[dict[str, object]] | None = None,
     actions: list[dict[str, object]] | None = None,
     events: list[dict[str, object]] | None = None,
     owner_fields: list[dict[str, object]] | None = None,
@@ -777,9 +746,8 @@ def _write_fixture(
     runtime_generation_domains: list[dict[str, object]] | None = None,
     runtime_diff_harness_checks: list[dict[str, object]] | None = None,
     runtime_transition_sequences: list[dict[str, object]] | None = None,
-) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, ...]:
     transitions_path = tmp_path / "transitions.json"
-    shims_path = tmp_path / "shims.json"
     action_coverage_path = tmp_path / "action_coverage.json"
     event_coverage_path = tmp_path / "event_coverage.json"
     owner_fields_path = tmp_path / "owner_fields.json"
@@ -791,7 +759,6 @@ def _write_fixture(
     actions_header_path = tmp_path / "ytnova_defs.h"
     action_runtime_path = tmp_path / "appstate_actions.c"
     _write(transitions_path, _jsonish({"schema_version": 1, "transitions": transitions}))
-    _write(shims_path, _jsonish({"schema_version": 1, "shims": shims or [_shim()]}))
     _write(
         action_coverage_path,
         _jsonish({"schema_version": 1, "actions": actions or _complete_actions()}),
@@ -909,7 +876,6 @@ def _write_fixture(
     )
     return (
         transitions_path,
-        shims_path,
         action_coverage_path,
         actions_header_path,
         event_coverage_path,
@@ -1941,16 +1907,15 @@ def _complete_owner_fields() -> list[dict[str, object]]:
 
 
 def _validate(
-    paths: tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path],
+    paths: tuple[Path, ...],
 ) -> list[str]:
     return guard.validate_contract(*paths)
 
 
 def _fixture_with_list_field_value(
     tmp_path: Path, record_type: str, field: str, value: object
-) -> tuple[Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path, Path]:
+) -> tuple[Path, ...]:
     transitions = _complete_transitions()
-    shims = [_shim()]
     actions = _complete_actions()
     events = _complete_events()
     owner_fields = _complete_owner_fields()
@@ -1969,8 +1934,6 @@ def _fixture_with_list_field_value(
         generation_domains[0][field] = value
     elif record_type == "transition":
         transitions[0][field] = value
-    elif record_type == "shim":
-        shims[0][field] = value
     elif record_type == "dispatch_surface":
         dispatch_surfaces[0][field] = value
     elif record_type == "invariant":
@@ -1984,7 +1947,6 @@ def _fixture_with_list_field_value(
     return _write_fixture(
         tmp_path,
         transitions=transitions,
-        shims=shims,
         actions=actions,
         events=events,
         owner_fields=owner_fields,
@@ -2018,20 +1980,39 @@ def test_guard_passes_complete_temporary_fixtures(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("path_index", "registry_name"),
+    ("target_name", "registry_name"),
     [
-        (2, "action coverage"),
-        (4, "event coverage"),
-        (5, "owner field"),
-        (6, "dispatch surface"),
-        (9, "diff harness"),
+        ("action_coverage", "action coverage"),
+        ("event_coverage", "event coverage"),
+        ("owner_fields", "owner field"),
+        ("dispatch_surfaces", "dispatch surface"),
+        ("diff_harness", "diff harness"),
     ],
 )
 def test_runtime_backed_registry_notes_reject_stale_non_runtime_wording(
-    tmp_path: Path, path_index: int, registry_name: str
+    tmp_path: Path, target_name: str, registry_name: str
 ) -> None:
     paths = _write_fixture(tmp_path, transitions=_complete_transitions())
-    target = paths[path_index]
+    (
+        _transitions_path,
+        action_coverage_path,
+        _actions_header_path,
+        event_coverage_path,
+        owner_fields_path,
+        dispatch_surfaces_path,
+        _invariants_path,
+        _generation_domains_path,
+        diff_harness_path,
+        _transition_sequences_path,
+        _action_runtime_path,
+    ) = paths
+    target = {
+        "action_coverage": action_coverage_path,
+        "event_coverage": event_coverage_path,
+        "owner_fields": owner_fields_path,
+        "dispatch_surfaces": dispatch_surfaces_path,
+        "diff_harness": diff_harness_path,
+    }[target_name]
     doc = json.loads(target.read_text(encoding="utf-8"))
     doc["notes"] = (
         f"Non-runtime registry for future-only {registry_name} coverage before "
@@ -5813,9 +5794,8 @@ def test_appstate_runtime_no_longer_exposes_shim_registry_support() -> None:
 
     assert "AppStateCompatibilityShimsReady(" not in startup
     assert "kAppStateRequiredShimIds" not in startup
-    assert "_parse_runtime_shim_registry(" not in guard_source
-    assert "_validate_runtime_shim_registry(" not in guard_source
-    assert "_validate_runtime_shim_callsites(" not in guard_source
+    assert "appstate_compat_shims.json" not in guard_source
+    assert "--shims" not in guard_source
 
 def test_volume_tree_runtime_breadcrumb_fields_are_retired() -> None:
     volume_defs = Path("include/ytnova_defs.h").read_text(encoding="utf-8")
@@ -5840,8 +5820,7 @@ def test_volume_tree_runtime_breadcrumb_fields_are_retired() -> None:
         assert "vol->saved_tree_generation" not in source
         assert "vol->saved_tree_volume_generation" not in source
 
-    shims = Path("docs/appstate_compat_shims.json").read_text(encoding="utf-8")
-    assert "shim.volume-saved-tree-index" not in shims
+    assert not Path("docs/appstate_compat_shims.json").exists()
 
 
 def test_visibility_session_mirror_is_retired() -> None:
@@ -5854,13 +5833,12 @@ def test_visibility_session_mirror_is_retired() -> None:
     for runtime_path in runtime_paths:
         assert "ctx->hide_dot_files" not in runtime_path.read_text(encoding="utf-8")
 
-    shims = Path("docs/appstate_compat_shims.json").read_text(encoding="utf-8")
     runtime_registry = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
     architecture = Path("docs/ARCHITECTURE.md").read_text(encoding="utf-8")
 
-    assert "shim.viewcontext-hide-dot-files" not in shims
+    assert not Path("docs/appstate_compat_shims.json").exists()
     assert "shim.viewcontext-hide-dot-files" not in runtime_registry
-    assert "ViewContext.hide_dot_files" not in shims
+    assert "ViewContext.hide_dot_files" not in runtime_registry
     assert "ctx->hide_dot_files" not in architecture
 
 
@@ -9680,20 +9658,6 @@ def test_focused_window_compatibility_carrier_is_removed() -> None:
         assert "ctx->focused_window" not in source, path.as_posix()
 
 
-def test_focused_window_shim_registry_removes_compatibility_carrier() -> None:
-    shim_registry = Path("docs/appstate_compat_shims.json").read_text(
-        encoding="utf-8"
-    )
-    action_registry = Path("src/core/appstate_actions.c").read_text(
-        encoding="utf-8"
-    )
-
-    assert "shim.focused-window-session-flag" not in shim_registry
-    assert "AppState focus compatibility carrier" not in shim_registry
-    assert "ViewContext.focused_window" not in shim_registry
-    assert "shim.focused-window-session-flag" not in action_registry
-    assert "AppState focus compatibility carrier" not in action_registry
-    assert "ViewContext.focused_window" not in action_registry
 
 
 def test_focused_window_runtime_no_longer_validates_removed_shim() -> None:
@@ -9708,21 +9672,6 @@ def test_focused_window_runtime_no_longer_validates_removed_shim() -> None:
         assert removed_validation not in source
 
 
-def test_focused_window_shim_metadata_is_removed() -> None:
-    shim_registry = Path("docs/appstate_compat_shims.json").read_text(
-        encoding="utf-8"
-    )
-    action_registry = Path("src/core/appstate_actions.c").read_text(
-        encoding="utf-8"
-    )
-
-    for text in [
-        "AppState focus compatibility carrier",
-        "ViewContext.focused_window",
-        "AppState focus helpers no longer need a ViewContext.focused_window compatibility fallback.",
-    ]:
-        assert text not in shim_registry
-        assert text not in action_registry
 
 
 def test_render_row_projection_uses_shared_helpers() -> None:
@@ -9762,34 +9711,8 @@ def test_render_row_projection_uses_shared_helpers() -> None:
     assert "render_start + render_cursor" not in file_body
 
 
-def test_render_row_shim_registry_is_removed() -> None:
-    shim_registry = Path("docs/appstate_compat_shims.json").read_text(
-        encoding="utf-8"
-    )
-    action_registry = Path("src/core/appstate_actions.c").read_text(
-        encoding="utf-8"
-    )
-
-    assert '"shims": []' in shim_registry
-    assert "shim-render-derived-row-position" not in shim_registry
-    assert "shim-render-derived-row-position" not in action_registry
 
 
-def test_render_row_shim_metadata_is_removed() -> None:
-    shim_registry = Path("docs/appstate_compat_shims.json").read_text(
-        encoding="utf-8"
-    )
-    action_registry = Path("src/core/appstate_actions.c").read_text(
-        encoding="utf-8"
-    )
-
-    for text in [
-        "AppState render projection helpers",
-        "disp_begin_pos + cursor_pos render-derived lookup",
-        "Remove render-derived row compatibility helpers once render callers carry explicit projection state.",
-    ]:
-        assert text not in shim_registry
-        assert text not in action_registry
 
 
 def test_split_file_focus_commits_use_appstate_helper() -> None:
@@ -11451,7 +11374,6 @@ def test_guard_fails_when_runtime_action_validation_callsite_is_missing(
 
     failures = guard.validate_contract(
         guard.DEFAULT_TRANSITIONS,
-        guard.DEFAULT_SHIMS,
         guard.DEFAULT_ACTION_COVERAGE,
         guard.DEFAULT_ACTION_HEADER,
         guard.DEFAULT_EVENT_COVERAGE,
@@ -11500,7 +11422,6 @@ def test_guard_fails_when_runtime_action_validation_moves_outside_source_boundar
 
     failures = guard.validate_contract(
         guard.DEFAULT_TRANSITIONS,
-        guard.DEFAULT_SHIMS,
         guard.DEFAULT_ACTION_COVERAGE,
         guard.DEFAULT_ACTION_HEADER,
         guard.DEFAULT_EVENT_COVERAGE,
@@ -11538,7 +11459,6 @@ def test_guard_fails_when_runtime_dispatch_surface_validation_callsite_is_missin
 
     failures = guard.validate_contract(
         guard.DEFAULT_TRANSITIONS,
-        guard.DEFAULT_SHIMS,
         guard.DEFAULT_ACTION_COVERAGE,
         guard.DEFAULT_ACTION_HEADER,
         guard.DEFAULT_EVENT_COVERAGE,
@@ -11585,7 +11505,6 @@ def test_guard_fails_when_runtime_dispatch_surface_validation_moves_outside_sour
 
     failures = guard.validate_contract(
         guard.DEFAULT_TRANSITIONS,
-        guard.DEFAULT_SHIMS,
         guard.DEFAULT_ACTION_COVERAGE,
         guard.DEFAULT_ACTION_HEADER,
         guard.DEFAULT_EVENT_COVERAGE,
@@ -11623,7 +11542,6 @@ def test_guard_fails_when_runtime_event_validation_callsite_is_missing(
 
     failures = guard.validate_contract(
         guard.DEFAULT_TRANSITIONS,
-        guard.DEFAULT_SHIMS,
         guard.DEFAULT_ACTION_COVERAGE,
         guard.DEFAULT_ACTION_HEADER,
         guard.DEFAULT_EVENT_COVERAGE,
@@ -11670,7 +11588,6 @@ def test_guard_fails_when_runtime_event_validation_moves_outside_source_boundary
 
     failures = guard.validate_contract(
         guard.DEFAULT_TRANSITIONS,
-        guard.DEFAULT_SHIMS,
         guard.DEFAULT_ACTION_COVERAGE,
         guard.DEFAULT_ACTION_HEADER,
         guard.DEFAULT_EVENT_COVERAGE,
@@ -12853,72 +12770,12 @@ def test_guard_fails_when_event_coverage_maps_to_broad_transition_status(
     assert any("must use covered_by_transition_record" in failure for failure in failures)
 
 
-def test_guard_fails_when_required_shim_field_is_missing(tmp_path: Path) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim.pop("removal_trigger")
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "missing required field" in failure and "removal_trigger" in failure
-        for failure in failures
-    )
 
 
-def test_guard_fails_when_required_shim_owner_field_refs_are_missing(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim.pop("owner_field_refs")
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "missing required field" in failure
-        and "owner_field_refs" in failure
-        for failure in failures
-    )
 
 
-def test_guard_fails_when_required_shim_generation_domain_refs_are_missing(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim.pop("generation_domain_refs")
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "missing required field" in failure
-        and "generation_domain_refs" in failure
-        for failure in failures
-    )
 
 
-def test_guard_fails_when_required_shim_diff_harness_refs_are_missing(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim.pop("diff_harness_refs")
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "missing required field" in failure
-        and "diff_harness_refs" in failure
-        for failure in failures
-    )
 
 
 def test_guard_fails_when_required_action_field_is_missing(tmp_path: Path) -> None:
@@ -12983,20 +12840,14 @@ def test_guard_fails_when_required_event_field_is_missing(tmp_path: Path) -> Non
     )
 
 
-def test_guard_fails_on_duplicate_transition_and_shim_ids(tmp_path: Path) -> None:
+def test_guard_fails_on_duplicate_transition_ids(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     transitions[1]["id"] = transitions[0]["id"]
-    duplicate_shim = _shim()
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        shims=[_shim(), duplicate_shim],
-    )
+    paths = _write_fixture(tmp_path, transitions=transitions)
 
     failures = _validate(paths)
 
     assert any("transition[1]" in failure and "duplicate id" in failure for failure in failures)
-    assert any("shim[1]" in failure and "duplicate id" in failure for failure in failures)
 
 
 def test_guard_fails_on_duplicate_action_records(tmp_path: Path) -> None:
@@ -13024,27 +12875,17 @@ def test_guard_fails_on_duplicate_event_ids(tmp_path: Path) -> None:
 def test_guard_fails_on_empty_required_list_fields(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     transitions[0]["declared_write_set"] = []
-    shim = _shim()
-    shim["invariant_checks"] = []
     actions = _complete_actions()
     actions[0]["declared_write_set"] = []
     events = _complete_events()
     events[0]["trigger_paths"] = []
-    paths = _write_fixture(
-        tmp_path, transitions=transitions, shims=[shim], actions=actions, events=events
-    )
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions, events=events)
 
     failures = _validate(paths)
 
     assert any(
         "transition[0]" in failure
         and "declared_write_set" in failure
-        and "must be non-empty" in failure
-        for failure in failures
-    )
-    assert any(
-        "shim[0]" in failure
-        and "invariant_checks" in failure
         and "must be non-empty" in failure
         for failure in failures
     )
@@ -13065,27 +12906,17 @@ def test_guard_fails_on_empty_required_list_fields(tmp_path: Path) -> None:
 def test_guard_fails_on_non_list_required_list_fields(tmp_path: Path) -> None:
     transitions = _complete_transitions()
     transitions[0]["declared_write_set"] = "field"
-    shim = _shim()
-    shim["invariant_checks"] = "invariant"
     actions = _complete_actions()
     actions[0]["migration_notes"] = "note"
     events = _complete_events()
     events[0]["declared_write_set"] = "field"
-    paths = _write_fixture(
-        tmp_path, transitions=transitions, shims=[shim], actions=actions, events=events
-    )
+    paths = _write_fixture(tmp_path, transitions=transitions, actions=actions, events=events)
 
     failures = _validate(paths)
 
     assert any(
         "transition[0]" in failure
         and "declared_write_set" in failure
-        and "must be a non-empty list" in failure
-        for failure in failures
-    )
-    assert any(
-        "shim[0]" in failure
-        and "invariant_checks" in failure
         and "must be a non-empty list" in failure
         for failure in failures
     )
@@ -13137,430 +12968,44 @@ def test_guard_fails_on_blank_required_list_elements(
     )
 
 
-def test_guard_fails_when_shim_targets_unknown_transition(tmp_path: Path) -> None:
-    transitions = _complete_transitions()
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        shims=[_shim(target_transition="transition.missing")],
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "target_transition does not match a transition id" in failure
-        and "transition.missing" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_invariant_check_is_not_runtime_registered(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim["invariant_checks"] = ["invariant.not_runtime_registered"]
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "invariant_checks" in failure
-        and "runtime invariant registry" in failure
-        and "invariant.not_runtime_registered" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_invariant_checks_do_not_cover_target_transition(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(target_transition="transition.render_reflow")
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and (
-            "invariant_checks must include at least one invariant covering "
-            "target_transition transition.render_reflow"
-        )
-        in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_each_shim_invariant_check_lacks_generation_target_coverage(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim["invariant_checks"] = [
-        "invariant.inactive_panel_frozen",
-        "invariant.render_projection_read_only",
-    ]
-    invariants = _complete_invariants()
-    for invariant in invariants:
-        if invariant["invariant_id"] == "invariant.render_projection_read_only":
-            invariant["transition_ids"] = ["transition.render_reflow"]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        shims=[shim],
-        invariants=invariants,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "invariant_checks[1] must cover target_transition transition.keybinding"
-        in failure
-        and "invariant.render_projection_read_only" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_generation_domain_ref_is_unknown(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(generation_domain_refs=["domain.unknown"])
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "generation_domain_refs does not match generation-domain registry"
-        in failure
-        and "domain.unknown" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_generation_domain_ref_is_duplicated(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(
-        generation_domain_refs=["domain.panel_generation", "domain.panel_generation"]
-    )
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "duplicate generation_domain_refs[1]" in failure
-        and "domain.panel_generation" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_generation_owner_ref_lacks_matching_domain(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    transitions[0]["declared_write_set"] = ["field", "panel.panel_generation"]
-    owner_fields = _complete_owner_fields() + [_owner_field("panel.panel_generation")]
-    generation_domains = _complete_generation_domains()
-    generation_domains[0]["generation_owner_field"] = "panel.panel_generation"
-    generation_domains[0]["identity_fields"] = ["panel.panel_generation"]
-    shim = _shim(
-        owner_field_refs=["panel.panel_generation"],
-        generation_domain_refs=["domain.volume_generation"],
-    )
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        owner_fields=owner_fields,
-        generation_domains=generation_domains,
-        shims=[shim],
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "generation_domain_refs must include a domain whose "
-        "generation_owner_field is panel.panel_generation" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_owner_field_ref_is_unknown(tmp_path: Path) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(owner_field_refs=["field.unknown"])
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "owner_field_refs does not match owner-field registry" in failure
-        and "field.unknown" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_owner_field_ref_is_duplicated(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(owner_field_refs=["field", "field"])
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "duplicate owner_field_refs[1]" in failure
-        and "field" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_diff_harness_ref_is_unknown(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(diff_harness_refs=["harness.unknown"])
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "diff_harness_refs references unknown diff harness id" in failure
-        and "harness.unknown" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_diff_harness_ref_is_duplicated(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(
-        diff_harness_refs=[
-            "harness.transition_before_after_snapshot",
-            "harness.transition_before_after_snapshot",
-        ]
-    )
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "duplicate diff_harness_refs[1]" in failure
-        and "harness.transition_before_after_snapshot" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_diff_harness_lacks_target_transition(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    diff_harness_checks = _complete_diff_harness_checks()
-    for harness in diff_harness_checks:
-        harness["transition_ids"] = ["transition.render_reflow"]
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        diff_harness_checks=diff_harness_checks,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "diff_harness_refs must include at least one diff harness covering"
-        in failure
-        and "transition.keybinding" in failure
-        for failure in failures
-    )
-
-
-@pytest.mark.parametrize(
-    ("field", "replacement", "expected_ref"),
-    (
-        ("owner_field_refs", ["panel.tree_selection_key"], "field"),
-        (
-            "invariant_ids",
-            ["invariant.blocked_transition_determinism"],
-            "invariant.inactive_panel_frozen",
-        ),
-        ("generation_domain_ids", ["domain.volume_generation"], "domain.panel_generation"),
-    ),
-)
-def test_guard_fails_when_shim_diff_harness_union_lacks_declared_coverage(
-    tmp_path: Path,
-    field: str,
-    replacement: list[str],
-    expected_ref: str,
-) -> None:
-    transitions = _complete_transitions()
-    diff_harness_checks = _complete_diff_harness_checks()
-    for harness in diff_harness_checks:
-        if harness["harness_id"] == "harness.transition_before_after_snapshot":
-            harness[field] = replacement
-    paths = _write_fixture(
-        tmp_path,
-        transitions=transitions,
-        diff_harness_checks=diff_harness_checks,
-    )
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "lacks referenced diff_harness_refs coverage" in failure
-        and expected_ref in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_write_capable_shim_owner_field_is_outside_write_set(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(owner_field_refs=["panel.tree_selection_key"])
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "owner_field_refs must be declared by target_transition write set"
-        in failure
-        and "panel.tree_selection_key" in failure
-        for failure in failures
-    )
-
-
-@pytest.mark.parametrize(
-    "write_permission",
-    (
-        "Do not write stale mirror directly; write only from transition commit after canonical state changes.",
-        "No write should happen before transition commit; write the compatibility mirror after canonical state changes.",
-        "Never write before canonical state changes; write during the transition commit.",
-        "Read-only before commit; write the compatibility mirror after canonical state changes.",
-    ),
-)
-def test_guard_treats_explicit_write_capability_as_authoritative_over_prose(
-    tmp_path: Path, write_permission: str
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(owner_field_refs=["panel.tree_selection_key"])
-    shim["write_permission"] = write_permission
-    shim["write_capability"] = "write_capable"
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "owner_field_refs must be declared by target_transition write set"
-        in failure
-        and "panel.tree_selection_key" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_write_capability_is_missing(tmp_path: Path) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim.pop("write_capability")
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "write_capability" in failure
-        and "missing required field" in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_shim_write_capability_is_unknown(tmp_path: Path) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim["write_capability"] = "sometimes"
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "write_capability must be one of" in failure
-        and "sometimes" in failure
-        for failure in failures
-    )
-
-
-def test_guard_allows_no_write_shim_owner_field_outside_write_set(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(owner_field_refs=["panel.tree_selection_key"])
-    shim["write_permission"] = "Never write authoritative selection from this projection."
-    shim["write_capability"] = "no_write"
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert not any(
-        "shim[0]" in failure
-        and "owner_field_refs must be declared by target_transition write set"
-        in failure
-        for failure in failures
-    )
-
-
-def test_guard_allows_read_only_projection_shim_owner_field_outside_write_set(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim(owner_field_refs=["panel.tree_selection_key"])
-    shim["write_permission"] = "Read-only projection for render calculations."
-    shim["write_capability"] = "read_only_projection"
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert not any(
-        "shim[0]" in failure
-        and "owner_field_refs must be declared by target_transition write set"
-        in failure
-        for failure in failures
-    )
-
-
-def test_guard_fails_when_read_only_projection_shim_owner_field_is_in_write_set(
-    tmp_path: Path,
-) -> None:
-    transitions = _complete_transitions()
-    shim = _shim()
-    shim["write_permission"] = "Read-only projection for render calculations."
-    shim["write_capability"] = "read_only_projection"
-    paths = _write_fixture(tmp_path, transitions=transitions, shims=[shim])
-
-    failures = _validate(paths)
-
-    assert any(
-        "shim[0]" in failure
-        and "read_only_projection owner_field_refs must stay outside "
-        "target_transition write set" in failure
-        and "field" in failure
-        for failure in failures
-    )
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 def test_guard_fails_when_runtime_invariant_metadata_drifts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove the empty compatibility-shim registry from the AppState contract guard surface
- delete the retired shim registry document and trim the matching contract-guard fixture coverage
- update architecture/spec guidance so legacy alternate authority is treated as a defect instead of a documented shim path

## Validation
- Red proof: not applicable for this contract-surface retirement; the targeted guard coverage was updated alongside the deleted registry surface.
- `python3 -m py_compile scripts/check_appstate_contract.py tests/test_appstate_contract_guard.py`
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'current_repository_appstate_contract_passes or guard_passes_complete_temporary_fixtures or appstate_runtime_no_longer_exposes_shim_registry_support or volume_tree_runtime_breadcrumb_fields_are_retired or visibility_session_mirror_is_retired or focused_window_runtime_no_longer_validates_removed_shim or render_row_projection_uses_shared_helpers or render_projection_runtime_uses_no_compatibility_shim or guard_fails_on_duplicate_transition_ids or guard_fails_on_empty_required_list_fields or guard_fails_on_non_list_required_list_fields or runtime_dispatch_surface_validation_callsite_is_missing or runtime_dispatch_surface_validation_moves_outside_source_boundary or runtime_event_validation_callsite_is_missing or runtime_event_validation_moves_outside_source_boundary'`
