### PR TITLE
feat(qa): add code-quality hotspot reporting cadence

### DIFF
--- a/.agent/handoffs/task-6.current.txt
+++ b/.agent/handoffs/task-6.current.txt
@@ -1,0 +1,35 @@
+Work item: docs/ROADMAP.md Task 6
+Title: Recurring Code-Quality Burn-Down + Lean Simplicity Contract
+Acceptance target:
+- Recurring cadence policy is documented and tied to explicit triggers.
+- Each cadence run produces measurable debt deltas (before/after hotspot list).
+- No regressions in behavior or UX semantics for touched paths.
+- make qa-module-boundaries and required bundled QA gates remain green for each pass.
+Completion objective:
+- Complete the roadmap item correctly by landing the largest coherent Task 6 family that closes the missing cadence/blueprint/evidence contract surfaces without leaving silent omissions.
+
+Selected work family:
+- Documentation and reporting foundation for recurring burn-down cadence, hotspot delta evidence, and lean-simplicity acceptance rules.
+
+Inventory reconciliation:
+- docs/ROADMAP.md — addressed (source-of-truth status edits included silently in the same commit).
+- docs/ai/CODE_QUALITY.md — addressed (expanded from prompt guide into the actionable Task 6 blueprint).
+- .ai/skills/code-quality/SKILL.md — addressed (now delegates canonical policy to docs/ai/CODE_QUALITY.md and keeps the execution workflow only).
+- docs/AUDIT.md — addressed (adds explicit recurring cadence triggers and minimum evidence commands).
+- docs/CONTRIBUTING.md — addressed (adds contributor-facing burn-down cadence/evidence guidance).
+- docs/ai/WORKFLOW.md — addressed (reference updated from prompt guide to blueprint).
+- Makefile / code-quality-hotspots target — addressed (adds a discoverable wrapper for the hotspot report command).
+- scripts/report_code_quality_hotspots.py — addressed (new measurable hotspot snapshot/delta reporter for the guarded controller file/function budgets).
+- tests/test_code_quality_hotspots_report.py — addressed (covers snapshot content, baseline delta rendering, and current-repo smoke execution).
+- scripts/check_module_boundaries.py — intentionally unchanged (existing guard already enforces the baseline budgets; Task 6 needed reporting on top of the guard, not new guard semantics).
+- tests/test_module_boundaries_guard.py — intentionally unchanged (guard behavior did not change; new coverage lives with the new report surface).
+
+Focused validation:
+- `make clean && make`
+- `source .venv/bin/activate && pytest -q tests/test_code_quality_hotspots_report.py`
+- `make qa-code-quality`
+- `make code-quality-hotspots HOTSPOT_ARGS='--top 4'`
+
+Remaining Task 6 work families after this slice:
+- None found in the selected cadence/blueprint/evidence contract family.
+- Post-merge final sweep still required against docs/ROADMAP.md and the touched docs/tooling surfaces before declaring the roadmap item closed.

--- a/.ai/skills/code-quality/SKILL.md
+++ b/.ai/skills/code-quality/SKILL.md
@@ -14,198 +14,30 @@ Use this skill when the request is about code quality, clean-code enforcement, d
 - Offer implementation only after presenting findings and obtaining user approval.
 - Keep implementations lean and readable without introducing clever/opaque patterns.
 
-## Lean-Readable Contract (Mandatory)
+## Canonical Blueprint
 
-Apply these conventions for all code-quality remediation:
+Read `docs/ai/CODE_QUALITY.md` before producing findings or edits.
 
-1. Prefer the simplest clear implementation that preserves behavior and invariants.
-2. Fewer lines is good only when readability and diagnosability are equal or better.
-3. Avoid shorthand/clever constructs that reduce clarity (dense nested ternaries, implicit side effects, compressed control flow).
-4. Use explicit names for ownership and state transitions; avoid ambiguous abbreviations outside local loop indices.
-5. Keep control flow straightforward (guard clauses over deep nesting where practical).
+That document is the source of truth for:
 
-## Anti-Obfuscation Rules (Mandatory)
+- smell classes and severity,
+- the lean simplicity / anti-obfuscation contract,
+- recurring burn-down cadence triggers,
+- before/after hotspot evidence,
+- and the per-pass acceptance checklist.
 
-Flag as smell (P1-P2 depending risk/context):
-
-- Dense expression chains that hide branching or side effects.
-- Flag-heavy APIs that multiplex unrelated behavior.
-- Hidden mutation through shared/global state without explicit contract.
-- Over-compressed helpers that trade maintainability for brevity.
-- Unnecessary indirection layers introduced without rule-of-three evidence.
-
-When suggesting a rewrite, include a short rationale: "why clearer" and "why safer to maintain."
-
-## Recursion Policy
-
-Recursion is allowed only when it is the clearest and safest representation of hierarchical traversal.
-
-Allowed patterns:
-- Bounded tree traversal with explicit base cases.
-- Recursive walk/cleanup routines with deterministic termination.
-
-Discouraged patterns:
-- Business-flow recursion where iterative control flow is clearer.
-- Recursion that obscures state transitions or makes error handling harder to follow.
-
-Review rule:
-- For any retained or introduced recursion, include a one-line justification and base-case/termination note.
+This skill adds the execution workflow on top of that policy.
 
 ## Workflow
 
 1. Define the target (`file`, `directory`, or repository slice) and keep scope explicit.
 2. Read only the minimum required context with semantic tools.
-3. Map findings to principles/smells (for example: DRY, SRP, guard clauses, cognitive load, comments-as-deodorant).
-4. Rank each finding using this priority scale:
-   - `P0`: security/data-loss/corruption risk
-   - `P1`: bug-prone behavior or correctness risk
-   - `P2`: maintainability risks that will slow normal changes
-   - `P3`: low-risk readability/polish issues
-   - `P4`: optional stylistic cleanup
-5. Apply effort modifiers:
-   - quick win (<5 min) can move one level higher
-   - risky/no-test change can move one level lower
-6. Output findings with concrete before/after snippets and rationale.
-7. Ask whether to implement all, some, or none of the recommended changes.
-8. If implementation is approved, execute minimal coherent edits and run relevant validation.
-
-## Comprehensive ytnova-Specific Smell Checklist
-
-### 0) Conceptual Integrity and Architecture Conformance
-
-- Treat the codebase as one integrated product, not a pile of locally correct patches.
-- Check whether the implementation still conforms to the intended architecture, not just whether each edited file works in isolation.
-- Look for architectural drift when the code no longer matches the documented design, and architectural erosion when the implementation violates architectural constraints.
-- Look for shotgun surgery when one logical change forces scattered edits across many files.
-- Look for duplicate or parallel implementations that survive after a refactor, migration, or feature replacement.
-- Look for sibling features that implement the same concept with divergent semantics, naming, ordering, polarity, or ownership.
-- Look for half-migrated replacements where old code remains reachable, inert, or only partially retired.
-
-Audit questions:
-- Is there exactly one authoritative implementation for each durable behavior?
-- Does the implementation still conform to the intended architecture and documented invariants?
-- Are any surviving alternatives intentionally transitional, or are they accidental leftovers?
-- Do similar code paths still express the same concept in the same way?
-- Would a maintainer understand the system as a coherent whole, or as stitched-together fragments?
-
-Required response when this smell is found:
-- Name the surviving duplicate, drift, or erosion point.
-- State whether it is dead, transitional, or still user-reachable.
-- Explain the architectural or conceptual-integrity breakage it causes.
-- Recommend the single durable owner or consolidation path.
-
-### 1) Architecture and Module Boundaries
-
-- Logic for non-controller concerns placed in `src/ui/ctrl_*.c` instead of dedicated modules.
-- New feature logic added as controller sub-functions even though it could be reused elsewhere.
-- Cross-panel state coupling that breaks active-panel isolation.
-- Hidden state transfer through globals instead of explicit context passing.
-- Large "manager"/"helper" files with mixed responsibilities.
-- Shotgun surgery patterns where one behavior change requires many unrelated file edits.
-
-### 2) State Ownership, Lifetime, and Memory Safety
-
-- Ambiguous ownership of pointers and buffers at function boundaries.
-- Missing `free`/cleanup on one or more error exits.
-- Borrowed pointer stored beyond owner lifetime.
-- Mutating shared state from multiple paths without clear invariants.
-- Unsafe or fragile string handling patterns.
-- Error-path cleanup asymmetry (happy-path cleanup is present, failure-path cleanup is partial).
-
-### 3) Error Handling and Defensive Behavior
-
-- Silent failure (`return` without signal/log when failure matters).
-- Inconsistent error contracts for similar operations.
-- Deep nesting where guard clauses would flatten control flow.
-- Fail-late behavior where invalid inputs propagate before rejection.
-- Missing validation at boundary points (user input, filesystem responses, command arguments).
-- Retries or recovery branches that hide deterministic failures.
-
-### 4) Performance and Event-Loop Determinism
-
-- Performance regressions in interactive flows, especially input latency, redraw lag, and avoidable blocking.
-- Event-loop nondeterminism that changes user-visible behavior under resize, watcher, or bursty input conditions.
-- Signal-safety violations that introduce complex logic, I/O, or ncurses calls into signal handlers.
-- Blocking work on the main loop when a non-blocking or deferred path is already the established architecture.
-
-### 5) UI/TUI Flow and Interaction Economy
-
-- Common path requires more than one submenu before result.
-- Prompt chains that can be collapsed into one prompt with defaults/toggles.
-- Inconsistent key behavior across similar screens.
-- Surprising side effects from query-like operations.
-- Redraw/update behavior that causes flicker or stale panel state.
-- UX confirmation friction on non-destructive common-path operations.
-
-### 6) API, Data Shape, and Logic Clarity
-
-- Long parameter lists suggesting data clumps.
-- Flag-heavy function signatures (`bool do_x, bool do_y`) indicating mixed responsibilities.
-- Primitive obsession for domain concepts (paths, modes, identifiers, options).
-- Duplicate business rules implemented in multiple locations.
-- Message-chain style calls that expose internal object structure.
-- Magic numbers/strings hiding domain meaning.
-
-### 7) Complexity and Readability
-
-- Functions with multiple abstraction levels mixed together.
-- Functions with deep conditional nesting or high branching complexity.
-- Comment-heavy code that explains "what" instead of expressing intent in names.
-- Over-abstraction with single-use interfaces or speculative extension points.
-- Wrong abstraction smell: generic helper gains branch flags per new callsite.
-- Dead code, unreachable branches, or stale fallback logic.
-
-### 8) Tests, QA Signals, and Regression Risk
-
-- Missing regression tests for bugfixes.
-- Tests added only after fix, without fail-first proof.
-- Brittle PTY/pexpect tests with timing hacks instead of synchronization fixes.
-- Test behavior diverges from specification.
-- Local suppressions/skips/xfails used to bypass root-cause remediation.
-- Changed behavior without corresponding spec/test updates.
-
-### 9) Documentation and Comment Hygiene
-
-- Stale comments that no longer match behavior.
-- Change-diary comments in source files.
-- Duplicate process guidance scattered in unrelated docs.
-- Missing rationale comments where invariants or ownership rules are non-obvious.
-- Overly broad docs updates that increase noise without helping the local audience.
-
-## Severity and Prioritization Rules
-
-- `P0`: security issues, memory corruption, data loss, destructive behavior surprises.
-- `P1`: correctness bugs waiting to happen, broken invariants, high-likelihood regressions.
-- `P2`: maintainability and architecture drift with medium-term delivery risk.
-- `P3`: readability/polish issues with low immediate risk.
-- `P4`: optional style and consistency cleanup.
-- Raise severity one level for quick wins.
-- Lower severity one level when change risk is high and coverage is weak.
-
-## Required Output Format
-
-1. Summary (1-2 sentences)
-2. Violations Found (grouped by principle/smell), each including:
-   - `Location`
-   - `Problem`
-   - `Before`
-   - `After`
-   - `Why`
-3. Recommendations (prioritized list)
-4. Explicit implementation question to the user
-
-## Recurring Burn-Down Cadence + Evidence Template
-
-For debt-burn-down missions (not one-off bugfixes), report measurable deltas:
-
-1. **Before hotspot table** (top N by size/complexity/smell impact in scope)
-2. **After hotspot table** (same rows, updated metrics)
-3. **Delta summary** (what reduced, what deferred, and why)
-4. **Risk note** (behavior-preservation checks and invariants touched)
-5. **Validation evidence** (commands run and outcomes)
-
-Default cadence guidance for maintainers:
-- Run a bounded burn-down pass periodically (for example every N feature merges or at milestone checkpoints), not only pre-release.
+3. Build an inventory before editing and map findings to the smell classes in `docs/ai/CODE_QUALITY.md`.
+4. Rank findings by the documented severity rules plus effort/risk modifiers.
+5. Output findings with concrete before/after snippets and rationale.
+6. Ask whether to implement all, some, or none of the recommended changes unless implementation approval is already explicit.
+7. If implementation is approved, execute the smallest coherent batch that closes the selected family and run relevant validation.
+8. For burn-down missions, capture before/after hotspot evidence with `scripts/report_code_quality_hotspots.py`.
 
 ## ytnova Guardrails
 

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ COMMANDS_CATALOG_SCRIPT = scripts/generate_default_commands_catalog.py
 COMMAND_PRESETS_SRC_DIR = etc/commands
 COMMAND_PRESETS_HDR = src/core/default_command_presets_catalog.h
 COMMAND_PRESETS_SCRIPT = scripts/generate_default_command_presets_catalog.py
+CODE_QUALITY_HOTSPOT_SCRIPT = scripts/report_code_quality_hotspots.py
 
 # Coverage build switch (for gcov/lcov-driven C coverage reports).
 COVERAGE    ?= 0
@@ -181,7 +182,8 @@ FUZZ_BINS := $(FUZZ_STRING_UTILS_BIN) $(FUZZ_PATH_UTILS_BIN) $(FUZZ_FILTER_CORE_
 		test-v qa-clang qa-cppcheck qa-scan qa-valgrind qa-valgrind-interactive qa-valgrind-full \
 		qa-pytest qa-fileops-integrity qa-split-panel-gates qa-pytest-coverage qa-sanitize qa-unsafe-apis qa-module-boundaries qa-appstate-contract qa-ai-config qa-theme-catalog qa-profile-template qa-commands-catalog qa-command-presets-catalog qa-code-quality qa-all \
 		ci-baseline mcp-doctor py-requirements \
-		qa-all-log qa-deep theme-catalog profile-template commands-catalog command-presets-catalog
+		qa-all-log qa-deep theme-catalog profile-template commands-catalog command-presets-catalog \
+		code-quality-hotspots
 
 all: $(MAIN_BIN) $(MANPAGE) $(if $(filter 1,$(QA_ON_BUILD)),qa-all)
 
@@ -450,6 +452,9 @@ qa-appstate-contract:
 
 qa-ai-config:
 	python3 scripts/check_project_ai_config.py
+
+code-quality-hotspots:
+	$(PYTHON) $(CODE_QUALITY_HOTSPOT_SCRIPT) $(HOTSPOT_ARGS)
 
 qa-theme-catalog:
 	$(PYTHON) $(THEME_CATALOG_SCRIPT) --source $(THEME_CATALOG_SRC) \

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -10,6 +10,29 @@ This document defines the mandatory quality process for the YtreeNova modernizat
 - Always run the merge/release gate before merge/release.
 - Do not run the full gate after every prompt-level micro-edit unless risk justifies it.
 
+### 1.1.1 Recurring Code-Quality Burn-Down Cadence
+
+Task 6 recurring burn-down passes are mandatory on this cadence:
+
+1. After every **five merged structural PRs** that touch `src/`, `include/`, or code-quality guard scripts under `scripts/`.
+2. Before any milestone or release tag.
+3. When a PR intentionally lowers a controller/file/function budget or retires a documented legacy boundary exception.
+
+Each burn-down pass must attach measurable before/after evidence for the same hotspot rows:
+
+```bash
+python3 scripts/report_code_quality_hotspots.py --format json > /tmp/ytnova-hotspots-before.json
+python3 scripts/report_code_quality_hotspots.py --baseline /tmp/ytnova-hotspots-before.json --format markdown --top 5
+```
+
+Required local evidence for the pass:
+
+- `make`
+- focused `pytest` for the touched behavior
+- `make qa-module-boundaries`
+
+Add the other bundled gates that match the changed risk surface (`make qa-code-quality`, `make qa-fileops-integrity`, `make qa-split-panel-gates`, and so on). The detailed smell taxonomy, simplicity contract, and burn-down checklist live in `docs/ai/CODE_QUALITY.md`.
+
 ## 1.2 QA Layers
 
 The project uses seven QA layers with increasing depth and cost:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -247,6 +247,22 @@ Individual gates:
 - `make fuzz` (builds all fuzz binaries under `build/fuzz/`)
 - `make fuzz-smoke` (runs bounded libFuzzer smoke passes for all harnesses)
 
+### Recurring code-quality burn-down cadence
+
+When you are doing deliberate debt burn-down work rather than a one-off bugfix, run the recurring cadence described in `docs/AUDIT.md` and `docs/ai/CODE_QUALITY.md`.
+
+The minimum evidence set is:
+
+```bash
+python3 scripts/report_code_quality_hotspots.py --format json > /tmp/ytnova-hotspots-before.json
+python3 scripts/report_code_quality_hotspots.py --baseline /tmp/ytnova-hotspots-before.json --format markdown --top 5
+make
+source .venv/bin/activate && pytest -q tests/path/to/focused_test.py
+make qa-module-boundaries
+```
+
+Also run the matching bundled QA gates for the surfaces you changed (`make qa-code-quality`, `make qa-fileops-integrity`, `make qa-split-panel-gates`, and so on). Record which hotspots shrank, which stayed flat, and any explicitly deferred items.
+
 ---
 
 ## Architectural Decisions & Constraints

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,7 +131,7 @@ Ordering policy (for all editors, including AI editors):
 #### **Task 5.3: Smell Gate Evidence as Merge Prerequisite**
 *   **Goal:** Ensure smell-audit results are part of mandatory merge evidence, not optional review notes.
 *   **Mechanism:** Require successful smell checks in QA artifacts and block integration on unresolved unapproved violations.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Completed.
 
 ### **Task 6: Recurring Code-Quality Burn-Down + Lean Simplicity Contract**
 *   **Goal:** Run ongoing debt burn-down passes (not only one-off cleanup) while enforcing a durable simplicity contract: code should stay lean, readable, and non-obfuscated.
@@ -147,7 +147,7 @@ Ordering policy (for all editors, including AI editors):
 *   Each cadence run produces measurable debt deltas (before/after hotspot list).
 *   No regressions in behavior or UX semantics for touched paths.
 *   `make qa-module-boundaries` and required bundled QA gates remain green for each pass.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Completed.
 
 ## **Phase 3: Build System, Documentation, and CI**
 *This phase focuses on project infrastructure, developer experience, and release readiness.*
@@ -343,7 +343,7 @@ Ordering policy (for all editors, including AI editors):
 *   Validation catches collisions and unresolved actions after preset + override resolution.
 *   Preset files carry concise comment headers explaining their role and constraints.
 *   `docs/SPECIFICATION.md`, `docs/ARCHITECTURE.md`, and F10/help docs describe command presets as read-only packaged data layered under one active commands file.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Completed.
 
 ---
 
@@ -1775,21 +1775,28 @@ Ordering policy (for all editors, including AI editors):
 *   **Rationale:** A stronger built-in viewer would make ytnova more self-contained for terminal inspection work, while still keeping the project focused on file management rather than format-specific rendering.
 *   - [ ] **Status:** Not Started.
 
-
-### **Idea FE-38: Terminal-Independent TUI Runtime (ncurses-Decoupling Investigation)**
-*   **Goal:** Investigate a runtime path where ytnova's TUI is not tightly coupled to ncurses.
-*   **Input-protocol spike:** As part of this investigation, evaluate opt-in enhanced keyboard protocols, starting with kitty keyboard protocol, to determine whether ytnova can distinguish collided control inputs such as `^M` versus `Enter` without breaking the portable terminal path.
-*   **Fallback contract:** If enhanced keyboard negotiation is unavailable, rejected, or stripped by the active terminal path, keep the current portable bindings and help semantics (for example `^N` for tagged move) rather than making kitty-only input a requirement.
-*   **Rationale:** This is a platform/input architecture effort intended to evaluate whether backend decoupling can reduce current control-key handling constraints (including limitations around mappings like `^M`) while preserving ytnova interaction semantics.
+### **Idea FE-38: Investigate Optional Enhanced Terminal Input Protocols**
+*   **Goal:** Investigate whether opt-in enhanced keyboard/input protocols can safely improve ytnova's TUI input model without replacing the portable baseline path.
+*   **Input-protocol spike:** Start with kitty keyboard protocol and evaluate whether richer key events can distinguish collided control inputs such as `^M` versus `Enter`.
+*   **Fallback contract:** If enhanced keyboard negotiation is unavailable, rejected, or stripped by the active terminal path, keep the current portable bindings and help semantics (for example `^N` for tagged move) rather than making any enhanced protocol a requirement.
+*   **Scope boundary:** Treat this as an optional capability layered above the normal terminal path, not as a prerequisite for core navigation or command workflows.
+*   **Rationale:** This is an input-capability investigation intended to determine whether optional terminal features can relieve current control-key collisions while keeping ytnova portable.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-39: Implement "Safe Delete" (Trash Can)**
+### **Idea FE-39: Investigate Replacing ncurses with a Better TUI Backend**
+*   **Goal:** Investigate whether ytnova should replace or meaningfully decouple from ncurses in favor of a better TUI/runtime layer while preserving current interaction semantics.
+*   **Investigation scope:** Evaluate candidate backends on portability, rendering/control over redraw behavior, input handling, testability, packaging friction, and migration risk for the current architecture.
+*   **Compatibility contract:** Any replacement path must preserve the portable baseline terminal workflow and must not require a single terminal family or GUI-specific runtime stack.
+*   **Rationale:** This is a platform/runtime architecture effort intended to determine whether ncurses remains the right long-term foundation for ytnova's TUI.
+*   - [ ] **Status:** Not Started.
+
+### **Idea FE-40: Implement "Safe Delete" (Trash Can)**
 *   **Goal:** Add optional trash-backed delete where the active filesystem/backend supports it.
 *   **Config:** Add a `ytnova.conf` switch for trash-delete with default `1` (enabled).
 *   **Fallback:** If trash-delete is disabled or unsupported for the active backend, use permanent delete with explicit confirmation.
 *   - [ ] **Status:** Not Started.
 
-### **Idea FE-40: Port to other platforms**
+### **Idea FE-41: Port to other platforms**
 *   **Validation:** Currently practical via WSL and QEMU
 *   **Possible:** OmniOS (illumos), GNU Hurd, FreeBSD
 *   **Possible but impractical for maintainers right now:**  macOS, AIX, OpenVMS, Solaris, Redox OS

--- a/docs/ai/CODE_QUALITY.md
+++ b/docs/ai/CODE_QUALITY.md
@@ -1,45 +1,28 @@
-# Code Quality Prompt Guide
+# Code Quality Burn-Down Blueprint
 
-Use this guide to invoke `code-quality` with a **prevention-first** posture.
+Use this doc when a session invokes `code-quality` explicitly or when a code-quality / clean-code remediation request auto-loads that skill.
 
-## When this doc is used
+This file is the canonical Task 6 policy for recurring burn-down work:
 
-This doc is for AI-assisted sessions (architect/developer/code-auditor) when prompts include:
+- smell classes and prioritization,
+- the lean simplicity contract,
+- recurring cadence triggers,
+- the before/after evidence format,
+- and the acceptance checklist for each pass.
 
-- `use skill code-quality`, or
-- code-quality / clean-code remediation requests that trigger cross-cutting auto-load.
+## Prevention-First Posture
 
-It is not runtime code and not read by the compiler; it guides how AI work is requested and executed.
+Code-quality work is not permission for cosmetic rewrites.
 
-## Canonical Audit Frame
+Before editing code:
 
-The code-quality skill checks for the canonical failure modes behind “looks fine locally, but not as a whole”:
+1. Reconfirm the behavior/spec that must remain true.
+2. Build an explicit inventory of the in-scope surfaces.
+3. Prefer root-cause fixes over cleanup that only rearranges symptoms.
+4. Keep the batch coherent: one owner boundary, one validation path, one risk class.
+5. Preserve architectural invariants (explicit context passing, panel isolation, deterministic single-threaded behavior).
 
-- conceptual integrity
-- architectural drift
-- architectural erosion
-- architecture conformance failures
-- shotgun surgery
-- duplicate or parallel implementations
-- performance regressions in interactive flows
-- event-loop nondeterminism and signal-safety violations
-
-When invoking `code-quality`, ask it to verify that the implementation still forms one coherent system rather than a set of independently edited fragments.
-
-## Canonical Blueprint Location
-
-This file is a concise prompt/entry guide.
-
-The comprehensive execution blueprint lives in:
-- `.ai/skills/code-quality/SKILL.md`
-
-That skill file is the source of truth for:
-- smell taxonomy and prioritization,
-- lean-readable and anti-obfuscation contract,
-- recursion policy (allowed vs discouraged),
-- recurring burn-down cadence and evidence template.
-
-## Prevention-first prompt template
+Use this prompt starter when needed:
 
 ```text
 use skill code-quality
@@ -58,20 +41,139 @@ Before code edits, enforce:
 - duplicate/parallel implementation check
 - performance regression check
 - event-loop determinism / signal-safety check
-Then report/implement only approved P0-P1 issues.
+Then report/implement only approved P0-P1 issues, plus any approved P2 burn-down batch.
 ```
 
-## Repo guardrails to rely on
+## Lean Simplicity Contract
 
-Keep these repo guardrails active in every change:
+Every burn-down pass must leave the code leaner **without** making it harder to read or debug.
+
+Mandatory rules:
+
+1. Prefer the simplest clear implementation that preserves behavior and invariants.
+2. Fewer lines is good only when readability and diagnosability stay equal or improve.
+3. Avoid shorthand or clever constructs that hide control flow, ownership, or side effects.
+4. Use explicit names for ownership and state transitions; avoid ambiguous abbreviations outside tiny local loops.
+5. Favor straightforward control flow (guard clauses over deep nesting where practical).
+6. Do not introduce speculative indirection, generic helpers, or flag-heavy APIs just to shrink one hotspot.
+
+### Anti-Obfuscation Checks
+
+Treat these as smells even when they technically work:
+
+- dense expression chains that hide branching or mutation,
+- nested ternaries or compressed control flow,
+- helpers that multiplex unrelated behavior via boolean flags,
+- hidden shared-state mutation without an explicit ownership contract,
+- unnecessary indirection layers introduced before a clear rule-of-three need,
+- recursion outside clearly bounded hierarchy traversal.
+
+If recursion is retained or introduced, record a one-line justification and its termination/base-case note in the review evidence.
+
+## Smell Classes and Prioritization
+
+### Severity
+
+- `P0`: security risk, corruption, data loss, destructive surprises.
+- `P1`: correctness risk, broken invariants, high-likelihood regression.
+- `P2`: maintainability drift that materially slows normal feature work.
+- `P3`: readability/polish issue with low immediate risk.
+- `P4`: optional stylistic cleanup.
+
+Raise severity one level for a safe quick win. Lower it one level when change risk is high and coverage is weak.
+
+### Canonical Smell Classes
+
+| Class | What to look for | Typical priority |
+| --- | --- | --- |
+| Conceptual integrity | duplicate or parallel implementations, half-migrations, divergent sibling semantics, architectural drift/erosion | P1-P2 |
+| Module boundaries | controller-owned logic that belongs in modules, mixed-responsibility files, cross-panel coupling, shotgun surgery | P1-P2 |
+| Ownership and lifetime | unclear buffer/pointer ownership, asymmetric cleanup, borrowed references outliving owners | P0-P1 |
+| Error handling | silent failure, inconsistent contracts, fail-late behavior, missing validation | P1-P2 |
+| Event-loop determinism | redraw lag, blocking main-loop work, resize/input nondeterminism, signal-safety violations | P1-P2 |
+| UI/TUI economy | extra submenu hops, prompt chains, inconsistent key behavior, stale redraw state | P2-P3 |
+| API and data shape | long parameter lists, primitive obsession, flag-heavy signatures, duplicated business rules | P2 |
+| Complexity and readability | deep nesting, mixed abstraction levels, wrong abstractions, dead code, comment-as-deodorant | P2-P3 |
+| Tests and QA | missing fail-first proof, timing hacks, spec drift, suppressions that bypass root-cause fixes | P1-P2 |
+| Docs and comments | stale comments, duplicated process guidance, missing invariant rationale | P2-P3 |
+
+## Recurring Burn-Down Cadence
+
+A burn-down pass is mandatory when **any** of these triggers fires:
+
+1. **Five merged structural PRs since the last pass:** five merged feature/refactor PRs that touch `src/`, `include/`, or code-quality guard scripts under `scripts/`.
+2. **Before milestone or release tags:** run a fresh pass before any milestone tag or release cut.
+3. **When a structural baseline is intentionally lowered:** after shrinking a guarded controller/file/function budget or retiring a legacy boundary exception, record the new baseline in the same effort or immediately after it.
+
+### Batch Size and Selection Rules
+
+- Default to the **top 3-5 hotspots** by size/complexity/smell impact in one owner boundary.
+- Do not mix unrelated subsystems solely to hit a count.
+- If a hotspot batch touches controller/file/function budgets, the pass must include `make qa-module-boundaries`.
+- Use the guarded hotspot report plus direct audit judgment together. The report ranks known budgeted hotspots; maintainers still need to spot duplicate logic, drift, or UX regressions that a size-only metric cannot see.
+
+## Evidence Format for Each Pass
+
+Create a measurable before/after record for the same hotspot rows:
+
+1. Save a **before** snapshot:
+
+   ```bash
+   python3 scripts/report_code_quality_hotspots.py --format json > /tmp/ytnova-hotspots-before.json
+   ```
+
+2. Land the bounded burn-down batch.
+3. Save the **after** comparison:
+
+   ```bash
+   python3 scripts/report_code_quality_hotspots.py \
+     --baseline /tmp/ytnova-hotspots-before.json \
+     --format markdown \
+     --top 5
+   ```
+
+4. Attach:
+   - the before/after hotspot table,
+   - the delta summary (what shrank, what stayed flat, what was deferred),
+   - behavior-preservation notes,
+   - focused validation results.
+
+### Minimum Validation Evidence
+
+Every burn-down pass must include:
+
+- `make`
+- focused `pytest` for touched behavior (with `.venv` activated)
+- `make qa-module-boundaries`
+
+Add these when their surfaces change:
+
+- `make qa-code-quality` when touching guards, AI config, or generated catalog/template surfaces
+- `make qa-fileops-integrity` for file/archive mutation flows
+- `make qa-split-panel-gates` for split-panel invariants
+
+Local `make qa-all` remains optional unless maintainer-requested; green PR full-QA CI remains the pre-merge gate.
+
+## Acceptance Checklist for One Burn-Down Pass
+
+Do not call a pass complete until all of these are true:
+
+- The selected hotspot batch is explicit and coherent.
+- The same hotspot rows appear in both before and after evidence.
+- Any unchanged or deferred hotspot is named with a reason.
+- Lean-simplicity rules were followed; no clever/obfuscated replacement code was introduced.
+- Behavior and UX semantics for touched paths were preserved.
+- `make qa-module-boundaries` and the required bundled QA gates are green for the touched surfaces.
+
+## Repo Guardrails to Keep Active
 
 1. Conventional commit-msg hook policy enforcement.
-2. Mandatory focused verification in development; green PR full-QA CI (`make qa-all` equivalent) at pre-merge gate.
+2. Mandatory focused verification during implementation; green PR full-QA CI before merge.
 3. QA remediation gate: fix root cause, do not patch around failures.
-4. Module ownership gate: keep business logic out of controllers when separable.
+4. Module ownership gate: keep controller files dispatch-oriented when logic can live elsewhere.
 5. UX economy gate for interactive paths.
 
 ## Notes
 
 - Skill name is `code-quality`.
-- This filename is intentionally short and discoverable: `CODE_QUALITY.md`.
+- This filename remains intentionally short and discoverable: `CODE_QUALITY.md`.

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -133,7 +133,7 @@ Cross-cutting skill auto-load:
 *   Manpage/usage doc sync tasks -> `manpage-sync`
 *   UI workflow/menu-depth/interaction-economy design -> `ui-economy-navigation`
 *   UI prompt-chain offender detection/audit -> `ui-flow-offender-audit`
-*   Code-quality audit/remediation (clean-code/deslop-style) -> `code-quality` (prompt guide: [CODE_QUALITY.md](CODE_QUALITY.md))
+*   Code-quality audit/remediation (clean-code/deslop-style) -> `code-quality` (blueprint: [CODE_QUALITY.md](CODE_QUALITY.md))
 *   AI-writing-tell and prose de-slop tasks -> `ai-writing-tells`
 
 Skill precedence (highest to lowest):

--- a/scripts/report_code_quality_hotspots.py
+++ b/scripts/report_code_quality_hotspots.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Report guarded code-quality hotspots and before/after debt deltas."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUARD_PATH = REPO_ROOT / "scripts" / "check_module_boundaries.py"
+
+
+def _load_guard_module() -> Any:
+    spec = importlib.util.spec_from_file_location("check_module_boundaries", GUARD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load guard module: {GUARD_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_guard_module()
+
+
+def _signed(value: int) -> str:
+    return f"{value:+d}"
+
+
+def _line_count(path: Path) -> int:
+    return sum(1 for _ in path.open("r", encoding="utf-8", errors="replace"))
+
+
+def _make_row(
+    *,
+    category: str,
+    surface: str,
+    metric: str,
+    current: int,
+    budget: int,
+) -> dict[str, Any]:
+    return {
+        "category": category,
+        "surface": surface,
+        "metric": metric,
+        "current": current,
+        "budget": budget,
+        "slack": budget - current,
+    }
+
+
+def build_snapshot(root: Path) -> dict[str, Any]:
+    root = root.resolve()
+    controller_files: list[dict[str, Any]] = []
+    controller_functions: list[dict[str, Any]] = []
+
+    for rel, budget in sorted(guard.CONTROLLER_FILE_LINE_BUDGET.items()):
+        path = root / rel
+        if not path.exists():
+            raise ValueError(f"missing guarded controller file: {rel}")
+        controller_files.append(
+            _make_row(
+                category="controller-file",
+                surface=rel,
+                metric="file_lines",
+                current=_line_count(path),
+                budget=budget,
+            )
+        )
+
+    for rel, fn_budgets in sorted(guard.CONTROLLER_GOD_FUNCTION_LINE_BUDGET.items()):
+        path = root / rel
+        if not path.exists():
+            raise ValueError(f"missing guarded controller file for function budgets: {rel}")
+        lengths = guard.parse_top_level_function_lengths(
+            path.read_text(encoding="utf-8", errors="replace")
+        )
+        for fn_name, budget in sorted(fn_budgets.items()):
+            current = lengths.get(fn_name)
+            if current is None:
+                raise ValueError(f"missing guarded top-level function: {rel}:{fn_name}")
+            controller_functions.append(
+                _make_row(
+                    category="controller-function",
+                    surface=f"{rel}:{fn_name}",
+                    metric="function_lines",
+                    current=current,
+                    budget=budget,
+                )
+            )
+
+    combined = sorted(
+        controller_files + controller_functions,
+        key=lambda row: (row["slack"], -row["current"], row["surface"]),
+    )
+    return {
+        "repo_root": str(root),
+        "guard_source": str(GUARD_PATH.relative_to(REPO_ROOT)),
+        "legacy_policy_exception_count": len(guard.LEGACY_POLICY_EXCEPTIONS),
+        "controller_files": controller_files,
+        "controller_functions": controller_functions,
+        "combined": combined,
+    }
+
+
+def _index_rows(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {row["surface"]: row for row in rows}
+
+
+def comparison_rows(
+    snapshot: dict[str, Any],
+    baseline: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    baseline_rows: dict[str, dict[str, Any]] = {}
+    if baseline is not None:
+        baseline_rows = _index_rows(baseline.get("combined", []))
+
+    for row in snapshot["combined"]:
+        annotated = dict(row)
+        previous = baseline_rows.get(row["surface"])
+        if previous is not None:
+            annotated["before"] = previous["current"]
+            annotated["delta"] = row["current"] - previous["current"]
+            annotated["slack_before"] = previous["slack"]
+            annotated["slack_delta"] = row["slack"] - previous["slack"]
+        else:
+            annotated["before"] = None
+            annotated["delta"] = None
+            annotated["slack_before"] = None
+            annotated["slack_delta"] = None
+        rows.append(annotated)
+    return rows
+
+
+def _top_rows(rows: list[dict[str, Any]], top: int) -> list[dict[str, Any]]:
+    if top <= 0:
+        return rows
+    return rows[:top]
+
+
+def render_markdown(
+    snapshot: dict[str, Any],
+    *,
+    baseline: dict[str, Any] | None = None,
+    top: int = 5,
+) -> str:
+    rows = _top_rows(comparison_rows(snapshot, baseline), top)
+    lines = [
+        "# Code-quality hotspots",
+        "",
+        f"- Guard source: `{snapshot['guard_source']}`",
+        f"- Repo root: `{snapshot['repo_root']}`",
+        f"- Legacy policy exceptions: `{snapshot['legacy_policy_exception_count']}`",
+        "",
+    ]
+
+    if baseline is None:
+        lines.extend(
+            [
+                "| Rank | Surface | Metric | Current | Budget | Slack |",
+                "| --- | --- | --- | ---: | ---: | ---: |",
+            ]
+        )
+        for idx, row in enumerate(rows, start=1):
+            lines.append(
+                f"| {idx} | {row['surface']} | {row['metric']} | "
+                f"{row['current']} | {row['budget']} | {_signed(row['slack'])} |"
+            )
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "| Rank | Surface | Metric | Before | After | Delta | Budget | Slack Δ |",
+            "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for idx, row in enumerate(rows, start=1):
+        before = "n/a" if row["before"] is None else str(row["before"])
+        delta = "n/a" if row["delta"] is None else _signed(row["delta"])
+        slack_delta = "n/a" if row["slack_delta"] is None else _signed(row["slack_delta"])
+        lines.append(
+            f"| {idx} | {row['surface']} | {row['metric']} | "
+            f"{before} | {row['current']} | {delta} | {row['budget']} | {slack_delta} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root to inspect (defaults to this checkout).",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        help="Optional JSON snapshot produced by this script for before/after comparison.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="How many highest-risk guarded hotspots to emit (<=0 means all).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        snapshot = build_snapshot(args.root)
+        baseline = None
+        if args.baseline is not None:
+            baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        payload = dict(snapshot)
+        payload["top_hotspots"] = _top_rows(snapshot["combined"], args.top)
+        if baseline is not None:
+            payload["comparison_top_hotspots"] = _top_rows(
+                comparison_rows(snapshot, baseline),
+                args.top,
+            )
+        json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+
+    sys.stdout.write(render_markdown(snapshot, baseline=baseline, top=args.top))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_code_quality_hotspots_report.py
+++ b/tests/test_code_quality_hotspots_report.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPORT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "report_code_quality_hotspots.py"
+)
+REPORT_SPEC = importlib.util.spec_from_file_location(
+    "report_code_quality_hotspots",
+    REPORT_PATH,
+)
+assert REPORT_SPEC is not None and REPORT_SPEC.loader is not None
+reporter = importlib.util.module_from_spec(REPORT_SPEC)
+REPORT_SPEC.loader.exec_module(reporter)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _build_long_function(name: str, body_lines: int) -> str:
+    body = "\n".join("    x += 1;" for _ in range(body_lines))
+    return (
+        f"int {name}(void)\n"
+        "{\n"
+        "    int x = 0;\n"
+        f"{body}\n"
+        "    return x;\n"
+        "}\n"
+    )
+
+
+def _write_repo_fixture(tmp_path: Path, *, dir_lines: int, file_lines: int) -> None:
+    _write(
+        tmp_path / "src/ui/ctrl_dir.c",
+        _build_long_function("HandleDirWindow", dir_lines),
+    )
+    _write(
+        tmp_path / "src/ui/ctrl_file.c",
+        _build_long_function("HandleFileWindow", file_lines),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _guarded_surfaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        reporter.guard,
+        "CONTROLLER_FILE_LINE_BUDGET",
+        {
+            "src/ui/ctrl_dir.c": 40,
+            "src/ui/ctrl_file.c": 40,
+        },
+    )
+    monkeypatch.setattr(
+        reporter.guard,
+        "CONTROLLER_GOD_FUNCTION_LINE_BUDGET",
+        {
+            "src/ui/ctrl_dir.c": {"HandleDirWindow": 30},
+            "src/ui/ctrl_file.c": {"HandleFileWindow": 30},
+        },
+    )
+
+
+def test_build_snapshot_reports_guarded_file_and_function_hotspots(
+    tmp_path: Path,
+) -> None:
+    _write_repo_fixture(tmp_path, dir_lines=8, file_lines=3)
+
+    snapshot = reporter.build_snapshot(tmp_path)
+
+    assert [row["surface"] for row in snapshot["controller_files"]] == [
+        "src/ui/ctrl_dir.c",
+        "src/ui/ctrl_file.c",
+    ]
+    assert [row["surface"] for row in snapshot["controller_functions"]] == [
+        "src/ui/ctrl_dir.c:HandleDirWindow",
+        "src/ui/ctrl_file.c:HandleFileWindow",
+    ]
+    assert {row["surface"] for row in snapshot["combined"]} == {
+        "src/ui/ctrl_dir.c",
+        "src/ui/ctrl_file.c",
+        "src/ui/ctrl_dir.c:HandleDirWindow",
+        "src/ui/ctrl_file.c:HandleFileWindow",
+    }
+
+
+def test_render_markdown_with_baseline_shows_before_after_delta(
+    tmp_path: Path,
+) -> None:
+    _write_repo_fixture(tmp_path, dir_lines=8, file_lines=3)
+    baseline = reporter.build_snapshot(tmp_path)
+
+    _write_repo_fixture(tmp_path, dir_lines=4, file_lines=3)
+    current = reporter.build_snapshot(tmp_path)
+
+    markdown = reporter.render_markdown(current, baseline=baseline, top=4)
+    baseline_rows = {row["surface"]: row for row in baseline["combined"]}
+    current_rows = {row["surface"]: row for row in current["combined"]}
+
+    assert "| Rank | Surface | Metric | Before | After | Delta | Budget | Slack Δ |" in markdown
+    for surface in ("src/ui/ctrl_dir.c", "src/ui/ctrl_dir.c:HandleDirWindow"):
+        baseline_row = baseline_rows[surface]
+        current_row = current_rows[surface]
+        assert (
+            f"| {surface} | {current_row['metric']} | "
+            f"{baseline_row['current']} | {current_row['current']} | "
+            f"{current_row['current'] - baseline_row['current']:+d} | "
+            f"{current_row['budget']} | "
+            f"{current_row['slack'] - baseline_row['slack']:+d} |"
+        ) in markdown
+    assert "-4" in markdown
+
+
+def test_current_repository_hotspot_report_runs() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    run = subprocess.run(
+        [
+            "python3",
+            "scripts/report_code_quality_hotspots.py",
+            "--format",
+            "markdown",
+            "--top",
+            "4",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "src/ui/ctrl_dir.c" in run.stdout
+    assert "HandleFileWindow" in run.stdout


### PR DESCRIPTION
## Summary
- codify the recurring code-quality burn-down cadence and acceptance evidence in the audit and contributor docs
- expand `docs/ai/CODE_QUALITY.md` into the canonical blueprint and point the code-quality skill/workflow guidance at it
- add a guarded hotspot reporting command plus regression coverage for before/after debt deltas

## Validation
- `make clean && make`
- `source .venv/bin/activate && pytest -q tests/test_code_quality_hotspots_report.py`
- `make qa-code-quality`
- `make code-quality-hotspots HOTSPOT_ARGS='--top 4'`
