### PR TITLE
fix(appstate): validate command message helper boundaries

### DIFF
--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -1,28 +1,28 @@
 # ytreenova AppState continuation checkpoint
 
-Date: 2026-07-08
+Date: 2026-07-09
 Repo: /home/rob/ytreenova
 Roadmap item: Unified AppState Transition Machine + Projection Contract
 Persona: developer
-Current branch: appstate-volume-registry-boundary-validation
-Active PR: draft https://github.com/robkam/ytreenova/pull/384
-Last merged PR: https://github.com/robkam/ytreenova/pull/383
+Current branch: appstate-command-message-boundary-validation
+Active PR: draft https://github.com/robkam/ytreenova/pull/385
+Last merged PR: https://github.com/robkam/ytreenova/pull/384
 Supersession state: resumed by maintainer; no later stop/pause override.
 
 Current AppState batch:
-- Merged the shared-volume generation-domain fail-closed guard around the `src/ui/appstate_volume.c` helper boundary.
-- Volume payload-cache, logged-state, subtree, generation-counter, and dir-entry-list helpers now validate `generation.volume.shared-authority` before mutating shared volume authority fields.
-- Focused contract regression coverage now asserts those helper writes stay behind the documented shared-volume generation-domain gate.
-- Next adjacent batch targets the `src/core/appstate_volume_registry.c` lifecycle boundary so registry add/remove/clear helpers validate `lifecycle.volume.registry` before mutating `ctx.volumes_head`.
+- Merged the volume-registry lifecycle fail-closed guard around the `src/core/appstate_volume_registry.c` helper boundary.
+- Registry add/remove/clear helpers now validate `lifecycle.volume.registry` before mutating `ctx.volumes_head`.
+- Focused contract regression coverage now asserts those registry writes stay behind the documented lifecycle generation-domain gate.
+- Next adjacent batch targets the command/message session boundary so global search term and status-line message helpers validate `target.modal-command.session` before mutating command/message session state.
 
 Merged validation evidence:
-- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_helpers_validate_generation_domain_before_writes'`
+- Red first: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_registry_helpers_validate_generation_domain_before_writes'`
 - Green:
-  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_helpers_validate_generation_domain_before_writes or volume_generation_commits_route_through_appstate_helper or volume_dir_entry_list_cache_commits_route_through_appstate_helper or volume_logged_state_commits_route_through_appstate_helper or directory_payload_reset_commits_route_through_appstate_helper or directory_log_flag_commits_route_through_appstate_helper or directory_matching_payload_commits_route_through_appstate_helper or directory_tagged_payload_commits_route_through_appstate_helper'`
+  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'volume_registry or select_loaded_volume_validates_volume_surfaces_before_menu_work'`
   - `make clean && make`
   - `git diff --check`
 - PR CI: green before ready/merge
-- Merge commit: `6e0acea74f53de2ecf2d53d18f831645539f54e5`
+- Merge commit: `8bdb16c2230ca6f7a055c5361f7171d453d80944`
 
 Next action:
 - Wait for the draft PR CI run to age past the first 15-minute checkpoint, then inspect compact status summary and either fix red or continue the wait loop.

--- a/TASK 1 PROMPT.md
+++ b/TASK 1 PROMPT.md
@@ -78,6 +78,7 @@ Wording rules:
 - Keep PR title style consistent across the AppState series; do not mix sentence-case descriptive titles with Conventional Commit Style titles.
 - Use real Markdown newlines and code-formatted validation commands in PR bodies; do not submit literal escaped `\n` text or shell commands as raw prose.
 - PR bodies: put red proof as a bullet under `## Validation`, not as a separate section.
+- PR bodies must omit repository template boilerplate or courtesy preambles.
 
 What you must do from now until completion of task 1, unless I tell you to pause:
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,15 +4,13 @@
 #
 #    pip-compile --output-file=scripts/requirements.txt scripts/requirements.in
 #
-#
-#
 annotated-types==0.7.0
     # via pydantic
 certifi==2026.6.17
     # via requests
-cffi==2.0.0
+cffi==2.1.0
     # via cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
 cryptography==49.0.0
     # via google-auth
@@ -25,7 +23,7 @@ google-api-core[grpc]==2.31.0
     #   google-generativeai
 google-api-python-client==2.198.0
     # via google-generativeai
-google-auth==2.55.1
+google-auth==2.55.2
     # via
     #   google-ai-generativelanguage
     #   google-api-core
@@ -35,7 +33,7 @@ google-auth==2.55.1
 google-auth-httplib2==0.4.0
     # via google-api-python-client
 google-generativeai==0.8.6
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 googleapis-common-protos==1.75.0
     # via
     #   google-api-core
@@ -59,11 +57,11 @@ nexus-rpc==1.4.0
 packaging==26.2
     # via pytest
 pexpect==4.9.0
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 pluggy==1.6.0
     # via pytest
 prompt-toolkit==3.0.52
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 proto-plus==1.28.0
     # via
     #   google-ai-generativelanguage
@@ -94,18 +92,18 @@ pygments==2.20.0
 pyparsing==3.3.2
     # via httplib2
 pyte==0.8.2
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 pytest==9.1.1
-    # via -r requirements.in
+    # via -r scripts/requirements.in
 requests==2.34.2
     # via google-api-core
 temporalio==1.30.0
-    # via -r requirements.in
-tqdm==4.68.3
+    # via -r scripts/requirements.in
+tqdm==4.68.4
     # via google-generativeai
-types-protobuf==6.32.1.20260221
+types-protobuf==7.34.1.20260518
     # via temporalio
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   google-generativeai
     #   grpcio
@@ -120,7 +118,7 @@ uritemplate==4.2.0
     # via google-api-python-client
 urllib3==2.7.0
     # via requests
-wcwidth==0.8.1
+wcwidth==0.8.2
     # via
     #   prompt-toolkit
     #   pyte

--- a/src/ui/appstate_message.c
+++ b/src/ui/appstate_message.c
@@ -11,6 +11,8 @@
 BOOL AppStateCommitStatusLineError(ViewContext *ctx, const char *message) {
   if (!AppStateValidatedOwnerField("ctx.message_state"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("target.modal-command.session"))
+    return FALSE;
   if (!ctx || !message)
     return FALSE;
 
@@ -22,6 +24,8 @@ BOOL AppStateCommitStatusLineError(ViewContext *ctx, const char *message) {
 
 BOOL AppStateClearStatusLineError(ViewContext *ctx) {
   if (!AppStateValidatedOwnerField("ctx.message_state"))
+    return FALSE;
+  if (!AppStateValidatedGenerationDomain("target.modal-command.session"))
     return FALSE;
   if (!ctx)
     return FALSE;

--- a/src/ui/appstate_session.c
+++ b/src/ui/appstate_session.c
@@ -25,6 +25,8 @@ BOOL AppStateCommitActivePanel(ViewContext *ctx, YtreeNovaPanel *panel) {
 BOOL AppStateCommitGlobalSearchTerm(ViewContext *ctx, const char *term) {
   if (!AppStateValidatedOwnerField("ctx.command_state"))
     return FALSE;
+  if (!AppStateValidatedGenerationDomain("target.modal-command.session"))
+    return FALSE;
   if (!ctx)
     return FALSE;
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -6633,6 +6633,44 @@ def test_status_line_message_commits_through_appstate_helper() -> None:
     assert not re.search(r"\bctx->status_line_error_pending\s*=[^=]", clear_body)
 
 
+def test_command_message_helpers_validate_generation_domain_before_writes() -> None:
+    generation_domains = json.loads(
+        Path("docs/appstate_generation_domains.json").read_text(encoding="utf-8")
+    )["generation_domains"]
+    assert any(
+        record["domain_id"] == "target.modal-command.session"
+        for record in generation_domains
+    )
+
+    validation = 'AppStateValidatedGenerationDomain("target.modal-command.session")'
+
+    session_source = Path("src/ui/appstate_session.c").read_text(encoding="utf-8")
+    session_start = session_source.index("BOOL AppStateCommitGlobalSearchTerm(")
+    session_end = session_source.index("\nBOOL AppStateCommitRefreshMode(", session_start)
+    session_body = session_source[session_start:session_end]
+    assert validation in session_body
+    session_validation_idx = session_body.index(validation)
+    for write in [
+        "ctx->global_search_term[0] = '\\0';",
+        'ctx->global_search_term[sizeof(ctx->global_search_term) - 1] = \'\\0\';',
+    ]:
+        assert session_validation_idx < session_body.index(write)
+
+    message_source = Path("src/ui/appstate_message.c").read_text(encoding="utf-8")
+    commit_start = message_source.index("BOOL AppStateCommitStatusLineError(")
+    clear_start = message_source.index("\nBOOL AppStateClearStatusLineError(", commit_start)
+    commit_body = message_source[commit_start:clear_start]
+    clear_body = message_source[clear_start:]
+    assert validation in commit_body
+    assert validation in clear_body
+    assert commit_body.index(validation) < commit_body.index(
+        "ctx->status_line_error_pending = TRUE;"
+    )
+    assert clear_body.index(validation) < clear_body.index(
+        "ctx->status_line_error_pending = FALSE;"
+    )
+
+
 def test_volume_registry_commits_through_appstate_helper() -> None:
     header = Path("include/ytnova_appstate_volume_registry.h").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary
- validate command/message AppState helpers against the documented session boundary before mutating global search and status-line message state
- add regression coverage that fails closed when those helpers bypass `target.modal-command.session`

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'command_message_helpers_validate_generation_domain_before_writes'`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'command_message_helpers_validate_generation_domain_before_writes or status_line_message_commits_through_appstate_helper or global_search_term_writes_route_through_appstate_helper'`
- `make clean && make`
- `git diff --check`
