### PR TITLE
fix(appstate): validate focus shape helper boundaries

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -1,21 +1,25 @@
 # ytreenova AppState continuation checkpoint
 
-Date: 2026-07-07
+Date: 2026-07-08
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-normalize-runtime-registry-status-labels
-Active PR: https://github.com/robkam/ytreenova/pull/378
+Current branch: appstate-focus-helper-boundary-validation
+Active PR: https://github.com/robkam/ytreenova/pull/379
 Supersession state: no active stop or pause condition.
 
 Current AppState batch:
-- Normalize the remaining runtime-registry status label mismatch across the AppState owner-field and transition-sequence registries.
-- Use `covered_by_runtime_registry` consistently in the docs, runtime metadata, contract guard, and fixture surface where those registries are already runtime-backed.
-- Keep the boundary-status versus runtime-registry-status split intact while removing the last `runtime_backed` status literals from active registry/runtime metadata.
+- Tighten the remaining owner-field/runtime boundary around panel focus-shape helpers identified from `docs/appstate_owner_fields.json` and `docs/appstate_generation_domains.json`.
+- Make `src/ui/appstate_focus.c` fail closed on `panel.focus_shape` writes unless the registered owner field and `shape.panel.focus` generation domain validate first.
+- Keep the batch scoped to the focus helper boundary plus its focused regression coverage.
 
 Local validation:
-- `python3 scripts/check_appstate_contract.py`
-- `source .venv/bin/activate && pytest tests/test_appstate_contract_guard.py -k 'fixture_registry_metadata_matches_current_docs or runtime_backed_registry_docs_require_contract_and_notes or runtime_backed_registry_notes_reject_stale_boundary_wording or current_repository_appstate_contract_passes or guard_passes_complete_temporary_fixtures'`
+- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'focus_shape_helpers_validate_owner_boundaries_before_writes'`
+- Green:
+  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'focus_shape_helpers_validate_owner_boundaries_before_writes or panel_file_shape_commits_use_appstate_helper or focus_restore_commits_use_appstate_helper'`
+  - `python3 scripts/check_appstate_contract.py`
+  - `make clean && make`
+  - `git diff --check`
 
 Next action:
-- Wait 15 minutes from the latest push before the first compact CI status check for PR #378, then continue the merge loop if checks go green.
+- Wait until after 2026-07-08 10:43 BST (09:43 UTC) for the first compact CI status check on PR 379, then continue the CI/merge loop from that PR state only.

--- a/src/ui/appstate_focus.c
+++ b/src/ui/appstate_focus.c
@@ -7,6 +7,7 @@
 
 #define NO_YTNOVA_MACROS
 
+#include "ytnova_appstate_actions.h"
 #include "ytnova_appstate_focus.h"
 
 ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx) {
@@ -19,6 +20,10 @@ ViewFocus AppStateResolveActivePanelFocus(const ViewContext *ctx) {
 
 BOOL AppStateCommitPanelFocus(const ViewContext *ctx, YtreeNovaPanel *panel,
                               ViewFocus focus) {
+  if (!AppStateValidatedGenerationDomain("shape.panel.focus"))
+    return FALSE;
+  if (!AppStateValidatedOwnerField("panel.focus_shape"))
+    return FALSE;
   if (!ctx || !panel)
     return FALSE;
   if (focus != FOCUS_TREE && focus != FOCUS_FILE)
@@ -29,6 +34,10 @@ BOOL AppStateCommitPanelFocus(const ViewContext *ctx, YtreeNovaPanel *panel,
 }
 
 BOOL AppStateCommitPanelFileShape(YtreeNovaPanel *panel, BOOL big_file_view) {
+  if (!AppStateValidatedGenerationDomain("shape.panel.focus"))
+    return FALSE;
+  if (!AppStateValidatedOwnerField("panel.focus_shape"))
+    return FALSE;
   if (!panel)
     return FALSE;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -10050,6 +10050,36 @@ def test_panel_file_shape_commits_use_appstate_helper() -> None:
     )
 
 
+def test_focus_shape_helpers_validate_owner_boundaries_before_writes() -> None:
+    focus_helper = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")
+
+    assert 'include "ytnova_appstate_actions.h"' in focus_helper
+
+    focus_start = focus_helper.index("BOOL AppStateCommitPanelFocus(")
+    shape_start = focus_helper.index("\nBOOL AppStateCommitPanelFileShape(", focus_start)
+    focus_body = focus_helper[focus_start:shape_start]
+    focus_validation = 'AppStateValidatedOwnerField("panel.focus_shape")'
+    focus_domain_validation = 'AppStateValidatedGenerationDomain("shape.panel.focus")'
+    focus_write = "panel->saved_focus = focus;"
+    assert focus_validation in focus_body
+    assert focus_domain_validation in focus_body
+    assert focus_body.index(focus_validation) < focus_body.index(focus_write)
+    assert focus_body.index(focus_domain_validation) < focus_body.index(focus_write)
+
+    shape_end = focus_helper.index(
+        "\nBOOL AppStateCommitDirEntryFileShape(",
+        shape_start,
+    )
+    shape_body = focus_helper[shape_start:shape_end]
+    shape_validation = 'AppStateValidatedOwnerField("panel.focus_shape")'
+    shape_domain_validation = 'AppStateValidatedGenerationDomain("shape.panel.focus")'
+    shape_write = "panel->saved_big_file_view = big_file_view ? TRUE : FALSE;"
+    assert shape_validation in shape_body
+    assert shape_domain_validation in shape_body
+    assert shape_body.index(shape_validation) < shape_body.index(shape_write)
+    assert shape_body.index(shape_domain_validation) < shape_body.index(shape_write)
+
+
 def test_dir_ops_restore_file_shape_commits_use_appstate_helper() -> None:
     focus_header = Path("include/ytnova_appstate_focus.h").read_text(encoding="utf-8")
     focus_helper = Path("src/ui/appstate_focus.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- make the focus-shape AppState helpers fail closed unless the registered owner field and generation domain validate first
- keep the change scoped to `src/ui/appstate_focus.c` and its focused contract regression coverage

## Validation
- Red proof: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'focus_shape_helpers_validate_owner_boundaries_before_writes'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'focus_shape_helpers_validate_owner_boundaries_before_writes or panel_file_shape_commits_use_appstate_helper or focus_restore_commits_use_appstate_helper'`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
