### PR TITLE
feat(ui): add tagged-only function-key parity

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -227,7 +227,7 @@ Compatibility shims are retired from the current AppState contract. Any legacy m
 *   **Transition Invariant:** A directory can only be entered (Tree to File Mode) if it contains at least one file.
 *   **Selection Memory (Breadcrumbs):** When returning from File Mode to Tree Mode and later re-entering the same directory, the panel restores the cursor to the last highlighted file.
 *   **Navigation Stability:** Moving through the Tree never automatically triggers a transition into File Mode.
-*   **Tag-View Scope Rule:** `i/I` (invert tags) and `o/O` (tagged-only file-list toggle) operate on the active panel's current file-list scope, regardless of whether focus is in tree or file window.
+*   **Tag-View Scope Rule:** `i/I` (invert tags) and `F4`/`o/O` (tagged-only file-list toggle) operate on the active panel's current file-list scope, regardless of whether focus is in tree or file window.
 *   **Root Boundary Rule:** `Left` on an expanded root performs the same node-local reset as `-` (collapse + release/unlog). Further `Left` on an already-unlogged root is a no-op.
 
 ### 5.2 Protocol B: Archive and Volume Lifecycle

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1369,7 +1369,7 @@ Ordering policy (for all editors, including AI editors):
     *   Leaving the mode restores the normal file/filter view; tags remain unchanged.
     *   This should compose cleanly with existing filters, grep-on-tagged workflows, and compare/tag workflows.
 *   **Rationale:** After tagging, compare, or grep operations, users often want a focused "show me only the files I marked" result view instead of manually navigating through the full list.
-*   - [ ] **Status:** In Progress (tagged-only toggle shipped on `o/O`; broader workflow/key-shape refinements remain).
+*   - [x] **Status:** Completed.
 
 ### **Idea FE-16: Investigate Recursive Tagging vs Existing Showall/Global Workflow**
 *   **Goal:** Determine whether recursive tagging provides enough real workflow benefit over the current `log dir -> Showall/Global -> tag` path to justify added complexity.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -160,7 +160,7 @@ The `ytnova` input system follows a layered model designed for high-speed intera
 *   **The Volume Menu Rule (`K` menu):** Selecting the already-active volume preserves its current in-memory state (no implicit relog/reload).
 *   **The Explicit Relog Rule (`L` on current path):** Logging an already logged volume/path performs a fresh relog/reload of that volume state and reanchors selection at volume root.
 *   **The Invert Rule (`i`/`I`):** In both tree and file windows, invert tags applies to the active panel's current file-list scope (filesystem and archive contexts).
-*   **The Only-Tagged Rule (`o`/`O`):** In both tree and file windows, toggle tagged-only file-list view for the active panel's current scope; toggling never changes tag state.
+*   **The Only-Tagged Rule (`F4`, `o`/`O`):** In both tree and file windows, toggle tagged-only file-list view for the active panel's current scope; toggling never changes tag state.
 *   **The Archive/Global Jump (`\`):** In Archive Mode, jumps to the archive root. in Global/Showall views, jumps to the highlighted file's directory.
 *   **Numeric FileInfo Band (`1..9`, `0`):** Number keys are the canonical file-display controls in normal list contexts (not active in `F7` preview). These controls apply to file-display rendering for the active panel whether focus is currently in the tree/dir window or file window.
 *   **Vi-Key Collision Policy:** When `VI_KEYS=1`, lowercase `h/j/k/l` are reserved for navigation. Uppercase `H/K/L/J` are used for commands (Hex, Volume, Log, Compare).
@@ -170,6 +170,7 @@ The `ytnova` input system follows a layered model designed for high-speed intera
 ### 4.4 Function Key Blueprint (F1-F12)
 *   **`F1`**: help.
 *   **`F2`**: directory picker (Prompts Only).
+*   **`F4`**: tagged-only toggle for the active panel's current file-list scope.
 *   **`F5`**: refresh.
 *   **`F6`**: stats toggle.
 *   **`F7`**: autoview toggle.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -90,6 +90,7 @@ Activated by **F7**. The screen layout changes to show the file list on the left
 These commands work in most modes:
 
   - **F1**: Help (context-sensitive in prompts/dialogs).
+  - **F4**: Toggle tagged-only view for the active panel's current file-list scope without changing tag state.
   - **F5**: Refresh (same as **^L**).
   - **F6**: Toggle Statistics Panel (Wide Mode).
   - **F7**: Toggle File Preview Pane.
@@ -130,7 +131,7 @@ Active when browsing the directory tree window.
   - **L** (Log): Log a new directory or archive file. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
   - **M** (Makedir): Create a new directory.
   - **N** (New File): Create a new empty file.
-  - **O** (Only tagged): Toggle tagged-only file-list view for the current directory scope.
+  - **O** (Only tagged): Toggle tagged-only file-list view for the current directory scope. **F4** is the function-key alias.
   - **P** (Pipe, or **|**): Pipe the selected directory to a command (stdin).
   - **R** (Rename): Rename selected directory.
   - **S** (Showall): Show all files in all directories of the current volume.
@@ -169,7 +170,7 @@ Active when the file window is focused.
   - **M** (Move): Move the selected file.
   - **^N**: Move all tagged files.
   - **N** (New File): Create a new empty file.
-  - **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only).
+  - **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only). **F4** is the function-key alias.
   - **P** (Pipe, or **|**): Pipe content of file to a command (stdin).
   - **R** (Rename): Rename the selected file.
   - **S** (Sort): Sort filelist (Access time, Change time, Extension, Group, Modification time, Name, Owner, Size).
@@ -207,7 +208,7 @@ When browsing an archive (ZIP, TAR, ISO, etc.), ytnova behaves like a virtual fi
   - **I** (Invert Tags): Toggle tag state for files in the selected/current archive directory scope.
   - **L** (Log): Log a new directory or archive. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
   - **M** (Makedir): Create directory in archive context where supported.
-  - **O** (Only tagged): Toggle tagged-only file-list view for the current archive directory scope.
+  - **O** (Only tagged): Toggle tagged-only file-list view for the current archive directory scope. **F4** is the function-key alias.
   - **R** (Rename): Rename selected archive directory entry.
   - **S** (Showall): Show all files in the archive.
   - **T** (Tag): Tag all files in current virtual directory.
@@ -229,7 +230,7 @@ When browsing an archive (ZIP, TAR, ISO, etc.), ytnova behaves like a virtual fi
   - **H** (Hex): View file in hex mode.
   - **I** (Invert Tags): Toggle the tag state of all visible files.
   - **M** (Move): Move selected file using archive-aware semantics.
-  - **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only).
+  - **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only). **F4** is the function-key alias.
   - **P** (Pipe, or **|**): Pipe content to command.
   - **R** (Rename): Rename selected archive file entry.
   - **S** (Sort): Sort file list.

--- a/etc/ytnova.1.md
+++ b/etc/ytnova.1.md
@@ -80,6 +80,7 @@ Activated by **F7**. The screen layout changes to show the file list on the left
 These commands work in most modes:
 
 *   **F1**: Help (context-sensitive in prompts/dialogs).
+*   **F4**: Toggle tagged-only view for the active panel's current file-list scope without changing tag state.
 *   **F5**: Refresh (same as **^L**).
 *   **F6**: Toggle Statistics Panel (Wide Mode).
 *   **F7**: Toggle File Preview Pane.
@@ -118,7 +119,7 @@ Active when browsing the directory tree window.
 *   **L** (Log): Log a new directory or archive file. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
 *   **M** (Makedir): Create a new directory.
 *   **N** (New File): Create a new empty file.
-*   **O** (Only tagged): Toggle tagged-only file-list view for the current directory scope.
+*   **O** (Only tagged): Toggle tagged-only file-list view for the current directory scope. **F4** is the function-key alias.
 *   **P** (Pipe, or **|**): Pipe the selected directory to a command (stdin).
 *   **R** (Rename): Rename selected directory.
 *   **S** (Showall): Show all files in all directories of the current volume.
@@ -156,7 +157,7 @@ Active when the file window is focused.
 *   **M** (Move): Move the selected file.
 *   **^N**: Move all tagged files.
 *   **N** (New File): Create a new empty file.
-*   **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only).
+*   **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only). **F4** is the function-key alias.
 *   **P** (Pipe, or **|**): Pipe content of file to a command (stdin).
 *   **R** (Rename): Rename the selected file.
 *   **S** (Sort): Sort filelist (Access time, Change time, Extension, Group, Modification time, Name, Owner, Size).
@@ -193,7 +194,7 @@ When browsing an archive (ZIP, TAR, ISO, etc.), ytnova behaves like a virtual fi
 *   **I** (Invert Tags): Toggle tag state for files in the selected/current archive directory scope.
 *   **L** (Log): Log a new directory or archive. Logging an already logged volume/path performs a fresh reload and reanchors selection at the volume root.
 *   **M** (Makedir): Create directory in archive context where supported.
-*   **O** (Only tagged): Toggle tagged-only file-list view for the current archive directory scope.
+*   **O** (Only tagged): Toggle tagged-only file-list view for the current archive directory scope. **F4** is the function-key alias.
 *   **R** (Rename): Rename selected archive directory entry.
 *   **S** (Showall): Show all files in the archive.
 *   **T** (Tag): Tag all files in current virtual directory.
@@ -215,7 +216,7 @@ When browsing an archive (ZIP, TAR, ISO, etc.), ytnova behaves like a virtual fi
 *   **H** (Hex): View file in hex mode.
 *   **I** (Invert Tags): Toggle the tag state of all visible files.
 *   **M** (Move): Move selected file using archive-aware semantics.
-*   **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only).
+*   **O** (Only tagged): Toggle tagged-only file-list view (show tagged files only). **F4** is the function-key alias.
 *   **P** (Pipe, or **|**): Pipe content to command.
 *   **R** (Rename): Rename selected archive file entry.
 *   **S** (Sort): Sort file list.

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -160,6 +160,7 @@ static const UICommandStripCommand preview_command_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "Exit Preview", "F7", NULL}};
 static const UICommandStripCommand dir_help_nav_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "help", "F1", NULL},
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, "tagged", "F4", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "refresh", "F5", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "stats", "F6", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "autoview", "F7", NULL},
@@ -168,6 +169,7 @@ static const UICommandStripCommand dir_help_nav_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "cancel", "Esc", NULL}};
 static const UICommandStripCommand dir_help_nav_archive_to_root_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "help", "F1", NULL},
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, "tagged", "F4", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "refresh", "F5", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "stats", "F6", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "autoview", "F7", NULL},
@@ -177,6 +179,7 @@ static const UICommandStripCommand dir_help_nav_archive_to_root_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "cancel", "Esc", NULL}};
 static const UICommandStripCommand dir_help_nav_archive_exit_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "help", "F1", NULL},
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, "tagged", "F4", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "refresh", "F5", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "stats", "F6", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "autoview", "F7", NULL},
@@ -186,6 +189,7 @@ static const UICommandStripCommand dir_help_nav_archive_exit_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "cancel", "Esc", NULL}};
 static const UICommandStripCommand file_help_nav_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "help", "F1", NULL},
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, "tagged", "F4", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "refresh", "F5", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "stats", "F6", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "autoview", "F7", NULL},
@@ -194,6 +198,7 @@ static const UICommandStripCommand file_help_nav_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "cancel", "Esc", NULL}};
 static const UICommandStripCommand file_help_nav_to_dir_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "help", "F1", NULL},
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, "tagged", "F4", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "refresh", "F5", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "stats", "F6", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "autoview", "F7", NULL},

--- a/src/ui/key_engine.c
+++ b/src/ui/key_engine.c
@@ -671,6 +671,8 @@ YtreeNovaAction GetKeyAction(const ViewContext *ctx, int ch) {
 #ifdef KEY_F
   case KEY_F(12):
     return AppStateValidatedKeyAction(ACTION_LIST_JUMP);
+  case KEY_F(4):
+    return AppStateValidatedKeyAction(ACTION_TOGGLE_TAGGED_MODE);
   case KEY_F(8):
     return AppStateValidatedKeyAction(ACTION_SPLIT_SCREEN);
   case KEY_F(7):

--- a/tests/test_appstate_contract_guard.py
+++ b/tests/test_appstate_contract_guard.py
@@ -5644,6 +5644,9 @@ def test_get_key_action_routes_decoded_actions_through_appstate_boundary() -> No
     assert body.count("return ACTION_NONE;") == 1
     assert body.index("return ACTION_NONE;") < body.index("switch (ch)")
     assert "AppStateValidatedKeyAction(" in body
+    assert 'case KEY_F(4):\n    return AppStateValidatedKeyAction(ACTION_TOGGLE_TAGGED_MODE);' in body
+    assert 'case KEY_F(16):\n    return AppStateValidatedKeyAction(ACTION_TOGGLE_TAGGED_MODE);' in body
+    assert 'case KEY_F(28):\n    return AppStateValidatedKeyAction(ACTION_TOGGLE_TAGGED_MODE);' in body
     assert not re.search(r"return\s+ACTION_(?!NONE;)", body)
 
 

--- a/tests/test_display_layout.py
+++ b/tests/test_display_layout.py
@@ -608,7 +608,7 @@ def test_backslash_to_dir_in_showall_and_global(ytnova_binary, tmp_path, mode_ke
 def test_footer_fkeys_render_as_text_in_dir_and_showall(ytnova_binary, tmp_path):
     """
     REGRESSION:
-    Footer command rows must render function key labels as text (F7/F8/F10/F1),
+    Footer command rows must render function key labels as text (F4/F7/F8/F10/F1),
     not ACS glyph substitutions.
     """
     d = tmp_path / "footer_fkeys"
@@ -622,7 +622,7 @@ def test_footer_fkeys_render_as_text_in_dir_and_showall(ytnova_binary, tmp_path)
     tui.send_keystroke("", wait=0.2)
 
     screen = "\n".join(tui.get_screen_dump())
-    assert "F7" in screen and "F8" in screen and "F10" in screen and "F1" in screen
+    assert "F4" in screen and "F7" in screen and "F8" in screen and "F10" in screen and "F1" in screen
     assert "Treespec" not in screen
     assert "Tree  F1 help" in screen
     assert "Dir   F1 help" not in screen
@@ -632,7 +632,7 @@ def test_footer_fkeys_render_as_text_in_dir_and_showall(ytnova_binary, tmp_path)
 
     tui.send_keystroke(Keys.SHOWALL, wait=0.6)
     screen = "\n".join(tui.get_screen_dump())
-    assert "F7" in screen and "F8" in screen and "F10" in screen and "F1" in screen
+    assert "F4" in screen and "F7" in screen and "F8" in screen and "F10" in screen and "F1" in screen
     assert "to dir" in screen
     assert "Dir   F1 help" in screen
     assert "jump" in screen

--- a/tests/test_panel_isolation.py
+++ b/tests/test_panel_isolation.py
@@ -170,7 +170,7 @@ def test_tree_viewport_helper_uses_current_row_and_exact_labels():
         "m" + "q" * left_width + "vqqqqqqqqqqqqqqqqqqqj",
         "DIR      Attributes Brief Copy Delete Filter Global Invert J compare Log Makedir Newfile",
         "COMMANDS Only tagged Pipe Quit Rename Showall Tag Untag moVedir Write eXecute Z archive",
-        "←j Tree  F1 help  F5 refresh  F6 stats  F7 autoview  F8 split  F10 config  Esc cancel",
+        "←j Tree  F1 help  F4 tagged  F5 refresh  F6 stats  F7 autoview  F8 split  F10 config  Esc cancel",
     ]
 
     assert _tree_panel_selected_label(lines) == "for later"

--- a/tests/test_tagged_action_regressions.py
+++ b/tests/test_tagged_action_regressions.py
@@ -106,7 +106,7 @@ def test_invert_tags_i_and_upper_i_in_archive_directory_window(
         tui.quit()
 
 
-def test_only_tagged_toggle_o_from_directory_window(ytnova_binary, tmp_path):
+def test_only_tagged_toggle_o_and_f4_from_directory_window(ytnova_binary, tmp_path):
     work_dir = tmp_path / "dir_window_only_tagged"
     work_dir.mkdir()
     (work_dir / "alpha.txt").write_text("alpha", encoding="utf-8")
@@ -127,7 +127,39 @@ def test_only_tagged_toggle_o_from_directory_window(ytnova_binary, tmp_path):
         footer = _footer_text(tui)
         assert "j tree" in footer, f"Expected directory footer before tagged-only toggle.\n{footer}"
 
+        tui.send_keystroke(Keys.F4, wait=0.35)
+        tagged_only_screen = _screen_text(tui)
+        assert "alpha.txt" in tagged_only_screen, tagged_only_screen
+        assert "gamma.txt" in tagged_only_screen, tagged_only_screen
+        assert "beta.txt" not in tagged_only_screen, tagged_only_screen
+
         tui.send_keystroke("o", wait=0.35)
+        full_screen = _screen_text(tui)
+        assert "alpha.txt" in full_screen, full_screen
+        assert "beta.txt" in full_screen, full_screen
+        assert "gamma.txt" in full_screen, full_screen
+    finally:
+        tui.quit()
+
+
+def test_only_tagged_toggle_o_and_f4_from_file_window(ytnova_binary, tmp_path):
+    work_dir = tmp_path / "file_window_only_tagged"
+    work_dir.mkdir()
+    (work_dir / "alpha.txt").write_text("alpha", encoding="utf-8")
+    (work_dir / "beta.txt").write_text("beta", encoding="utf-8")
+    (work_dir / "gamma.txt").write_text("gamma", encoding="utf-8")
+
+    tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(work_dir))
+    time.sleep(0.5)
+
+    try:
+        tui.send_keystroke(Keys.ENTER, wait=0.35)
+        tui.send_keystroke("t", wait=0.2)  # alpha
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke(Keys.DOWN, wait=0.2)
+        tui.send_keystroke("t", wait=0.2)  # gamma
+
+        tui.send_keystroke(Keys.F4, wait=0.35)
         tagged_only_screen = _screen_text(tui)
         assert "alpha.txt" in tagged_only_screen, tagged_only_screen
         assert "gamma.txt" in tagged_only_screen, tagged_only_screen

--- a/tests/ytnova_keys.py
+++ b/tests/ytnova_keys.py
@@ -22,6 +22,7 @@ class Keys:
     # Note: If these fail, try "\033OR" for F7 and "\033OS" for F8
     F1 = "\033OP"
     F2 = "\033OQ"
+    F4 = "\033OS"
     F5 = "\033[15~"
     F7 = "\033[18~"
     F8 = "\033[19~"


### PR DESCRIPTION
## Summary
- finish the Tagged-Only Results View key-shape by adding plain `F4` alongside the existing `o/O` and legacy modified-function-key aliases
- surface the canonical tagged-only function-key path in tree, file, showall/global, and archive footer help rows
- sync roadmap, specification, architecture, manpage, generated usage, and focused regression coverage for tagged-only toggle parity

## Validation
- Red proof: `source .venv/bin/activate && pytest -q tests/test_tagged_action_regressions.py::test_only_tagged_toggle_o_and_f4_from_directory_window tests/test_display_layout.py::test_footer_fkeys_render_as_text_in_dir_and_showall`
- `make clean && make`
- `make docs`
- `source .venv/bin/activate && pytest -q tests/test_tagged_action_regressions.py::test_only_tagged_toggle_o_and_f4_from_directory_window tests/test_tagged_action_regressions.py::test_only_tagged_toggle_o_and_f4_from_file_window tests/test_display_layout.py::test_footer_fkeys_render_as_text_in_dir_and_showall tests/test_panel_isolation.py::test_tree_viewport_helper_uses_current_row_and_exact_labels tests/test_appstate_contract_guard.py::test_get_key_action_routes_decoded_actions_through_appstate_boundary`
- `git diff --check`
