### PR TITLE
fix(appstate): validate shared volume helper boundaries

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,28 +4,22 @@ Date: 2026-07-08
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-panel-local-boundary-validation
-Active PR: https://github.com/robkam/ytreenova/pull/382
-Last merged PR: https://github.com/robkam/ytreenova/pull/381
-Supersession state: resumed by maintainer command; autonomous continuation active.
+Current branch: appstate-volume-shared-boundary-validation
+Active PR: draft https://github.com/robkam/ytreenova/pull/383
+Last merged PR: https://github.com/robkam/ytreenova/pull/382
+Supersession state: resumed by maintainer; no later stop/pause override.
 
 Current AppState batch:
-- Added a panel-local generation-domain fail-closed guard around the `src/ui/appstate_panel.c` helper boundary.
-- Panel generation, volume binding, restore snapshot, selection, anchor, and viewport helper commits now validate `generation.panel.local-authority` before mutating panel-local authority fields.
-- Focused contract regression coverage now asserts those helper writes stay behind the documented generation-domain gate.
+- Added the shared-volume generation-domain fail-closed guard around the `src/ui/appstate_volume.c` helper boundary.
+- Volume payload-cache, logged-state, subtree, generation-counter, and dir-entry-list helpers now validate `generation.volume.shared-authority` before mutating shared volume authority fields.
+- Focused contract regression coverage now asserts those helper writes stay behind the documented shared-volume generation-domain gate.
 
 Local validation evidence:
-- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'panel_local_helpers_validate_generation_domain_before_writes'`
+- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_helpers_validate_generation_domain_before_writes'`
 - Green:
-  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'panel_local_helpers_validate_generation_domain_before_writes or panel_generation_restores_route_through_appstate_helper or panel_file_viewport_commits_route_through_appstate_helper or panel_tree_viewport_commits_route_through_appstate_helper or panel_volume_binding_commits_route_through_appstate_helper or panel_tree_selection_commits_route_through_appstate_helper or panel_anchor_viewport_generation_commits_through_appstate_helper or panel_volume_tree_viewport_snapshot_routes_through_appstate_helper or panel_volume_file_snapshot_routes_through_appstate_helper or panel_volume_file_state_list_routes_through_appstate_helper or panel_file_selection_commits_route_through_appstate_helper'`
-  - `python3 scripts/check_appstate_contract.py`
+  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_helpers_validate_generation_domain_before_writes or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper or directory_log_flag_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or directory_tagged_payload_commits_route_through_appstate_helper'`
   - `make clean && make`
   - `git diff --check`
 
-PR state:
-- Draft PR opened: https://github.com/robkam/ytreenova/pull/382
-- CI wait window started: 2026-07-08 20:25:26 BST
-- First allowed CI status check: 2026-07-08 20:40:26 BST
-
 Next action:
-- Wait until the first allowed CI status check, then inspect only a compact pass/fail/running summary.
+- Wait for the draft PR CI run to age past the first 15-minute checkpoint, then inspect compact status summary and either fix red or continue the wait loop.

--- a/src/ui/appstate_volume.c
+++ b/src/ui/appstate_volume.c
@@ -11,6 +11,8 @@
 BOOL AppStateCommitDirEntryFileList(DirEntry *dir_entry, FileEntry *file_list) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
+    return FALSE;
   if (!dir_entry)
     return FALSE;
 
@@ -22,6 +24,8 @@ BOOL AppStateCommitDirEntryTotalPayload(DirEntry *dir_entry,
                                         unsigned int total_files,
                                         long long total_bytes) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
     return FALSE;
   if (!dir_entry)
     return FALSE;
@@ -36,6 +40,8 @@ BOOL AppStateCommitDirEntryMatchingPayload(DirEntry *dir_entry,
                                            long long matching_bytes) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
+    return FALSE;
   if (!dir_entry)
     return FALSE;
 
@@ -49,6 +55,8 @@ BOOL AppStateCommitDirEntryTaggedPayload(DirEntry *dir_entry,
                                          long long tagged_bytes) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
+    return FALSE;
   if (!dir_entry)
     return FALSE;
 
@@ -61,6 +69,8 @@ BOOL AppStateCommitDirEntryAccessDenied(DirEntry *dir_entry,
                                         BOOL access_denied) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
+    return FALSE;
   if (!dir_entry)
     return FALSE;
 
@@ -70,6 +80,8 @@ BOOL AppStateCommitDirEntryAccessDenied(DirEntry *dir_entry,
 
 BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
+    return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
     return FALSE;
   if (!dir_entry)
     return FALSE;
@@ -89,6 +101,8 @@ BOOL AppStateResetDirEntryPayloadCache(DirEntry *dir_entry) {
 BOOL AppStateCommitDirEntryLogFlag(DirEntry *dir_entry, BOOL log_flag) {
   if (!AppStateValidatedOwnerField("volume.payload_cache"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
+    return FALSE;
   if (!dir_entry)
     return FALSE;
 
@@ -99,6 +113,8 @@ BOOL AppStateCommitDirEntryLogFlag(DirEntry *dir_entry, BOOL log_flag) {
 BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
                                        BOOL unlogged_flag) {
   if (!AppStateValidatedOwnerField("volume.logged_state"))
+    return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
     return FALSE;
   if (!dir_entry)
     return FALSE;
@@ -111,6 +127,8 @@ BOOL AppStateCommitDirEntryLoggedState(DirEntry *dir_entry, BOOL not_scanned,
 BOOL AppStateCommitDirEntrySubTree(DirEntry *dir_entry, DirEntry *sub_tree) {
   if (!AppStateValidatedOwnerField("volume.dir_tree"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
+    return FALSE;
   if (!dir_entry)
     return FALSE;
 
@@ -120,6 +138,8 @@ BOOL AppStateCommitDirEntrySubTree(DirEntry *dir_entry, DirEntry *sub_tree) {
 
 BOOL AppStateCommitVolumeGeneration(struct Volume *volume) {
   if (!AppStateValidatedOwnerField("volume.volume_generation"))
+    return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
     return FALSE;
   if (!volume)
     return FALSE;
@@ -133,6 +153,8 @@ BOOL AppStateCommitVolumeDirEntryList(struct Volume *volume,
                                       size_t capacity, int total_dirs) {
   if (!AppStateValidatedOwnerField("volume.dir_tree"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
+    return FALSE;
   if (!volume)
     return FALSE;
 
@@ -144,6 +166,8 @@ BOOL AppStateCommitVolumeDirEntryList(struct Volume *volume,
 
 BOOL AppStateReleaseVolumeDirEntryList(struct Volume *volume) {
   if (!AppStateValidatedOwnerField("volume.dir_tree"))
+    return FALSE;
+  if (!AppStateValidatedGenerationDomain("generation.volume.shared-authority"))
     return FALSE;
   if (!volume)
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -9219,6 +9219,90 @@ def test_volume_generation_commits_route_through_appstate_helper() -> None:
     assert dir_ops.count("AppStateCommitVolumeGeneration(") == 4
 
 
+def test_volume_helpers_validate_generation_domain_before_writes() -> None:
+    generation_domains = json.loads(
+        Path("docs/appstate_generation_domains.json").read_text(encoding="utf-8")
+    )["generation_domains"]
+    assert any(
+        record["domain_id"] == "generation.volume.shared-authority"
+        for record in generation_domains
+    )
+
+    source = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")
+    validation = (
+        'AppStateValidatedGenerationDomain("generation.volume.shared-authority")'
+    )
+    signatures_and_writes = [
+        ("BOOL AppStateCommitDirEntryFileList(", ["dir_entry->file = file_list;"]),
+        (
+            "BOOL AppStateCommitDirEntryTotalPayload(",
+            [
+                "dir_entry->total_files = total_files;",
+                "dir_entry->total_bytes = total_bytes;",
+            ],
+        ),
+        (
+            "BOOL AppStateCommitDirEntryMatchingPayload(",
+            [
+                "dir_entry->matching_files = matching_files;",
+                "dir_entry->matching_bytes = matching_bytes;",
+            ],
+        ),
+        (
+            "BOOL AppStateCommitDirEntryTaggedPayload(",
+            [
+                "dir_entry->tagged_files = tagged_files;",
+                "dir_entry->tagged_bytes = tagged_bytes;",
+            ],
+        ),
+        (
+            "BOOL AppStateCommitDirEntryAccessDenied(",
+            ["dir_entry->access_denied = access_denied ? TRUE : FALSE;"],
+        ),
+        (
+            "BOOL AppStateResetDirEntryPayloadCache(",
+            ["dir_entry->file = NULL;", "dir_entry->log_flag = FALSE;"],
+        ),
+        (
+            "BOOL AppStateCommitDirEntryLogFlag(",
+            ["dir_entry->log_flag = log_flag ? TRUE : FALSE;"],
+        ),
+        (
+            "BOOL AppStateCommitDirEntryLoggedState(",
+            [
+                "dir_entry->not_scanned = not_scanned ? TRUE : FALSE;",
+                "dir_entry->unlogged_flag = unlogged_flag ? TRUE : FALSE;",
+            ],
+        ),
+        ("BOOL AppStateCommitDirEntrySubTree(", ["dir_entry->sub_tree = sub_tree;"]),
+        ("BOOL AppStateCommitVolumeGeneration(", ["volume->volume_generation++;"]),
+        (
+            "BOOL AppStateCommitVolumeDirEntryList(",
+            [
+                "volume->dir_entry_list = dir_entry_list;",
+                "volume->dir_entry_list_capacity = capacity;",
+                "volume->total_dirs = total_dirs;",
+            ],
+        ),
+        (
+            "BOOL AppStateReleaseVolumeDirEntryList(",
+            ["free(volume->dir_entry_list);", "volume->dir_entry_list = NULL;"],
+        ),
+    ]
+
+    for index, (signature, writes) in enumerate(signatures_and_writes):
+        start = source.index(signature)
+        if index + 1 < len(signatures_and_writes):
+            end = source.index(signatures_and_writes[index + 1][0], start + 1)
+        else:
+            end = len(source)
+        body = source[start:end]
+        assert validation in body
+        validation_idx = body.index(validation)
+        for write in writes:
+            assert validation_idx < body.index(write)
+
+
 def test_volume_dir_entry_list_cache_commits_route_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_volume.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- validate shared-volume AppState helpers against the documented generation boundary before mutating payload, logged-state, topology, or generation fields
- add regression coverage that fails closed when those helpers bypass `generation.volume.shared-authority`

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_helpers_validate_generation_domain_before_writes'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_helpers_validate_generation_domain_before_writes or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper or directory_log_flag_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or directory_tagged_payload_commits_route_through_appstate_helper'`
- `make clean && make`
- `git diff --check`
