### PR TITLE
fix(exec): restore file-view execute defaults and redraw

### DIFF
--- a/.agent/handoffs/active.execute-shell-script-default.txt
+++ b/.agent/handoffs/active.execute-shell-script-default.txt
@@ -1,0 +1,61 @@
+Work item: file-view x defaults should use a clean current-directory command and restore the full UI immediately after command return.
+Status: In Progress.
+
+Selected family: file-view execute-command default template, post-command UI restore, and adjacent history-help command strip parity.
+Source of truth:
+- Maintainer bug report: selecting an executable shell script, pressing x, then Enter should run it like ./foobar.sh from the current directory instead of plain foobar.sh.
+- Maintainer follow-up: the prompt should show `./blob.sh`, not `./'blob.sh'`, and the UI should not pause on a partial redraw after dismissing `[Hit return to continue]`.
+
+Inventory:
+- tests/test_security_shell_paths.py
+  - reproducer path for x-command execution from file view [addressed]
+  - prompt text regression for simple executable names [addressed]
+  - QuerySystemCall UI-restore contract after continue prompt [addressed]
+  - adjacent placeholder/injection execute tests [addressed via focused regression rerun]
+- tests/test_ui_display.py
+  - adjacent footer visibility/no-flicker coverage for command-return redraw surfaces [addressed via focused rerun]
+- tests/test_compare_actions.py
+  - history-window shared edit-navigation help strip should show Delete for `D`/history-up flows [addressed]
+- src/ui/ctrl_file_ops.c
+  - ACTION_CMD_X default command_template prefill for executable files [addressed]
+  - adjacent tagged execute/search placeholder normalization surfaces [intentionally unchanged: they expand explicit user commands and do not prefill executable names]
+- src/ui/interactions.c
+  - QuerySystemCall restore path after HitReturnToContinue [addressed]
+- src/ui/display.c
+  - history help command strip content for Ctrl-P/history window [addressed]
+- src/cmd/execute.c
+  - Execute() command expansion/chdir/runtime execution path [intentionally unchanged: already chdirs into the selected directory and executes the built command line]
+  - ExecuteCommand() tagged execution path [intentionally unchanged: tagged execution already expands explicit user templates against selected paths]
+- src/util/path_utils.c
+  - Path_ShellQuote / Path_BuildCommandLine quoting behavior used by execute flow [intentionally unchanged: quoting helpers already preserve literal argv values; fixes belong in the executable-prefill and QuerySystemCall callers]
+- src/ui/ctrl_dir.c
+  - tree/directory ACTION_CMD_X path for non-file commands [intentionally unchanged: directory-mode x does not prefill the selected executable filename]
+
+Reproducer:
+- file view on an executable shell script in current directory
+- press x
+- expected prompt default for simple names: `./name`
+- expected Enter behavior: run from cwd, then restore footer/path/stats/clock immediately after dismissing `[Hit return to continue]`
+- previous failures:
+  - prompt showed `./'name'` for simple script names
+  - shell previously reported name not found before the first fix because current directory is not searched via PATH
+  - QuerySystemCall restored only a partial screen state after the continue prompt because it skipped clock re-init and full dialog-stack redraw
+
+Closure tracking:
+- tests/test_security_shell_paths.py: addressed
+- tests/test_ui_display.py focused coverage: addressed
+- tests/test_compare_actions.py history-help coverage: addressed
+- src/ui/ctrl_file_ops.c ACTION_CMD_X prefill: addressed
+- src/ui/interactions.c QuerySystemCall restore path: addressed
+- src/ui/display.c history-help strip: addressed
+- src/cmd/execute.c: intentionally unchanged (existing chdir/execute path already correct)
+- src/util/path_utils.c: intentionally unchanged (quoting helpers already correct)
+- src/ui/ctrl_dir.c: intentionally unchanged (different owner surface and behavior)
+
+Validation:
+- Red: `source .venv/bin/activate && pytest -q tests/test_security_shell_paths.py -k 'plain_dot_slash or query_system_call_reinitializes_clock'`
+- `make clean && make -j4`
+- Green: `source .venv/bin/activate && pytest -q tests/test_compare_actions.py -k reuses_shared_edit_navigation_behavior`
+- Green focused: `source .venv/bin/activate && pytest -q tests/test_security_shell_paths.py -k 'plain_dot_slash or query_system_call_reinitializes_clock or execute_default_prefill_runs_executable_from_current_directory or execute_command_placeholder_preserves_metacharacter_filename_literal or execute_placeholder_in_user_quotes_does_not_enable_shell_injection'`
+- Green broader: `source .venv/bin/activate && pytest -q tests/test_compare_actions.py tests/test_security_shell_paths.py tests/test_ui_display.py -k 'reuses_shared_edit_navigation_behavior or execute_default_prefill or query_system_call_reinitializes_clock or footer_visible or footer_no_flicker or footer_blank_on_big_window_entry'`
+- Green targeted static analysis: `cppcheck --enable=all --inconclusive --force --std=c99 -I include --error-exitcode=1 --suppressions-list=.cppcheck-suppressions.txt src/ui/ctrl_file_ops.c`

--- a/src/ui/ctrl_file_ops.c
+++ b/src/ui/ctrl_file_ops.c
@@ -21,6 +21,7 @@
 #include "ytnova_panel_anchor.h"
 #include "ytnova_ui.h"
 #include <assert.h>
+#include <ctype.h>
 #include <string.h>
 #include <utime.h>
 
@@ -266,6 +267,48 @@ static void NormalizeQuotedExecPlaceholders(char *command_template,
   }
 
   command_template[write_idx] = '\0';
+}
+
+static BOOL IsShellBarewordSafe(const char *path) {
+  const unsigned char *cptr = (const unsigned char *)path;
+
+  if (!cptr || *cptr == '\0')
+    return FALSE;
+
+  while (*cptr) {
+    if (!isalnum(*cptr) && strchr("_@%+=:,./-", (int)*cptr) == NULL)
+      return FALSE;
+    cptr++;
+  }
+
+  return TRUE;
+}
+
+static BOOL BuildExecutableCommandPrefill(const char *file_name,
+                                          char *command_template,
+                                          size_t command_template_size) {
+  char relative_path[PATH_LENGTH + 3];
+  int written;
+
+  if (!file_name || !command_template || command_template_size == 0)
+    return FALSE;
+
+  written = snprintf(relative_path, sizeof(relative_path), "./%s", file_name);
+  if (written < 0 || (size_t)written >= sizeof(relative_path)) {
+    return FALSE;
+  }
+
+  if (IsShellBarewordSafe(relative_path)) {
+    written = snprintf(command_template, command_template_size, "%s",
+                       relative_path);
+    if (written < 0 || (size_t)written >= command_template_size) {
+      command_template[command_template_size - 1] = '\0';
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  return Path_ShellQuote(relative_path, command_template, command_template_size);
 }
 
 BOOL handle_file_window_preview_action(
@@ -844,8 +887,8 @@ BOOL handle_file_window_command_action(ViewContext *ctx, YtreeNovaAction action,
       char command_template[COMMAND_LINE_LENGTH + 1];
       command_template[0] = '\0';
       if (fe_ptr->stat_struct.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) {
-        if (!Path_ShellQuote(fe_ptr->name, command_template,
-                             sizeof(command_template))) {
+        if (!BuildExecutableCommandPrefill(fe_ptr->name, command_template,
+                                           sizeof(command_template))) {
           WARNING(ctx, "Command line too long.");
           break;
         }

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -149,6 +149,7 @@ static const UICommandStripCommand file_help_archive_mode_1_commands[] = {
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "pathcopy", "Y", NULL}};
 static const UICommandStripCommand history_help_commands[] = {
     {UI_COMMAND_LAYOUT_MNEMONIC, "Pin/unpin", "P", NULL},
+    {UI_COMMAND_LAYOUT_MNEMONIC, "Delete", "D", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "OK", "Enter", NULL},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, "Cancel", "Esc", NULL}};
 static const UICommandStripCommand preview_help_commands[] = {

--- a/src/ui/interactions.c
+++ b/src/ui/interactions.c
@@ -9,6 +9,7 @@
 #include "watcher.h"
 #include "ytnova_appstate_panel.h"
 #include "ytnova_cmd.h"
+#include "ytnova_dialog.h"
 #include "ytnova_fs.h"
 #include "ytnova_ui.h"
 #include "interactions_panel_paths.h"
@@ -664,12 +665,12 @@ int QuerySystemCall(ViewContext *ctx, const char *command_line, Statistic *s) {
 
   HitReturnToContinue(); /* 3. Print message and wait for key in raw terminal */
 
-  /* 4. Aggressive redraw/refresh to restore the curses UI completely */
-  touchwin(stdscr);
-  wnoutrefresh(stdscr);
-  doupdate();
-
+  if (ctx->hook_init_clock)
+    ctx->hook_init_clock(ctx);
   (void)GetAvailBytes(&s->disk_space, s);
+  UI_Dialog_RefreshAll(ctx);
+  ClockHandler(ctx, 0);
+  doupdate();
 
   return (result);
 }

--- a/tests/test_compare_actions.py
+++ b/tests/test_compare_actions.py
@@ -341,6 +341,7 @@ def test_compare_target_prompt_reuses_shared_edit_navigation_behavior(ytnova_bin
     assert tui.wait_for_content("COMPARE TARGET:", timeout=1.0)
     tui.send_keystroke("\x10", wait=0.3)  # Ctrl-P history-up
     assert tui.wait_for_content("Pin/unpin", timeout=1.0)
+    assert "Delete" in _screen_text(tui), _screen_text(tui)
     tui.send_keystroke(Keys.ESC, wait=0.2)
     tui.quit()
 

--- a/tests/test_security_shell_paths.py
+++ b/tests/test_security_shell_paths.py
@@ -2,6 +2,7 @@ import shlex
 import time
 
 from helpers_files import wait_for_file as _wait_for_file
+from helpers_ui import screen_text
 from helpers_source import read_repo_source
 from tui_harness import YtreeNovaTUI
 from ytnova_keys import Keys
@@ -238,3 +239,93 @@ def test_execute_placeholder_in_user_quotes_does_not_enable_shell_injection(
     )
 
     tui.quit()
+
+
+def test_execute_default_prefill_runs_executable_from_current_directory(
+    ytnova_binary, tmp_path
+):
+    root = tmp_path / "execute_default_prefill_current_dir"
+    root.mkdir()
+
+    script_path = root / "run me.sh"
+    marker_path = root / "script_ran.marker"
+    script_path.write_text(
+        "#!/bin/sh\n"
+        f"printf 'ran\\n' > {shlex.quote(str(marker_path))}\n",
+        encoding="utf-8",
+    )
+    script_path.chmod(0o755)
+
+    tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
+    time.sleep(0.6)
+    tui.send_keystroke(Keys.ENTER, wait=0.35)  # tree -> file view
+    tui.send_keystroke("x", wait=0.35)
+    assert tui.wait_for_content("COMMAND:", timeout=1.0)
+    tui.send_keystroke(Keys.ENTER, wait=0.8)
+
+    assert _wait_for_file(marker_path, timeout=2.0), (
+        "Default execute command should run the selected executable from the "
+        "current directory."
+    )
+    if tui.wait_for_content("Hit return to continue", timeout=1.0):
+        tui.send_keystroke(Keys.ENTER, wait=0.3)
+
+    tui.quit()
+
+
+def test_execute_default_prefill_shows_plain_dot_slash_for_simple_script_name(
+    ytnova_binary, tmp_path
+):
+    root = tmp_path / "execute_default_prefill_prompt"
+    root.mkdir()
+
+    script_path = root / "blob.sh"
+    script_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    script_path.chmod(0o755)
+
+    tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
+    time.sleep(0.6)
+    tui.send_keystroke(Keys.ENTER, wait=0.35)  # tree -> file view
+    tui.send_keystroke("x", wait=0.35)
+
+    screen = screen_text(tui)
+    assert "COMMAND: ./blob.sh" in screen, screen
+    assert "COMMAND: ./'blob.sh'" not in screen, screen
+
+    tui.quit()
+
+
+def test_query_system_call_reinitializes_clock_and_dialog_refresh_after_continue():
+    src = read_repo_source("src/ui/interactions.c")
+    start = src.index("int QuerySystemCall(")
+    end = src.index("\nint UI_ReadFilter(", start)
+    body = src[start:end]
+
+    assert "HitReturnToContinue();" in body, (
+        "QuerySystemCall should keep the raw-terminal continue prompt after the "
+        "external command returns."
+    )
+    assert "ctx->hook_init_clock(ctx);" in body, (
+        "QuerySystemCall must restore the clock/curses state immediately after "
+        "the continue prompt returns."
+    )
+    assert "UI_Dialog_RefreshAll(ctx);" in body, (
+        "QuerySystemCall must restage the full window stack after restoring the "
+        "clock so footer, borders, path, and stats redraw immediately."
+    )
+    assert "ClockHandler(ctx, 0);" in body, (
+        "QuerySystemCall must repaint the live clock/calendar after restoring "
+        "the dialog stack."
+    )
+
+    continue_idx = body.index("HitReturnToContinue();")
+    clock_idx = body.index("ctx->hook_init_clock(ctx);")
+    dialog_idx = body.index("UI_Dialog_RefreshAll(ctx);")
+    clock_draw_idx = body.index("ClockHandler(ctx, 0);")
+    doupdate_idx = body.index("doupdate();")
+
+    assert continue_idx < clock_idx < dialog_idx < clock_draw_idx < doupdate_idx, (
+        "QuerySystemCall must reinitialize curses, refresh the dialog stack, "
+        "redraw the clock, and only then flush the redraw after the continue "
+        "prompt."
+    )


### PR DESCRIPTION
## Summary
- prefill executable file-view `x` commands as bare `./name` for simple script names while still quoting the full relative path safely when the filename needs shell protection
- restore the full UI immediately after `[Hit return to continue]` so the footer, path, borders, stats, and clock redraw together instead of lagging behind the file/tree panes
- show `Delete` with `D` in the history help strip so the shared history dialog advertises the existing delete action

## Validation
- Red proof: `source .venv/bin/activate && pytest -q tests/test_security_shell_paths.py -k 'plain_dot_slash or query_system_call_reinitializes_clock'`
- `make clean && make -j4`
- `source .venv/bin/activate && pytest -q tests/test_compare_actions.py tests/test_security_shell_paths.py tests/test_ui_display.py -k 'reuses_shared_edit_navigation_behavior or execute_default_prefill or query_system_call_reinitializes_clock or footer_visible or footer_no_flicker or footer_blank_on_big_window_entry'`
- `cppcheck --enable=all --inconclusive --force --std=c99 -I include --error-exitcode=1 --suppressions-list=.cppcheck-suppressions.txt src/ui/ctrl_file_ops.c`
