### PR TITLE
fix(appstate): validate modal target helper boundaries

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,22 +4,22 @@ Date: 2026-07-08
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-layout-projection-boundary-validation
-Active PR: https://github.com/robkam/ytreenova/pull/380
+Current branch: appstate-modal-target-boundary-validation
+Active PR: https://github.com/robkam/ytreenova/pull/381
 Supersession state: no active stop or pause condition.
 
 Current AppState batch:
-- Tighten the next projection-domain/runtime boundary identified from `docs/appstate_generation_domains.json` around `reflow.layout.projection`.
-- Make the layout, render-dirty, and window-handle AppState helper modules fail closed unless that generation domain validates before they write `ctx.layout`, `ctx.render_dirty_flags`, or `ctx.window_handles`.
-- Keep the batch scoped to `src/ui/appstate_layout.c`, `src/ui/appstate_render.c`, `src/ui/appstate_window.c`, and the focused contract regression coverage.
+- Tighten the next modal-session runtime boundary identified from `docs/appstate_generation_domains.json` around `target.modal-command.session`.
+- Make `src/ui/appstate_modal.c` fail closed unless that generation domain validates before modal helper commits write preview, return-focus, or modal viewport session state.
+- Keep the batch scoped to the modal helper module plus its focused contract regression coverage.
 
 Local validation:
-- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'layout_projection_helpers_validate_generation_domain_before_writes'`
+- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'modal_target_helpers_validate_generation_domain_before_writes'`
 - Green:
-  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'layout_projection_helpers_validate_generation_domain_before_writes or split_layout_commits_through_appstate_helper or active_window_handles_sync_through_appstate_helper or resize_dirty_flag_writes_route_through_appstate_helpers'`
+  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'modal_target_helpers_validate_generation_domain_before_writes or preview_mode_routes_through_appstate_helper or history_viewport_routes_through_appstate_helper or completion_viewport_routes_through_appstate_helper'`
   - `python3 scripts/check_appstate_contract.py`
   - `make clean && make`
   - `git diff --check`
 
 Next action:
-- Wait until after 2026-07-08 11:24 BST (10:24 UTC) for the first compact CI status check on PR 380, then continue the CI/merge loop from that PR state only.
+- Wait until after 2026-07-08 19:41 BST (18:41 UTC) for the first compact CI status check on PR 381, then continue the CI/merge loop from that PR state only.

--- a/src/ui/appstate_modal.c
+++ b/src/ui/appstate_modal.c
@@ -3,6 +3,8 @@
 #include "ytnova_appstate_actions.h"
 
 BOOL AppStateCommitPreviewMode(ViewContext *ctx, BOOL preview_mode) {
+  if (!AppStateValidatedGenerationDomain("target.modal-command.session"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.modal_state"))
     return FALSE;
   if (!ctx)
@@ -14,6 +16,8 @@ BOOL AppStateCommitPreviewMode(ViewContext *ctx, BOOL preview_mode) {
 
 BOOL AppStateCommitPreviewReturn(ViewContext *ctx, YtreeNovaPanel *panel,
                                  ViewFocus focus) {
+  if (!AppStateValidatedGenerationDomain("target.modal-command.session"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.modal_state"))
     return FALSE;
   if (!ctx)
@@ -25,6 +29,8 @@ BOOL AppStateCommitPreviewReturn(ViewContext *ctx, YtreeNovaPanel *panel,
 }
 
 BOOL AppStateCommitPreviewEntryFocus(ViewContext *ctx, ViewFocus focus) {
+  if (!AppStateValidatedGenerationDomain("target.modal-command.session"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.modal_state"))
     return FALSE;
   if (!ctx)
@@ -36,6 +42,8 @@ BOOL AppStateCommitPreviewEntryFocus(ViewContext *ctx, ViewFocus focus) {
 
 BOOL AppStateCommitHistoryViewport(ViewContext *ctx, int disp_begin_pos,
                                    int cursor_pos) {
+  if (!AppStateValidatedGenerationDomain("target.modal-command.session"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.modal_state"))
     return FALSE;
   if (!ctx)
@@ -48,6 +56,8 @@ BOOL AppStateCommitHistoryViewport(ViewContext *ctx, int disp_begin_pos,
 
 BOOL AppStateCommitCompletionViewport(ViewContext *ctx, int disp_begin_pos,
                                       int cursor_pos) {
+  if (!AppStateValidatedGenerationDomain("target.modal-command.session"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("ctx.modal_state"))
     return FALSE;
   if (!ctx)

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7452,6 +7452,35 @@ def test_completion_viewport_routes_through_appstate_helper() -> None:
     )
 
 
+def test_modal_target_helpers_validate_generation_domain_before_writes() -> None:
+    generation_domains = json.loads(
+        Path("docs/appstate_generation_domains.json").read_text(encoding="utf-8")
+    )["generation_domains"]
+    assert any(
+        record["domain_id"] == "target.modal-command.session"
+        for record in generation_domains
+    )
+
+    helper = Path("src/ui/appstate_modal.c").read_text(encoding="utf-8")
+    domain_validation = (
+        'AppStateValidatedGenerationDomain("target.modal-command.session")'
+    )
+    writes = [
+        "ctx->preview_mode = preview_mode ? TRUE : FALSE;",
+        "ctx->preview_return_panel = panel;",
+        "ctx->preview_return_focus = focus;",
+        "ctx->preview_entry_focus = focus;",
+        "ctx->disp_begin_pos = disp_begin_pos;",
+        "ctx->cursor_pos = cursor_pos;",
+        "ctx->tab_disp_begin_pos = disp_begin_pos;",
+        "ctx->tab_cursor_pos = cursor_pos;",
+    ]
+
+    assert domain_validation in helper
+    for write in writes:
+        assert helper.index(domain_validation) < helper.index(write)
+
+
 def test_event_coverage_transition_sequence_arrays_are_referenced() -> None:
     source = Path("src/core/appstate_actions.c").read_text(encoding="utf-8")
     array_names = set(


### PR DESCRIPTION
## Summary
- make the modal-session AppState helpers fail closed unless the registered modal target generation domain validates first
- keep the change scoped to `src/ui/appstate_modal.c` and focused contract regression coverage

## Validation
- Red proof: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'modal_target_helpers_validate_generation_domain_before_writes'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'modal_target_helpers_validate_generation_domain_before_writes or preview_mode_routes_through_appstate_helper or history_viewport_routes_through_appstate_helper or completion_viewport_routes_through_appstate_helper'`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
