### PR TITLE
fix(appstate): validate layout projection helper boundaries

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,22 +4,22 @@ Date: 2026-07-08
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-focus-helper-boundary-validation
-Active PR: https://github.com/robkam/ytreenova/pull/379
+Current branch: appstate-layout-projection-boundary-validation
+Active PR: https://github.com/robkam/ytreenova/pull/380
 Supersession state: no active stop or pause condition.
 
 Current AppState batch:
-- Tighten the remaining owner-field/runtime boundary around panel focus-shape helpers identified from `docs/appstate_owner_fields.json` and `docs/appstate_generation_domains.json`.
-- Make `src/ui/appstate_focus.c` fail closed on `panel.focus_shape` writes unless the registered owner field and `shape.panel.focus` generation domain validate first.
-- Keep the batch scoped to the focus helper boundary plus its focused regression coverage.
+- Tighten the next projection-domain/runtime boundary identified from `docs/appstate_generation_domains.json` around `reflow.layout.projection`.
+- Make the layout, render-dirty, and window-handle AppState helper modules fail closed unless that generation domain validates before they write `ctx.layout`, `ctx.render_dirty_flags`, or `ctx.window_handles`.
+- Keep the batch scoped to `src/ui/appstate_layout.c`, `src/ui/appstate_render.c`, `src/ui/appstate_window.c`, and the focused contract regression coverage.
 
 Local validation:
-- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'focus_shape_helpers_validate_owner_boundaries_before_writes'`
+- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'layout_projection_helpers_validate_generation_domain_before_writes'`
 - Green:
-  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'focus_shape_helpers_validate_owner_boundaries_before_writes or panel_file_shape_commits_use_appstate_helper or focus_restore_commits_use_appstate_helper'`
+  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'layout_projection_helpers_validate_generation_domain_before_writes or split_layout_commits_through_appstate_helper or active_window_handles_sync_through_appstate_helper or resize_dirty_flag_writes_route_through_appstate_helpers'`
   - `python3 scripts/check_appstate_contract.py`
   - `make clean && make`
   - `git diff --check`
 
 Next action:
-- Wait until after 2026-07-08 10:43 BST (09:43 UTC) for the first compact CI status check on PR 379, then continue the CI/merge loop from that PR state only.
+- Wait until after 2026-07-08 11:24 BST (10:24 UTC) for the first compact CI status check on PR 380, then continue the CI/merge loop from that PR state only.

--- a/src/ui/appstate_layout.c
+++ b/src/ui/appstate_layout.c
@@ -9,6 +9,8 @@
 #include "ytnova_appstate_layout.h"
 
 BOOL AppStateCommitSplitScreenLayout(ViewContext *ctx, BOOL is_split_screen) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.layout"))
     return FALSE;
   if (!ctx)
@@ -20,6 +22,8 @@ BOOL AppStateCommitSplitScreenLayout(ViewContext *ctx, BOOL is_split_screen) {
 
 BOOL AppStateCommitTerminalGeometryCache(ViewContext *ctx, int terminal_lines,
                                          int terminal_cols) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.layout"))
     return FALSE;
   if (!ctx)
@@ -32,6 +36,8 @@ BOOL AppStateCommitTerminalGeometryCache(ViewContext *ctx, int terminal_lines,
 
 BOOL AppStateCommitLayoutGeometry(ViewContext *ctx,
                                   const YtreeNovaLayout *layout) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.layout"))
     return FALSE;
   if (!ctx || !layout)
@@ -43,6 +49,8 @@ BOOL AppStateCommitLayoutGeometry(ViewContext *ctx,
 
 BOOL AppStateCommitPanelWindowGeometry(
     YtreeNovaPanel *panel, const YtreeNovaPanelWindowGeometry *geometry) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.layout"))
     return FALSE;
   if (!panel || !geometry)
@@ -64,6 +72,8 @@ BOOL AppStateCommitPanelWindowGeometry(
 }
 
 BOOL AppStateCommitFixedColumnWidth(ViewContext *ctx, int fixed_col_width) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.layout"))
     return FALSE;
   if (!ctx)
@@ -75,6 +85,8 @@ BOOL AppStateCommitFixedColumnWidth(ViewContext *ctx, int fixed_col_width) {
 
 BOOL AppStateCommitSmallWindowBypass(ViewContext *ctx,
                                      BOOL bypass_small_window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.layout"))
     return FALSE;
   if (!ctx)
@@ -86,6 +98,8 @@ BOOL AppStateCommitSmallWindowBypass(ViewContext *ctx,
 
 BOOL AppStateCommitFullLineHighlight(ViewContext *ctx,
                                      BOOL highlight_full_line) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.layout"))
     return FALSE;
   if (!ctx)

--- a/src/ui/appstate_render.c
+++ b/src/ui/appstate_render.c
@@ -9,6 +9,8 @@
 #include "ytnova_appstate_render.h"
 
 BOOL AppStateCommitResizeRequest(ViewContext *ctx, BOOL resize_request) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.render_dirty_flags"))
     return FALSE;
   if (!ctx)

--- a/src/ui/appstate_window.c
+++ b/src/ui/appstate_window.c
@@ -9,6 +9,8 @@
 #include "ytnova_appstate_window.h"
 
 BOOL AppStateSyncActiveWindowHandles(ViewContext *ctx) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx || !ctx->active)
@@ -23,6 +25,8 @@ BOOL AppStateSyncActiveWindowHandles(ViewContext *ctx) {
 
 BOOL AppStateSetPanelFileWindowHandle(ViewContext *ctx, YtreeNovaPanel *panel,
                                       BOOL big_file_window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx || !panel)
@@ -36,6 +40,8 @@ BOOL AppStateSetPanelFileWindowHandle(ViewContext *ctx, YtreeNovaPanel *panel,
 }
 
 BOOL AppStateSetPreviewWindowHandle(ViewContext *ctx, WINDOW *preview_window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)
@@ -46,6 +52,8 @@ BOOL AppStateSetPreviewWindowHandle(ViewContext *ctx, WINDOW *preview_window) {
 }
 
 BOOL AppStateSetBorderWindowHandle(ViewContext *ctx, WINDOW *window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)
@@ -56,6 +64,8 @@ BOOL AppStateSetBorderWindowHandle(ViewContext *ctx, WINDOW *window) {
 }
 
 BOOL AppStateSetPathWindowHandle(ViewContext *ctx, WINDOW *window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)
@@ -66,6 +76,8 @@ BOOL AppStateSetPathWindowHandle(ViewContext *ctx, WINDOW *window) {
 }
 
 BOOL AppStateSetErrorWindowHandle(ViewContext *ctx, WINDOW *window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)
@@ -76,6 +88,8 @@ BOOL AppStateSetErrorWindowHandle(ViewContext *ctx, WINDOW *window) {
 }
 
 BOOL AppStateSetTimeWindowHandle(ViewContext *ctx, WINDOW *window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)
@@ -86,6 +100,8 @@ BOOL AppStateSetTimeWindowHandle(ViewContext *ctx, WINDOW *window) {
 }
 
 BOOL AppStateSetHistoryWindowHandle(ViewContext *ctx, WINDOW *window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)
@@ -96,6 +112,8 @@ BOOL AppStateSetHistoryWindowHandle(ViewContext *ctx, WINDOW *window) {
 }
 
 BOOL AppStateSetMatchesWindowHandle(ViewContext *ctx, WINDOW *window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)
@@ -106,6 +124,8 @@ BOOL AppStateSetMatchesWindowHandle(ViewContext *ctx, WINDOW *window) {
 }
 
 BOOL AppStateSetMenuWindowHandle(ViewContext *ctx, WINDOW *window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)
@@ -116,6 +136,8 @@ BOOL AppStateSetMenuWindowHandle(ViewContext *ctx, WINDOW *window) {
 }
 
 BOOL AppStateSetF2WindowHandle(ViewContext *ctx, WINDOW *window) {
+  if (!AppStateValidatedGenerationDomain("reflow.layout.projection"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.window_handles"))
     return FALSE;
   if (!ctx)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6820,6 +6820,55 @@ def test_auxiliary_window_handle_lifecycle_routes_through_appstate_helpers() -> 
     )
 
 
+def test_layout_projection_helpers_validate_generation_domain_before_writes() -> None:
+    generation_domains = json.loads(
+        Path("docs/appstate_generation_domains.json").read_text(encoding="utf-8")
+    )["generation_domains"]
+    assert any(
+        record["domain_id"] == "reflow.layout.projection"
+        for record in generation_domains
+    )
+
+    domain_validation = 'AppStateValidatedGenerationDomain("reflow.layout.projection")'
+
+    layout_helper = Path("src/ui/appstate_layout.c").read_text(encoding="utf-8")
+    layout_assignments = [
+        "ctx->is_split_screen = is_split_screen ? TRUE : FALSE;",
+        "ctx->cached_lines = terminal_lines;",
+        "ctx->layout = *layout;",
+        "panel->dir_x = geometry->dir_x;",
+        "ctx->fixed_col_width = fixed_col_width;",
+        "ctx->bypass_small_window = bypass_small_window ? TRUE : FALSE;",
+        "ctx->highlight_full_line = highlight_full_line ? TRUE : FALSE;",
+    ]
+    assert domain_validation in layout_helper
+    for assignment in layout_assignments:
+        assert layout_helper.index(domain_validation) < layout_helper.index(assignment)
+
+    render_helper = Path("src/ui/appstate_render.c").read_text(encoding="utf-8")
+    render_assignment = "ctx->resize_request = resize_request ? TRUE : FALSE;"
+    assert domain_validation in render_helper
+    assert render_helper.index(domain_validation) < render_helper.index(render_assignment)
+
+    window_helper = Path("src/ui/appstate_window.c").read_text(encoding="utf-8")
+    window_assignments = [
+        "ctx->ctx_dir_window = ctx->active->pan_dir_window;",
+        "panel->pan_file_window = big_file_window ? panel->pan_big_file_window",
+        "ctx->ctx_preview_window = preview_window;",
+        "ctx->ctx_border_window = window;",
+        "ctx->ctx_path_window = window;",
+        "ctx->ctx_error_window = window;",
+        "ctx->ctx_time_window = window;",
+        "ctx->ctx_history_window = window;",
+        "ctx->ctx_matches_window = window;",
+        "ctx->ctx_menu_window = window;",
+        "ctx->ctx_f2_window = window;",
+    ]
+    assert domain_validation in window_helper
+    for assignment in window_assignments:
+        assert window_helper.index(domain_validation) < window_helper.index(assignment)
+
+
 def test_resize_dirty_flag_writes_route_through_appstate_helpers() -> None:
     header = Path("include/ytnova_appstate_render.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_render.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- make the layout-projection AppState helpers fail closed unless the registered generation domain validates first
- keep the change scoped to the layout, render-dirty, and window-handle helper modules plus focused contract regression coverage

## Validation
- Red proof: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'layout_projection_helpers_validate_generation_domain_before_writes'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'layout_projection_helpers_validate_generation_domain_before_writes or split_layout_commits_through_appstate_helper or active_window_handles_sync_through_appstate_helper or resize_dirty_flag_writes_route_through_appstate_helpers'`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
