### PR TITLE
ci(workflows): run full pull request validation automatically

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -39,7 +39,7 @@ These instructions apply to all AI agents used in this repository.
 
 - When finishing a long-running mission or when explicitly requesting user review via `notify_user`, you SHOULD trigger a desktop notification on the Windows host.
 - Execute: `/home/rob/ytreenova/scripts/wsl-notify.sh "ytnova" "<Context-specific milestone>"`
-- Use a concrete milestone string, not a placeholder. Examples: `Draft PR created.` or `Implementation complete, ready for review.`
+- Use a concrete milestone string, not a placeholder. Examples: `PR created.` or `Implementation complete, ready to merge.`
 
 ## Persona Skill Auto-Load
 
@@ -108,17 +108,17 @@ These instructions apply to all AI agents used in this repository.
 21. GitHub branch protection workflow is mandatory: for any change intended for GitHub, create/use a non-`main` branch, push that branch, and open/update a PR. Do not push directly to `main`. If work was committed locally on `main`, branch from current HEAD before the first push and continue via PR.
 22. Hybrid PR quality workflow is mandatory:
     - Before first push, run a quick local gate (build plus targeted smoke/tests).
-    - Open a draft PR early; red is allowed while iterating.
+    - Open a regular PR early; red is allowed while iterating.
     - For an active PR, proactively poll the live required-check state every 5 minutes and remediate clearly repo-side CI failures until the required set is green, unless the failure is external, inconclusive, or the maintainer explicitly tells you to stop.
     - Keep a durable PR title even while checks are red; do not use temporary `WIP:` title prefixes.
     - PR title, summary, and validation text must describe the durable behavior or architecture aim of the atomic unit, not volatile tracker numbers or broader-roadmap labels.
     - PR validation text must be concise local evidence only; do not duplicate self-evident CI/check output or paste full check transcripts into PR bodies or comments.
-    - While PR is red, keep the PR in draft and do not request reviewers.
+    - While PR is red, do not request reviewers unless the maintainer explicitly asks.
     - Before merge to `main`, require green PR full-QA CI gate (`make qa-all` equivalent) and required audit-loop evidence; local `make qa-all` is optional unless the maintainer explicitly requests it.
-    - Convert draft PR to ready only after green PR evidence is available and maintainer direction allows it; do not trigger another long ready-conversion gate without explicit instruction.
+    - Once the required checks are green on the current head SHA, avoid non-essential PR mutations before merge (for example PR-body edits, base syncs, or other metadata changes) because they may restart CI or invalidate freshness.
     - Before merge, require green PR checks and reviewer signoff.
-    - Actual merge-safety gate is mandatory: immediately before ready conversion and again immediately before merge, re-query the live PR state/checks against the current head SHA. Treat required checks as not green if any required check is red, pending, cancelled, missing, or rerunning, or if the branch is not up to date with the base branch at that moment.
-    - If any PR mutation (push, ready conversion, base update, branch sync, or other GitHub-triggered rerun) restarts required checks, restart the wait cycle from the beginning and do not merge until the rerun set is green on the current head SHA.
+    - Actual merge-safety gate is mandatory: immediately before merge, re-query the live PR state/checks against the current head SHA. Treat required checks as not green if any required check is red, pending, cancelled, missing, or rerunning, or if the branch is not up to date with the base branch at that moment.
+    - If any PR mutation (push, PR metadata edits, base update, branch sync, or other GitHub-triggered rerun) restarts required checks, restart the wait cycle from the beginning and do not merge until the rerun set is green on the current head SHA.
 23. Boundary-family batching gate is mandatory: for roadmap, migration, registry, guard, or contract-enforcement work, you MUST default to the largest coherent adjacent boundary-family batch that shares the same owner boundary, generation domain, risk class, and focused validation path. You MUST NOT slice one boundary family into helper-by-helper or guard-by-guard micro-PRs unless the remaining adjacent work is blocked, requires a materially different validation path, or would materially increase review/regression risk.
 24. Coverage-inventory gate is mandatory: for any non-trivial roadmap item, migration, bugfix, or multi-surface task, you MUST build an explicit in-scope inventory before editing. The inventory must name the relevant code surfaces, tests, docs/trackers, and call paths or compatibility seams that could make the work falsely appear complete. For bugfixes, the inventory MUST include the reproducer path plus adjacent failure surfaces that share the same root cause. Record the inventory in the applicable plan, handoff, or tracked checkpoint before or alongside implementation; do not start coding until scope is explicit enough to prove what is in and out.
 25. Closure-reconciliation gate is mandatory: before opening a PR or declaring a work item complete, you MUST reconcile the inventory item by item. Each inventoried item must be marked as addressed, intentionally unchanged with reason, or deferred/blocked with a concrete reason. Silent omission is forbidden. If an item is deferred, the reason must be explicit (for example blocked dependency, materially different validation path, materially different risk class, or different owner boundary) rather than a vague "later" note.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       qa_relevant: ${{ steps.force.outputs.qa_relevant || steps.filter.outputs.qa_relevant }}
       split_panel_relevant: ${{ steps.force.outputs.split_panel_relevant || steps.filter.outputs.split_panel_relevant }}
+      docs_relevant: ${{ steps.force.outputs.docs_relevant || steps.filter.outputs.docs_relevant }}
     steps:
     - name: Force QA on main pushes
       id: force
@@ -30,6 +31,7 @@ jobs:
       run: |
         echo "qa_relevant=true" >> "$GITHUB_OUTPUT"
         echo "split_panel_relevant=true" >> "$GITHUB_OUTPUT"
+        echo "docs_relevant=true" >> "$GITHUB_OUTPUT"
 
     - name: Detect PR file changes
       id: filter
@@ -60,6 +62,52 @@ jobs:
             - 'tests/test_panel_isolation.py'
             - 'tests/test_file_window_dispatch_regressions.py'
             - 'tests/test_dir_window_dispatch_regressions.py'
+          docs_relevant:
+            - 'docs/**'
+            - 'etc/ytnova.1.md'
+            - 'README.md'
+
+  docs-gate:
+    name: Docs gate
+    runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.docs_relevant == 'true'
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install System Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmark libncurses-dev libtinfo-dev libreadline-dev libarchive-dev libarchive-tools
+
+    - name: Set up Python 3
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: scripts/requirements.txt
+
+    - name: Install Python Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r scripts/requirements.txt
+
+    - name: Verify generated usage doc is in sync
+      run: |
+        make docs
+        git diff --exit-code -- docs/USAGE.md
+
+    - name: Run docs contract tests
+      run: |
+        pytest -q \
+          tests/test_color_config.py::test_spec_documents_user_visible_theme_contract \
+          tests/test_color_config.py::test_manpage_documents_user_visible_theme_contract \
+          tests/test_color_config.py::test_architecture_documents_theme_boundaries \
+          tests/test_theme_ui_contract.py::test_incremental_jump_uses_slash_without_f12_alias \
+          tests/test_theme_ui_contract.py::test_disabled_role_is_not_advertised_in_starter_theme_contract \
+          tests/test_theme_ui_contract.py::test_theme_docs_capture_role_routing_invariants \
+          tests/test_appstate_contract_guard.py::test_appstate_contract_docs_share_active_registry_reference
 
   guard-fuzz-sync:
     name: Guard fuzz harness sync

--- a/.github/workflows/full-qa.yml
+++ b/.github/workflows/full-qa.yml
@@ -3,7 +3,7 @@ name: C/C++ Full QA
 on:
   pull_request:
     branches: [ "main" ]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -244,10 +244,10 @@ jobs:
       run: ccache --show-stats
 
   qa-pytest:
-    name: Full pytest gate (manual only)
+    name: Full pytest gate
     runs-on: ubuntu-latest
     needs: changes
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.qa_relevant == 'true'
     timeout-minutes: 90
     env:
       CC: ccache cc
@@ -308,16 +308,10 @@ jobs:
       run: ccache --show-stats
 
   qa-sanitize:
-    name: Sanitizer gate (qa-sanitize, labeled/manual)
+    name: Sanitizer gate
     runs-on: ubuntu-latest
     needs: changes
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request' &&
-        needs.changes.outputs.qa_relevant == 'true' &&
-        contains(github.event.pull_request.labels.*.name, 'qa-sanitize')
-      )
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.qa_relevant == 'true'
     timeout-minutes: 120
     env:
       CC: ccache cc

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -56,8 +56,8 @@ Scope is strict: QA/check/test organization and efficiency only. Non-QA workflow
 ### Hybrid PR Cadence (Mandatory)
 
 - Before first push, run a quick local gate (`make`, plus targeted smoke/tests for touched scope).
-- Open a draft PR early; draft PR checks may be red while iterating.
-- Do not request review while draft checks are red.
+- Open a regular PR early; PR checks may be red while iterating.
+- Do not request review while checks are red unless the maintainer explicitly asks.
 - Before merge to `main`, require green PR full-QA CI (`make qa-all` equivalent) plus required loop evidence from this document; local full audit reruns are optional unless the maintainer explicitly requests them.
 - Before merge, require green PR checks and reviewer signoff.
 
@@ -66,14 +66,13 @@ Scope is strict: QA/check/test organization and efficiency only. Non-QA workflow
 | Tier | Owner | Trigger | Required checks | Non-overlap default intent |
 |---|---|---|---|---|
 | Tier A (local fast iteration) | Developer | During implementation before first push and between risky edits | `make`; targeted pytest for touched scope; targeted guards (`qa-unsafe-apis`, `qa-fileops-integrity`) when relevant | Keep iteration fast; avoid full-suite duplication unless local risk demands it |
-| Tier B (draft PR baseline CI) | CI + PR author | Every push while PR is draft | `ci-baseline` (`qa-code-quality` + `qa-fileops-integrity` + `qa-pytest-coverage` + `qa-fuzz`) plus path-filtered `qa-split-panel-gates` on split-touching PRs | Provide baseline branch-protection signal (includes coverage by design); do not duplicate Tier C full local gate content |
+| Tier B (PR baseline CI) | CI + PR author | Every push while the PR is active | `ci-baseline` (`qa-code-quality` + `qa-fileops-integrity` + `qa-pytest-coverage` + `qa-fuzz`) plus path-filtered `qa-split-panel-gates` on split-touching PRs | Provide baseline branch-protection signal (includes coverage by design); do not duplicate Tier C full local gate content |
 | Tier C (pre-merge full gate) | CI + PR author | Before merge to `main` (or earlier only when explicitly requested) | Green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent); optional local `make qa-all-log` evidence when maintainer-requested; plus explicit `qa-fileops-integrity` evidence when mutation workflows changed | Use CI as canonical full-gate signal; avoid duplicate local full-gate reruns during routine iteration |
 | Tier D (merge/release gate) | Maintainer + reviewer | Before merge and before release/tag cut | Branch-protection checks green; reviewer signoff; `qa-sanitize`; `qa-valgrind-full` for release-risk changes; `qa-valgrind-interactive` after major feature flows | Reserve deepest runtime checks for merge/release assurance to avoid slowing every draft iteration |
 
 ### branch-protection and PR State Criteria (Mandatory)
 
-- **Draft PR:** Branch exists and PR stays draft. Red checks are acceptable while iterating. No review requests.
-- **Ready for review:** Tier B branch-protection checks are green and no unresolved blocker findings remain. Tier C may be deferred to pre-merge unless explicitly requested earlier.
+- **Open PR:** Branch exists and the PR is open. Red checks are acceptable while iterating. No review requests while checks are red unless the maintainer explicitly asks.
 - **Merge:** All required branch-protection checks are green, reviewer signoff is present, and Tier D evidence is attached for the current diff/risk.
 - Required branch-protection checks (sync with current workflows):
   - `.github/workflows/ci.yml`: `Guard fuzz harness sync`
@@ -107,8 +106,8 @@ Within a gate, prefer this order:
 
 Track these metrics per PR and as rolling team trends:
 
-- **median draft feedback time:** median elapsed time from draft-PR push to first CI result.
-- **time-to-green:** elapsed time from first draft push to all required branch-protection checks passing.
+- **median PR feedback time:** median elapsed time from PR push to first CI result.
+- **time-to-green:** elapsed time from first PR push to all required branch-protection checks passing.
 - **full-gate runtime:** runtime for full local/CI gates (`make qa-all-log`, plus sanitizer/deep gates when invoked).
 - **flake rate:** reruns caused by non-deterministic failures ÷ total gate runs.
 
@@ -116,10 +115,10 @@ Report metrics in PR notes or release prep notes with before/after deltas when g
 
 Provisional targets (make completion auditable; tighten over time as data improves):
 
-- **Tier B p50 runtime target:** <= 30 minutes per draft-PR push.
+- **Tier B p50 runtime target:** <= 30 minutes per PR push.
 - **Full-gate p50 runtime target:** <= 60 minutes for `make qa-all-log` evidence runs.
 - **Max acceptable flake rate:** <= 5% of gate runs requiring rerun due to non-determinism.
-- **Target time-to-green:** <= 120 minutes from first draft push to required checks all green.
+- **Target time-to-green:** <= 120 minutes from first PR push to required checks all green.
 
 ### Rollout, Rollback, and Risk Register (Mandatory)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -267,7 +267,7 @@ Ordering policy (for all editors, including AI editors):
 *   Legacy sections in `ytnova.conf` still load during the compatibility phase, but `commands.conf` overrides them deterministically.
 *   Reload fails closed if any one of config/theme/commands is malformed or invalid, and the previous working state remains active.
 *   `docs/SPECIFICATION.md`, manpage/USAGE docs, and contributor guidance describe commands as structured overrides rather than rendered-line text replacement.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Completed.
 
 #### **Task 11.3: Config/History Robustness Gate (Strict Parse, Validation, Atomic Persistence)**
 *   **Goal:** Harden config/history reliability and corruption resistance without changing user-facing feature semantics.

--- a/docs/ai/TASK_PROMPT_TEMPLATE.md
+++ b/docs/ai/TASK_PROMPT_TEMPLATE.md
@@ -150,9 +150,9 @@ CI wait rule:
 - Fetch detailed check or log output only if a check is red.
 - Keep maintainer-facing updates to one short line.
 - If a pushed fix changes the PR, restart the wait cycle from the beginning.
-- If ready conversion, branch sync, base update, or any other PR mutation restarts required checks, restart the wait cycle from the beginning.
+- If PR metadata edits, branch sync, base update, or any other PR mutation restarts required checks, restart the wait cycle from the beginning.
 - A PR is mergeable only when required checks are actually green at the moment you act. If an allegedly green PR is red or pending when rechecked, treat it as not ready and continue remediation/waiting.
-- Recheck the live PR state against the current head SHA immediately before ready conversion and again immediately before merge. Treat the PR as not ready if any required check is red, pending, cancelled, missing, rerunning, or if freshness/up-to-date is no longer green.
+- Recheck the live PR state against the current head SHA immediately before merge. Treat the PR as not ready if any required check is red, pending, cancelled, missing, rerunning, or if freshness/up-to-date is no longer green.
 
 Continuation and stop rules:
 - After every merge, resume the next largest coherent remaining work family without waiting for my go-ahead, unless I later tell you to pause or stop.
@@ -169,7 +169,8 @@ What to do now:
 1. Inspect current git/GitHub state.
 2. If there is an active PR:
    - Follow the CI wait rule.
-   - If checks are green when rechecked live, mark ready if needed, merge when allowed, clean up stale remote/local branch state, delete or refresh any consumed relay files as required by the outcome, then continue according to the continuation rule unless a superseding stop condition applies.
+   - Once required checks are green on the current head SHA, do not edit the PR body, push new commits, update the branch, sync with base, or perform any other PR mutation before merging unless a real fix is required, because those actions may restart CI.
+   - If checks are green when rechecked live, merge when allowed, clean up stale remote/local branch state, delete or refresh any consumed relay files as required by the outcome, then continue according to the continuation rule unless a superseding stop condition applies.
    - If checks failed, inspect only the failure-relevant summary or log tail. Fix only clearly repo-side, in-scope failures.
    - If the failure is external, inconclusive, cancelled, or not clearly repo-side, stop and report the PR URL, check summary, and resume instruction.
 3. If there is no active PR:
@@ -180,10 +181,10 @@ What to do now:
    - Implement the full coherent batch through the repo's developer/auditor/PR workflow.
    - Run focused local validation only.
    - Reconcile the inventory before opening the PR.
-   - Push a draft PR.
+   - Push a regular PR.
    - Update any active relay file needed for recovery, including the inventory and closure status.
    - Follow the CI wait rule.
-   - When CI is green when rechecked live, mark ready if needed, merge when allowed, clean up stale remote/local branch state, delete or refresh relay files so `.agent/handoffs/` does not retain stale work-item residue, then continue with the next largest coherent work family unless a superseding stop condition applies.
+   - When CI is green when rechecked live, merge when allowed, clean up stale remote/local branch state, delete or refresh relay files so `.agent/handoffs/` does not retain stale work-item residue, then continue with the next largest coherent work family unless a superseding stop condition applies.
 
 Reporting discipline:
 - Do not provide broad recaps unless asked.

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -309,7 +309,7 @@ make qa-fuzz
     *   Maintainer-facing status wording should be constrained to `active`, `completed`, or `blocked`; avoid ambiguous runtime labels (for example `awaiting instruction`) in relay updates.
 5.  Before merge to `main`, architect MUST ensure green PR full-QA CI evidence (`make qa-all` equivalent) for accepted branch state.
 6.  Actual merge-safety gate is mandatory:
-    *   immediately before ready conversion and immediately before merge, re-query the live PR state/checks for the current head SHA,
+    *   immediately before merge, re-query the live PR state/checks for the current head SHA,
     *   treat required checks as not green if any required check is red, pending, cancelled, missing, or rerunning,
     *   require the branch freshness/up-to-date gate to be green at that moment when such a gate exists,
     *   if the head SHA or required-check set changes after the last green observation, restart the wait cycle and do not merge yet.
@@ -328,7 +328,7 @@ make qa-fuzz
 #### 3.1.7 Completion Gate, Merge, and Manual Fallback
 
 1.  When preparing merge to `main`, require green PR full-QA CI gate (`make qa-all` equivalent).
-2.  Immediately before ready conversion and again immediately before merge, recheck live PR status on the current head SHA; if any required check is red, pending, cancelled, missing, rerunning, or freshness is no longer green, do not merge and restart the wait/remediation loop.
+2.  Immediately before merge, recheck live PR status on the current head SHA; if any required check is red, pending, cancelled, missing, rerunning, or freshness is no longer green, do not merge and restart the wait/remediation loop.
 3.  Integrate branch to `main` using fast-forward only.
 4.  For any bug or task, mark final status (Fixed/Completed) in the commit that is fast-forwarded to main; before that, status must stay non-final (Confirmed/In Progress).
 5.  Delete temporary feature branch locally and on remote after merge.
@@ -349,14 +349,15 @@ Use this when wrapping up a PROMPT_TEMPLATE-driven mission and returning the rep
 4.  **Architect/AI:** Run quick local checks only (build + targeted smoke/tests for touched scope).
 5.  **Architect/AI:** Stage intended changes only (exclude unrelated local edits and workflow artifacts).
 6.  **Architect/AI:** Choose a Conventional Commit subject autonomously unless current repo policy or the maintainer explicitly requires approval.
-7.  **Architect/AI:** Commit, push branch, and open/update a draft PR.
+7.  **Architect/AI:** Commit, push branch, and open/update a regular PR.
     *   PR title must use Conventional Commit format and describe the current atomic unit's durable aim, not a volatile task/bug number or the whole roadmap initiative.
     *   PR body should be concise: summary, scope, and local validation evidence. Do not duplicate obvious CI output or paste check transcripts into the body/comments.
-8.  **Maintainer (GitHub):** Review draft PR scope and evidence.
+8.  **Maintainer (GitHub):** Review PR scope and evidence.
 9.  **Architect/AI + Maintainer (GitHub):** Monitor PR CI full gate proactively (for example `gh pr checks <pr-number> --watch`). Do not wait passively for a separate reminder when checks change state.
 10. **Architect/AI:** If any checks are red, triage failing jobs immediately, fix CI failures root-cause-first, push updates, and repeat until required PR full-QA CI (`make qa-all` equivalent) is green.
-    *   Do not convert a draft PR to ready, request reviewers, or otherwise trigger another long PR gate unless the maintainer explicitly instructs it.
-11. **Architect/AI + Maintainer (GitHub):** If ready conversion, branch sync, or any other PR mutation restarts required checks, restart the wait loop and do not merge against stale earlier green results.
+    *   Do not request reviewers while checks are red unless the maintainer explicitly instructs it.
+    *   Once checks are green on the current head SHA, avoid non-essential PR mutations before merge (for example PR-body edits or base-sync actions) because they may restart CI or invalidate freshness.
+11. **Architect/AI + Maintainer (GitHub):** If PR metadata edits, branch sync, or any other PR mutation restarts required checks, restart the wait loop and do not merge against stale earlier green results.
 12. **Maintainer (GitHub):** Merge PR to `main` only after checks are rechecked live as green on the current head SHA and review is satisfied. Never merge or close a PR while required checks are red, pending, cancelled, missing, rerunning, or freshness is stale.
 13. **Maintainer (GitHub):** Delete remote branch:
     *   `git push origin --delete <branch>`


### PR DESCRIPTION
## Summary
- add an automatic `Docs gate` in baseline CI so docs and manpage-source PRs must keep `docs/USAGE.md` synchronized and satisfy the existing documentation contract tests
- run the full pytest and sanitizer lanes automatically for QA-relevant pull requests, and remove the label-only/manual-only trigger path from those gates
- align the audit and AI workflow docs with the regular-PR flow and record the roadmap item as completed

## Validation
- `ruby -e 'require "yaml"; [".github/workflows/ci.yml", ".github/workflows/full-qa.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- `git diff --check -- .github/workflows/ci.yml .github/workflows/full-qa.yml`
- `make docs`
- `git diff --exit-code -- docs/USAGE.md`
- `source .venv/bin/activate && pytest -q tests/test_color_config.py::test_spec_documents_user_visible_theme_contract tests/test_color_config.py::test_manpage_documents_user_visible_theme_contract tests/test_color_config.py::test_architecture_documents_theme_boundaries tests/test_theme_ui_contract.py::test_incremental_jump_uses_slash_without_f12_alias tests/test_theme_ui_contract.py::test_disabled_role_is_not_advertised_in_starter_theme_contract tests/test_theme_ui_contract.py::test_theme_docs_capture_role_routing_invariants tests/test_appstate_contract_guard.py::test_appstate_contract_docs_share_active_registry_reference`
