### PR TITLE
fix(appstate): invalidate stale panel restore snapshots

### DIFF
--- a/.agent/handoffs/audit.current.txt
+++ b/.agent/handoffs/audit.current.txt
@@ -1,0 +1,93 @@
+Locked audit target
+- Source: docs/ROADMAP.md Task 1
+- Title: Task 1: Unified AppState Transition Machine + Projection Contract
+- Acceptance target: one explicit AppState transition/ownership contract where UI-affecting actions/events route through registered transition boundaries, render is projection-only, generation-based restore fails closed, and the direct contract docs/tests/registries match the runtime.
+- Discoverable merged work set: the merged AppState-labelled history on main beginning at 4cf8a9a (`chore(appstate): establish transition contract registry`) and ending at 344be74 (`docs(appstate): close transition contract roadmap item (#388)`), with the live checkpoint `.agent/handoffs/prompt.1.txt` stating prior boundary batches were already merged through PR 387 and the closeout batch was PR 388.
+- Locked audit scope: the Task 1 registry metadata under `registry/appstate/`; the direct runtime/lookup/validation surfaces (`include/ytnova_appstate_*.h`, `src/core/appstate_actions.c`, `src/core/main.c`, `src/core/appstate_volume_registry.c`); the directly touched AppState helper and dispatch/restore files (`src/ui/appstate_*.c`, `src/ui/key_engine.c`, `src/ui/ctrl_dir.c`, `src/ui/ctrl_file.c`, `src/ui/ctrl_file_ops.c`, `src/ui/dir_ops.c`, `src/ui/display.c`, `src/ui/panel_anchor.c`, `src/ui/volume_menu.c`, `src/cmd/log.c`, `src/core/init.c`, `src/core/volume.c`, `src/ui/dir_nav.c`, `src/ui/file_nav.c`, `src/ui/file_list.c`, `src/ui/split_transition.c`); direct guard surfaces (`scripts/check_appstate_contract.py`, `tests/test_appstate_contract_guard.py`); direct contract docs (`docs/ARCHITECTURE.md`, `docs/SPECIFICATION.md`, `docs/ROADMAP.md`); and the live checkpoint ` .agent/handoffs/prompt.1.txt`.
+
+Audit inventory
+- Merged commit families inventoried:
+  - registry foundation and lookup/validation series from 4cf8a9a through the runtime-registry/accessor/coverage-status commits;
+  - dispatch/event boundary guard series (modal, command, render, watcher, filesystem, volume, panel-anchor, key decode);
+  - helper-routing migration series across focus, visibility, layout, viewport, selection, anchor, volume binding, payload, render projection, and split transitions;
+  - compatibility-shim retirement/runtime wording/closeout series through 344be74;
+  - direct guard/test/doc closeout for Task 1.
+- Directly affected runtime surfaces audited:
+  - registry/action/event/dispatch accessors and startup validation in `src/core/appstate_actions.c` and `src/core/main.c`;
+  - panel-local commit helpers in `src/ui/appstate_panel.c`, plus focus/layout/visibility/render/session/volume helpers;
+  - canonical restore and donation paths in `src/ui/panel_anchor.c`;
+  - representative dispatch/update callers in `src/ui/key_engine.c`, `src/ui/ctrl_dir.c`, `src/ui/ctrl_file.c`, `src/ui/ctrl_file_ops.c`, `src/ui/dir_ops.c`, `src/ui/dir_nav.c`, `src/ui/file_nav.c`, `src/ui/file_list.c`, `src/ui/volume_menu.c`, `src/ui/split_transition.c`, `src/cmd/log.c`, `src/core/init.c`, `src/core/volume.c`, `src/ui/display.c`.
+- Directly affected tests audited:
+  - `tests/test_appstate_contract_guard.py`
+  - focused runtime validation via `python3 scripts/check_appstate_contract.py`
+  - focused pytest selection covering current-repository contract pass, render projection no-shim path, generation-domain projection note check, and transition accessor fail-closed behavior.
+- Directly affected docs/spec surfaces audited:
+  - `docs/ROADMAP.md` Task 1 contract and acceptance text
+  - `docs/ARCHITECTURE.md` AppState transition/generation rules
+  - `docs/SPECIFICATION.md` canonical panel restore and generation rules
+  - `.agent/handoffs/prompt.1.txt` closeout checkpoint
+- Compatibility/replacement/transitional seams audited:
+  - retired compatibility-shim path claims in docs/tests/runtime lookup;
+  - old direct field-write paths versus `AppStateCommit*` helper routing;
+  - snapshot generation checks in `src/ui/panel_anchor.c` and `src/cmd/log.c`;
+  - render/projection read-only claim versus `src/ui/display.c`/`src/ui/appstate_render.c`.
+
+Findings
+
+1) Severity: high
+   Confidence: high
+   Defect family: panel-generation invalidation contract is still broken for several authoritative panel-local commits
+   File:line: `src/ui/appstate_panel.c:148-158`, `src/ui/appstate_panel.c:282-323`, `docs/ARCHITECTURE.md:208-212`, `docs/SPECIFICATION.md:273-278`, `src/ui/panel_anchor.c:495-499`, `src/cmd/log.c:145-147`, representative call sites `src/ui/dir_nav.c:24-28`, `src/ui/file_nav.c:58-59`, `src/ui/volume_menu.c:43`, guard coverage gap `tests/test_appstate_contract_guard.py:7683-7725`, `tests/test_appstate_contract_guard.py:8868-8920`, `tests/test_appstate_contract_guard.py:9113-9119`
+   Evidence: Task 1’s contract says `panel_generation` must advance when panel-local selection or viewport state changes, and restore paths in `panel_anchor.c` / `log.c` rely on saved-vs-current generation matches to decide whether snapshots are still valid. But `AppStateCommitPanelTreeSelection`, `AppStateCommitPanelTreeViewport`, `AppStateCommitPanelFileViewport`, and `AppStateCommitPanelFileAnchor` only write the mutable fields and return; they never increment `panel->panel_generation`, and common navigation/normalization callers invoke those helpers without any compensating `AppStateCommitPanelGeneration(...)`. The focused guard suite passes because it checks helper routing and field writes, not that these mutations advance generation.
+   Impact: stale tree/file snapshots can remain falsely “current” after selection/viewport/anchor changes, so restore/rebind can accept outdated panel-local state instead of forcing the fail-closed re-resolution promised by Task 1. That directly undercuts the roadmap acceptance claim that stale snapshots fail closed through deterministic fallback, so the task is not safely complete.
+   Concrete fix: make the authoritative panel-local commit helpers that change restore-relevant state advance `panel_generation` themselves (or route them through a single wrapper that does), audit any restore-copy paths that intentionally preserve generations and convert those to explicit restore helpers, then add regression tests that prove tree/file viewport, selection, and file-anchor changes bump `panel_generation` and cause stale snapshots to be rejected in `panel_anchor.c`/`log.c`.
+
+2) Severity: medium
+   Confidence: high
+   Defect family: dead-history/change-diary comments remain in a Task 1-touched runtime surface
+   File:line: `src/ui/display.c:20-33`, `src/ui/display.c:45`, `src/ui/display.c:423-424`
+   Evidence: the file still contains comments such as “PrintMenuLine is removed...”, “Removed: PrintLine...”, “Unused function”, “Legacy border strings removed”, and “Updated: (F)ilespec -> (F)ilter...”. These narrate deleted history rather than current invariants or design rationale.
+   Impact: this violates the repository’s source-comment contract and leaves misleading maintenance noise inside the locked AppState surface, which is the opposite of the roadmap phase’s clean-code/guardrail goal.
+   Concrete fix: delete the dead-history comments entirely, and keep only current invariant/rationale comments that explain active behavior.
+
+Validation run during audit
+- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` -> PASS
+- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'current_repository_appstate_contract_passes or render_projection_runtime_uses_no_compatibility_shim or runtime_generation_domain_startup_requires_projection_note_for_coverage_only or appstate_transition_accessor_fails_closed_on_invalid_metadata'` -> 4 passed
+
+FAIL for the locked task scope.
+The task does not appear completed/fixed satisfactorily within the locked scope, because the live implementation still violates the documented `panel_generation` invalidation contract that Task 1 depends on for fail-closed restore semantics.
+
+Residual risks
+- Additional panel-local helper paths may share the same generation-invalidation defect pattern beyond the representative tree/file selection and viewport helpers audited here.
+- The focused guard suite currently gives a false sense of closure for this defect family because it emphasizes routing and metadata presence over generation-behavior correctness.
+
+Exhaustiveness statement
+- This audit appears broad and materially exhaustive within the locked scope: registry metadata, startup validation, canonical restore paths, representative dispatch callers, direct guard tests, and closeout docs/checkpoint were all reconciled. I did not perform an unrelated repository-wide audit.
+
+Audit inventory reconciliation summary
+- Audited:
+  - `docs/ROADMAP.md` Task 1 source of truth and completion line
+  - `docs/ARCHITECTURE.md` AppState contract and generation rules
+  - `docs/SPECIFICATION.md` canonical restore/generation rules
+  - `.agent/handoffs/prompt.1.txt` closeout inventory
+  - `registry/appstate/*.json`
+  - `scripts/check_appstate_contract.py`
+  - `tests/test_appstate_contract_guard.py`
+  - runtime helper/restore/dispatch files listed in the locked scope above
+- Intentionally not audited with reason:
+  - incidental AI/process/documentation files that appeared in the long AppState-labelled git history but do not affect Task 1 runtime acceptance (for example `.ai/*`, workflow governance docs, unrelated named handoff reports) were excluded to preserve the scope lock.
+  - unrelated repository areas not directly touched by the Task 1 work item were not audited.
+- Uncertain with reason:
+  - full historical PR-to-commit mapping for every AppState batch is only partially discoverable from local linear history; the merged work set above is reconstructed from the on-branch commit series plus the live checkpoint’s PR 387/388 statements.
+
+Grouped defect families
+- Generation-invalidation contract break in panel-local AppState commit helpers and corresponding guard coverage gap.
+- Dead-history comment drift in a Task 1-touched runtime file.
+
+Next highest-value coherent family to fix first
+- Fix the panel-generation invalidation family first. It is the acceptance-critical root-cause family because it directly invalidates the fail-closed restore contract that justified marking Task 1 complete.
+
+Focused validation path for that family
+- Add/adjust contract tests so panel-local selection/viewport/file-anchor helper commits must advance `panel_generation`.
+- Add a regression path proving that a saved tree/file snapshot becomes stale after navigation-only helper mutations and is then re-resolved/fallen back rather than reused.
+- Re-run `python3 scripts/check_appstate_contract.py` and the focused `tests/test_appstate_contract_guard.py` selection, then any newly added targeted restore/navigation regression tests.

--- a/.agent/handoffs/audit.task-1.txt
+++ b/.agent/handoffs/audit.task-1.txt
@@ -1,0 +1,93 @@
+Locked audit target
+- Source: docs/ROADMAP.md Task 1
+- Title: Task 1: Unified AppState Transition Machine + Projection Contract
+- Acceptance target: one explicit AppState transition/ownership contract where UI-affecting actions/events route through registered transition boundaries, render is projection-only, generation-based restore fails closed, and the direct contract docs/tests/registries match the runtime.
+- Discoverable merged work set: the merged AppState-labelled history on main beginning at 4cf8a9a (`chore(appstate): establish transition contract registry`) and ending at 344be74 (`docs(appstate): close transition contract roadmap item (#388)`), with the live checkpoint `.agent/handoffs/prompt.1.txt` stating prior boundary batches were already merged through PR 387 and the closeout batch was PR 388.
+- Locked audit scope: the Task 1 registry metadata under `registry/appstate/`; the direct runtime/lookup/validation surfaces (`include/ytnova_appstate_*.h`, `src/core/appstate_actions.c`, `src/core/main.c`, `src/core/appstate_volume_registry.c`); the directly touched AppState helper and dispatch/restore files (`src/ui/appstate_*.c`, `src/ui/key_engine.c`, `src/ui/ctrl_dir.c`, `src/ui/ctrl_file.c`, `src/ui/ctrl_file_ops.c`, `src/ui/dir_ops.c`, `src/ui/display.c`, `src/ui/panel_anchor.c`, `src/ui/volume_menu.c`, `src/cmd/log.c`, `src/core/init.c`, `src/core/volume.c`, `src/ui/dir_nav.c`, `src/ui/file_nav.c`, `src/ui/file_list.c`, `src/ui/split_transition.c`); direct guard surfaces (`scripts/check_appstate_contract.py`, `tests/test_appstate_contract_guard.py`); direct contract docs (`docs/ARCHITECTURE.md`, `docs/SPECIFICATION.md`, `docs/ROADMAP.md`); and the live checkpoint ` .agent/handoffs/prompt.1.txt`.
+
+Audit inventory
+- Merged commit families inventoried:
+  - registry foundation and lookup/validation series from 4cf8a9a through the runtime-registry/accessor/coverage-status commits;
+  - dispatch/event boundary guard series (modal, command, render, watcher, filesystem, volume, panel-anchor, key decode);
+  - helper-routing migration series across focus, visibility, layout, viewport, selection, anchor, volume binding, payload, render projection, and split transitions;
+  - compatibility-shim retirement/runtime wording/closeout series through 344be74;
+  - direct guard/test/doc closeout for Task 1.
+- Directly affected runtime surfaces audited:
+  - registry/action/event/dispatch accessors and startup validation in `src/core/appstate_actions.c` and `src/core/main.c`;
+  - panel-local commit helpers in `src/ui/appstate_panel.c`, plus focus/layout/visibility/render/session/volume helpers;
+  - canonical restore and donation paths in `src/ui/panel_anchor.c`;
+  - representative dispatch/update callers in `src/ui/key_engine.c`, `src/ui/ctrl_dir.c`, `src/ui/ctrl_file.c`, `src/ui/ctrl_file_ops.c`, `src/ui/dir_ops.c`, `src/ui/dir_nav.c`, `src/ui/file_nav.c`, `src/ui/file_list.c`, `src/ui/volume_menu.c`, `src/ui/split_transition.c`, `src/cmd/log.c`, `src/core/init.c`, `src/core/volume.c`, `src/ui/display.c`.
+- Directly affected tests audited:
+  - `tests/test_appstate_contract_guard.py`
+  - focused runtime validation via `python3 scripts/check_appstate_contract.py`
+  - focused pytest selection covering current-repository contract pass, render projection no-shim path, generation-domain projection note check, and transition accessor fail-closed behavior.
+- Directly affected docs/spec surfaces audited:
+  - `docs/ROADMAP.md` Task 1 contract and acceptance text
+  - `docs/ARCHITECTURE.md` AppState transition/generation rules
+  - `docs/SPECIFICATION.md` canonical panel restore and generation rules
+  - `.agent/handoffs/prompt.1.txt` closeout checkpoint
+- Compatibility/replacement/transitional seams audited:
+  - retired compatibility-shim path claims in docs/tests/runtime lookup;
+  - old direct field-write paths versus `AppStateCommit*` helper routing;
+  - snapshot generation checks in `src/ui/panel_anchor.c` and `src/cmd/log.c`;
+  - render/projection read-only claim versus `src/ui/display.c`/`src/ui/appstate_render.c`.
+
+Findings
+
+1) Severity: high
+   Confidence: high
+   Defect family: panel-generation invalidation contract is still broken for several authoritative panel-local commits
+   File:line: `src/ui/appstate_panel.c:148-158`, `src/ui/appstate_panel.c:282-323`, `docs/ARCHITECTURE.md:208-212`, `docs/SPECIFICATION.md:273-278`, `src/ui/panel_anchor.c:495-499`, `src/cmd/log.c:145-147`, representative call sites `src/ui/dir_nav.c:24-28`, `src/ui/file_nav.c:58-59`, `src/ui/volume_menu.c:43`, guard coverage gap `tests/test_appstate_contract_guard.py:7683-7725`, `tests/test_appstate_contract_guard.py:8868-8920`, `tests/test_appstate_contract_guard.py:9113-9119`
+   Evidence: Task 1’s contract says `panel_generation` must advance when panel-local selection or viewport state changes, and restore paths in `panel_anchor.c` / `log.c` rely on saved-vs-current generation matches to decide whether snapshots are still valid. But `AppStateCommitPanelTreeSelection`, `AppStateCommitPanelTreeViewport`, `AppStateCommitPanelFileViewport`, and `AppStateCommitPanelFileAnchor` only write the mutable fields and return; they never increment `panel->panel_generation`, and common navigation/normalization callers invoke those helpers without any compensating `AppStateCommitPanelGeneration(...)`. The focused guard suite passes because it checks helper routing and field writes, not that these mutations advance generation.
+   Impact: stale tree/file snapshots can remain falsely “current” after selection/viewport/anchor changes, so restore/rebind can accept outdated panel-local state instead of forcing the fail-closed re-resolution promised by Task 1. That directly undercuts the roadmap acceptance claim that stale snapshots fail closed through deterministic fallback, so the task is not safely complete.
+   Concrete fix: make the authoritative panel-local commit helpers that change restore-relevant state advance `panel_generation` themselves (or route them through a single wrapper that does), audit any restore-copy paths that intentionally preserve generations and convert those to explicit restore helpers, then add regression tests that prove tree/file viewport, selection, and file-anchor changes bump `panel_generation` and cause stale snapshots to be rejected in `panel_anchor.c`/`log.c`.
+
+2) Severity: medium
+   Confidence: high
+   Defect family: dead-history/change-diary comments remain in a Task 1-touched runtime surface
+   File:line: `src/ui/display.c:20-33`, `src/ui/display.c:45`, `src/ui/display.c:423-424`
+   Evidence: the file still contains comments such as “PrintMenuLine is removed...”, “Removed: PrintLine...”, “Unused function”, “Legacy border strings removed”, and “Updated: (F)ilespec -> (F)ilter...”. These narrate deleted history rather than current invariants or design rationale.
+   Impact: this violates the repository’s source-comment contract and leaves misleading maintenance noise inside the locked AppState surface, which is the opposite of the roadmap phase’s clean-code/guardrail goal.
+   Concrete fix: delete the dead-history comments entirely, and keep only current invariant/rationale comments that explain active behavior.
+
+Validation run during audit
+- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py` -> PASS
+- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'current_repository_appstate_contract_passes or render_projection_runtime_uses_no_compatibility_shim or runtime_generation_domain_startup_requires_projection_note_for_coverage_only or appstate_transition_accessor_fails_closed_on_invalid_metadata'` -> 4 passed
+
+FAIL for the locked task scope.
+The task does not appear completed/fixed satisfactorily within the locked scope, because the live implementation still violates the documented `panel_generation` invalidation contract that Task 1 depends on for fail-closed restore semantics.
+
+Residual risks
+- Additional panel-local helper paths may share the same generation-invalidation defect pattern beyond the representative tree/file selection and viewport helpers audited here.
+- The focused guard suite currently gives a false sense of closure for this defect family because it emphasizes routing and metadata presence over generation-behavior correctness.
+
+Exhaustiveness statement
+- This audit appears broad and materially exhaustive within the locked scope: registry metadata, startup validation, canonical restore paths, representative dispatch callers, direct guard tests, and closeout docs/checkpoint were all reconciled. I did not perform an unrelated repository-wide audit.
+
+Audit inventory reconciliation summary
+- Audited:
+  - `docs/ROADMAP.md` Task 1 source of truth and completion line
+  - `docs/ARCHITECTURE.md` AppState contract and generation rules
+  - `docs/SPECIFICATION.md` canonical restore/generation rules
+  - `.agent/handoffs/prompt.1.txt` closeout inventory
+  - `registry/appstate/*.json`
+  - `scripts/check_appstate_contract.py`
+  - `tests/test_appstate_contract_guard.py`
+  - runtime helper/restore/dispatch files listed in the locked scope above
+- Intentionally not audited with reason:
+  - incidental AI/process/documentation files that appeared in the long AppState-labelled git history but do not affect Task 1 runtime acceptance (for example `.ai/*`, workflow governance docs, unrelated named handoff reports) were excluded to preserve the scope lock.
+  - unrelated repository areas not directly touched by the Task 1 work item were not audited.
+- Uncertain with reason:
+  - full historical PR-to-commit mapping for every AppState batch is only partially discoverable from local linear history; the merged work set above is reconstructed from the on-branch commit series plus the live checkpoint’s PR 387/388 statements.
+
+Grouped defect families
+- Generation-invalidation contract break in panel-local AppState commit helpers and corresponding guard coverage gap.
+- Dead-history comment drift in a Task 1-touched runtime file.
+
+Next highest-value coherent family to fix first
+- Fix the panel-generation invalidation family first. It is the acceptance-critical root-cause family because it directly invalidates the fail-closed restore contract that justified marking Task 1 complete.
+
+Focused validation path for that family
+- Add/adjust contract tests so panel-local selection/viewport/file-anchor helper commits must advance `panel_generation`.
+- Add a regression path proving that a saved tree/file snapshot becomes stale after navigation-only helper mutations and is then re-resolved/fallen back rather than reused.
+- Re-run `python3 scripts/check_appstate_contract.py` and the focused `tests/test_appstate_contract_guard.py` selection, then any newly added targeted restore/navigation regression tests.

--- a/.agent/handoffs/prompt.1.txt
+++ b/.agent/handoffs/prompt.1.txt
@@ -2,43 +2,100 @@
 
 Date: 2026-07-09
 Repo: /home/rob/ytreenova
-Roadmap item: Unified AppState Transition Machine + Projection Contract
-Persona: developer
-Current branch: appstate-transition-contract-closeout
-Active PR: draft https://github.com/robkam/ytreenova/pull/388
-Last merged PR: https://github.com/robkam/ytreenova/pull/387
-Supersession state: resumed by maintainer; no later stop/pause override.
+Work item source: docs/ROADMAP.md Task 1
+Title: Task 1: Unified AppState Transition Machine + Projection Contract
+Acceptance target: one explicit AppState transition/ownership contract where UI-affecting actions/events route through registered transition boundaries, render is projection-only, generation-based restore fails closed, and the direct contract docs/tests/registries match the runtime.
+Completion objective: complete Task 1 correctly by fixing the remaining acceptance-critical repo-side defects, reconciling every in-scope surface, and leaving no unaccounted Task 1 runtime/doc/test gap.
 
-Current AppState batch:
-- Final closure audit for the Unified AppState Transition Machine + Projection Contract roadmap item.
-- Git/GitHub audit found no active PRs and confirmed the previous AppState boundary batches are already merged through PR 387.
-- docs/appstate*.json now show runtime/transition coverage across owner fields, transition matrix, action/event coverage, generation domains, invariants, diff harness checks, dispatch surfaces, and transition sequences.
-- Focused contract validation now passes on the current repository state, so this closeout batch only needs the roadmap/handoff source-of-truth updates and draft PR/CI loop.
+Current git/GitHub state:
+- Current branch: `fix/appstate-panel-generation`
+- Active PR: draft `https://github.com/robkam/ytreenova/pull/390`
+- PR 390 head: current branch `HEAD` after the latest force-push for this slice
+- Latest merged PR discovered during resume: `https://github.com/robkam/ytreenova/pull/389`
+- Base branch for the current slice: `origin/main` at `826e8b5`
+- PR 390 CI wait window restarted after the latest force-push for this slice; do not poll before the first 15-minute checkpoint from that push.
+- Local worktree also contains unrelated unstaged edits/deletions outside this Task 1 slice; keep the current commit scoped to the files listed below.
 
-Closure family inventory:
-- docs/ROADMAP.md Task 1 status line: migrated in this batch; marked complete after the focused closure audit passed.
-- docs/appstate_owner_fields.json (26 owner fields): migrated; every entry is `covered_by_runtime_registry`.
-- docs/appstate_generation_domains.json (11 domains): migrated; every entry is `covered_by_runtime_registry`.
-- docs/appstate_invariants.json (8 invariants): migrated; every entry is `covered_by_runtime_registry`.
-- docs/appstate_diff_harness.json (5 harness checks): migrated; every entry is `covered_by_runtime_registry`.
-- docs/appstate_transition_matrix.json (12 transitions): migrated; every entry is `covered_by_transition_record`.
-- docs/appstate_action_coverage.json (85 actions): migrated; every entry is `covered_by_transition_record`.
-- docs/appstate_event_coverage.json (9 events): migrated; every entry is `covered_by_transition_record`.
-- docs/appstate_dispatch_surfaces.json (14 surfaces): migrated; every entry is `covered_by_transition_record`.
-- docs/appstate_transition_sequences.json (17 scenarios): migrated; every entry is `covered_by_runtime_registry`.
-- Runtime registry/accessor surfaces (`include/ytnova_appstate_actions.h`, `src/core/appstate_actions.c`, `src/core/main.c`): intentionally unchanged in this batch; audit shows startup/accessor validation already fails closed on invalid registry metadata and cross-links actions/events/sequences/harness coverage.
-- Runtime dispatch/helper boundary cluster (`src/ui/key_engine.c`, `src/ui/ctrl_dir.c`, `src/ui/ctrl_file.c`, `src/ui/ctrl_file_ops.c`, `src/ui/dir_ops.c`, `src/ui/display.c`, `src/ui/panel_anchor.c`, `src/ui/volume_menu.c`, `src/core/appstate_volume_registry.c`, `src/ui/appstate_*.c` helpers): intentionally unchanged in this batch; their documented boundary families were migrated in earlier merged PRs and no uncovered adjacent surface remains in the registries.
-- Contract enforcement/test surfaces (`scripts/check_appstate_contract.py`, `tests/test_appstate_contract_guard.py`): intentionally unchanged in this batch; focused validation passed without exposing a repo-side gap.
-- Legacy compatibility seam audit (render/projection authority): migrated; focused guard coverage asserts there is no remaining render compatibility shim path.
+Audit-selected defect family for the next coherent batch:
+- Panel-generation invalidation contract break in authoritative panel-local AppState commit helpers.
+- Why this family now: it is the highest-value Task 1 defect family because it directly breaks the documented fail-closed restore contract for stale tree/file snapshots.
 
-Closure reconciliation:
-- No remaining AppState boundary family is currently unaccounted for in the roadmap-item registries.
-- No deferred/blocked item is currently identified; if CI disproves the closure audit, reopen the affected family instead of forcing roadmap completion.
+Deferred audit defect families:
+- Dead-history/change-diary comments in `src/ui/display.c`.
+- Split reason: different owner boundary and validation path. The current family is runtime restore/generation correctness with focused AppState helper + restore tests; the display-comment cleanup is source-comment hygiene and can land separately without coupling to the runtime fix.
 
-Validation evidence:
-- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
-- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'current_repository_appstate_contract_passes or render_projection_runtime_uses_no_compatibility_shim or runtime_generation_domain_startup_requires_projection_note_for_coverage_only or appstate_transition_accessor_fails_closed_on_invalid_metadata'`
-- `git diff --check`
+Explicit in-scope inventory for the panel-generation invalidation family:
+- Source-of-truth/task tracking:
+  - `docs/ROADMAP.md` Task 1 status/acceptance line
+  - `docs/ARCHITECTURE.md` panel-generation / fail-closed restore contract text
+  - `docs/SPECIFICATION.md` canonical restore and generation-validation text
+  - `.agent/handoffs/prompt.1.txt` (this tracked checkpoint)
+  - `.agent/handoffs/audit.current.txt`
+  - `.agent/handoffs/audit.task-1.txt`
+- Authoritative runtime helper surface:
+  - `src/ui/appstate_panel.c`
+    - `AppStateCommitPanelGeneration`
+    - `AppStateRestorePanelGeneration`
+    - `AppStateCommitPanelFileSelection` (existing model that already advances generation)
+    - `AppStateCommitPanelTreeSelection`
+    - `AppStateCommitPanelFileViewport`
+    - `AppStateCommitPanelFileAnchor`
+    - `AppStateCommitPanelTreeViewport`
+- Direct generation-preserving restore/copy seams that must be audited alongside the helper fix:
+  - `src/ui/panel_anchor.c`
+    - `PositionPanelAtIndex`
+    - `RestorePanelViewportSnapshot`
+    - `RestorePanelTreeViewportSnapshot`
+    - `DonatePanelState`
+  - `src/cmd/log.c`
+    - `RestorePanelFileSelection`
+    - tree restore path that reapplies `saved_tree_panel_generation`
+  - `src/ui/split_transition.c`
+    - split-collapse path that restores preserved tree state with `source_panel_generation`
+- Adjacent caller surfaces to reconcile after the helper fix:
+  - `src/ui/dir_nav.c`
+  - `src/ui/file_nav.c`
+  - `src/ui/file_list.c`
+  - `src/ui/ctrl_dir.c`
+  - `src/ui/ctrl_file.c`
+  - `src/ui/ctrl_file_ops.c`
+  - `src/ui/dir_ops.c`
+  - `src/ui/volume_menu.c`
+  - `src/core/init.c`
+  - `src/core/volume.c`
+  - `src/ui/f2_picker.c`
+  - Intention: most should remain unchanged if the authoritative helpers own the generation bump and the explicit generation-preserving seams stay correct.
+- Directly affected tests/guards:
+  - `tests/test_appstate_contract_guard.py`
+  - `tests/test_dir_window_dispatch_regressions.py`
+  - `scripts/check_appstate_contract.py`
+
+Bug reproducer and adjacent failure surfaces:
+- Reproducer path: `AppStateCommitPanelTreeSelection`, `AppStateCommitPanelTreeViewport`, `AppStateCommitPanelFileViewport`, and `AppStateCommitPanelFileAnchor` currently mutate panel-local restore-relevant state without advancing `panel->panel_generation`.
+- Shared root-cause surfaces: restore code in `src/ui/panel_anchor.c` and `src/cmd/log.c` compares saved-vs-current panel generations to decide whether a snapshot is stale, so helper-only mutations can leave stale snapshots appearing current.
+- Adjacent failure surfaces: navigation/normalization paths that call only those helpers (`dir_nav`, `file_nav`, `volume_menu`, `ctrl_dir`, `ctrl_file`, `dir_ops`, `file_list`, split preserve/donate flows) may all inherit the same stale-snapshot risk until the helper boundary is corrected.
+
+Planned closure reconciliation for this family:
+- `docs/ROADMAP.md`: addressed; Task 1 status is reset to `In Progress` while the acceptance-critical fix is active on a non-main branch.
+- `docs/ARCHITECTURE.md`: intentionally unchanged; the documented contract was already correct and the runtime now conforms to it.
+- `docs/SPECIFICATION.md`: intentionally unchanged; the documented restore/generation rules were already correct and the runtime now conforms to them.
+- `src/ui/appstate_panel.c`: addressed; the authoritative tree selection, tree viewport, file viewport, and file anchor helpers now validate and advance `panel.panel_generation`.
+- `src/ui/panel_anchor.c`: addressed; tree viewport positioning/restore now rely on the authoritative helper-owned generation bump instead of a duplicate manual increment.
+- `src/cmd/log.c`: addressed; restore-only file-anchor materialization now restores `panel_generation` after replaying saved file state.
+- `src/ui/split_transition.c`: intentionally unchanged; its explicit `AppStateRestorePanelGeneration(...)` reconciliation remains sufficient after the helper-owned bump.
+- Adjacent caller surfaces listed above: intentionally unchanged; the centralized helper fix covers their panel-generation behavior without further call-site edits.
+- `tests/test_appstate_contract_guard.py`: addressed; focused helper/restore guard coverage now requires the authoritative helpers to own panel-generation advances.
+- `tests/test_dir_window_dispatch_regressions.py`: addressed; restore-generation guard coverage now requires helper-owned invalidation and no duplicate panel-anchor manual bump.
+- `scripts/check_appstate_contract.py`: intentionally unchanged; it passed after the runtime/test fix without exposing registry drift.
+- Deferred `src/ui/display.c` comment cleanup family: deferred with reason above; do not mix into this batch unless the current family becomes blocked.
+
+Focused validation completed:
+- Red: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'panel_anchor_viewport_generation_commits_through_appstate_helper or panel_local_helpers_validate_generation_domain_before_writes' tests/test_dir_window_dispatch_regressions.py -k 'restore_snapshots_validate_generation_before_reuse'` failed before the runtime fix because the authoritative helpers did not validate/advance `panel.panel_generation`.
+- Green:
+  - `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
+  - `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py::test_panel_local_helpers_validate_generation_domain_before_writes tests/test_appstate_contract_guard.py::test_file_selection_anchor_generation_commits_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_anchor_viewport_generation_commits_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_file_viewport_commits_route_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_tree_viewport_commits_route_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_tree_selection_commits_route_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_generation_restores_route_through_appstate_helper tests/test_dir_window_dispatch_regressions.py::test_restore_snapshots_validate_generation_before_reuse tests/test_dir_window_dispatch_regressions.py::test_split_tab_refresh_rejects_stale_file_restore_snapshot`
+  - `make clean && make`
+  - `git diff --check`
 
 Next action:
-- Wait for PR 388 CI to age past the first 15-minute checkpoint, then inspect a compact pass/fail/running summary and either fix red or continue the wait loop.
+- Wait for PR 390 to age past the first CI checkpoint from the latest push, then recheck live status on the current head before deciding whether to fix red or continue the wait loop.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,7 +72,7 @@ Ordering policy (for all editors, including AI editors):
 *   Existing split/viewport fixes are either routed through the transition boundary or explicitly marked as compatibility shims with removal tasks.
 *   `docs/SPECIFICATION.md` and `docs/ARCHITECTURE.md` are updated or cross-linked so existing restore/split contracts do not preserve a narrower `F8`/`Tab`-only transition model, stale task references, or conflicting ownership language.
 *   `make qa-all` / PR full-QA CI passes with the invariant test harness enabled.
-*   - [x] **Status:** Complete.
+*   - [ ] **Status:** In Progress.
 
 ### **Task 2: Remove Dead-History Comments + Add Anti-History Comment Gate**
 *   **Goal:** Remove comments that describe removed code/history and prevent their reintroduction.

--- a/src/cmd/log.c
+++ b/src/cmd/log.c
@@ -118,10 +118,12 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
   if (!panel || !panel->vol)
     return;
 
+  restore_generation = panel->panel_generation;
   ResetPanelFileContext(panel);
+  if (!AppStateRestorePanelGeneration(panel, restore_generation))
+    return;
   vol = panel->vol;
   state = FindPanelVolumeFileState(panel, vol->id);
-  restore_generation = panel->panel_generation;
   if (!AppStateCommitPanelFileViewport(panel, 0, 0))
     return;
   if (!AppStateCommitPanelFileSelection(panel, NULL, NULL))
@@ -131,6 +133,8 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
   if (!AppStateCommitPanelFileAnchor(panel, NULL))
     return;
   if (!AppStateCommitPanelFileShape(panel, FALSE))
+    return;
+  if (!AppStateRestorePanelGeneration(panel, restore_generation))
     return;
   if (!state)
     return;
@@ -174,6 +178,8 @@ static void RestorePanelFileSelection(ViewContext *ctx, YtreeNovaPanel *panel) {
                                  state->saved_file_selection_name);
     }
   }
+  if (!AppStateRestorePanelGeneration(panel, restore_generation))
+    return;
   if (!AppStateCommitPanelFocus(ctx, panel, state->saved_focus))
     return;
   (void)AppStateCommitPanelFileShape(panel, state->saved_big_file_view);

--- a/src/ui/appstate_panel.c
+++ b/src/ui/appstate_panel.c
@@ -47,8 +47,7 @@ BOOL AppStateCommitPanelVolume(YtreeNovaPanel *panel, struct Volume *vol) {
     return FALSE;
 
   panel->vol = vol;
-  panel->panel_generation++;
-  return TRUE;
+  return AppStateCommitPanelGeneration(panel);
 }
 
 BOOL AppStateSetPanelVolumeFileStateList(
@@ -141,8 +140,7 @@ BOOL AppStateCommitPanelFileSelection(YtreeNovaPanel *panel,
     panel->file_selection_name[PATH_LENGTH] = '\0';
   }
 
-  panel->panel_generation++;
-  return TRUE;
+  return AppStateCommitPanelGeneration(panel);
 }
 
 BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
@@ -151,11 +149,13 @@ BOOL AppStateCommitPanelTreeSelection(YtreeNovaPanel *panel,
     return FALSE;
   if (!AppStateValidatedOwnerField("panel.tree_selection_key"))
     return FALSE;
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
   if (!panel)
     return FALSE;
 
   panel->current_dir_entry = current_dir_entry;
-  return TRUE;
+  return AppStateCommitPanelGeneration(panel);
 }
 
 BOOL AppStateCommitPanelTreeViewportTopPath(YtreeNovaPanel *panel, int slot,
@@ -285,12 +285,14 @@ BOOL AppStateCommitPanelFileViewport(YtreeNovaPanel *panel, int start_file,
     return FALSE;
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))
     return FALSE;
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
   if (!panel)
     return FALSE;
 
   panel->start_file = start_file;
   panel->file_cursor_pos = file_cursor_pos;
-  return TRUE;
+  return AppStateCommitPanelGeneration(panel);
 }
 
 BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,
@@ -299,11 +301,13 @@ BOOL AppStateCommitPanelFileAnchor(YtreeNovaPanel *panel,
     return FALSE;
   if (!AppStateValidatedOwnerField("panel.file_viewport_origin"))
     return FALSE;
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
   if (!panel)
     return FALSE;
 
   panel->file_dir_entry = file_dir_entry;
-  return TRUE;
+  return AppStateCommitPanelGeneration(panel);
 }
 
 BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,
@@ -314,10 +318,12 @@ BOOL AppStateCommitPanelTreeViewport(YtreeNovaPanel *panel, int disp_begin_pos,
     return FALSE;
   if (!AppStateValidatedOwnerField("panel.tree_cursor_pos"))
     return FALSE;
+  if (!AppStateValidatedOwnerField("panel.panel_generation"))
+    return FALSE;
   if (!panel)
     return FALSE;
 
   panel->disp_begin_pos = disp_begin_pos;
   panel->cursor_pos = cursor_pos;
-  return TRUE;
+  return AppStateCommitPanelGeneration(panel);
 }

--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -345,6 +345,7 @@ void PositionPanelAtIndex(YtreeNovaPanel *panel, int idx) {
   int height;
   int begin;
   int cursor;
+  unsigned int viewport_generation;
 
   if (!panel || !panel->vol || !panel->vol->dir_entry_list ||
       panel->vol->total_dirs <= 0)
@@ -368,9 +369,12 @@ void PositionPanelAtIndex(YtreeNovaPanel *panel, int idx) {
 
   if (!AppStateCommitPanelTreeViewport(panel, begin, cursor))
     return;
-  RememberPanelViewportTop(panel);
-  if (!AppStateCommitPanelGeneration(panel))
+  viewport_generation = panel->panel_generation;
+  if (!AppStateCommitPanelTreeSelection(panel, idx))
     return;
+  if (!AppStateRestorePanelGeneration(panel, viewport_generation))
+    return;
+  RememberPanelViewportTop(panel);
 }
 
 static BOOL VisibleIndexWithinTopPath(const struct Volume *vol,
@@ -424,6 +428,7 @@ BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *pane
   int height;
   int begin;
   int cursor;
+  unsigned int viewport_generation;
 
   if (!vol || !panel || !snapshot)
     return FALSE;
@@ -469,9 +474,12 @@ BOOL RestorePanelViewportSnapshot(const struct Volume *vol, YtreeNovaPanel *pane
 
   if (!AppStateCommitPanelTreeViewport(panel, begin, cursor))
     return FALSE;
-  RememberPanelViewportTop(panel);
-  if (!AppStateCommitPanelGeneration(panel))
+  viewport_generation = panel->panel_generation;
+  if (!AppStateCommitPanelTreeSelection(panel, target_idx))
     return FALSE;
+  if (!AppStateRestorePanelGeneration(panel, viewport_generation))
+    return FALSE;
+  RememberPanelViewportTop(panel);
   return TRUE;
 }
 

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -7037,9 +7037,13 @@ def test_file_selection_anchor_generation_commits_through_appstate_helper() -> N
 
 
 def test_panel_anchor_viewport_generation_commits_through_appstate_helper() -> None:
+    helper = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     panel_anchor = Path("src/ui/panel_anchor.c").read_text(encoding="utf-8")
 
     assert 'include "ytnova_appstate_panel.h"' in panel_anchor
+    helper_start = helper.index("BOOL AppStateCommitPanelTreeViewport(")
+    helper_body = helper[helper_start:]
+    assert "return AppStateCommitPanelGeneration(panel);" in helper_body
 
     position_start = panel_anchor.index("void PositionPanelAtIndex(")
     position_end = panel_anchor.index(
@@ -7054,8 +7058,16 @@ def test_panel_anchor_viewport_generation_commits_through_appstate_helper() -> N
 
     assert "panel->panel_generation++;" not in position_body
     assert "panel->panel_generation++;" not in restore_body
-    assert position_body.count("AppStateCommitPanelGeneration(panel)") == 1
-    assert restore_body.count("AppStateCommitPanelGeneration(panel)") == 1
+    assert (
+        position_body.count("AppStateCommitPanelTreeViewport(panel, begin, cursor)")
+        == 1
+    )
+    assert (
+        restore_body.count("AppStateCommitPanelTreeViewport(panel, begin, cursor)")
+        == 1
+    )
+    assert "AppStateCommitPanelGeneration(panel)" not in position_body
+    assert "AppStateCommitPanelGeneration(panel)" not in restore_body
 
 
 def test_panel_tree_viewport_top_paths_route_through_appstate_helper() -> None:
@@ -7654,10 +7666,11 @@ def test_panel_generation_restores_route_through_appstate_helper() -> None:
 def test_panel_local_helpers_validate_generation_domain_before_writes() -> None:
     source = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     validation = 'AppStateValidatedGenerationDomain("generation.panel.local-authority")'
+    generation_validation = 'AppStateValidatedOwnerField("panel.panel_generation")'
     signatures_and_writes = [
         (
             "BOOL AppStateCommitPanelGeneration(",
-            ["panel->panel_generation++;"],
+            [generation_validation, "panel->panel_generation++;"],
         ),
         (
             "BOOL AppStateRestorePanelGeneration(",
@@ -7665,7 +7678,11 @@ def test_panel_local_helpers_validate_generation_domain_before_writes() -> None:
         ),
         (
             "BOOL AppStateCommitPanelVolume(",
-            ["panel->vol = vol;", "panel->panel_generation++;"],
+            [
+                generation_validation,
+                "panel->vol = vol;",
+                "return AppStateCommitPanelGeneration(panel);",
+            ],
         ),
         (
             "BOOL AppStateSetPanelVolumeFileStateList(",
@@ -7674,14 +7691,19 @@ def test_panel_local_helpers_validate_generation_domain_before_writes() -> None:
         (
             "BOOL AppStateCommitPanelFileSelection(",
             [
+                generation_validation,
                 "panel->file_selection_dir_path[0] = '\\0';",
                 "panel->file_selection_name[0] = '\\0';",
-                "panel->panel_generation++;",
+                "return AppStateCommitPanelGeneration(panel);",
             ],
         ),
         (
             "BOOL AppStateCommitPanelTreeSelection(",
-            ["panel->current_dir_entry = current_dir_entry;"],
+            [
+                generation_validation,
+                "panel->current_dir_entry = current_dir_entry;",
+                "return AppStateCommitPanelGeneration(panel);",
+            ],
         ),
         (
             "BOOL AppStateCommitPanelTreeViewportTopPath(",
@@ -7709,19 +7731,27 @@ def test_panel_local_helpers_validate_generation_domain_before_writes() -> None:
         (
             "BOOL AppStateCommitPanelFileViewport(",
             [
+                generation_validation,
                 "panel->start_file = start_file;",
                 "panel->file_cursor_pos = file_cursor_pos;",
+                "return AppStateCommitPanelGeneration(panel);",
             ],
         ),
         (
             "BOOL AppStateCommitPanelFileAnchor(",
-            ["panel->file_dir_entry = file_dir_entry;"],
+            [
+                generation_validation,
+                "panel->file_dir_entry = file_dir_entry;",
+                "return AppStateCommitPanelGeneration(panel);",
+            ],
         ),
         (
             "BOOL AppStateCommitPanelTreeViewport(",
             [
+                generation_validation,
                 "panel->disp_begin_pos = disp_begin_pos;",
                 "panel->cursor_pos = cursor_pos;",
+                "return AppStateCommitPanelGeneration(panel);",
             ],
         ),
     ]
@@ -8723,7 +8753,7 @@ def test_panel_file_selection_commits_route_through_appstate_helper() -> None:
         selection_name_write
     )
     assert helper_body.index(generation_validation) < helper_body.index(
-        "panel->panel_generation++;"
+        "return AppStateCommitPanelGeneration(panel);"
     )
 
     capture_start = ctrl_file_ops.index("void CapturePanelSelectionAnchor(")
@@ -9169,7 +9199,7 @@ def test_panel_volume_binding_commits_route_through_appstate_helper() -> None:
     volume_validation = 'AppStateValidatedOwnerField("panel.volume_key")'
     generation_validation = 'AppStateValidatedOwnerField("panel.panel_generation")'
     volume_write = "panel->vol = vol;"
-    generation_write = "panel->panel_generation++;"
+    generation_write = "return AppStateCommitPanelGeneration(panel);"
     assert volume_validation in helper_body
     assert generation_validation in helper_body
     assert volume_write in helper_body

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -257,6 +257,7 @@ def test_restore_snapshots_validate_generation_before_reuse():
     defs_source = _defs_source()
     log_source = _log_source()
     panel_anchor_source = _panel_anchor_file_source()
+    panel_helper_source = Path("src/ui/appstate_panel.c").read_text(encoding="utf-8")
     dir_ops_source = _dir_ops_source()
     visibility_source = _appstate_visibility_source()
 
@@ -286,10 +287,23 @@ def test_restore_snapshots_validate_generation_before_reuse():
     )
 
     assert 'include "ytnova_appstate_panel.h"' in panel_anchor_source
-    assert "AppStateCommitPanelGeneration(panel)" in panel_anchor_source
-    assert "AppStateRestorePanelGeneration(dst, src->panel_generation)" in (
-        panel_anchor_source
-    )
+    for signature in (
+        "BOOL AppStateCommitPanelTreeSelection(",
+        "BOOL AppStateCommitPanelFileViewport(",
+        "BOOL AppStateCommitPanelFileAnchor(",
+        "BOOL AppStateCommitPanelTreeViewport(",
+    ):
+        start = panel_helper_source.index(signature)
+        end = panel_helper_source.find("\nBOOL ", start + 1)
+        body = (
+            panel_helper_source[start:]
+            if end < 0
+            else panel_helper_source[start:end]
+        )
+        assert 'AppStateValidatedOwnerField("panel.panel_generation")' in body
+        assert "return AppStateCommitPanelGeneration(panel);" in body
+    assert "AppStateRestorePanelGeneration(dst, src->panel_generation)" in panel_anchor_source
+    assert "AppStateCommitPanelGeneration(panel)" not in panel_anchor_source
 
     assert "AppStateCommitPanelVisibilityFilter(p, !p->hide_dot_files)" in dir_ops_source
     assert "panel->panel_generation++;" in visibility_source, visibility_source


### PR DESCRIPTION
## Summary
- make authoritative panel-local AppState helper commits advance `panel_generation`
- preserve restore-only generations explicitly in panel-anchor and log restore paths so stale snapshots fail closed
- tighten focused guard coverage for panel-generation invalidation and leave dead-history comment cleanup in `src/ui/display.c` for follow-up

## Validation
- Red proof before the fix: `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py -k 'panel_anchor_viewport_generation_commits_through_appstate_helper or panel_local_helpers_validate_generation_domain_before_writes' tests/test_dir_window_dispatch_regressions.py -k 'restore_snapshots_validate_generation_before_reuse'`
- `source .venv/bin/activate && python3 scripts/check_appstate_contract.py`
- `source .venv/bin/activate && pytest -q tests/test_appstate_contract_guard.py::test_panel_local_helpers_validate_generation_domain_before_writes tests/test_appstate_contract_guard.py::test_file_selection_anchor_generation_commits_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_anchor_viewport_generation_commits_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_file_viewport_commits_route_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_tree_viewport_commits_route_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_tree_selection_commits_route_through_appstate_helper tests/test_appstate_contract_guard.py::test_panel_generation_restores_route_through_appstate_helper tests/test_dir_window_dispatch_regressions.py::test_restore_snapshots_validate_generation_before_reuse tests/test_dir_window_dispatch_regressions.py::test_split_tab_refresh_rejects_stale_file_restore_snapshot`
- `make clean && make`
- `git diff --check`
