### PR TITLE
fix(appstate): validate panel-local helper boundaries

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,22 +4,28 @@ Date: 2026-07-08
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-modal-target-boundary-validation
-Active PR: https://github.com/robkam/ytreenova/pull/381
-Supersession state: no active stop or pause condition.
+Current branch: appstate-panel-local-boundary-validation
+Active PR: https://github.com/robkam/ytreenova/pull/382
+Last merged PR: https://github.com/robkam/ytreenova/pull/381
+Supersession state: resumed by maintainer command; autonomous continuation active.
 
 Current AppState batch:
-- Tighten the next modal-session runtime boundary identified from `docs/appstate_generation_domains.json` around `target.modal-command.session`.
-- Make `src/ui/appstate_modal.c` fail closed unless that generation domain validates before modal helper commits write preview, return-focus, or modal viewport session state.
-- Keep the batch scoped to the modal helper module plus its focused contract regression coverage.
+- Added a panel-local generation-domain fail-closed guard around the `src/ui/appstate_panel.c` helper boundary.
+- Panel generation, volume binding, restore snapshot, selection, anchor, and viewport helper commits now validate `generation.panel.local-authority` before mutating panel-local authority fields.
+- Focused contract regression coverage now asserts those helper writes stay behind the documented generation-domain gate.
 
-Local validation:
-- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'modal_target_helpers_validate_generation_domain_before_writes'`
+Local validation evidence:
+- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'panel_local_helpers_validate_generation_domain_before_writes'`
 - Green:
-  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'modal_target_helpers_validate_generation_domain_before_writes or preview_mode_routes_through_appstate_helper or history_viewport_routes_through_appstate_helper or completion_viewport_routes_through_appstate_helper'`
+  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'panel_local_helpers_validate_generation_domain_before_writes or panel_generation_restores_route_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or panel_tree_viewport_commits_route_through_appstate_helper or panel_volume_binding_commits_route_through_appstate_helper or panel_tree_selection_commits_route_through_appstate_helper or panel_anchor_viewport_generation_commits_through_appstate_helper or panel_volume_tree_viewport_snapshot_routes_through_appstate_helper or panel_volume_file_snapshot_routes_through_appstate_helper or panel_volume_file_state_list_routes_through_appstate_helper or panel_file_selection_commits_route_through_appstate_helper'`
   - `python3 scripts/check_appstate_contract.py`
   - `make clean && make`
   - `git diff --check`
 
+PR state:
+- Draft PR opened: https://github.com/robkam/ytreenova/pull/382
+- CI wait window started: 2026-07-08 20:25:26 BST
+- First allowed CI status check: 2026-07-08 20:40:26 BST
+
 Next action:
-- Wait until after 2026-07-08 19:41 BST (18:41 UTC) for the first compact CI status check on PR 381, then continue the CI/merge loop from that PR state only.
+- Wait until the first allowed CI status check, then inspect only a compact pass/fail/running summary.

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -12,6 +12,8 @@
 #include <string.h>
 
 BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.panel_generation"))
     return FALSE;
   if (!panel)
@@ -23,6 +25,8 @@ BOOL AppStateCommitPanelGeneration(YtreeNovaPanel *panel) {
 
 BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
                                     unsigned int panel_generation) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.panel_generation"))
     return FALSE;
   if (!panel)
@@ -33,6 +37,8 @@ BOOL AppStateRestorePanelGeneration(YtreeNovaPanel *panel,
 }
 
 BOOL AppStateCommitPanelVolume(YtreeNovaPanel *panel, struct Volume *vol) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.volume_key"))
     return FALSE;
   if (!AppStateValidatedOwnerField("panel.panel_generation"))
@@ -47,6 +53,8 @@ BOOL AppStateCommitPanelVolume(YtreeNovaPanel *panel, struct Volume *vol) {
 
 BOOL AppStateSetPanelVolumeFileStateList(
     YtreeNovaPanel *panel, PanelVolumeFileState *volume_file_state) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
     return FALSE;
   if (!panel)
@@ -110,6 +118,8 @@ BOOL AppStateCommitPanelFileSortOrder(YtreeNovaPanel *panel,
 BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
                                       const char *dir_path,
                                       const char *file_name) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.file_selection_key"))
     return FALSE;
   if (!AppStateValidatedOwnerField("panel.panel_generation"))
@@ -137,6 +147,8 @@ BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
 
 BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
                                       int current_dir_entry) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.tree_selection_key"))
     return FALSE;
   if (!panel)
@@ -148,6 +160,8 @@ BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
 
 BOOL AppStateCommitPanelTreeViewportTopPath(YtreeNovaPanel *panel, int slot,
                                             const char *top_path) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
     return FALSE;
   if (!panel || slot < 0 || slot >= 2)
@@ -165,6 +179,8 @@ BOOL AppStateCommitPanelTreeViewportTopPath(YtreeNovaPanel *panel, int slot,
 
 BOOL AppStateCommitPanelTreeViewportTopPaths(YtreeNovaPanel *panel,
                                              const YtreeNovaPanel *source) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
     return FALSE;
   if (!panel || !source)
@@ -180,6 +196,8 @@ BOOL AppStateCommitPanelVolumeTreeViewportSnapshot(
     unsigned int volume_generation, BOOL has_selected_dir_path,
     const char *selected_dir_path, BOOL has_top_dir_path,
     const char *top_dir_path) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
     return FALSE;
   if (!state)
@@ -211,6 +229,8 @@ BOOL AppStateCommitPanelVolumeFileSnapshot(
     unsigned int panel_generation, unsigned int volume_generation,
     ViewFocus focus, BOOL big_file_view, const char *file_dir_path,
     const char *file_selection_dir_path, const char *file_selection_name) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.restore_snapshot"))
     return FALSE;
   if (!state)
@@ -247,6 +267,8 @@ BOOL AppStateCommitPanelVolumeFileSnapshot(
 
 BOOL AppStateCommitDirEntryFileViewport(DirEntry *dir_entry, int start_file,
                                         int cursor_pos) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))
     return FALSE;
   if (!dir_entry)
@@ -259,6 +281,8 @@ BOOL AppStateCommitDirEntryFileViewport(DirEntry *dir_entry, int start_file,
 
 BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
                                      int file_cursor_pos) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))
     return FALSE;
   if (!panel)
@@ -271,6 +295,8 @@ BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
 
 BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,
                                    DirEntry *file_dir_entry) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))
     return FALSE;
   if (!panel)
@@ -282,6 +308,8 @@ BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,
 
 BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,
                                      int cursor_pos) {
+  if (!AppStateValidatedGenerationDomain("generation.panel.local-authority"))
+    return FALSE;
   if (!AppStateValidatedOwnerField("panel.tree_viewport_origin"))
     return FALSE;
   if (!AppStateValidatedOwnerField("panel.tree_cursor_pos"))

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7551,6 +7551,94 @@ def test_panel_generation_restores_route_through_appstate_helper() -> None:
     assert "source_panel_generation" in split_body
 
 
+def test_panel_local_helpers_validate_generation_domain_before_writes() -> None:
+    source = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
+    validation = 'AppStateValidatedGenerationDomain("generation.panel.local-authority")'
+    signatures_and_writes = [
+        (
+            "BOOL AppStateCommitPanelGeneration(",
+            ["panel->panel_generation++;"],
+        ),
+        (
+            "BOOL AppStateRestorePanelGeneration(",
+            ["panel->panel_generation = panel_generation;"],
+        ),
+        (
+            "BOOL AppStateCommitPanelVolume(",
+            ["panel->vol = vol;", "panel->panel_generation++;"],
+        ),
+        (
+            "BOOL AppStateSetPanelVolumeFileStateList(",
+            ["panel->volume_file_state = volume_file_state;"],
+        ),
+        (
+            "BOOL AppStateCommitPanelFileSelection(",
+            [
+                "panel->file_selection_dir_path[0] = '\\0';",
+                "panel->file_selection_name[0] = '\\0';",
+                "panel->panel_generation++;",
+            ],
+        ),
+        (
+            "BOOL AppStateCommitPanelTreeSelection(",
+            ["panel->current_dir_entry = current_dir_entry;"],
+        ),
+        (
+            "BOOL AppStateCommitPanelTreeViewportTopPath(",
+            ["panel->tree_viewport_top_dir_path[slot][0] = '\\0';"],
+        ),
+        (
+            "BOOL AppStateCommitPanelTreeViewportTopPaths(",
+            ["memcpy(panel->tree_viewport_top_dir_path,"],
+        ),
+        (
+            "BOOL AppStateCommitPanelVolumeTreeViewportSnapshot(",
+            ["state->saved_tree_panel_generation = panel_generation;"],
+        ),
+        (
+            "BOOL AppStateCommitPanelVolumeFileSnapshot(",
+            [
+                "state->saved_file_start = start_file;",
+                "state->saved_panel_generation = panel_generation;",
+            ],
+        ),
+        (
+            "BOOL AppStateCommitDirEntryFileViewport(",
+            ["dir_entry->start_file = start_file;"],
+        ),
+        (
+            "BOOL AppStateCommitPanelFileViewport(",
+            [
+                "panel->start_file = start_file;",
+                "panel->file_cursor_pos = file_cursor_pos;",
+            ],
+        ),
+        (
+            "BOOL AppStateCommitPanelFileAnchor(",
+            ["panel->file_dir_entry = file_dir_entry;"],
+        ),
+        (
+            "BOOL AppStateCommitPanelTreeViewport(",
+            [
+                "panel->disp_begin_pos = disp_begin_pos;",
+                "panel->cursor_pos = cursor_pos;",
+            ],
+        ),
+    ]
+
+    for index, (signature, writes) in enumerate(signatures_and_writes):
+        start = source.index(signature)
+        if index + 1 < len(signatures_and_writes):
+            end = source.index(signatures_and_writes[index + 1][0], start + 1)
+        else:
+            end = len(source)
+        body = source[start:end]
+        assert validation in body
+        validation_idx = body.index(validation)
+        for write in writes:
+            assert validation_idx < body.index(write)
+
+
 def test_panel_file_viewport_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_panel.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- validate the panel-local AppState helper boundary before panel authority writes run
- fail closed when `generation.panel.local-authority` runtime metadata is missing or invalid
- lock the new guard in place with focused contract coverage

## Why
The recent AppState batches already guard focus, layout, and modal helper boundaries with generation-domain validation. Panel-local restore, selection, and viewport helpers still mutated authoritative panel state without that newer guard, leaving a gap between the runtime registry contract and the helper boundary that enforces it.

## Impact
Panel-local generation, binding, snapshot, selection, anchor, and viewport helpers now refuse writes unless the documented generation-domain metadata validates first.

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'panel_local_helpers_validate_generation_domain_before_writes'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'panel_local_helpers_validate_generation_domain_before_writes or panel_generation_restores_route_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or panel_tree_viewport_commits_route_through_appstate_helper or panel_volume_binding_commits_route_through_appstate_helper or panel_tree_selection_commits_route_through_appstate_helper or panel_anchor_viewport_generation_commits_through_appstate_helper or panel_volume_tree_viewport_snapshot_routes_through_appstate_helper or panel_volume_file_snapshot_routes_through_appstate_helper or panel_volume_file_state_list_routes_through_appstate_helper or panel_file_selection_commits_route_through_appstate_helper'`
- `python3 scripts/check_appstate_contract.py`
- `make clean && make`
- `git diff --check`
