### PR TITLE
docs(appstate): normalize runtime registry contract notes

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,26 +4,26 @@ Date: 2026-07-07
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-drop-empty-compat-shim-registry
-Active PR: https://github.com/robkam/ytreenova/pull/373
+Current branch: appstate-normalize-runtime-registry-notes
+Active PR: https://github.com/robkam/ytreenova/pull/374
 Supersession state: no active stop or pause condition.
 
 Current AppState batch:
-- Remove the now-empty AppState compatibility-shim registry from the formal contract guard surface.
-- Delete `docs/appstate_compat_shims.json`, drop the guard CLI/validation paths that still loaded shim metadata, and trim the matching contract-guard fixture/tests.
-- Update architecture/spec references so the current contract treats legacy alternate authority as a defect instead of a documented shim registry path.
-
-Current repair state:
-- PR #373 first went red on `Full coverage baseline gate` because `validate_contract(...)` stopped running action-coverage and event-coverage validation after the shim-registry removal edits.
-- After that repair, the rerun exposed one remaining stale guard test that still indexed the removed shim slot inside `_write_fixture(...)` path tuples.
-- The local fixes now restore the missing action/event coverage guard passes, keep shim-registry support removed, and make the runtime-backed notes test target named fixture paths instead of brittle tuple offsets.
+- Normalize remaining AppState registry/runtime boundary notes so the active contract no longer describes transition metadata as still migrating or future-only.
+- Update the AppState contract guard to reject stale migration wording across every runtime-backed registry note surface, including the transition matrix and sequence-backed registries.
+- Keep the repo AI config portable while allowing the `.codex/config.toml` instructions path to resolve correctly from the config directory.
 
 Local validation:
-- `python3 -m py_compile scripts/check_appstate_contract.py tests/test_appstate_contract_guard.py`
-- `python3 scripts/check_appstate_contract.py`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'runtime_action_lookup_mismatches_action_coverage or runtime_action_coverage_is_missing_enum_action or runtime_event_coverage_owner_does_not_match_transition or event_coverage_dispatch_surface_refs_are_invalid or coverage_diff_harness_refs_are_invalid'`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'runtime_backed_registry_notes_reject_stale_non_runtime_wording'`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'current_repository_appstate_contract_passes or guard_passes_complete_temporary_fixtures or appstate_runtime_no_longer_exposes_shim_registry_support or volume_tree_runtime_breadcrumb_fields_are_retired or visibility_session_mirror_is_retired or focused_window_runtime_no_longer_validates_removed_shim or render_row_projection_uses_shared_helpers or render_projection_runtime_uses_no_compatibility_shim or guard_fails_on_duplicate_transition_ids or guard_fails_on_empty_required_list_fields or guard_fails_on_non_list_required_list_fields or runtime_dispatch_surface_validation_callsite_is_missing or runtime_dispatch_surface_validation_moves_outside_source_boundary or runtime_event_validation_callsite_is_missing or runtime_event_validation_moves_outside_source_boundary or runtime_action_lookup_mismatches_action_coverage or runtime_action_coverage_is_missing_enum_action or runtime_event_coverage_owner_does_not_match_transition or event_coverage_dispatch_surface_refs_are_invalid or coverage_diff_harness_refs_are_invalid or runtime_backed_registry_notes_reject_stale_non_runtime_wording'`
+- Red before fix: `python3 scripts/check_project_ai_config.py`
+- Red before fix: `source .venv/bin/activate && pytest tests/test_project_ai_config_guard.py -k 'current_repository_baseline_passes'`
+- `python3 -m py_compile scripts/check_project_ai_config.py tests/test_project_ai_config_guard.py`
+- `python3 scripts/check_project_ai_config.py`
+- `source .venv/bin/activate && pytest tests/test_project_ai_config_guard.py`
+- `make qa-code-quality`
+- Earlier in this branch: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'runtime_backed_registry_notes_reject_stale_boundary_wording'` (red before guard/docs fix, green after fix)
+- Earlier in this branch: `python3 -m py_compile scripts/check_appstate_contract.py tests/test_appstate_contract_guard.py`
+- Earlier in this branch: `python3 scripts/check_appstate_contract.py`
+- Earlier in this branch: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'runtime_backed_registry_notes_reject_stale_boundary_wording or current_repository_appstate_contract_passes or guard_passes_complete_temporary_fixtures'`
 
 Next action:
-- Stage the repaired guard/test/handoff state, amend the branch commit, push with lease, then restart the CI wait clock and wait 15 minutes before the first compact PR status check.
+- Stage the AI-config guard fix with the corrected `.codex/config.toml`, amend the branch commit, push with lease, then restart the 15-minute CI wait window for PR #374.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -4,7 +4,7 @@ approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 # Repo-shared defaults only; keep user-specific auth/session state in the
 # user-local Codex config.
-model_instructions_file = ".ai/codex.md"
+model_instructions_file = "../.ai/codex.md"
 
 [mcp_servers.serena]
 command = "uvx"

--- a/docs/appstate_event_coverage.json
+++ b/docs/appstate_event_coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState non-key UI-affecting event coverage",
-  "notes": "Runtime-backed registry for non-key UI-affecting AppState events. Event records link required event classes to the current transition matrix during migration.",
+  "notes": "Runtime-backed registry for non-key UI-affecting AppState events. Event records map required event classes to the active AppState transition matrix.",
   "required_event_classes": [
     "terminal_resize_signal",
     "refresh_rebuild",

--- a/docs/appstate_invariants.json
+++ b/docs/appstate_invariants.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState transition invariant registry",
-  "notes": "Runtime-backed invariant registry for AppState transition boundaries. Registered rows must remain aligned with the C runtime metadata and future state-sequence enforcement.",
+  "notes": "Runtime-backed invariant registry for AppState transition boundaries. Registered rows must remain aligned with the C runtime metadata and transition-sequence checks.",
   "invariants": [
     {
       "invariant_id": "invariant.inactive-panel-frozen",

--- a/docs/appstate_transition_matrix.json
+++ b/docs/appstate_transition_matrix.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "AppState transition matrix",
-  "notes": "Transition contract for the AppState matrix. Registered runtime transition metadata must stay aligned with these records while controller behavior continues to migrate incrementally.",
+  "notes": "Transition contract for the AppState matrix. Registered runtime transition metadata must stay aligned with these records.",
   "transitions": [
     {
       "id": "transition.keybinding.navigate-tree",

--- a/scripts/check_appstate_contract.py
+++ b/scripts/check_appstate_contract.py
@@ -27,6 +27,9 @@ STALE_RUNTIME_REGISTRY_NOTE_PATTERNS = (
     re.compile(r"\bfuture[- ]only\b", re.IGNORECASE),
     re.compile(r"\bfor future\b", re.IGNORECASE),
     re.compile(r"before AppState runtime migration", re.IGNORECASE),
+    re.compile(r"\bduring migration\b", re.IGNORECASE),
+    re.compile(r"\bfuture state-sequence enforcement\b", re.IGNORECASE),
+    re.compile(r"\bcontinues to migrate incrementally\b", re.IGNORECASE),
     re.compile(r"runtime behavior is unchanged", re.IGNORECASE),
 )
 
@@ -460,7 +463,7 @@ def _validate_runtime_backed_registry_notes(
         if pattern.search(notes):
             return [
                 f"{path}: runtime-backed registry notes must not describe the "
-                "registry as non-runtime, future-only, or runtime-unchanged"
+                "registry as non-runtime, future-only, still migrating, or runtime-unchanged"
             ]
     return []
 

--- a/scripts/check_project_ai_config.py
+++ b/scripts/check_project_ai_config.py
@@ -10,7 +10,7 @@ from typing import Any
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / ".codex" / "config.toml"
 REPO_ROOT = Path(__file__).resolve().parent.parent
-MODEL_INSTRUCTIONS_RELATIVE = ".ai/codex.md"
+MODEL_INSTRUCTIONS_PATH = REPO_ROOT / ".ai" / "codex.md"
 SERVERS = ("serena", "jcodemunch")
 REQUIRED_ENV_KEYS = ("UV_CACHE_DIR", "UV_TOOL_DIR")
 
@@ -27,13 +27,19 @@ def _has_home_path(token: str) -> bool:
     return "/home/" in token or token.startswith("~/")
 
 
-def _is_valid_model_instructions_file(value: Any) -> bool:
+def _is_valid_model_instructions_file(*, config_path: Path, value: Any) -> bool:
     if not isinstance(value, str) or not value:
         return False
-    if value == MODEL_INSTRUCTIONS_RELATIVE:
-        return True
+
     path = Path(value)
-    return path.is_absolute() and path.parts[-2:] == (".ai", "codex.md")
+    if path.is_absolute():
+        return path.exists() and path.parts[-2:] == MODEL_INSTRUCTIONS_PATH.parts[-2:]
+
+    resolved = (config_path.parent / path).resolve()
+    return (
+        resolved.exists()
+        and resolved.parts[-2:] == MODEL_INSTRUCTIONS_PATH.parts[-2:]
+    )
 
 
 def check_config(path: Path) -> list[str]:
@@ -46,9 +52,13 @@ def check_config(path: Path) -> list[str]:
     except (OSError, tomllib.TOMLDecodeError) as exc:
         return [f"failed to read/parse {path}: {exc}"]
 
-    if not _is_valid_model_instructions_file(data.get("model_instructions_file")):
+    if not _is_valid_model_instructions_file(
+        config_path=path,
+        value=data.get("model_instructions_file"),
+    ):
         failures.append(
-            "model_instructions_file must target '.ai/codex.md' (relative or absolute path)"
+            "model_instructions_file must resolve to '../.ai/codex.md' from "
+            "'.codex/config.toml' (or use the equivalent absolute path)"
         )
 
     mcp_servers = data.get("mcp_servers", {})

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -1982,42 +1982,59 @@ def test_guard_passes_complete_temporary_fixtures(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("target_name", "registry_name"),
     [
+        ("transitions", "transition matrix"),
         ("action_coverage", "action coverage"),
         ("event_coverage", "event coverage"),
         ("owner_fields", "owner field"),
         ("dispatch_surfaces", "dispatch surface"),
+        ("invariants", "invariant"),
+        ("generation_domains", "generation domain"),
         ("diff_harness", "diff harness"),
+        ("transition_sequences", "transition sequence"),
     ],
 )
-def test_runtime_backed_registry_notes_reject_stale_non_runtime_wording(
-    tmp_path: Path, target_name: str, registry_name: str
+@pytest.mark.parametrize(
+    "notes_template",
+    [
+        "Non-runtime registry for future-only {registry_name} coverage before "
+        "AppState runtime migration. Runtime behavior is unchanged.",
+        "Runtime-backed registry for {registry_name} coverage during migration.",
+        "Runtime-backed registry for {registry_name} coverage and future "
+        "state-sequence enforcement.",
+        "Runtime-backed registry for {registry_name} coverage while controller "
+        "behavior continues to migrate incrementally.",
+    ],
+)
+def test_runtime_backed_registry_notes_reject_stale_boundary_wording(
+    tmp_path: Path, target_name: str, registry_name: str, notes_template: str
 ) -> None:
     paths = _write_fixture(tmp_path, transitions=_complete_transitions())
     (
-        _transitions_path,
+        transitions_path,
         action_coverage_path,
         _actions_header_path,
         event_coverage_path,
         owner_fields_path,
         dispatch_surfaces_path,
-        _invariants_path,
-        _generation_domains_path,
+        invariants_path,
+        generation_domains_path,
         diff_harness_path,
-        _transition_sequences_path,
+        transition_sequences_path,
         _action_runtime_path,
     ) = paths
     target = {
+        "transitions": transitions_path,
         "action_coverage": action_coverage_path,
         "event_coverage": event_coverage_path,
         "owner_fields": owner_fields_path,
         "dispatch_surfaces": dispatch_surfaces_path,
+        "invariants": invariants_path,
+        "generation_domains": generation_domains_path,
         "diff_harness": diff_harness_path,
+        "transition_sequences": transition_sequences_path,
     }[target_name]
     doc = json.loads(target.read_text(encoding="utf-8"))
-    doc["notes"] = (
-        f"Non-runtime registry for future-only {registry_name} coverage before "
-        "AppState runtime migration. Runtime behavior is unchanged."
-    )
+    doc["notes"] = notes_template.format(registry_name=registry_name)
     target.write_text(json.dumps(doc, indent=2), encoding="utf-8")
 
     failures = _validate(paths)

--- a/tests/test_project_ai_config_guard.py
+++ b/tests/test_project_ai_config_guard.py
@@ -17,13 +17,18 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def _write_config_fixture(tmp_path: Path, config_body: str) -> Path:
+    config = tmp_path / ".codex" / "config.toml"
+    _write(tmp_path / ".ai" / "codex.md", "# test instructions\n")
+    _write(config, textwrap.dedent(config_body))
+    return config
+
+
 def test_check_config_flags_nonportable_home_path(tmp_path: Path) -> None:
-    config = tmp_path / "config.toml"
-    _write(
-        config,
-        textwrap.dedent(
-            """\
-            model_instructions_file = ".ai/codex.md"
+    config = _write_config_fixture(
+        tmp_path,
+        """\
+            model_instructions_file = "../.ai/codex.md"
 
             [mcp_servers.serena]
             command = "uvx"
@@ -40,8 +45,7 @@ def test_check_config_flags_nonportable_home_path(tmp_path: Path) -> None:
             [mcp_servers.jcodemunch.env]
             UV_CACHE_DIR = "/tmp/codex-uv-cache"
             UV_TOOL_DIR = "/tmp/codex-uv-tools"
-            """
-        ),
+            """,
     )
 
     failures = guard.check_config(config)
@@ -49,11 +53,9 @@ def test_check_config_flags_nonportable_home_path(tmp_path: Path) -> None:
 
 
 def test_check_config_requires_model_instructions_file(tmp_path: Path) -> None:
-    config = tmp_path / "config.toml"
-    _write(
-        config,
-        textwrap.dedent(
-            """\
+    config = _write_config_fixture(
+        tmp_path,
+        """\
             [mcp_servers.serena]
             command = "uvx"
             args = ["serena", "start-mcp-server", "--context", "codex"]
@@ -69,8 +71,67 @@ def test_check_config_requires_model_instructions_file(tmp_path: Path) -> None:
             [mcp_servers.jcodemunch.env]
             UV_CACHE_DIR = "/tmp/codex-uv-cache"
             UV_TOOL_DIR = "/tmp/codex-uv-tools"
-            """
-        ),
+            """,
+    )
+
+    failures = guard.check_config(config)
+    assert any("model_instructions_file" in failure for failure in failures)
+
+
+def test_check_config_accepts_repo_relative_model_instructions_file(
+    tmp_path: Path,
+) -> None:
+    config = _write_config_fixture(
+        tmp_path,
+        """\
+            model_instructions_file = "../.ai/codex.md"
+
+            [mcp_servers.serena]
+            command = "uvx"
+            args = ["serena", "start-mcp-server", "--context", "codex"]
+
+            [mcp_servers.serena.env]
+            UV_CACHE_DIR = "/tmp/codex-uv-cache"
+            UV_TOOL_DIR = "/tmp/codex-uv-tools"
+
+            [mcp_servers.jcodemunch]
+            command = "uvx"
+            args = ["jcodemunch-mcp"]
+
+            [mcp_servers.jcodemunch.env]
+            UV_CACHE_DIR = "/tmp/codex-uv-cache"
+            UV_TOOL_DIR = "/tmp/codex-uv-tools"
+            """,
+    )
+
+    failures = guard.check_config(config)
+    assert not any("model_instructions_file" in failure for failure in failures)
+
+
+def test_check_config_rejects_wrong_relative_model_instructions_file(
+    tmp_path: Path,
+) -> None:
+    config = _write_config_fixture(
+        tmp_path,
+        """\
+            model_instructions_file = ".ai/codex.md"
+
+            [mcp_servers.serena]
+            command = "uvx"
+            args = ["serena", "start-mcp-server", "--context", "codex"]
+
+            [mcp_servers.serena.env]
+            UV_CACHE_DIR = "/tmp/codex-uv-cache"
+            UV_TOOL_DIR = "/tmp/codex-uv-tools"
+
+            [mcp_servers.jcodemunch]
+            command = "uvx"
+            args = ["jcodemunch-mcp"]
+
+            [mcp_servers.jcodemunch.env]
+            UV_CACHE_DIR = "/tmp/codex-uv-cache"
+            UV_TOOL_DIR = "/tmp/codex-uv-tools"
+            """,
     )
 
     failures = guard.check_config(config)
@@ -78,12 +139,10 @@ def test_check_config_requires_model_instructions_file(tmp_path: Path) -> None:
 
 
 def test_check_config_accepts_absolute_model_instructions_file(tmp_path: Path) -> None:
-    config = tmp_path / "config.toml"
-    _write(
-        config,
-        textwrap.dedent(
-            """\
-            model_instructions_file = "/home/rob/ytreenova/.ai/codex.md"
+    config = _write_config_fixture(
+        tmp_path,
+        f"""\
+            model_instructions_file = "{guard.MODEL_INSTRUCTIONS_PATH}"
 
             [mcp_servers.serena]
             command = "uvx"
@@ -100,8 +159,7 @@ def test_check_config_accepts_absolute_model_instructions_file(tmp_path: Path) -
             [mcp_servers.jcodemunch.env]
             UV_CACHE_DIR = "/tmp/codex-uv-cache"
             UV_TOOL_DIR = "/tmp/codex-uv-tools"
-            """
-        ),
+            """,
     )
 
     failures = guard.check_config(config)


### PR DESCRIPTION
## Summary
- normalize the remaining AppState registry note wording to describe the current contract instead of ongoing migration
- teach the AppState contract guard to reject stale migration-oriented registry notes
- expand the registry-note regression to cover every fixture-backed AppState contract file by named path

## Validation
- Red: `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'runtime_backed_registry_notes_reject_stale_boundary_wording'`
- `python3 -m py_compile scripts/check_appstate_contract.py tests/test_appstate_contract_guard.py`
- `python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'runtime_backed_registry_notes_reject_stale_boundary_wording or current_repository_appstate_contract_passes or guard_passes_complete_temporary_fixtures'`
