### PR TITLE
ci(ai): automate branch repair loop

### DIFF
--- a/.ai/shared.md
+++ b/.ai/shared.md
@@ -109,6 +109,7 @@ These instructions apply to all AI agents used in this repository.
 22. Hybrid PR quality workflow is mandatory:
     - Before first push, run a quick local gate (build plus targeted smoke/tests).
     - Open a regular PR early; red is allowed while iterating.
+    - After the first push for an active branch, the AI MUST start the detached branch repair loop itself (`make ci-repair-start`, relying on auto-discovered handoff when possible) and own that loop autonomously. Do not ask the maintainer to start, watch, or manually poll branch CI while the AI can do it. Use `make ci-repair-status` / `make ci-repair-log` as the AI-facing control surface, restart the loop if needed after later pushes, and interrupt the maintainer only when the loop reaches a true blocked state.
     - For an active PR, proactively poll the live required-check state every 5 minutes and remediate clearly repo-side CI failures until the required set is green, unless the failure is external, inconclusive, or the maintainer explicitly tells you to stop.
     - Keep a durable PR title even while checks are red; do not use temporary `WIP:` title prefixes.
     - PR title, summary, and validation text must describe the durable behavior or architecture aim of the atomic unit, not volatile tracker numbers or broader-roadmap labels.

--- a/Makefile
+++ b/Makefile
@@ -498,6 +498,20 @@ qa-all-log:
 qa-deep:
 	bash scripts/qa-deep.sh "$(CURDIR)"
 
+ci-repair-loop:
+	python3 scripts/ci_repair_loop.py $(ARGS)
+
+ci-repair-start:
+	python3 scripts/ci_repair_loop.py --detach $(ARGS)
+
+ci-repair-status:
+	@if [ -f .agent/handoffs/ci-repair.current.md ]; then cat .agent/handoffs/ci-repair.current.md; \
+	else echo "No ci-repair status file yet."; fi
+
+ci-repair-log:
+	@if [ -f .agent/handoffs/ci-repair.current.log ]; then tail -n 80 .agent/handoffs/ci-repair.current.log; \
+	else echo "No ci-repair log yet."; fi
+
 mcp-doctor:
 	python3 scripts/mcp_doctor.py $(if $(filter 1,$(FIX)),--fix,)
 

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -354,6 +354,14 @@ Use this when wrapping up a PROMPT_TEMPLATE-driven mission and returning the rep
     *   PR body should be concise: summary, scope, and local validation evidence. Do not duplicate obvious CI output or paste check transcripts into the body/comments.
 8.  **Maintainer (GitHub):** Review PR scope and evidence.
 9.  **Architect/AI + Maintainer (GitHub):** Monitor PR CI full gate proactively (for example `gh pr checks <pr-number> --watch`). Do not wait passively for a separate reminder when checks change state.
+    *   To avoid branch-CI babysitting during active implementation, use the branch repair loop. It watches the current branch head, writes a live GitHub failure packet, and launches a fresh Codex repair pass on each red run until checks go green or the retry budget is exhausted.
+    *   Normal start (detached): `make ci-repair-start`
+    *   Detached start with explicit handoff and tuned polling: `make ci-repair-start ARGS='--handoff .agent/handoffs/<task>.current.md --poll-seconds 120 --max-attempts 5'`
+    *   Foreground/debug run: `make ci-repair-loop ARGS='--handoff .agent/handoffs/<task>.current.md'`
+    *   Status: `make ci-repair-status`
+    *   Recent log tail: `make ci-repair-log`
+    *   If exactly one `*.current.md` handoff exists under `.agent/handoffs/`, the loop auto-discovers it and you do not need `--handoff`.
+    *   Detached mode uses `tmux` when available; otherwise it starts a plain detached background process. In both cases the loop keeps running after you close the terminal, and writes state/log artifacts under `.agent/handoffs/`.
 10. **Architect/AI:** If any checks are red, triage failing jobs immediately, fix CI failures root-cause-first, push updates, and repeat until required PR full-QA CI (`make qa-all` equivalent) is green.
     *   Do not request reviewers while checks are red unless the maintainer explicitly instructs it.
     *   Once checks are green on the current head SHA, avoid non-essential PR mutations before merge (for example PR-body edits or base-sync actions) because they may restart CI or invalidate freshness.

--- a/scripts/ci_repair_loop.py
+++ b/scripts/ci_repair_loop.py
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+"""Watch branch GitHub Actions and spawn fresh Codex repair attempts on red."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HANDOFF_DIR = REPO_ROOT / ".agent" / "handoffs"
+FAILURE_PACKET_PATH = HANDOFF_DIR / "ci-failure.current.md"
+PROMPT_PATH = HANDOFF_DIR / "ci-repair.prompt.current.txt"
+RESPONSE_PATH = HANDOFF_DIR / "ci-repair.response.current.txt"
+STATE_PATH = HANDOFF_DIR / "ci-repair.current.md"
+LOG_PATH = HANDOFF_DIR / "ci-repair.current.log"
+LAUNCH_INFO_PATH = HANDOFF_DIR / "ci-repair.launch.current.json"
+DEFAULT_POLL_SECONDS = 300
+DEFAULT_MAX_ATTEMPTS = 3
+RUN_FIELDS = (
+    "databaseId,workflowName,headSha,status,conclusion,event,displayTitle,createdAt,updatedAt,url"
+)
+RUN_DETAIL_FIELDS = (
+    "databaseId,workflowName,headSha,status,conclusion,url,jobs,displayTitle,event,createdAt,updatedAt"
+)
+SUCCESS_CONCLUSIONS = {"success", "neutral", "skipped"}
+FAILURE_CONCLUSIONS = {
+    "failure",
+    "cancelled",
+    "timed_out",
+    "action_required",
+    "startup_failure",
+    "stale",
+}
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path = REPO_ROOT,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _require_ok(
+    args: list[str],
+    *,
+    cwd: Path = REPO_ROOT,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    run = _run(args, cwd=cwd, input_text=input_text)
+    if run.returncode != 0:
+        detail = (run.stderr or run.stdout or "").strip()
+        raise RuntimeError(f"{' '.join(args)} failed: {detail}")
+    return run
+
+
+def _git(args: list[str], *, repo_root: Path) -> str:
+    return _require_ok(["git", *args], cwd=repo_root).stdout.strip()
+
+
+def _gh_json(args: list[str], *, repo: str, repo_root: Path) -> Any:
+    run = _require_ok(["gh", *args, "--repo", repo], cwd=repo_root)
+    return json.loads(run.stdout)
+
+
+def _gh_text(args: list[str], *, repo: str, repo_root: Path) -> str:
+    return _require_ok(["gh", *args, "--repo", repo], cwd=repo_root).stdout
+
+
+def _parse_repo_slug(remote_url: str) -> str:
+    remote = remote_url.strip()
+    ssh_match = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", remote)
+    if ssh_match:
+        return ssh_match.group(1)
+    raise RuntimeError(f"unsupported origin remote URL: {remote_url}")
+
+
+def _discover_handoff(explicit: str | None) -> Path | None:
+    if explicit:
+        path = Path(explicit)
+        if not path.is_absolute():
+            path = REPO_ROOT / path
+        if not path.exists():
+            raise RuntimeError(f"handoff file not found: {path}")
+        return path
+
+    candidates = sorted(
+        path
+        for path in HANDOFF_DIR.glob("*.current.md")
+        if path.name not in {FAILURE_PACKET_PATH.name, STATE_PATH.name}
+    )
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        names = ", ".join(path.name for path in candidates)
+        raise RuntimeError(
+            "multiple current handoffs found; pass --handoff explicitly "
+            f"({names})"
+        )
+    return candidates[0]
+
+
+def _load_runs(repo: str, *, repo_root: Path, branch: str, sha: str) -> list[dict[str, Any]]:
+    payload = _gh_json(
+        [
+            "run",
+            "list",
+            "--branch",
+            branch,
+            "--commit",
+            sha,
+            "--limit",
+            "50",
+            "--json",
+            RUN_FIELDS,
+        ],
+        repo=repo,
+        repo_root=repo_root,
+    )
+    if not isinstance(payload, list):
+        raise RuntimeError("unexpected gh run list payload")
+    return payload
+
+
+def _classify_runs(runs: list[dict[str, Any]]) -> str:
+    if not runs:
+        return "missing"
+    for run in runs:
+        status = str(run.get("status", "") or "")
+        conclusion = str(run.get("conclusion", "") or "")
+        if status != "completed" or not conclusion:
+            return "pending"
+    for run in runs:
+        conclusion = str(run.get("conclusion", "") or "")
+        if conclusion in FAILURE_CONCLUSIONS:
+            return "failure"
+        if conclusion not in SUCCESS_CONCLUSIONS:
+            return "failure"
+    return "success"
+
+
+def _failed_runs(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    failed = []
+    for run in runs:
+        conclusion = str(run.get("conclusion", "") or "")
+        if conclusion in FAILURE_CONCLUSIONS or (
+            conclusion and conclusion not in SUCCESS_CONCLUSIONS
+        ):
+            failed.append(run)
+    return failed
+
+
+def _failed_signature(sha: str, failed_runs: list[dict[str, Any]]) -> tuple[str, tuple[int, ...]]:
+    return sha, tuple(sorted(int(run["databaseId"]) for run in failed_runs))
+
+
+def _summarize_pending(runs: list[dict[str, Any]]) -> str:
+    pieces = []
+    for run in sorted(runs, key=lambda item: (item.get("workflowName", ""), item.get("databaseId", 0))):
+        status = str(run.get("status", "") or "")
+        conclusion = str(run.get("conclusion", "") or "")
+        if status != "completed" or not conclusion:
+            pieces.append(f"{run.get('workflowName', 'workflow')}={status}")
+    return ", ".join(pieces) if pieces else "waiting"
+
+
+def _trim_log(text: str, *, max_lines: int = 220, max_chars: int = 30000) -> str:
+    text = text.strip()
+    if not text:
+        return "(no failed-step log output returned by gh)"
+    lines = text.splitlines()
+    if len(lines) > max_lines:
+        lines = lines[-max_lines:]
+        text = "[... truncated to last failed log lines ...]\n" + "\n".join(lines)
+    else:
+        text = "\n".join(lines)
+    if len(text) > max_chars:
+        text = "[... truncated log excerpt ...]\n" + text[-max_chars:]
+    return text
+
+
+def _load_run_detail(repo: str, *, repo_root: Path, run_id: int) -> dict[str, Any]:
+    payload = _gh_json(
+        ["run", "view", str(run_id), "--json", RUN_DETAIL_FIELDS],
+        repo=repo,
+        repo_root=repo_root,
+    )
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"unexpected gh run view payload for run {run_id}")
+    return payload
+
+
+def _load_failed_log(repo: str, *, repo_root: Path, run_id: int) -> str:
+    return _gh_text(
+        ["run", "view", str(run_id), "--log-failed"],
+        repo=repo,
+        repo_root=repo_root,
+    )
+
+
+def _failure_jobs(detail: dict[str, Any]) -> list[dict[str, Any]]:
+    jobs = detail.get("jobs", [])
+    if not isinstance(jobs, list):
+        return []
+    failed_jobs: list[dict[str, Any]] = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        conclusion = str(job.get("conclusion", "") or "")
+        if conclusion not in FAILURE_CONCLUSIONS and conclusion in SUCCESS_CONCLUSIONS:
+            continue
+        steps = job.get("steps", [])
+        failed_steps = []
+        if isinstance(steps, list):
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                step_conclusion = str(step.get("conclusion", "") or "")
+                if step_conclusion in FAILURE_CONCLUSIONS or (
+                    step_conclusion and step_conclusion not in SUCCESS_CONCLUSIONS
+                ):
+                    failed_steps.append(str(step.get("name", "unnamed step")))
+        failed_jobs.append(
+            {
+                "name": str(job.get("name", "unnamed job")),
+                "url": str(job.get("url", "")),
+                "failed_steps": failed_steps,
+            }
+        )
+    return failed_jobs
+
+
+def _build_failure_packet(
+    *,
+    repo: str,
+    branch: str,
+    sha: str,
+    attempt: int,
+    handoff_path: Path | None,
+    failed_runs: list[dict[str, Any]],
+    run_details: list[dict[str, Any]],
+    logs: list[str],
+) -> str:
+    lines = [
+        "# GitHub CI failure packet",
+        "",
+        "This file is the authoritative current failure context for the next fresh repair pass.",
+        "",
+        f"- Generated: {_now()}",
+        f"- Repository: {repo}",
+        f"- Branch: {branch}",
+        f"- Head SHA: {sha}",
+        f"- Repair attempt: {attempt}",
+        f"- Background handoff: {handoff_path if handoff_path else '(none)'}",
+        "",
+        "## Failed workflow runs",
+        "",
+        "| Workflow | Event | Conclusion | Run |",
+        "| --- | --- | --- | --- |",
+    ]
+    for run in failed_runs:
+        lines.append(
+            f"| {run.get('workflowName', 'workflow')} | {run.get('event', '')} | "
+            f"{run.get('conclusion', '')} | {run.get('url', '')} |"
+        )
+
+    for detail, log_text in zip(run_details, logs):
+        workflow_name = str(detail.get("workflowName", "workflow"))
+        lines.extend(["", f"## {workflow_name}", ""])
+        failed_jobs = _failure_jobs(detail)
+        if not failed_jobs:
+            lines.append("- No failed jobs were returned by `gh run view`.")
+        else:
+            for job in failed_jobs:
+                lines.append(f"### Job: {job['name']}")
+                if job["failed_steps"]:
+                    lines.append(f"- Failed step(s): {', '.join(job['failed_steps'])}")
+                if job["url"]:
+                    lines.append(f"- Job URL: {job['url']}")
+                lines.append("")
+        lines.extend(["```text", _trim_log(log_text), "```"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_prompt(
+    *,
+    branch: str,
+    sha: str,
+    handoff_path: Path | None,
+    failure_packet_path: Path,
+) -> str:
+    handoff_text = str(handoff_path) if handoff_path else "(none)"
+    return "\n".join(
+        [
+            f"Fresh repair pass for branch {branch} at HEAD {sha}.",
+            "",
+            "Current GitHub CI is red.",
+            "",
+            "Read these files first:",
+            f"- Failure packet (authoritative current truth): {failure_packet_path}",
+            f"- Background task handoff (scope/acceptance only): {handoff_text}",
+            "",
+            "Rules:",
+            "- Treat the failure packet as the source of truth for what is failing now.",
+            "- Use the background handoff only for task scope and acceptance context.",
+            "- If the background handoff sounds complete but the failure packet says CI is red, trust the failure packet.",
+            "- Make the smallest root-cause repo fix that gets the branch green.",
+            "- Run focused local validation for the failing area before you change GitHub state.",
+            "- If you make a repo fix, amend or create the branch commit as appropriate and push the same branch.",
+            "- Do not wait for human approval.",
+            "- If the failure is external, flaky, or inconclusive and no safe repo-side fix exists, explain that clearly and stop without repo changes.",
+            "",
+            "Goal: get the current branch's GitHub CI green without human babysitting.",
+        ]
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_state(
+    *,
+    branch: str,
+    sha: str,
+    attempts: int,
+    status: str,
+    handoff_path: Path | None,
+    note: str,
+) -> None:
+    body = "\n".join(
+        [
+            "# CI repair loop",
+            "",
+            f"- Updated: {_now()}",
+            f"- Branch: {branch}",
+            f"- Head SHA: {sha}",
+            f"- Attempts used: {attempts}",
+            f"- Status: {status}",
+            f"- Background handoff: {handoff_path if handoff_path else '(none)'}",
+            f"- Failure packet: {FAILURE_PACKET_PATH}",
+            f"- Prompt: {PROMPT_PATH}",
+            f"- Last Codex response: {RESPONSE_PATH}",
+            "",
+            note,
+            "",
+        ]
+    )
+    _write_text(STATE_PATH, body)
+
+
+def _notify(repo_root: Path, message: str) -> None:
+    script = repo_root / "scripts" / "wsl-notify.sh"
+    if not script.exists():
+        return
+    subprocess.run(
+        [str(script), "ytnova", message],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _session_name(branch: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", branch).strip("-")
+    if not safe:
+        safe = "branch"
+    return f"ytnova-ci-repair-{safe}"
+
+
+def _base_command(*, handoff: str | None, poll_seconds: int, max_attempts: int,
+                  model: str | None, profile: str | None, dry_run: bool) -> list[str]:
+    args = ["python3", str(REPO_ROOT / "scripts" / "ci_repair_loop.py")]
+    if handoff:
+        args.extend(["--handoff", handoff])
+    if poll_seconds != DEFAULT_POLL_SECONDS:
+        args.extend(["--poll-seconds", str(poll_seconds)])
+    if max_attempts != DEFAULT_MAX_ATTEMPTS:
+        args.extend(["--max-attempts", str(max_attempts)])
+    if model:
+        args.extend(["--model", model])
+    if profile:
+        args.extend(["--profile", profile])
+    if dry_run:
+        args.append("--dry-run")
+    return args
+
+
+def _write_launch_info(payload: dict[str, Any]) -> None:
+    _write_text(LAUNCH_INFO_PATH, json.dumps(payload, indent=2) + "\n")
+
+
+def _tmux_session_exists(session_name: str, *, repo_root: Path) -> bool:
+    run = _run(["tmux", "has-session", "-t", session_name], cwd=repo_root)
+    return run.returncode == 0
+
+
+def _start_detached(
+    *,
+    repo_root: Path,
+    branch: str,
+    handoff: str | None,
+    poll_seconds: int,
+    max_attempts: int,
+    model: str | None,
+    profile: str | None,
+    dry_run: bool,
+) -> tuple[str, str]:
+    HANDOFF_DIR.mkdir(parents=True, exist_ok=True)
+    base_cmd = _base_command(
+        handoff=handoff,
+        poll_seconds=poll_seconds,
+        max_attempts=max_attempts,
+        model=model,
+        profile=profile,
+        dry_run=dry_run,
+    )
+    command_text = " ".join(shlex.quote(part) for part in base_cmd)
+    log_handle = LOG_PATH.open("a", encoding="utf-8")
+    session_name = _session_name(branch)
+
+    if shutil.which("tmux"):
+        if _tmux_session_exists(session_name, repo_root=repo_root):
+            _write_launch_info(
+                {
+                    "mode": "tmux",
+                    "session": session_name,
+                    "branch": branch,
+                    "log": str(LOG_PATH),
+                    "command": command_text,
+                    "status": "already-running",
+                }
+            )
+            return "already-running", session_name
+        shell_command = (
+            f"cd {shlex.quote(str(repo_root))} && "
+            f"{command_text} >> {shlex.quote(str(LOG_PATH))} 2>&1"
+        )
+        run = _require_ok(
+            ["tmux", "new-session", "-d", "-s", session_name, shell_command],
+            cwd=repo_root,
+        )
+        del run
+        _write_launch_info(
+            {
+                "mode": "tmux",
+                "session": session_name,
+                "branch": branch,
+                "log": str(LOG_PATH),
+                "command": command_text,
+                "status": "started",
+            }
+        )
+        return "tmux", session_name
+
+    proc = subprocess.Popen(
+        base_cmd,
+        cwd=repo_root,
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+        text=True,
+    )
+    log_handle.close()
+    _write_launch_info(
+        {
+            "mode": "background",
+            "pid": proc.pid,
+            "branch": branch,
+            "log": str(LOG_PATH),
+            "command": command_text,
+            "status": "started",
+        }
+    )
+    return "background", str(proc.pid)
+
+
+def _invoke_codex(
+    *,
+    repo_root: Path,
+    prompt_text: str,
+    model: str | None,
+    profile: str | None,
+    dry_run: bool,
+) -> int:
+    _write_text(PROMPT_PATH, prompt_text)
+    if dry_run:
+        _write_text(RESPONSE_PATH, "dry-run: Codex invocation skipped.\n")
+        return 0
+
+    args = [
+        "codex",
+        "exec",
+        "--cd",
+        str(repo_root),
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--color",
+        "never",
+        "-o",
+        str(RESPONSE_PATH),
+        "-",
+    ]
+    if model:
+        args[2:2] = ["--model", model]
+    if profile:
+        insert_at = 2 if model is None else 4
+        args[insert_at:insert_at] = ["--profile", profile]
+
+    run = subprocess.run(args, cwd=repo_root, input=prompt_text, text=True, check=False)
+    return run.returncode
+
+
+def _branch_green_message(branch: str, sha: str) -> str:
+    return f"{branch} CI green at {sha[:12]}"
+
+
+def _blocked_message(branch: str, reason: str) -> str:
+    return f"{branch} CI repair blocked: {reason}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Watch current branch GitHub Actions and launch fresh Codex repairs on red."
+    )
+    parser.add_argument("--handoff", help="Task handoff file to layer under live CI failure context.")
+    parser.add_argument(
+        "--poll-seconds",
+        type=int,
+        default=DEFAULT_POLL_SECONDS,
+        help=f"Polling interval while GitHub runs are pending (default: {DEFAULT_POLL_SECONDS}).",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=DEFAULT_MAX_ATTEMPTS,
+        help=f"Maximum fresh Codex repair attempts before stopping (default: {DEFAULT_MAX_ATTEMPTS}).",
+    )
+    parser.add_argument("--model", help="Optional Codex model override for repair attempts.")
+    parser.add_argument("--profile", help="Optional Codex profile override for repair attempts.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write failure packet/prompt but skip the Codex invocation.",
+    )
+    parser.add_argument(
+        "--detach",
+        action="store_true",
+        help="Start the repair loop in tmux if available, otherwise as a detached background process.",
+    )
+    args = parser.parse_args()
+
+    if args.poll_seconds < 0:
+        print("--poll-seconds must be >= 0", file=sys.stderr)
+        return 2
+    if args.max_attempts < 1:
+        print("--max-attempts must be >= 1", file=sys.stderr)
+        return 2
+
+    repo_root = REPO_ROOT
+    handoff_path = _discover_handoff(args.handoff)
+    branch = _git(["branch", "--show-current"], repo_root=repo_root)
+    sha = _git(["rev-parse", "HEAD"], repo_root=repo_root)
+    repo = _parse_repo_slug(_git(["remote", "get-url", "origin"], repo_root=repo_root))
+    attempts = 0
+    last_attempt_signature: tuple[str, tuple[int, ...]] | None = None
+
+    if args.detach:
+        handoff_text = str(handoff_path) if handoff_path else None
+        mode, handle = _start_detached(
+            repo_root=repo_root,
+            branch=branch,
+            handoff=handoff_text,
+            poll_seconds=args.poll_seconds,
+            max_attempts=args.max_attempts,
+            model=args.model,
+            profile=args.profile,
+            dry_run=args.dry_run,
+        )
+        if mode == "already-running":
+            print(
+                f"ci-repair loop already running in tmux session {handle}\n"
+                f"log: {LOG_PATH}\n"
+                f"state: {STATE_PATH}"
+            )
+            return 0
+        print(
+            f"started ci-repair loop in {mode}: {handle}\n"
+            f"log: {LOG_PATH}\n"
+            f"state: {STATE_PATH}"
+        )
+        return 0
+
+    print(f"[{_now()}] Watching {repo} branch {branch} at {sha[:12]}")
+    _write_state(
+        branch=branch,
+        sha=sha,
+        attempts=attempts,
+        status="active",
+        handoff_path=handoff_path,
+        note="Waiting for GitHub Actions state for the current branch head.",
+    )
+
+    while True:
+        branch = _git(["branch", "--show-current"], repo_root=repo_root)
+        sha = _git(["rev-parse", "HEAD"], repo_root=repo_root)
+        runs = _load_runs(repo, repo_root=repo_root, branch=branch, sha=sha)
+        state = _classify_runs(runs)
+
+        if state == "missing":
+            print(f"[{_now()}] No GitHub runs yet for {sha[:12]}; sleeping {args.poll_seconds}s.")
+            _write_state(
+                branch=branch,
+                sha=sha,
+                attempts=attempts,
+                status="active",
+                handoff_path=handoff_path,
+                note="No GitHub workflow runs have appeared yet for the current head SHA.",
+            )
+            time.sleep(args.poll_seconds)
+            continue
+
+        if state == "pending":
+            pending_summary = _summarize_pending(runs)
+            print(
+                f"[{_now()}] GitHub runs still pending for {sha[:12]}: "
+                f"{pending_summary}. Sleeping {args.poll_seconds}s."
+            )
+            _write_state(
+                branch=branch,
+                sha=sha,
+                attempts=attempts,
+                status="active",
+                handoff_path=handoff_path,
+                note=f"Pending workflows: {pending_summary}",
+            )
+            time.sleep(args.poll_seconds)
+            continue
+
+        if state == "success":
+            message = _branch_green_message(branch, sha)
+            print(f"[{_now()}] {message}")
+            _write_state(
+                branch=branch,
+                sha=sha,
+                attempts=attempts,
+                status="completed",
+                handoff_path=handoff_path,
+                note="All observed GitHub workflow runs for the current head SHA are green.",
+            )
+            _notify(repo_root, message)
+            return 0
+
+        failed_runs = _failed_runs(runs)
+        signature = _failed_signature(sha, failed_runs)
+        if signature == last_attempt_signature:
+            reason = "same failed run set is still red after the last repair attempt"
+            print(f"[{_now()}] BLOCKED: {reason}.")
+            _write_state(
+                branch=branch,
+                sha=sha,
+                attempts=attempts,
+                status="blocked",
+                handoff_path=handoff_path,
+                note=reason,
+            )
+            _notify(repo_root, _blocked_message(branch, reason))
+            return 1
+
+        if attempts >= args.max_attempts:
+            reason = f"attempt budget exhausted ({args.max_attempts})"
+            print(f"[{_now()}] BLOCKED: {reason}.")
+            _write_state(
+                branch=branch,
+                sha=sha,
+                attempts=attempts,
+                status="blocked",
+                handoff_path=handoff_path,
+                note=reason,
+            )
+            _notify(repo_root, _blocked_message(branch, reason))
+            return 1
+
+        attempts += 1
+        print(
+            f"[{_now()}] GitHub CI red for {sha[:12]}; "
+            f"launching fresh repair attempt {attempts}/{args.max_attempts}."
+        )
+        run_details = [
+            _load_run_detail(repo, repo_root=repo_root, run_id=int(run["databaseId"]))
+            for run in failed_runs
+        ]
+        logs = [
+            _load_failed_log(repo, repo_root=repo_root, run_id=int(run["databaseId"]))
+            for run in failed_runs
+        ]
+        failure_packet = _build_failure_packet(
+            repo=repo,
+            branch=branch,
+            sha=sha,
+            attempt=attempts,
+            handoff_path=handoff_path,
+            failed_runs=failed_runs,
+            run_details=run_details,
+            logs=logs,
+        )
+        _write_text(FAILURE_PACKET_PATH, failure_packet)
+        prompt_text = _build_prompt(
+            branch=branch,
+            sha=sha,
+            handoff_path=handoff_path,
+            failure_packet_path=FAILURE_PACKET_PATH,
+        )
+        _write_state(
+            branch=branch,
+            sha=sha,
+            attempts=attempts,
+            status="active",
+            handoff_path=handoff_path,
+            note=f"Repair attempt {attempts} launched from current failure packet.",
+        )
+        rc = _invoke_codex(
+            repo_root=repo_root,
+            prompt_text=prompt_text,
+            model=args.model,
+            profile=args.profile,
+            dry_run=args.dry_run,
+        )
+        last_attempt_signature = signature
+        if rc != 0:
+            reason = f"Codex repair process exited {rc}"
+            print(f"[{_now()}] BLOCKED: {reason}.")
+            _write_state(
+                branch=branch,
+                sha=sha,
+                attempts=attempts,
+                status="blocked",
+                handoff_path=handoff_path,
+                note=reason,
+            )
+            _notify(repo_root, _blocked_message(branch, reason))
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_repair_loop.py
+++ b/tests/test_ci_repair_loop.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ci_repair_loop.py"
+SCRIPT_SPEC = importlib.util.spec_from_file_location("ci_repair_loop", SCRIPT_PATH)
+assert SCRIPT_SPEC is not None and SCRIPT_SPEC.loader is not None
+ci_repair = importlib.util.module_from_spec(SCRIPT_SPEC)
+SCRIPT_SPEC.loader.exec_module(ci_repair)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_discover_handoff_requires_explicit_choice_when_multiple_currents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handoff_dir = tmp_path / ".agent" / "handoffs"
+    _write(handoff_dir / "task-a.current.md", "a")
+    _write(handoff_dir / "task-b.current.md", "b")
+
+    monkeypatch.setattr(ci_repair, "HANDOFF_DIR", handoff_dir)
+    monkeypatch.setattr(ci_repair, "FAILURE_PACKET_PATH", handoff_dir / "ci-failure.current.md")
+    monkeypatch.setattr(ci_repair, "STATE_PATH", handoff_dir / "ci-repair.current.md")
+
+    with pytest.raises(RuntimeError, match="multiple current handoffs found"):
+        ci_repair._discover_handoff(None)
+
+
+def test_build_failure_packet_includes_failed_jobs_and_log_excerpt() -> None:
+    failed_runs = [
+        {
+            "workflowName": "C/C++ Baseline CI",
+            "event": "push",
+            "conclusion": "failure",
+            "url": "https://example.invalid/run/1",
+        }
+    ]
+    run_details = [
+        {
+            "workflowName": "C/C++ Baseline CI",
+            "jobs": [
+                {
+                    "name": "Full coverage baseline gate",
+                    "url": "https://example.invalid/job/1",
+                    "conclusion": "failure",
+                    "steps": [
+                        {
+                            "name": "Run coverage baseline gate",
+                            "conclusion": "failure",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    logs = [
+        "Full coverage baseline gate\tRun coverage baseline gate\tpytest -q tests/test_example.py\n"
+        "E   assert 1 == 2\n"
+    ]
+
+    packet = ci_repair._build_failure_packet(
+        repo="robkam/ytreenova",
+        branch="feat/test",
+        sha="abc123",
+        attempt=2,
+        handoff_path=Path(".agent/handoffs/task.current.md"),
+        failed_runs=failed_runs,
+        run_details=run_details,
+        logs=logs,
+    )
+
+    assert "authoritative current failure context" in packet
+    assert "Full coverage baseline gate" in packet
+    assert "Run coverage baseline gate" in packet
+    assert "assert 1 == 2" in packet
+
+
+def test_main_retries_failed_branch_until_green(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    handoff_dir = tmp_path / ".agent" / "handoffs"
+    handoff_path = handoff_dir / "task-11.5.current.md"
+    _write(handoff_path, "# task\n")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    monkeypatch.setattr(ci_repair, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(ci_repair, "HANDOFF_DIR", handoff_dir)
+    monkeypatch.setattr(ci_repair, "FAILURE_PACKET_PATH", handoff_dir / "ci-failure.current.md")
+    monkeypatch.setattr(ci_repair, "PROMPT_PATH", handoff_dir / "ci-repair.prompt.current.txt")
+    monkeypatch.setattr(ci_repair, "RESPONSE_PATH", handoff_dir / "ci-repair.response.current.txt")
+    monkeypatch.setattr(ci_repair, "STATE_PATH", handoff_dir / "ci-repair.current.md")
+
+    sha_values = iter(["sha-old", "sha-old", "sha-new", "sha-new"])
+    git_map = {
+        ("branch", "--show-current"): "feat/branch",
+        ("remote", "get-url", "origin"): "https://github.com/robkam/ytreenova.git",
+    }
+
+    def fake_git(args: list[str], *, repo_root: Path) -> str:
+        key = tuple(args)
+        if key == ("rev-parse", "HEAD"):
+            return next(sha_values)
+        return git_map[key]
+
+    runs_by_sha = {
+        "sha-old": [
+            {
+                "databaseId": 1001,
+                "workflowName": "C/C++ Baseline CI",
+                "headSha": "sha-old",
+                "status": "completed",
+                "conclusion": "failure",
+                "event": "push",
+                "displayTitle": "test",
+                "createdAt": "2026-07-18T00:00:00Z",
+                "updatedAt": "2026-07-18T00:01:00Z",
+                "url": "https://example.invalid/run/1001",
+            }
+        ],
+        "sha-new": [
+            {
+                "databaseId": 1002,
+                "workflowName": "C/C++ Baseline CI",
+                "headSha": "sha-new",
+                "status": "completed",
+                "conclusion": "success",
+                "event": "push",
+                "displayTitle": "test",
+                "createdAt": "2026-07-18T00:02:00Z",
+                "updatedAt": "2026-07-18T00:03:00Z",
+                "url": "https://example.invalid/run/1002",
+            }
+        ],
+    }
+
+    def fake_load_runs(
+        repo: str, *, repo_root: Path, branch: str, sha: str
+    ) -> list[dict[str, object]]:
+        return runs_by_sha[sha]
+
+    monkeypatch.setattr(ci_repair, "_git", fake_git)
+    monkeypatch.setattr(ci_repair, "_load_runs", fake_load_runs)
+    monkeypatch.setattr(
+        ci_repair,
+        "_load_run_detail",
+        lambda repo, *, repo_root, run_id: {
+            "workflowName": "C/C++ Baseline CI",
+            "jobs": [
+                {
+                    "name": "Full coverage baseline gate",
+                    "url": "https://example.invalid/job/1001",
+                    "conclusion": "failure",
+                    "steps": [
+                        {"name": "Run coverage baseline gate", "conclusion": "failure"}
+                    ],
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        ci_repair,
+        "_load_failed_log",
+        lambda repo, *, repo_root, run_id: "pytest -q tests/test_example.py\nE assert 1 == 2\n",
+    )
+    codex_prompts: list[str] = []
+    monkeypatch.setattr(
+        ci_repair,
+        "_invoke_codex",
+        lambda *, repo_root, prompt_text, model, profile, dry_run: codex_prompts.append(
+            prompt_text
+        )
+        or 0,
+    )
+    notifications: list[str] = []
+    monkeypatch.setattr(ci_repair, "_notify", lambda repo_root, message: notifications.append(message))
+    monkeypatch.setattr(ci_repair.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(sys, "argv", ["ci_repair_loop.py", "--poll-seconds", "0"])
+
+    rc = ci_repair.main()
+    output = capsys.readouterr().out
+
+    assert rc == 0
+    assert len(codex_prompts) == 1
+    assert "Failure packet (authoritative current truth)" in codex_prompts[0]
+    assert "launching fresh repair attempt 1/3" in output
+    assert notifications == ["feat/branch CI green at sha-new"]
+    assert (handoff_dir / "ci-failure.current.md").exists()
+    assert (handoff_dir / "ci-repair.current.md").read_text(encoding="utf-8").find("completed") != -1
+
+
+def test_main_blocks_when_same_failed_run_set_stays_red(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    handoff_dir = tmp_path / ".agent" / "handoffs"
+    _write(handoff_dir / "task-11.5.current.md", "# task\n")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    monkeypatch.setattr(ci_repair, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(ci_repair, "HANDOFF_DIR", handoff_dir)
+    monkeypatch.setattr(ci_repair, "FAILURE_PACKET_PATH", handoff_dir / "ci-failure.current.md")
+    monkeypatch.setattr(ci_repair, "PROMPT_PATH", handoff_dir / "ci-repair.prompt.current.txt")
+    monkeypatch.setattr(ci_repair, "RESPONSE_PATH", handoff_dir / "ci-repair.response.current.txt")
+    monkeypatch.setattr(ci_repair, "STATE_PATH", handoff_dir / "ci-repair.current.md")
+
+    monkeypatch.setattr(
+        ci_repair,
+        "_git",
+        lambda args, *, repo_root: {
+            ("branch", "--show-current"): "feat/branch",
+            ("rev-parse", "HEAD"): "sha-stuck",
+            ("remote", "get-url", "origin"): "https://github.com/robkam/ytreenova.git",
+        }[tuple(args)],
+    )
+    failing_runs = [
+        {
+            "databaseId": 2001,
+            "workflowName": "C/C++ Baseline CI",
+            "headSha": "sha-stuck",
+            "status": "completed",
+            "conclusion": "failure",
+            "event": "push",
+            "displayTitle": "test",
+            "createdAt": "2026-07-18T00:00:00Z",
+            "updatedAt": "2026-07-18T00:01:00Z",
+            "url": "https://example.invalid/run/2001",
+        }
+    ]
+    monkeypatch.setattr(
+        ci_repair,
+        "_load_runs",
+        lambda repo, *, repo_root, branch, sha: list(failing_runs),
+    )
+    monkeypatch.setattr(
+        ci_repair,
+        "_load_run_detail",
+        lambda repo, *, repo_root, run_id: {"workflowName": "C/C++ Baseline CI", "jobs": []},
+    )
+    monkeypatch.setattr(
+        ci_repair,
+        "_load_failed_log",
+        lambda repo, *, repo_root, run_id: "same failure\n",
+    )
+    monkeypatch.setattr(ci_repair, "_invoke_codex", lambda **kwargs: 0)
+    notifications: list[str] = []
+    monkeypatch.setattr(ci_repair, "_notify", lambda repo_root, message: notifications.append(message))
+    monkeypatch.setattr(ci_repair.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(sys, "argv", ["ci_repair_loop.py", "--poll-seconds", "0"])
+
+    rc = ci_repair.main()
+    output = capsys.readouterr().out
+
+    assert rc == 1
+    assert "same failed run set is still red" in output
+    assert notifications == [
+        "feat/branch CI repair blocked: same failed run set is still red after the last repair attempt"
+    ]
+
+
+def test_base_command_omits_default_values() -> None:
+    command = ci_repair._base_command(
+        handoff=None,
+        poll_seconds=ci_repair.DEFAULT_POLL_SECONDS,
+        max_attempts=ci_repair.DEFAULT_MAX_ATTEMPTS,
+        model=None,
+        profile=None,
+        dry_run=False,
+    )
+
+    assert command == ["python3", str(ci_repair.REPO_ROOT / "scripts" / "ci_repair_loop.py")]
+
+
+def test_main_detach_prints_started_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    handoff_dir = tmp_path / ".agent" / "handoffs"
+    handoff_path = handoff_dir / "task-11.5.current.md"
+    _write(handoff_path, "# task\n")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    monkeypatch.setattr(ci_repair, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(ci_repair, "HANDOFF_DIR", handoff_dir)
+    monkeypatch.setattr(ci_repair, "FAILURE_PACKET_PATH", handoff_dir / "ci-failure.current.md")
+    monkeypatch.setattr(ci_repair, "PROMPT_PATH", handoff_dir / "ci-repair.prompt.current.txt")
+    monkeypatch.setattr(ci_repair, "RESPONSE_PATH", handoff_dir / "ci-repair.response.current.txt")
+    monkeypatch.setattr(ci_repair, "STATE_PATH", handoff_dir / "ci-repair.current.md")
+    monkeypatch.setattr(ci_repair, "LOG_PATH", handoff_dir / "ci-repair.current.log")
+    monkeypatch.setattr(ci_repair, "LAUNCH_INFO_PATH", handoff_dir / "ci-repair.launch.current.json")
+    monkeypatch.setattr(
+        ci_repair,
+        "_git",
+        lambda args, *, repo_root: {
+            ("branch", "--show-current"): "feat/branch",
+            ("rev-parse", "HEAD"): "sha-detach",
+            ("remote", "get-url", "origin"): "https://github.com/robkam/ytreenova.git",
+        }[tuple(args)],
+    )
+    monkeypatch.setattr(
+        ci_repair,
+        "_start_detached",
+        lambda **kwargs: ("tmux", "ytnova-ci-repair-feat-branch"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ci_repair_loop.py", "--detach", "--handoff", str(handoff_path)],
+    )
+
+    rc = ci_repair.main()
+    output = capsys.readouterr().out
+
+    assert rc == 0
+    assert "started ci-repair loop in tmux" in output
+    assert "ytnova-ci-repair-feat-branch" in output


### PR DESCRIPTION
## Summary
- add a detached branch CI repair loop that watches GitHub Actions on the current branch head
- generate a live CI failure packet and fresh repair prompt whenever GitHub CI turns red
- add make targets and workflow guidance so branch CI remediation can run without manual polling

## Validation
- `source .venv/bin/activate && pytest -q tests/test_ci_repair_loop.py`
- `python3 scripts/ci_repair_loop.py --help`