### PR TITLE
perf(tests): speed up stats panel waits

### DIFF
--- a/.agent/handoffs/patch-2-stats-panel-latency.txt
+++ b/.agent/handoffs/patch-2-stats-panel-latency.txt
@@ -1,0 +1,60 @@
+Work item: Patch 2 Stats Panel Test Optimization
+Branch: perf/stats-panel-latency
+Draft PR: https://github.com/robkam/ytreenova/pull/400
+Depends on branch/PR: perf/tui-harness-latency / https://github.com/robkam/ytreenova/pull/399
+Selected family: dynamic screen-polling controller helpers plus the slow stats-panel regressions that relied on fixed sleeps and layout-rigid stats/footer extraction.
+Source of truth:
+- User focus action: Patch 2 of the test optimization.
+- docs/ROADMAP.md Task 8 (test helper conventions and contributor-safe regression structure).
+- User addendum to include AGENTS.md in the next commit.
+
+Inventory
+- Active related handoff preserved because Patch 1 PR is still open and this branch stacks on it:
+  - .agent/handoffs/patch-1-tui-harness-latency.txt
+- Controller harness surfaces:
+  - tests/ytnova_control.py
+    - YtreeNovaController.wait_for_startup
+    - YtreeNovaController.wait_for_refresh
+    - YtreeNovaController.select_file
+    - YtreeNovaController.input_text
+    - YtreeNovaController.quit
+    - new dynamic helpers mirroring tui_harness: get_screen_dump/peek_screen_dump, wait_for_condition, wait_for_text, send_and_wait_for_condition, send_and_wait_for_screen_change, plus PTY drain support
+    - post-rebase CI compatibility seam: pexpect buffer mirroring so legacy `controller.child.expect(...)` archive/fileops tests can coexist with screen-poll reads
+- Stats-panel regression surfaces:
+  - tests/test_stats_panel.py
+    - layout-rigid helpers: _stats_area, _stats_view_value, file-list/tag/footer extraction helpers
+    - slow targeted tests from baseline durations: compact/base-view toggles, repeated numeric reset, tag/untag, pipe prompt, cursor/stats sync, git overlay rows, human-readable size toggle, footer restoration
+    - exact requested validation command: `TERM=xterm pytest -q tests/test_stats_panel.py`
+- Shared helper / parsing seams consumed as source-of-truth:
+  - tests/helpers_stats.py split detection/current-file helpers
+  - tests/helpers_ui.py footer text normalization
+- Docs / instruction surface requested in same commit:
+  - AGENTS.md
+
+Closure reconciliation
+- tests/ytnova_control.py: addressed (dynamic screen-driven PTY helpers added, explicit post-send sleep blocks removed from controller workflows, and pexpect buffer mirroring restored compatibility for archive/fileops tests that still rely on `controller.child.expect(...)` after controller-managed reads).
+- tests/test_stats_panel.py: addressed (slow sleeps replaced with event-driven waits; stats/footer/tag assertions now consume fuzzy token or semantic helpers instead of fixed column 90 slices or rigid line equality).
+- AGENTS.md: addressed (testing guidance now records the no-hard-sleeps and layout-resilient assertion rules requested for this optimization series).
+- patch-2 handoff: addressed (records stacked-branch dependency, baseline timings, and final closure state).
+- Deferred/blocked: none inside Patch 2.
+
+Validation
+- Baseline before Patch 2:
+  - `source .venv/bin/activate && TERM=xterm pytest -q tests/test_stats_panel.py --durations=20`
+  - Result: 33 passed in 168.01s. Slowest calls: 11.44s `test_selecting_base_views_clears_compact_named_state`, 11.43s `test_compact_key_is_ignored_in_dense_file_views`, 10.49s `test_compact_key_is_ignored_in_dense_dir_views`, 8.89s `test_repeated_numeric_view_keys_reset_back_to_name`, 7.03s `test_case_insensitive_tag_untag`.
+- Final exact requested command:
+  - `source .venv/bin/activate && TERM=xterm pytest -q tests/test_stats_panel.py`
+  - Result: 33 passed in 74.60s.
+- Final timing comparison command:
+  - `source .venv/bin/activate && TERM=xterm pytest -q tests/test_stats_panel.py --durations=20`
+  - Result: 33 passed in 75.21s. Slowest calls: 6.22s, 5.45s, 4.96s, 4.03s, 3.56s for the same top five tests.
+- Hygiene:
+  - `git diff --check`
+- Post-rebase CI remediation:
+  - Red reproducer: `source .venv/bin/activate && TERM=xterm pytest -q tests/test_archive_write_parity.py::test_archive_copy_matrix_fs_to_vfs`
+  - Result before fix: failed in 10.25s because `input_text()` consumed prompt output for `controller.child.expect("To Directory")`.
+  - Root cause: `tests/ytnova_control.py` screen-polling reads drained PTY output into pyte without mirroring it back into pexpect's internal `_before` / `_buffer`, so legacy `expect(...)`-based tests lost prompt text.
+  - Green exact gate: `source .venv/bin/activate && make qa-fileops-integrity`
+  - Result after fix: 42 passed in 113.49s.
+  - Green regression confirmation: `source .venv/bin/activate && TERM=xterm pytest -q tests/test_stats_panel.py`
+  - Result after fix: 33 passed in 61.84s.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ Testing quick reference (Codex):
 - Always run pytest with host permissions from the start (no sandbox-first run), because PTY-based tests require unrestricted PTY allocation.
 - Run audit targets (`make qa-all`, `make qa-*`) with host permissions from the start (no sandbox-first run), because toolchain steps can require unrestricted environment access.
 - Pre-merge quality gate is PR full-QA CI (`make qa-all` equivalent). Local `make qa-all` is optional unless maintainer-requested.
+- **Inner-Loop Dev Workflow:** Never run full QA sweeps (`qa-all` or `qa-deep`) for single-file edits. Compile with `make` (utilizing ccache and parallel jobs) and execute exactly one target test file or test case using `pytest -q tests/path/to/file.py::test_name`.
+- **No Hard Sleeps:** Replacing `time.sleep()` blocks with static delays is strictly forbidden. All TUI/PTY wait states must use the event-driven polling methods defined in `tests/tui_harness.py` (e.g., `wait_for_condition` or `wait_for_text`).
+- **Layout-Resilient Assertions:** Assertions must never rely on hard-coded line coordinates, exact screen character grids, or rigid UI alignments. Use fuzzy matching, substring searches, and semantic token checks so that the tests do not break during active UI design iteration.
 
 MCP health check (Codex):
 - Diagnose MCP startup/config drift: `make mcp-doctor`

--- a/tests/test_stats_panel.py
+++ b/tests/test_stats_panel.py
@@ -12,9 +12,13 @@ These tests verify:
 
 import pytest
 import subprocess
-import time
 import re
 import os
+from helpers_stats import (
+    current_file_from_stats as _current_file_from_stats,
+    detect_stats_split_x as _detect_stats_split_x,
+)
+from helpers_ui import footer_text_from_lines as _footer_text_from_lines
 from tui_harness import YtreeNovaTUI
 from ytnova_keys import Keys
 
@@ -33,26 +37,95 @@ def test_dir_with_files(tmp_path):
     return test_root
 
 
+def _screen_lines(screen_or_lines):
+    if isinstance(screen_or_lines, str):
+        return screen_or_lines.split("\n")
+    return list(screen_or_lines)
+
+
+def _screen_text(screen_or_lines):
+    return "\n".join(_screen_lines(screen_or_lines))
+
+
+def _send_and_wait(tui, keys, timeout=1.0):
+    before = tui.get_screen_dump()
+    lines = tui.send_and_wait_for_condition(
+        keys,
+        lambda current_lines: current_lines
+        if current_lines != before
+        else False,
+        timeout=timeout,
+    )
+    return lines or tui.get_screen_dump()
+
+
+def _footer_text(screen_or_lines):
+    return _footer_text_from_lines(_screen_lines(screen_or_lines))
+
+
+def _stats_area(screen_or_lines):
+    lines = _screen_lines(screen_or_lines)
+    split_x = _detect_stats_split_x(lines)
+    if split_x is None:
+        return []
+
+    stats_lines = []
+    for line in lines[:-3]:
+        segment = line[split_x:].strip()
+        if not segment:
+            continue
+        stats_lines.append(segment)
+    return stats_lines
+
+
+def _stats_view_value(screen_or_lines):
+    view_line = _line_with_text(_stats_area(screen_or_lines), "View:")
+    return view_line.split("View:", 1)[1].split("x", 1)[0].strip()
+
+
+def _current_file_name(screen_or_lines):
+    lines = _screen_lines(screen_or_lines)
+    return _current_file_from_stats(lines, _detect_stats_split_x(lines))
+
+
+def _file_lines_with_names(screen_or_lines, *names):
+    return [
+        line
+        for line in _screen_lines(screen_or_lines)
+        if any(name in line for name in names)
+    ]
+
+
+def _tagged_file_count(screen_or_lines, *names):
+    count = 0
+    for line in _file_lines_with_names(screen_or_lines, *names):
+        for name in names:
+            if name in line and "*" in line.split(name, 1)[0]:
+                count += 1
+                break
+    return count
+
+
 def test_stats_show_current_file_on_entry(test_dir_with_files, ytnova_binary):
     """
     BUG: Stats panel shows "CURRENT DIR" instead of "CURRENT FILE" when entering file window.
     EXPECTED: Stats should immediately show "CURRENT FILE" with file metadata.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window (small)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-
-    screen = "\n".join(tui.get_screen_dump())
+    lines = _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    screen = _screen_text(lines)
+    stats_text = "\n".join(_stats_area(lines))
 
     # CRITICAL: Stats panel should show "CURRENT FILE" not "CURRENT DIR"
-    if "CURRENT DIR" in screen:
+    if "CURRENT DIR" in stats_text:
         pytest.fail(f"BUG: Stats show 'CURRENT DIR' instead of 'CURRENT FILE' on file window entry\n{screen}")
 
-    assert "CURRENT FILE" in screen, f"Stats should show 'CURRENT FILE' header\n{screen}"
-    assert "file1.txt" in screen, f"Stats should show selected filename\n{screen}"
+    assert "CURRENT FILE" in stats_text, f"Stats should show 'CURRENT FILE' header\n{screen}"
+    assert _current_file_name(lines) == "file1.txt", (
+        f"Stats should show file1.txt as the selected file.\n{screen}"
+    )
 
     tui.quit()
 
@@ -63,18 +136,16 @@ def test_attributes_section_appears_on_entry(test_dir_with_files, ytnova_binary)
     EXPECTED: Attributes (Size, Perm, Mod time) should appear immediately.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-
-    screen = "\n".join(tui.get_screen_dump())
+    lines = _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    screen = _screen_text(lines)
+    stats_text = "\n".join(_stats_area(lines))
 
     # Check for attributes section keywords
-    has_size = "Size:" in screen or "5" in screen  # 5 bytes for file1.txt
-    has_perm = "Perm:" in screen or "rw" in screen
-    has_mod = "Mod" in screen or "20" in screen  # date pattern
+    has_size = "Size:" in stats_text or "5" in stats_text
+    has_perm = "Perm:" in stats_text or "rw" in stats_text
+    has_mod = "Mod" in stats_text or "20" in stats_text
 
     if not (has_size or has_perm or has_mod):
         pytest.fail(f"BUG: Attributes section missing on file window entry\n{screen}")
@@ -88,45 +159,44 @@ def test_stats_synchronize_with_cursor_movement(test_dir_with_files, ytnova_bina
     EXPECTED: Stats should update to show currently selected file immediately.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window - should select file1.txt
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-
-    screen1 = "\n".join(tui.get_screen_dump())
-    assert "file1.txt" in screen1, "Should start on file1.txt"
+    lines = _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    screen1 = _screen_text(lines)
+    assert _current_file_name(lines) == "file1.txt", "Should start on file1.txt"
 
     # Press DOWN - should move to file2.txt
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.3)
-
-    screen2 = "\n".join(tui.get_screen_dump())
-
-    # CRITICAL: Stats should show file2.txt NOW, not file1.txt
-    if "file1.txt" in screen2 and "CURRENT FILE" in screen2:
-        # Check if file1.txt appears in stats area (not just file list)
-        # Stats panel is on the right side, starting around column 90
-        lines = screen2.split('\n')
-        stats_area = '\n'.join([line[90:] if len(line) > 90 else "" for line in lines[2:25]])
-        if "file1.txt" in stats_area:
-            pytest.fail(f"BUG: Stats still show file1.txt after moving to file2.txt (one behind)\n{screen2}")
-
-    assert "file2.txt" in screen2, f"Stats should update to show file2.txt\n{screen2}"
+    lines = tui.send_and_wait_for_condition(
+        Keys.DOWN,
+        lambda current_lines: current_lines
+        if _current_file_name(current_lines) == "file2.txt"
+        else False,
+        timeout=1.0,
+    )
+    assert lines, "Stats should update to show file2.txt immediately"
+    screen2 = _screen_text(lines)
 
     # Press DOWN again - should move to file3.txt
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.3)
-
-    screen3 = "\n".join(tui.get_screen_dump())
-    assert "file3.txt" in screen3, f"Stats should update to show file3.txt\n{screen3}"
+    lines = tui.send_and_wait_for_condition(
+        Keys.DOWN,
+        lambda current_lines: current_lines
+        if _current_file_name(current_lines) == "file3.txt"
+        else False,
+        timeout=1.0,
+    )
+    assert lines, "Stats should update to show file3.txt immediately"
+    screen3 = _screen_text(lines)
 
     # Press UP - should move back to file2.txt
-    tui.send_keystroke(Keys.UP)
-    time.sleep(0.3)
-
-    screen4 = "\n".join(tui.get_screen_dump())
-    assert "file2.txt" in screen4, f"Stats should update back to file2.txt\n{screen4}"
+    lines = tui.send_and_wait_for_condition(
+        Keys.UP,
+        lambda current_lines: current_lines
+        if _current_file_name(current_lines) == "file2.txt"
+        else False,
+        timeout=1.0,
+    )
+    assert lines, "Stats should update back to file2.txt immediately"
+    screen4 = _screen_text(lines)
 
     tui.quit()
 
@@ -140,19 +210,17 @@ def test_stats_in_big_window_mode(test_dir_with_files, ytnova_binary):
     so we only need one ENTER to get into big window mode.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window (enters big mode by default)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-
-    screen = "\n".join(tui.get_screen_dump())
+    lines = _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    screen = _screen_text(lines)
+    stats_text = "\n".join(_stats_area(lines))
 
     # Should show file stats, not directory stats
-    if "CURRENT DIR" in screen and "FILE" not in screen:
+    if "CURRENT DIR" in stats_text and "FILE" not in stats_text:
         pytest.fail(f"BUG: Stats show 'CURRENT DIR' in file window\n{screen}")
 
-    assert "CURRENT FILE" in screen, f"Stats should show 'CURRENT FILE' in file window\n{screen}"
+    assert "CURRENT FILE" in stats_text, f"Stats should show 'CURRENT FILE' in file window\n{screen}"
 
     tui.quit()
 
@@ -163,19 +231,16 @@ def test_lowercase_l_key_triggers_log(test_dir_with_files, ytnova_binary):
     EXPECTED: Both 'l' and 'L' should trigger Log prompt.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Press lowercase 'l'
-    tui.send_keystroke('l')
-    time.sleep(0.5)
-
-    screen = "\n".join(tui.get_screen_dump())
+    lines = _send_and_wait(tui, 'l', timeout=0.5)
+    screen = _screen_text(lines)
 
     # Should show "Log Path:" prompt
     if "Log" not in screen and "log" not in screen and "Path" not in screen:
         pytest.fail(f"BUG: Lowercase 'l' did not trigger Log prompt\n{screen}")
 
-    tui.send_keystroke(Keys.ESC)
+    _send_and_wait(tui, Keys.ESC, timeout=0.3)
     tui.quit()
 
 
@@ -188,19 +253,16 @@ def test_lowercase_k_key_opens_volume_menu(test_dir_with_files, ytnova_binary):
     default `VI_KEYS=0`, lowercase bindings remain case-insensitive.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Press lowercase 'k' (should work with VI keys disabled)
-    tui.send_keystroke('k')
-    time.sleep(0.5)
-
-    screen = "\n".join(tui.get_screen_dump())
+    lines = _send_and_wait(tui, 'k', timeout=0.5)
+    screen = _screen_text(lines)
 
     # Should show volume menu
     if "Volume" not in screen and "volume" not in screen:
         pytest.fail(f"BUG: Lowercase 'k' did not open volume menu\n{screen}")
 
-    tui.send_keystroke(Keys.ESC)
+    _send_and_wait(tui, Keys.ESC, timeout=0.3)
     tui.quit()
 
 
@@ -214,47 +276,35 @@ def test_case_insensitive_tag_untag(test_dir_with_files, ytnova_binary):
       - Ctrl+U = untag all
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     # Press lowercase 't' to tag single file
-    tui.send_keystroke('t')
-    time.sleep(0.3)
+    _send_and_wait(tui, 't', timeout=0.3)
 
-    screen1 = "\n".join(tui.get_screen_dump())
-    # file1.txt should be tagged (marked with *)
-    assert "*" in screen1 or "1 " in screen1, "file1.txt should be tagged"
+    lines = tui.get_screen_dump()
+    assert _tagged_file_count(lines, "file1.txt") == 1, "file1.txt should be tagged"
 
     # Press DOWN to move to file2.txt
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.3)
+    _send_and_wait(tui, Keys.DOWN, timeout=0.3)
 
     # Press uppercase 'T' to tag file2.txt (should tag SINGLE, not all)
-    tui.send_keystroke('T')
-    time.sleep(0.3)
+    _send_and_wait(tui, 'T', timeout=0.3)
 
-    screen2 = "\n".join(tui.get_screen_dump())
-    # file3.txt should NOT be tagged yet
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.3)
-    screen3 = "\n".join(tui.get_screen_dump())
-
-    # If all files were tagged, it's a bug
-    # Extract only file list area (left side, excluding filter display at top-right)
-    lines = screen3.split('\n')
-    file_list_area = '\n'.join([line[:90] if len(line) > 90 else line for line in lines[20:25]])
-    tag_count = file_list_area.count('*')
+    _send_and_wait(tui, Keys.DOWN, timeout=0.3)
+    screen3 = tui.get_screen_dump()
+    tag_count = _tagged_file_count(screen3, "file1.txt", "file2.txt", "file3.txt")
 
     # Should have exactly 2 tagged files (file1, file2), not 3
     if tag_count >= 3:
-        pytest.fail(f"BUG: Uppercase 'T' tagged all files instead of single file (found {tag_count} tags)\n{screen3}")
+        pytest.fail(
+            "BUG: Uppercase 'T' tagged all files instead of a single file "
+            f"(found {tag_count} tags)\n{_screen_text(screen3)}"
+        )
 
     # Press lowercase 'u' to untag file3 (which should not be tagged)
-    tui.send_keystroke('u')
-    time.sleep(0.3)
+    _send_and_wait(tui, 'u', timeout=0.3)
 
     tui.quit()
 
@@ -264,22 +314,19 @@ def test_ctrl_t_tags_all(test_dir_with_files, ytnova_binary):
     Verify Ctrl+T tags all files (not just uppercase T).
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     # Press Ctrl+T to tag all
-    tui.send_keystroke('\x14')  # Ctrl+T
-    time.sleep(0.5)
-
-    screen = "\n".join(tui.get_screen_dump())
+    screen = _send_and_wait(tui, '\x14', timeout=0.5)
 
     # All three files should be tagged
-    tag_count = screen.count('*')
+    tag_count = _tagged_file_count(screen, "file1.txt", "file2.txt", "file3.txt")
     if tag_count < 3:
-        pytest.fail(f"BUG: Ctrl+T did not tag all files (found {tag_count} tags)\n{screen}")
+        pytest.fail(
+            f"BUG: Ctrl+T did not tag all files (found {tag_count} tags)\n{_screen_text(screen)}"
+        )
 
     tui.quit()
 
@@ -290,32 +337,22 @@ def test_ctrl_u_untags_all(test_dir_with_files, ytnova_binary):
     EXPECTED: Ctrl+U should untag all files.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window and tag all
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-    tui.send_keystroke('\x14')  # Ctrl+T to tag all
-    time.sleep(0.5)
-
-    screen1 = "\n".join(tui.get_screen_dump())
-    assert screen1.count('*') >= 3, "All files should be tagged"
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    screen1 = _send_and_wait(tui, '\x14', timeout=0.5)
+    assert _tagged_file_count(screen1, "file1.txt", "file2.txt", "file3.txt") >= 3, (
+        "All files should be tagged"
+    )
 
     # Press Ctrl+U to untag all
-    tui.send_keystroke('\x15')  # Ctrl+U
-    time.sleep(0.5)
-
-    screen2 = "\n".join(tui.get_screen_dump())
-
-    # Check if files are still tagged (exclude the filter area which also shows *)
-    # Extract only file list lines (typically left side, lines 2-20)
-    lines = screen2.split('\n')
-    file_list_area = '\n'.join([line[:90] if len(line) > 90 else line for line in lines[2:25]])
-
-    # Count asterisks in file list area (excluding filter display)
-    tagged_count = file_list_area.count('*')
-    if tagged_count > 1:  # Allow 1 for potential filter display remnants
-        pytest.fail(f"BUG: Ctrl+U did not untag files (found {tagged_count} asterisks)\n{screen2}")
+    screen2 = _send_and_wait(tui, '\x15', timeout=0.5)
+    tagged_count = _tagged_file_count(screen2, "file1.txt", "file2.txt", "file3.txt")
+    if tagged_count > 0:
+        pytest.fail(
+            f"BUG: Ctrl+U did not untag files (found {tagged_count} tagged rows)\n"
+            f"{_screen_text(screen2)}"
+        )
 
     tui.quit()
 
@@ -326,17 +363,13 @@ def test_footer_shows_fileinfo_band(test_dir_with_files, ytnova_binary):
     EXPECTED: Footer should show "1..0 file view" and should not show Brief/About.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    screen = "\n".join(tui.get_screen_dump())
-    lines = screen.split('\n')
-
-    # Footer is the last 2-3 lines
-    footer = '\n'.join(lines[-3:]).lower()
+    lines = tui.get_screen_dump()
+    screen = _screen_text(lines)
+    footer = _footer_text(lines)
 
     if "1..0 file view" not in footer:
         pytest.fail(f"BUG: Footer missing unified FileInfo band\nFooter:\n{footer}\n\nFull screen:\n{screen}")
@@ -350,11 +383,6 @@ def test_footer_shows_fileinfo_band(test_dir_with_files, ytnova_binary):
     tui.quit()
 
 
-def _stats_area(screen):
-    lines = screen.split('\n')
-    return [line[90:] if len(line) > 90 else "" for line in lines[2:25]]
-
-
 def _line_with_text(lines, needle):
     for line in lines:
         if needle in line:
@@ -362,22 +390,17 @@ def _line_with_text(lines, needle):
     raise AssertionError(f"Missing line containing {needle!r}\n" + "\n".join(lines))
 
 
-def _file_lines_with_names(screen, *names):
-    lines = screen.split('\n')
-    return [
-        line
-        for line in lines
-        if any(name in line for name in names)
-    ]
+def _line_tokens(line):
+    return tuple(re.findall(r"[A-Za-z0-9._:/+-]+", line))
 
 
 def _stats_without_view(lines):
-    return "\n".join(line for line in lines if "View:" not in line)
-
-
-def _stats_view_value(screen):
-    view_line = _line_with_text(_stats_area(screen), "View:")
-    return view_line.split("View:", 1)[1].split("x", 1)[0].strip()
+    return "\n".join(
+        line
+        for line in lines
+        if "View:" not in line
+        and not re.fullmatch(r"\d{2}-\d{2}-\d{4}\s+\d{2}:\d{2}:\d{2}", line.strip())
+    )
 
 
 def test_stats_stay_human_readable_without_wrapping_when_fileinfo_size_toggles(
@@ -391,17 +414,14 @@ def test_stats_stay_human_readable_without_wrapping_when_fileinfo_size_toggles(
     (test_root / "zzz.txt").write_text("tail\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-    tui.send_keystroke("2")
-    time.sleep(0.4)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    _send_and_wait(tui, "2", timeout=0.4)
 
-    screen1 = "\n".join(tui.get_screen_dump())
+    screen1 = tui.get_screen_dump()
     stats_lines1 = _stats_area(screen1)
     stats_text1 = "\n".join(stats_lines1)
     file_row_before = _line_with_text(
-        [line for line in screen1.split('\n') if "000-big.bin -" in line], "000-big.bin"
+        _file_lines_with_names(screen1, "000-big.bin"), "000-big.bin"
     )
 
     assert "11.5G" in stats_text1, f"Stats should stay human-readable.\n{stats_text1}"
@@ -411,21 +431,20 @@ def test_stats_stay_human_readable_without_wrapping_when_fileinfo_size_toggles(
         if line.strip()
     ), f"Stats should not wrap numeric spillover onto a separate line.\n{stats_text1}"
 
-    tui.send_keystroke("6")
-    time.sleep(0.4)
+    _send_and_wait(tui, "6", timeout=0.4)
 
-    screen2 = "\n".join(tui.get_screen_dump())
+    screen2 = tui.get_screen_dump()
     stats_lines2 = _stats_area(screen2)
     stats_text2 = "\n".join(stats_lines2)
     file_row_after = _line_with_text(
-        [line for line in screen2.split('\n') if "000-big.bin -" in line], "000-big.bin"
+        _file_lines_with_names(screen2, "000-big.bin"), "000-big.bin"
     )
 
     assert _stats_without_view(stats_lines2) == _stats_without_view(stats_lines1), (
         "FileInfo size toggle should not change stats rendering.\n"
         f"Before:\n{stats_text1}\n\nAfter:\n{stats_text2}"
     )
-    assert file_row_after != file_row_before, (
+    assert _line_tokens(file_row_after) != _line_tokens(file_row_before), (
         "FileInfo size toggle should still change the file-row projection."
     )
 
@@ -439,14 +458,12 @@ def test_file_window_starts_in_name_only_view_by_default(tmp_path, ytnova_binary
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    screen = "\n".join(tui.get_screen_dump())
-    file_lines = [line for line in screen.split('\n') if "alpha.txt" in line or "beta.txt" in line]
+    screen = tui.get_screen_dump()
+    file_lines = _file_lines_with_names(screen, "alpha.txt", "beta.txt")
 
-    assert file_lines, f"Expected file rows after entering the file window.\n{screen}"
+    assert file_lines, f"Expected file rows after entering the file window.\n{_screen_text(screen)}"
     assert all("-rw" not in line for line in file_lines), (
         "Default file window should start plain with filename.ext only, not long rows.\n"
         + "\n".join(file_lines)
@@ -462,23 +479,20 @@ def test_default_fileinfo_view_is_combined_across_dir_and_file(tmp_path, ytnova_
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke("2")
-    time.sleep(0.4)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, "2", timeout=0.4)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    screen = "\n".join(tui.get_screen_dump())
-    file_lines = [line for line in screen.split("\n") if "alpha.txt" in line or "beta.txt" in line]
+    screen = tui.get_screen_dump()
+    file_lines = _file_lines_with_names(screen, "alpha.txt", "beta.txt")
 
-    assert file_lines, f"Expected file rows after entering the file window.\n{screen}"
+    assert file_lines, f"Expected file rows after entering the file window.\n{_screen_text(screen)}"
     assert any("-rw" in line for line in file_lines), (
         "Default FileInfo behavior should be combined: pressing 2 in the dir view should carry into the file view.\n"
         + "\n".join(file_lines)
     )
     assert _stats_view_value(screen) == "Attributes", (
         "Combined FileInfo behavior should keep the stats label in sync across dir -> file transitions.\n"
-        + screen
+        + _screen_text(screen)
     )
 
     tui.quit()
@@ -495,23 +509,20 @@ def test_separate_dir_file_views_can_be_opted_into(tmp_path, ytnova_binary):
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke("2")
-    time.sleep(0.4)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, "2", timeout=0.4)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    screen = "\n".join(tui.get_screen_dump())
-    file_lines = [line for line in screen.split("\n") if "alpha.txt" in line or "beta.txt" in line]
+    screen = tui.get_screen_dump()
+    file_lines = _file_lines_with_names(screen, "alpha.txt", "beta.txt")
 
-    assert file_lines, f"Expected file rows after entering the file window.\n{screen}"
+    assert file_lines, f"Expected file rows after entering the file window.\n{_screen_text(screen)}"
     assert all("-rw" not in line for line in file_lines), (
         "SEPARATE_DIR_FILE_VIEWS=1 should keep the file window on its own plain startup view.\n"
         + "\n".join(file_lines)
     )
     assert _stats_view_value(screen) == "Name", (
         "With SEPARATE_DIR_FILE_VIEWS=1, the file window should still report View: Name here.\n"
-        + screen
+        + _screen_text(screen)
     )
 
     tui.quit()
@@ -524,29 +535,25 @@ def test_stats_show_named_fileinfo_view_state(tmp_path, ytnova_binary):
     (test_root / "beta_long_name.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     assert _stats_view_value(screen) == "Name", (
-        "Plain startup should say View: Name in the stats panel.\n" + screen
+        "Plain startup should say View: Name in the stats panel.\n" + _screen_text(screen)
     )
 
-    tui.send_keystroke("2")
-    time.sleep(0.4)
-    screen = "\n".join(tui.get_screen_dump())
+    _send_and_wait(tui, "2", timeout=0.4)
+    screen = tui.get_screen_dump()
     assert _stats_view_value(screen) == "Attributes", (
         "Pressing 2 should switch both the rows and the stats label to Attributes.\n"
-        + screen
+        + _screen_text(screen)
     )
 
-    tui.send_keystroke("7")
-    time.sleep(0.4)
-    screen = "\n".join(tui.get_screen_dump())
+    _send_and_wait(tui, "7", timeout=0.4)
+    screen = tui.get_screen_dump()
     assert _stats_view_value(screen) == "Mini preview", (
         "Pressing 7 should expose a named Mini preview FileInfo mode, not a stacked or stale label.\n"
-        + screen
+        + _screen_text(screen)
     )
 
     tui.quit()
@@ -570,33 +577,31 @@ def test_startup_ignores_legacy_filemode_config_and_stays_plain(
         cwd=str(test_root),
         env_extra={"HOME": str(home)},
     )
-    time.sleep(1.0)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     file_lines = _file_lines_with_names(screen, "alpha.txt", "beta.txt")
-    assert file_lines, f"Expected embedded file rows on startup.\n{screen}"
+    assert file_lines, f"Expected embedded file rows on startup.\n{_screen_text(screen)}"
     assert all("-rw" not in line for line in file_lines), (
         "Legacy FILEMODE configs should not override the always-plain startup view.\n"
         + "\n".join(file_lines)
     )
     assert _stats_view_value(screen) == "Name", (
         "Plain startup should keep the stats label at View: Name even when an old FILEMODE=2 config exists.\n"
-        + screen
+        + _screen_text(screen)
     )
 
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     file_lines = _file_lines_with_names(screen, "alpha.txt", "beta.txt")
-    assert file_lines, f"Expected file rows after entering file focus.\n{screen}"
+    assert file_lines, f"Expected file rows after entering file focus.\n{_screen_text(screen)}"
     assert all("-rw" not in line for line in file_lines), (
         "Entering file focus after startup should still stay in the plain Name view.\n"
         + "\n".join(file_lines)
     )
     assert _stats_view_value(screen) == "Name", (
         "File focus should still report View: Name after the always-plain startup.\n"
-        + screen
+        + _screen_text(screen)
     )
 
     tui.quit()
@@ -611,36 +616,33 @@ def test_dir_focus_view_changes_redraw_embedded_file_window_when_shared(
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
 
-    tui.send_keystroke("2")
-    time.sleep(0.4)
+    _send_and_wait(tui, "2", timeout=0.4)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     file_lines = _file_lines_with_names(screen, "alpha.txt", "beta.txt")
-    assert file_lines, f"Expected embedded file rows after pressing 2 in dir focus.\n{screen}"
+    assert file_lines, f"Expected embedded file rows after pressing 2 in dir focus.\n{_screen_text(screen)}"
     assert any("-rw" in line for line in file_lines), (
         "Shared 1..4 views should redraw the embedded file window immediately when dir focus switches to Attributes.\n"
         + "\n".join(file_lines)
     )
     assert _stats_view_value(screen) == "Attributes", (
         "The stats label should stay in sync with the shared Attributes view.\n"
-        + screen
+        + _screen_text(screen)
     )
 
-    tui.send_keystroke("1")
-    time.sleep(0.4)
+    _send_and_wait(tui, "1", timeout=0.4)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     file_lines = _file_lines_with_names(screen, "alpha.txt", "beta.txt")
-    assert file_lines, f"Expected embedded file rows after pressing 1 in dir focus.\n{screen}"
+    assert file_lines, f"Expected embedded file rows after pressing 1 in dir focus.\n{_screen_text(screen)}"
     assert all("-rw" not in line for line in file_lines), (
         "Switching back to Name from dir focus should redraw the embedded file window immediately.\n"
         + "\n".join(file_lines)
     )
     assert _stats_view_value(screen) == "Name", (
         "The stats label should return to View: Name with the shared plain view.\n"
-        + screen
+        + _screen_text(screen)
     )
 
     tui.quit()
@@ -656,47 +658,43 @@ def test_attributes_view_controls_symlink_targets_in_small_file_window(
     (test_root / "alpha-link").symlink_to("alpha.txt")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
 
-    screen = "\n".join(tui.get_screen_dump())
-    symlink_line = _line_with_text(screen.split("\n"), "alpha-link")
+    screen = tui.get_screen_dump()
+    symlink_line = _line_with_text(_screen_lines(screen), "alpha-link")
     assert " -> " not in symlink_line, (
         "Plain startup should keep symlink rows in the simple Name view.\n"
-        f"{symlink_line}\n\nFull screen:\n{screen}"
+        f"{symlink_line}\n\nFull screen:\n{_screen_text(screen)}"
     )
 
-    tui.send_keystroke("6")
-    time.sleep(0.4)
+    _send_and_wait(tui, "6", timeout=0.4)
 
-    screen = "\n".join(tui.get_screen_dump())
-    symlink_line = _line_with_text(screen.split("\n"), "alpha-link")
+    screen = tui.get_screen_dump()
+    symlink_line = _line_with_text(_screen_lines(screen), "alpha-link")
     assert " -> " not in symlink_line, (
         "Key 6 should no longer own symlink rendering once that detail moves into Attributes view.\n"
-        f"{symlink_line}\n\nFull screen:\n{screen}"
+        f"{symlink_line}\n\nFull screen:\n{_screen_text(screen)}"
     )
 
-    tui.send_keystroke("2")
-    time.sleep(0.4)
+    _send_and_wait(tui, "2", timeout=0.4)
 
-    screen = "\n".join(tui.get_screen_dump())
-    symlink_line = _line_with_text(screen.split("\n"), "alpha-link")
+    screen = tui.get_screen_dump()
+    symlink_line = _line_with_text(_screen_lines(screen), "alpha-link")
     assert "alpha-link -> alpha.txt" in symlink_line, (
         "Attributes view should now own symlink target rendering in the embedded small file window.\n"
-        f"{symlink_line}\n\nFull screen:\n{screen}"
+        f"{symlink_line}\n\nFull screen:\n{_screen_text(screen)}"
     )
     assert _stats_view_value(screen) == "Attributes", (
         "The stats label should stay aligned with the Attributes base view.\n"
-        + screen
+        + _screen_text(screen)
     )
 
-    tui.send_keystroke("2")
-    time.sleep(0.4)
+    _send_and_wait(tui, "2", timeout=0.4)
 
-    screen = "\n".join(tui.get_screen_dump())
-    symlink_line = _line_with_text(screen.split("\n"), "alpha-link")
+    screen = tui.get_screen_dump()
+    symlink_line = _line_with_text(_screen_lines(screen), "alpha-link")
     assert " -> " not in symlink_line, (
         "Leaving Attributes view should restore plain symlink labels.\n"
-        f"{symlink_line}\n\nFull screen:\n{screen}"
+        f"{symlink_line}\n\nFull screen:\n{_screen_text(screen)}"
     )
 
     tui.quit()
@@ -745,19 +743,17 @@ def test_tree_focus_git_view_uses_single_column_overlay_rows(
     )
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     assert _file_lines_with_names(screen, *names), (
-        f"Expected embedded file rows on startup.\n{screen}"
+        f"Expected embedded file rows on startup.\n{_screen_text(screen)}"
     )
 
-    tui.send_keystroke("9")
-    time.sleep(0.8)
+    _send_and_wait(tui, "9", timeout=0.8)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     after_lines = _file_lines_with_names(screen, *names)
-    assert after_lines, f"Expected embedded file rows after enabling Git view.\n{screen}"
+    assert after_lines, f"Expected embedded file rows after enabling Git view.\n{_screen_text(screen)}"
     assert all("[clean]" in line for line in after_lines), (
         "Tree-focus Git view should show a Git status on every visible small-window row.\n"
         + "\n".join(after_lines)
@@ -768,26 +764,24 @@ def test_tree_focus_git_view_uses_single_column_overlay_rows(
     )
     assert _stats_view_value(screen) == "Git", (
         "The stats label should switch to View: Git when the embedded Git file projection is active.\n"
-        + screen
+        + _screen_text(screen)
     )
 
-    tui.send_keystroke("5")
-    time.sleep(0.4)
+    _send_and_wait(tui, "5", timeout=0.4)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     assert _stats_view_value(screen) == "Compact", (
         "Compact should become the named active view when 5 is enabled on top of Git.\n"
-        + screen
+        + _screen_text(screen)
     )
 
-    tui.send_keystroke("1")
-    time.sleep(0.4)
+    _send_and_wait(tui, "1", timeout=0.4)
 
-    screen = "\n".join(tui.get_screen_dump())
+    screen = tui.get_screen_dump()
     after_lines = _file_lines_with_names(screen, *names)
     assert _stats_view_value(screen) == "Name", (
         "Pressing 1 should clear extra toggles and return the named view to Name.\n"
-        + screen
+        + _screen_text(screen)
     )
     assert after_lines and all("[clean]" not in line for line in after_lines), (
         "Resetting extras should remove the Git overlay from the small file window.\n"
@@ -834,10 +828,8 @@ def test_git_view_marks_modified_files_inside_repo_subdirectory(
     (subdir / "alpha.txt").write_text("alpha changed\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(subdir))
-    time.sleep(1.0)
 
-    tui.send_keystroke("9")
-    time.sleep(0.8)
+    _send_and_wait(tui, "9", timeout=0.8)
 
     screen = "\n".join(tui.get_screen_dump())
     alpha_line = _line_with_text(screen.split("\n"), "alpha.txt")
@@ -868,9 +860,7 @@ def test_compact_view_adds_columns_in_small_file_window(tmp_path, ytnova_binary)
         )
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     screen = "\n".join(tui.get_screen_dump())
     before_row = _line_with_text(screen.split("\n"), "00_very_long_filename_sample")
@@ -880,8 +870,7 @@ def test_compact_view_adds_columns_in_small_file_window(tmp_path, ytnova_binary)
         + screen
     )
 
-    tui.send_keystroke("5")
-    time.sleep(0.4)
+    _send_and_wait(tui, "5", timeout=0.4)
 
     screen = "\n".join(tui.get_screen_dump())
     after_row = _line_with_text(screen.split("\n"), "00_very_long_filename")
@@ -901,29 +890,24 @@ def test_selecting_base_views_clears_compact_named_state(tmp_path, ytnova_binary
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     for key, expected in (("2", "Attributes"), ("3", "Owner"), ("4", "Times")):
-        tui.send_keystroke("5")
-        time.sleep(0.4)
+        _send_and_wait(tui, "5", timeout=0.4)
         screen = "\n".join(tui.get_screen_dump())
         assert _stats_view_value(screen) == "Compact", (
             "Precondition failed: 5 should first name the active view Compact.\n"
             + screen
         )
 
-        tui.send_keystroke(key)
-        time.sleep(0.4)
+        _send_and_wait(tui, key, timeout=0.4)
         screen = "\n".join(tui.get_screen_dump())
         assert _stats_view_value(screen) == expected, (
             f"Pressing {key} while compact is active should switch the named view to {expected}, not stay stuck on Compact.\n"
             + screen
         )
 
-        tui.send_keystroke("1")
-        time.sleep(0.4)
+        _send_and_wait(tui, "1", timeout=0.4)
 
     tui.quit()
 
@@ -935,13 +919,10 @@ def test_compact_key_is_ignored_in_dense_file_views(tmp_path, ytnova_binary):
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     for key, expected in (("2", "Attributes"), ("3", "Owner"), ("4", "Times")):
-        tui.send_keystroke(key)
-        time.sleep(0.4)
+        _send_and_wait(tui, key, timeout=0.4)
         screen = "\n".join(tui.get_screen_dump())
         before_line = _line_with_text(screen.split("\n"), "alpha.txt")
         assert _stats_view_value(screen) == expected, (
@@ -949,21 +930,19 @@ def test_compact_key_is_ignored_in_dense_file_views(tmp_path, ytnova_binary):
             + screen
         )
 
-        tui.send_keystroke("5")
-        time.sleep(0.4)
+        _send_and_wait(tui, "5", timeout=0.4)
         screen = "\n".join(tui.get_screen_dump())
         after_line = _line_with_text(screen.split("\n"), "alpha.txt")
         assert _stats_view_value(screen) == expected, (
             f"Key 5 should do nothing while {expected} is active in file focus.\n"
             + screen
         )
-        assert after_line == before_line, (
-            f"Key 5 should not change the visible file row while {expected} is active.\n"
+        assert _line_tokens(after_line) == _line_tokens(before_line), (
+            f"Key 5 should not change the visible file-row tokens while {expected} is active.\n"
             f"Before: {before_line}\nAfter:  {after_line}\n\nFull screen:\n{screen}"
         )
 
-        tui.send_keystroke("1")
-        time.sleep(0.4)
+        _send_and_wait(tui, "1", timeout=0.4)
 
     tui.quit()
 
@@ -975,11 +954,9 @@ def test_compact_key_is_ignored_in_dense_dir_views(tmp_path, ytnova_binary):
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
 
     for key, expected in (("2", "Attributes"), ("3", "Owner"), ("4", "Times")):
-        tui.send_keystroke(key)
-        time.sleep(0.4)
+        _send_and_wait(tui, key, timeout=0.4)
         screen = "\n".join(tui.get_screen_dump())
         before_line = _line_with_text(screen.split("\n"), "alpha.txt")
         assert _stats_view_value(screen) == expected, (
@@ -987,21 +964,19 @@ def test_compact_key_is_ignored_in_dense_dir_views(tmp_path, ytnova_binary):
             + screen
         )
 
-        tui.send_keystroke("5")
-        time.sleep(0.4)
+        _send_and_wait(tui, "5", timeout=0.4)
         screen = "\n".join(tui.get_screen_dump())
         after_line = _line_with_text(screen.split("\n"), "alpha.txt")
         assert _stats_view_value(screen) == expected, (
             f"Key 5 should do nothing while {expected} is active in tree focus.\n"
             + screen
         )
-        assert after_line == before_line, (
-            f"Key 5 should not change the small file window while {expected} is active in tree focus.\n"
+        assert _line_tokens(after_line) == _line_tokens(before_line), (
+            f"Key 5 should not change the small-window row tokens while {expected} is active in tree focus.\n"
             f"Before: {before_line}\nAfter:  {after_line}\n\nFull screen:\n{screen}"
         )
 
-        tui.send_keystroke("1")
-        time.sleep(0.4)
+        _send_and_wait(tui, "1", timeout=0.4)
 
     tui.quit()
 
@@ -1014,33 +989,28 @@ def test_zero_is_unused_and_one_resets_back_to_name(tmp_path, ytnova_binary):
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    tui.send_keystroke("5")
-    time.sleep(0.4)
+    _send_and_wait(tui, "5", timeout=0.4)
     screen = "\n".join(tui.get_screen_dump())
     compact_line = _line_with_text(screen.split("\n"), "alpha.bin")
     assert _stats_view_value(screen) == "Compact", (
         "Precondition failed: key 5 should first enable Compact.\n" + screen
     )
 
-    tui.send_keystroke("0")
-    time.sleep(0.4)
+    _send_and_wait(tui, "0", timeout=0.4)
     screen = "\n".join(tui.get_screen_dump())
     unchanged_line = _line_with_text(screen.split("\n"), "alpha.bin")
     assert _stats_view_value(screen) == "Compact", (
         "Key 0 should currently be a silent no-op.\n"
         + screen
     )
-    assert unchanged_line == compact_line, (
-        "Key 0 should not change the visible file row.\n"
+    assert _line_tokens(unchanged_line) == _line_tokens(compact_line), (
+        "Key 0 should not change the visible file-row tokens.\n"
         f"Before: {compact_line}\nAfter:  {unchanged_line}\n\nFull screen:\n{screen}"
     )
 
-    tui.send_keystroke("1")
-    time.sleep(0.4)
+    _send_and_wait(tui, "1", timeout=0.4)
     screen = "\n".join(tui.get_screen_dump())
     reset_line = _line_with_text(screen.split("\n"), "alpha.bin")
     assert _stats_view_value(screen) == "Name", (
@@ -1061,20 +1031,16 @@ def test_repeated_numeric_view_keys_reset_back_to_name(tmp_path, ytnova_binary):
     (test_root / "beta.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     for key, expected in (("2", "Attributes"), ("3", "Owner"), ("4", "Times")):
-        tui.send_keystroke(key)
-        time.sleep(0.4)
+        _send_and_wait(tui, key, timeout=0.4)
         screen = "\n".join(tui.get_screen_dump())
         assert _stats_view_value(screen) == expected, (
             f"Pressing {key} once should select {expected}.\n{screen}"
         )
 
-        tui.send_keystroke(key)
-        time.sleep(0.4)
+        _send_and_wait(tui, key, timeout=0.4)
         screen = "\n".join(tui.get_screen_dump())
         assert _stats_view_value(screen) == "Name", (
             f"Pressing {key} again should reset back to Name.\n{screen}"
@@ -1093,11 +1059,8 @@ def test_rich_fileinfo_overlay_shows_text_snippet(tmp_path, ytnova_binary):
     (test_root / "gamma.txt").write_text("gamma tail\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root))
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-    tui.send_keystroke("7")
-    time.sleep(0.4)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    _send_and_wait(tui, "7", timeout=0.4)
 
     screen = "\n".join(tui.get_screen_dump())
     file_lines = _file_lines_with_names(screen, "alpha.txt", "beta_long_name.txt", "gamma.txt")
@@ -1143,11 +1106,8 @@ def test_summary_fileinfo_overlay_uses_file_command_output(tmp_path, ytnova_bina
 
     env_extra = {"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}"}
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root), env_extra=env_extra)
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-    tui.send_keystroke("8")
-    time.sleep(0.4)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    _send_and_wait(tui, "8", timeout=0.4)
 
     screen = "\n".join(tui.get_screen_dump())
     file_lines = _file_lines_with_names(screen, "alpha.txt", "script.sh")
@@ -1194,12 +1154,9 @@ def test_long_filename_does_not_hide_preview_or_file_overlays(
 
     env_extra = {"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}"}
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root), env_extra=env_extra)
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    tui.send_keystroke("7")
-    time.sleep(0.4)
+    _send_and_wait(tui, "7", timeout=0.4)
     screen = "\n".join(tui.get_screen_dump())
     alpha_line = _line_with_text(screen.split("\n"), "alpha.sh")
     assert "#!/bin/sh echo alpha" in alpha_line, (
@@ -1210,8 +1167,7 @@ def test_long_filename_does_not_hide_preview_or_file_overlays(
         "The stats label should still report View: Mini preview.\n" + screen
     )
 
-    tui.send_keystroke("8")
-    time.sleep(0.4)
+    _send_and_wait(tui, "8", timeout=0.4)
     screen = "\n".join(tui.get_screen_dump())
     alpha_line = _line_with_text(screen.split("\n"), "alpha.sh")
     assert "POSIX shell script, ASCII text executable" in alpha_line, (
@@ -1251,19 +1207,15 @@ def test_compact_view_yields_to_visible_rich_and_summary_overlays(
 
     env_extra = {"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}"}
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_root), env_extra=env_extra)
-    time.sleep(1.0)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
-    tui.send_keystroke("5")
-    time.sleep(0.4)
+    _send_and_wait(tui, "5", timeout=0.4)
     screen = "\n".join(tui.get_screen_dump())
     assert _stats_view_value(screen) == "Compact", (
         "Precondition failed: key 5 should first enable Compact.\n" + screen
     )
 
-    tui.send_keystroke("7")
-    time.sleep(0.4)
+    _send_and_wait(tui, "7", timeout=0.4)
     screen = "\n".join(tui.get_screen_dump())
     alpha_line = _line_with_text(screen.split("\n"), "alpha.txt")
     assert _stats_view_value(screen) == "Mini preview", (
@@ -1275,8 +1227,7 @@ def test_compact_view_yields_to_visible_rich_and_summary_overlays(
         f"{alpha_line}\n\nFull screen:\n{screen}"
     )
 
-    tui.send_keystroke("8")
-    time.sleep(0.4)
+    _send_and_wait(tui, "8", timeout=0.4)
     screen = "\n".join(tui.get_screen_dump())
     alpha_line = _line_with_text(screen.split("\n"), "alpha.txt")
     assert _stats_view_value(screen) == "File", (
@@ -1297,11 +1248,9 @@ def test_footer_after_execute_escape(test_dir_with_files, ytnova_binary):
     EXPECTED: Footer should be fully restored after canceling command.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     # Capture normal footer
     screen1 = "\n".join(tui.get_screen_dump())
@@ -1309,12 +1258,10 @@ def test_footer_after_execute_escape(test_dir_with_files, ytnova_binary):
     footer1 = '\n'.join(lines1[-3:])
 
     # Press 'x' for execute
-    tui.send_keystroke('x')
-    time.sleep(0.5)
+    _send_and_wait(tui, 'x', timeout=0.5)
 
     # Press ESC to cancel
-    tui.send_keystroke(Keys.ESC)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ESC, timeout=0.5)
 
     # Check footer is restored
     screen2 = "\n".join(tui.get_screen_dump())
@@ -1335,23 +1282,19 @@ def test_footer_visible_in_big_window(test_dir_with_files, ytnova_binary):
     EXPECTED: Footer menu should be visible when zoomed.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-    time.sleep(1.0)
 
     # Enter file window and zoom
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     screen = "\n".join(tui.get_screen_dump())
-    lines = screen.split('\n')
-    footer = '\n'.join(lines[-3:])
+    footer = _footer_text(screen)
 
     # Footer should have some command text
     if len(footer.strip()) < 10:
-        assert len(footer_text) > 10, f"Footer blank in big window mode:\n{footer}"
+        pytest.fail(f"Footer blank in big window mode:\n{footer}\n\n{screen}")
 
-        tui.quit()
+    tui.quit()
 
 def test_pipe_command_in_big_file_window(test_dir_with_files, ytnova_binary):
     """
@@ -1366,21 +1309,16 @@ def test_pipe_command_in_big_file_window(test_dir_with_files, ytnova_binary):
         executable=ytnova_binary,
         cwd=str(test_dir_with_files.parent)
     )
-    time.sleep(1.0)
     # Move down to highlight test_dir_with_files
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.DOWN, timeout=0.5)
 
     # Enter small file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
     # Enter big file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    _send_and_wait(tui, Keys.ENTER, timeout=0.5)
 
     # Press 'p' for Pipe
-    tui.send_keystroke('p')
-    time.sleep(0.5)
+    _send_and_wait(tui, 'p', timeout=0.5)
 
     screen = "\n".join(tui.get_screen_dump()).lower()
 

--- a/tests/ytnova_control.py
+++ b/tests/ytnova_control.py
@@ -1,5 +1,5 @@
 import pexpect
-import sys
+import pyte
 import time
 import os
 import signal
@@ -8,6 +8,7 @@ from ytnova_keys import Keys
 
 class YtreeNovaController:
     def __init__(self, binary_path, cwd):
+        self.time_scale = self._read_time_scale()
         log_target = os.environ.get("YTNOVA_TUI_DEBUG_LOG")
         if log_target:
             if log_target.lower() in {"1", "true", "yes"}:
@@ -21,21 +22,101 @@ class YtreeNovaController:
             dimensions=(24, 160),
             encoding='utf-8',
             env={'TERM': 'xterm', 'LC_ALL': 'C.UTF-8', 'HOME': cwd},
-            timeout=5
+            timeout=max(5.0 * self.time_scale, 5.0),
         )
         self.child.logfile = self.log_file
+        self.screen = pyte.Screen(160, 24)
+        self.stream = pyte.Stream(self.screen)
 
     def __del__(self):
         if hasattr(self, 'log_file'):
             self.log_file.close()
 
+    @staticmethod
+    def _read_time_scale():
+        raw = os.getenv("YTNOVA_TUI_TIME_SCALE", "1.0")
+        try:
+            scale = float(raw)
+        except (TypeError, ValueError):
+            return 1.0
+        return max(1.0, scale)
+
+    def _scaled(self, seconds):
+        return seconds * self.time_scale
+
+    def _mirror_child_buffers(self, data):
+        # Keep pexpect's expect() buffer in sync with screen-poll reads so
+        # legacy controller helpers can mix both synchronization styles.
+        self.child._before.write(data)
+        self.child._buffer.write(data)
+
+    def _read_output(self, timeout=0.1):
+        try:
+            time.sleep(self._scaled(timeout))
+            while True:
+                data = self.child.read_nonblocking(size=4096, timeout=self._scaled(0.1))
+                self.stream.feed(data)
+                self._mirror_child_buffers(data)
+        except (pexpect.TIMEOUT, pexpect.EOF):
+            pass
+
+    def peek_screen_dump(self):
+        return [str(line) for line in self.screen.display]
+
+    def get_screen_dump(self):
+        self._read_output(timeout=0.05)
+        return self.peek_screen_dump()
+
+    def wait_for_condition(self, predicate, timeout=5.0, poll_interval=0.02):
+        deadline = time.monotonic() + self._scaled(timeout)
+
+        while True:
+            self._read_output(timeout=0.0)
+            lines = self.peek_screen_dump()
+            result = predicate(lines)
+            if result:
+                return result
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(self._scaled(poll_interval))
+
+    def wait_for_text(self, target, timeout=5.0, poll_interval=0.02):
+        return self.wait_for_condition(
+            lambda lines: lines
+            if any(target in line for line in lines)
+            else False,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+
+    def send_and_wait_for_condition(
+        self, keys, predicate, timeout=5.0, poll_interval=0.02
+    ):
+        self.child.send(keys)
+        return self.wait_for_condition(
+            predicate, timeout=timeout, poll_interval=poll_interval
+        )
+
+    def send_and_wait_for_screen_change(
+        self, keys, timeout=5.0, poll_interval=0.02
+    ):
+        before = self.get_screen_dump()
+        return self.send_and_wait_for_condition(
+            keys,
+            lambda lines: lines if lines != before else False,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+
     def wait_for_startup(self):
         # Wait for first UI paint; do not couple startup sync to clock text.
-        idx = self.child.expect(
-            [r"Path:", r"COMMANDS", r"\x1b\[[0-9;?]*[A-Za-z]", pexpect.TIMEOUT],
-            timeout=8,
+        lines = self.wait_for_condition(
+            lambda screen: screen
+            if any("Path:" in line or "COMMANDS" in line for line in screen)
+            else False,
+            timeout=8.0,
         )
-        if idx == 3:
+        if not lines:
             raise pexpect.TIMEOUT("Startup sync failed: no UI activity detected")
 
     def select_file(self, filename):
@@ -43,43 +124,46 @@ class YtreeNovaController:
         Selects a file using Show All + Filter.
         Remains in the Show All window so file commands work immediately.
         """
-        # 0. Expand tree to ensure deep files are visible
-        # Note: If tree is already expanded, this might toggle it, but for fresh start it's safe.
-        # Ideally, we should check state, but unconditional expand (*) works for 'init' state usually.
-        time.sleep(0.5)
-        self.child.send(Keys.EXPAND_ALL)
-        self.wait_for_refresh()
+        # 0. Expand tree to ensure deep files are visible.
+        self.send_and_wait_for_screen_change(Keys.EXPAND_ALL, timeout=1.0)
 
         # 1. Flatten tree to find nested files
-        time.sleep(0.5)
-        self.child.send(Keys.SHOWALL)
-        self.wait_for_refresh()
+        self.send_and_wait_for_screen_change(Keys.SHOWALL, timeout=1.0)
 
         # 2. Filter for the specific file
-        time.sleep(0.5)
-        self.child.send(Keys.FILTER)
-        self.child.expect(r"FILTER")
+        lines = self.send_and_wait_for_condition(
+            Keys.FILTER,
+            lambda screen: screen
+            if any("FILTER" in line for line in screen)
+            else False,
+            timeout=1.0,
+        )
+        if not lines:
+            raise pexpect.TIMEOUT("Filter prompt did not appear")
         self.input_text(filename)
-        self.wait_for_refresh()
 
         # 3. Verify file is visible (do NOT press Enter)
-        self.child.expect(filename)
+        if not self.wait_for_text(filename, timeout=2.0):
+            raise pexpect.TIMEOUT(f"Filtered file {filename!r} did not appear")
 
     def input_text(self, text):
         """Clears line with Ctrl-U and types text."""
         # Use Ctrl-U (\x15) instead of Ctrl-K (\x0b) because UI_ReadString
         # starts with the cursor at the end of the line.
         self.child.send("\x15")
-        time.sleep(0.1)
-        self.child.send(text + Keys.ENTER)
-        time.sleep(0.2)
+        self._read_output(timeout=0.0)
+        self.send_and_wait_for_screen_change(text + Keys.ENTER, timeout=1.5)
 
     def wait_for_refresh(self):
         """Waits for a screen update without depending on clock redraw text."""
-        self.child.expect(
-            [r"Path:", r"COMMANDS", r"\x1b\[[0-9;?]*[A-Za-z]", pexpect.TIMEOUT],
+        before = self.get_screen_dump()
+        lines = self.wait_for_condition(
+            lambda screen: screen if screen != before else False,
             timeout=2.0,
         )
+        if not lines:
+            raise pexpect.TIMEOUT("Refresh sync failed: no UI repaint detected")
+        return lines
 
     def quit(self):
         """Aggressive quit."""
@@ -88,13 +172,19 @@ class YtreeNovaController:
                 return
 
             self.child.send(Keys.QUIT)
-            time.sleep(0.5)
+            try:
+                self.child.expect(pexpect.EOF, timeout=0.5)
+            except pexpect.TIMEOUT:
+                pass
 
             if not self.child.isalive():
                 return
 
             self.child.send(Keys.CONFIRM_YES)
-            time.sleep(0.5)
+            try:
+                self.child.expect(pexpect.EOF, timeout=0.5)
+            except pexpect.TIMEOUT:
+                pass
 
             if self.child.isalive():
                 try:


### PR DESCRIPTION
## Summary
- port the dynamic PTY wait helpers into `tests/ytnova_control.py` and remove the controller's fixed post-send sleeps
- refactor `tests/test_stats_panel.py` to use event-driven waits and layout-resilient stats/footer/tag assertions instead of fixed sleeps and rigid screen coordinates
- document the no-hard-sleeps and layout-resilient test rules in `AGENTS.md` for future PTY/TUI test work

## Validation
- Red: `source .venv/bin/activate && TERM=xterm pytest -q tests/test_stats_panel.py --durations=20` (baseline: 33 passed in 168.01s; slowest calls 11.44s, 11.43s, 10.49s, 8.89s, 7.03s)
- Green: `source .venv/bin/activate && TERM=xterm pytest -q tests/test_stats_panel.py`
- Green: `source .venv/bin/activate && TERM=xterm pytest -q tests/test_stats_panel.py --durations=20` (33 passed in 75.21s; slowest calls 6.22s, 5.45s, 4.96s, 4.03s, 3.56s)
