### PR TITLE
fix(appstate): validate volume registry helper boundaries

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -4,22 +4,25 @@ Date: 2026-07-08
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-volume-shared-boundary-validation
-Active PR: draft https://github.com/robkam/ytreenova/pull/383
-Last merged PR: https://github.com/robkam/ytreenova/pull/382
+Current branch: appstate-volume-registry-boundary-validation
+Active PR: draft https://github.com/robkam/ytreenova/pull/384
+Last merged PR: https://github.com/robkam/ytreenova/pull/383
 Supersession state: resumed by maintainer; no later stop/pause override.
 
 Current AppState batch:
-- Added the shared-volume generation-domain fail-closed guard around the `src/ui/appstate_volume.c` helper boundary.
+- Merged the shared-volume generation-domain fail-closed guard around the `src/ui/appstate_volume.c` helper boundary.
 - Volume payload-cache, logged-state, subtree, generation-counter, and dir-entry-list helpers now validate `generation.volume.shared-authority` before mutating shared volume authority fields.
 - Focused contract regression coverage now asserts those helper writes stay behind the documented shared-volume generation-domain gate.
+- Next adjacent batch targets the `src/core/appstate_volume_registry.c` lifecycle boundary so registry add/remove/clear helpers validate `lifecycle.volume.registry` before mutating `ctx.volumes_head`.
 
-Local validation evidence:
+Merged validation evidence:
 - Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_helpers_validate_generation_domain_before_writes'`
 - Green:
   - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_helpers_validate_generation_domain_before_writes or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper or directory_log_flag_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or directory_tagged_payload_commits_route_through_appstate_helper'`
   - `make clean && make`
   - `git diff --check`
+- PR CI: green before ready/merge
+- Merge commit: `6e0acea74f53de2ecf2d53d18f831645539f54e5`
 
 Next action:
 - Wait for the draft PR CI run to age past the first 15-minute checkpoint, then inspect compact status summary and either fix red or continue the wait loop.

--- a/src/core/appstate_volume_registry.c
+++ b/src/core/appstate_volume_registry.c
@@ -11,6 +11,8 @@
 BOOL AppStateRegisterVolume(ViewContext *ctx, struct Volume *volume) {
   if (!AppStateValidatedOwnerField("ctx.volumes_head"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("lifecycle.volume.registry"))
+    return FALSE;
   if (!ctx || !volume)
     return FALSE;
 
@@ -21,6 +23,8 @@ BOOL AppStateRegisterVolume(ViewContext *ctx, struct Volume *volume) {
 BOOL AppStateUnregisterVolume(ViewContext *ctx, struct Volume *volume) {
   if (!AppStateValidatedOwnerField("ctx.volumes_head"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("lifecycle.volume.registry"))
+    return FALSE;
   if (!ctx || !volume)
     return FALSE;
 
@@ -30,6 +34,8 @@ BOOL AppStateUnregisterVolume(ViewContext *ctx, struct Volume *volume) {
 
 BOOL AppStateClearVolumeRegistry(ViewContext *ctx) {
   if (!AppStateValidatedOwnerField("ctx.volumes_head"))
+    return FALSE;
+  if (!AppStateValidatedGenerationDomain("lifecycle.volume.registry"))
     return FALSE;
   if (!ctx)
     return FALSE;

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6675,6 +6675,36 @@ def test_volume_registry_commits_through_appstate_helper() -> None:
     assert "ctx->volumes_head = NULL;" not in volume_source
 
 
+def test_volume_registry_helpers_validate_generation_domain_before_writes() -> None:
+    generation_domains = json.loads(
+        Path("docs/appstate_generation_domains.json").read_text(encoding="utf-8")
+    )["generation_domains"]
+    assert any(
+        record["domain_id"] == "lifecycle.volume.registry"
+        for record in generation_domains
+    )
+
+    source = Path("src/core/appstate_volume_registry.c").read_text(encoding="utf-8")
+    validation = 'AppStateValidatedGenerationDomain("lifecycle.volume.registry")'
+    signatures_and_writes = [
+        ("BOOL AppStateRegisterVolume(", ["HASH_ADD_INT(ctx->volumes_head, id, volume);"]),
+        ("BOOL AppStateUnregisterVolume(", ["HASH_DEL(ctx->volumes_head, volume);"]),
+        ("BOOL AppStateClearVolumeRegistry(", ["ctx->volumes_head = NULL;"]),
+    ]
+
+    for index, (signature, writes) in enumerate(signatures_and_writes):
+        start = source.index(signature)
+        if index + 1 < len(signatures_and_writes):
+            end = source.index(signatures_and_writes[index + 1][0], start + 1)
+        else:
+            end = len(source)
+        body = source[start:end]
+        assert validation in body
+        validation_idx = body.index(validation)
+        for write in writes:
+            assert validation_idx < body.index(write)
+
+
 def test_active_window_handles_sync_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_window.h").read_text(encoding="utf-8")
     helper = Path("src/ui/appstate_window.c").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- validate volume-registry AppState helpers against the documented lifecycle boundary before mutating the loaded-volume registry
- add regression coverage that fails closed when registry add, remove, or clear helpers bypass `lifecycle.volume.registry`

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_registry_helpers_validate_generation_domain_before_writes'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_registry or select_loaded_volume_validates_volume_surfaces_before_menu_work'`
- `make clean && make`
- `git diff --check`
