### PR TITLE
docs(project): clarify YtreeNova identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ YtreeNova logs filesystem hierarchies into memory, so you can work across whole 
 
 ## Background
 
-YtreeNova is an independent fork of [Ytree](https://www.han.de/~werner/ytree.html) v2.10, created by Werner Bregulla and others. The fork began in October 2025 and now has its own name, release line, command (`ytnova`), and repository.
+YtreeNova is a separate Unix-like XTreeGold tribute project with Ytree v2.10 lineage. It began from Werner Bregulla's Ytree codebase in October 2025 and now has its own name, command (`ytnova`), repository, and release history.
 
-It remains in the [XTree&trade;](https://www.xtreefanpage.org/lowres/x10dirja.htm)/Ytree family of full-tree logging and tagging file managers: scan a hierarchy first, then navigate, filter, tag, view, and operate across the logged set as a whole. The YtreeNova line focuses on feature completeness for Unix power users, adding split-screen work, integrated preview/autoview, archive-as-directory operations, and modernized internals.
+It remains in the [XTree](https://www.xtreefanpage.org/lowres/x10dirja.htm)/Ytree family of full-tree logging and tagging file managers: scan a hierarchy first, then navigate, filter, tag, view, and operate across the logged set as a whole. YtreeNova focuses on feature completeness for Unix power users, with split-screen work, integrated preview/autoview, archive-as-directory operations, and contemporary POSIX-oriented internals rather than old-system portability.
 
 Many file managers today function as "browsers"—they look at one directory at a time and rely on the OS to fetch files on demand. YtreeNova keeps the logger model: it scans ("logs") entire drive hierarchies into memory. This treats the filesystem as a database, allowing you to **Show All** files in a flat view, filter across thousands of subdirectories instantly, and perform bulk operations on tagged files regardless of their location.
 
 ## Development Methodology
 
-This modernization is an experiment in AI-assisted systems engineering. The codebase was not simply "ported"; it was systematically disassembled and re-architected toward feature completeness and maintainability.
+This project is an experiment in AI-assisted systems engineering. The codebase was not simply "ported"; it has been reworked toward feature completeness and maintainability.
 
 In practice, the human maintains design ownership and quality control, while AI is used as an implementation assistant. This requires substantial iteration, verification, and architectural guardrails for each meaningful change. The goal is to show that LLM-assisted development can still meet normal project standards when the process is disciplined, specification-driven, and strongly validated.
 
@@ -39,7 +39,7 @@ v1.0.0-alpha is being published early so people can use the program, inspect the
 
 ## Features (v1.0.0-alpha)
 
-*   **Classic XTree™ Interface:** Directory Tree + File List layout.
+*   **Classic XTree Interface:** Directory Tree + File List layout.
 *   **Split Screen Mode (F8):** Manage two independent file panels side-by-side.
 *   **File Preview (F7):** Instant view of file contents without launching external tools.
 *   **Multi-Volume Support:** Log multiple drives or archives simultaneously and switch instantly.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 > **Purpose:** This document defines the internal design of `ytnova`. It serves as the authoritative guide for maintaining the codebase's structural integrity.
 
 ## **1. Core Quality Principles**
-To maintain architectural stability throughout the modernization, all changes must adhere to these foundational rules:
+To maintain architectural stability throughout YtreeNova's development, all changes must adhere to these foundational rules:
 
 *   **Code Quality (DRY):** All development must adhere to the "Don't Repeat Yourself" principle. Code must be modular, reusable, and free of redundancy.
 *   **Architectural Integrity (Anti-Patching):** Do not apply superficial fixes for deep architectural problems. If a bug is caused by fragmented state or logic, **STOP**. Refactor the architecture to unify the logic before fixing the specific bug. It is better to break one thing to fix the system than to patch the system and break everything.
@@ -48,7 +48,7 @@ This does **not** replace architecture review. It is a fitness function: mechani
 ## **2. Architectural Overview**
 This document outlines the architectural design of `ytnova`. The codebase utilizes a modular, context-oriented C99 design.
 
-The primary objective is to maintain a **predictable, high-integrity state machine**. Every component is designed to uphold the **Focus vs. Freeze** logic and the specific hierarchy of modal priorities inherited from the XTree&trade; lineage.
+The primary objective is to maintain a **predictable, high-integrity state machine**. Every component is designed to uphold the **Focus vs. Freeze** logic and the specific hierarchy of modal priorities inherited from the XTree lineage.
 
 ---
 

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,7 +1,7 @@
 # AUDIT.md
 
 ## 1. Purpose
-This document defines the mandatory quality process for the YtreeNova modernization project. Auditing is an ongoing process that starts during implementation and continues through merge and release. The release gate is the final checkpoint.
+This document defines the mandatory quality process for YtreeNova. Auditing is an ongoing process that starts during implementation and continues through merge and release. The release gate is the final checkpoint.
 
 ## 1.1 Cadence
 - Use focused checks during feature-sized change or PR iteration.

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -22,6 +22,6 @@ Originally developed by [Werner Bregulla](https://www.han.de/~werner/ytree.html)
 *   **Valere Monseur aka Dobedo** - NetBSD
 *   **Victor Vislobokov** - UTF-8 support
 
-**YtreeNova Modernization**
+**YtreeNova Development**
 
-* **Rob Kam** - Forked YtreeNova in October 2025 from Ytree v2.10. Modernized and extended the fork while making extensive use of LLMs for code generation and debugging.
+* **Rob Kam** - Started YtreeNova in October 2025 from Ytree v2.10 and developed it as a separate Unix-like XTreeGold tribute project, with extensive use of LLMs for code generation and debugging.

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -10,12 +10,12 @@ Minor/trivial fixes are tracked in git history.
 
 ## [1.0.0-alpha] - 2026-06-10
 
-*YtreeNova alpha release line starts here after the project rebrand. Modernization Project initiated 30 Oct 2025 from Ytree v2.10. This release represents an independent fork and comprehensive architectural modernization to C99/POSIX standards, introducing significant power-user features, enhanced safety, and robust quality assurance.*
+*YtreeNova release history starts here after the rebrand. The codebase began from Ytree v2.10 on 30 Oct 2025 and has since been developed as a separate Unix-like XTreeGold tribute with broader workflows, stronger QA, and contemporary POSIX-focused internals.*
 
 ### Lineage
-- YtreeNova is an independent fork of [Ytree](https://www.han.de/~werner/ytree.html) v2.10, created by Werner Bregulla and others, with its own name and release line to keep the projects distinct.
+- YtreeNova began from the [Ytree](https://www.han.de/~werner/ytree.html) v2.10 codebase by Werner Bregulla and others, but now has its own name and release history.
 
-### Core Architecture & Modernization
+### Core Architecture & Runtime
 - **Refactoring & Standardization**: Modernized the original C89-oriented codebase to C99/POSIX standards.
 - **Context-Passing Architecture**: Replaced implicit cross-module state access with explicit context parameters and ownership boundaries.
 - **Global State Removal**: Drove major mutable application state out of file-scope globals and into structured runtime state.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,19 +27,19 @@ The alpha is published early so users and contributors can inspect the code, tes
 
 In short: the project is usable now, but not stable yet. Expect rough edges, occasional regressions, and evolving UX details until beta and then stable release.
 
-### Why fork Ytree v2.10 instead of starting from scratch?
+### What is YtreeNova's relationship to Ytree?
 
-YtreeNova began as a fork of Werner Bregulla’s Ytree v2.10. The original intention was to develop a major enhanced line from that codebase, but the project was renamed to YtreeNova to avoid confusion with Werner’s continuing Ytree 2.x work. The name keeps the Ytree lineage visible while the Nova suffix marks it as a separate enhanced fork rather than the next official Ytree release.
+YtreeNova started from Werner Bregulla’s Ytree v2.10 codebase, but it is now a separate line with its own name, command, repository, and release history. The aim is to build a Unix-like XTreeGold tribute that keeps the logged-tree workflow and extends it in its own direction.
 
-A clean-slate implementation could have copied the same UI/UX, but it would still have meant rebuilding existing behaviour before adding the missing features. Starting from Ytree preserved the working baseline and made it possible to focus on extending the program with split-screen workflows, integrated preview/autoview, archive-as-directory operations, and a more modular C99/POSIX codebase.
+A clean-slate implementation could have copied the same UI/UX, but it would still have meant rebuilding existing behaviour before adding the missing features. Starting from Ytree preserved a working logged-tree baseline and made it possible to focus on split-screen workflows, integrated preview/autoview, archive-as-directory operations, and a more modular C99/POSIX codebase instead of first rebuilding those foundations from scratch.
 
-Werner’s Ytree continues to value portability across a broad range of Unix systems, including older environments. YtreeNova currently targets contemporary POSIX-style Unix systems and, so far, has mainly been tested only on a small number of recent Linux distributions.
+Werner’s Ytree continues to value portability across a broad range of Unix systems, including older environments. YtreeNova does not promise the same portability target; it currently aims at contemporary POSIX-style Unix systems and, so far, has mainly been tested only on a small number of recent Linux distributions.
 
 ### Why is this not written in Rust?
 
 The primary objective of this phase was architectural cleanup and feature completion in the existing C codebase.
 
-Switching languages immediately would constitute a total rewrite rather than a modernization. However, now that the architecture has been simplified, legacy dependencies removed, and the project stabilized, a port to a modern memory-safe language like Rust is a possibility for a future version.
+Switching languages immediately would have turned this phase into a total rewrite instead of continuing the existing codebase. However, now that the architecture has been simplified, legacy dependencies removed, and the project stabilized, a port to a modern memory-safe language like Rust is a possibility for a future version.
 
 ### Why ncurses, why not termbox2 or notcurses?
 
@@ -51,7 +51,7 @@ YtreeNova only needs fast, reliable text/line-box terminal UI for file and VFS b
 
 ### How is YtreeNova different from UnixTree?
 
-YtreeNova and UnixTree are separate XTree&trade;-inspired projects with different histories, codebases, and design choices. They overlap in several user-facing goals, including logged-tree navigation, tagging, split-screen operation, preview/autoview, and archive handling, but they differ substantially in architecture and maintenance approach.
+YtreeNova and UnixTree are separate XTree-inspired projects with different histories, codebases, and design choices. They overlap in several user-facing goals, including logged-tree navigation, tagging, split-screen operation, preview/autoview, and archive handling, but they differ substantially in architecture and maintenance approach.
 
 #### How do the YtreeNova and UnixTree architectures compare?
 
@@ -84,6 +84,6 @@ Yes. While graphical file managers are standard for desktop users, TUI (Text Use
 ### Who is the target audience?
 
 YtreeNova specifically targets:
-1.  **XTree&trade; Veterans:** Users who developed "muscle memory" for the XTree&trade; layout and keybindings in the DOS era and find the Midnight Commander style unintuitive.
+1.  **XTree Veterans:** Users who developed "muscle memory" for the XTree layout and keybindings in the DOS era and find the Midnight Commander style unintuitive.
 2.  **Terminal Power Users:** Developers and Admins who want a fast, lightweight file manager that integrates seamlessly with their shell history and standard CLI tools.
 3.  **Open Source Archivists:** Those interested in keeping classic Unix tools alive, compilable, and secure on modern hardware.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# **Modernization Roadmap**
+# **YtreeNova Roadmap**
 
 ---
 
@@ -83,7 +83,7 @@ Ordering policy (for all editors, including AI editors):
 *   Existing dead-history comments in first-party code are removed or rewritten to durable design intent.
 *   New guard fails on forbidden patterns and passes on current baseline.
 *   `make qa-all` passes with the new guard enabled.
-*   - [ ] **Status:** In Progress. A picker-themed `F9` Applications menu shell now exists so theme surfaces can be previewed there; preset execution, user-configurable entries, and completion reporting remain open.
+*   - [ ] **Status:** In Progress.
 
 ### **Task 3: Unified Clean-Code Compliance Gate**
 *   **Goal:** Enforce clean-code rules continuously through one measurable gate instead of ad-hoc review.
@@ -1083,8 +1083,8 @@ Ordering policy (for all editors, including AI editors):
     *   The synchronize path prefers `rsync` for plain filesystem paths and does not require ytnova to own a new recursive sync engine.
 *   - [ ] **Status:** Not Started.
 
-### **Task 55: Promote Applications Menu (`F9`) with Safe Default Presets**
-*   **Goal:** Bring `F9` Applications Menu into current-delivery scope as a visible, contributor-friendly command surface with sensible default entries.
+### **Task 55: Implement Applications Menu (`F9`) with Safe Default Presets**
+*   **Goal:** Implement `F9` Applications Menu as a visible, contributor-friendly command surface with sensible default entries.
 *   **Semantics:** Entries are user commands/templates (with optional placeholders/parameters) that execute commands; this is not keystroke recording.
 *   **Default Presets (initial set):**
     *   `wget` fetch preset (option-heavy fetch with URL prompt).
@@ -1097,7 +1097,7 @@ Ordering policy (for all editors, including AI editors):
     *   User-added commands are not restricted, including commands that duplicate existing builtins.
     *   Prompt/help/F1/manpage text documents `F9` basics and preset intent in contributor-friendly language.
     *   Command completion reporting is explicit (`success` on zero exit, actionable error summary on non-zero exit).
-*   - [ ] **Status:** Not Started.
+*   - [ ] **Status:** In Progress. A picker-themed `F9` Applications menu shell now exists so theme surfaces can be previewed there; preset execution, user-configurable entries, and completion reporting remain open.
 
 ### **Task 56: Define Extension Surface Contract (`F9` Apps + `F7` Preview Plugins)**
 *   **Goal:** Define one explicit extension contract for external-tool integrations so command apps (`F9`) and preview plugins (`F7`) follow the same safety, UX, and fallback rules.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -49,7 +49,7 @@ The screen is divided into non-overlapping zones. Geometry is calculated dynamic
 | **Stats Panel** | Right Column (**Fixed 26**) | Metadata, Filters, Disk Stats | Context-aware. Always visible in Standard Mode. |
 | **Command Area** | Bottom 3 Rows | Menu, Prompts, Messages | Handles all user interaction feedback. |
 
-### 2.3 Visual Grammar (The "XTree&trade; Look")
+### 2.3 Visual Grammar (The "XTree Look")
 *   **Junction Grammar:** Ncurses junctions (T-pieces, crosses) must **only** be used for horizontal boundary lines. Vertical separators must remain clean, unbroken lines to avoid visual clutter.
 *   **Empty State:** If a directory contains no files, the File View window must display the text: `** No files **`.
 *   **Small-Window Name Column Alignment:** In the small File View, reserve the first post-border cell for tag (`*` or space), the second as a spacer, and start all row text at the same column. This applies to regular names, symlink labels, and placeholders (e.g., `No files`, `Unlogged`).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -8,9 +8,9 @@ ytnova - a file manager for Unix-like systems
 
 # DESCRIPTION
 
-**ytnova** is a file manager for UNIX-like systems (Linux, BSD, etc.). It is inspired by the DOS file manager **XTree™**, offering a text-based user interface (TUI) that is fast, lightweight, and keyboard-driven.
+**ytnova** is a file manager for UNIX-like systems (Linux, BSD, etc.). It is inspired by the DOS file manager **XTree**, offering a text-based user interface (TUI) that is fast, lightweight, and keyboard-driven.
 
-This version is a modern refactor of the original **ytree** by Werner Bregulla, incorporating features from XTree™ and ZTreeWin, using modern C standards (C99/POSIX), and integrating robust libraries like `libarchive`.
+It began from Ytree v2.10 but now continues as a separate Unix-like XTreeGold tribute, using contemporary POSIX/C99 code and libraries such as `libarchive`.
 
 If no command line arguments are provided, the current directory will be logged.
 

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -1,6 +1,6 @@
 # AI-Assisted Development Workflow
 
-This document defines the standards and processes for using AI agents to maintain and modernize the `ytnova` codebase. These rules ensure architectural integrity and prevent "hallucination debt."
+This document defines the standards and processes for using AI agents to maintain and extend the `ytnova` codebase. These rules ensure architectural integrity and prevent "hallucination debt."
 For canonical governance file ownership and edit targets, see [GOVERNANCE.md](GOVERNANCE.md).
 
 ---

--- a/etc/ytnova.1.md
+++ b/etc/ytnova.1.md
@@ -8,9 +8,9 @@ ytnova - a file manager for Unix-like systems
 
 # DESCRIPTION
 
-**ytnova** is a file manager for UNIX-like systems (Linux, BSD, etc.). It is inspired by the DOS file manager **XTree&trade;**, offering a text-based user interface (TUI) that is fast, lightweight, and keyboard-driven.
+**ytnova** is a file manager for UNIX-like systems (Linux, BSD, etc.). It is inspired by the DOS file manager **XTree**, offering a text-based user interface (TUI) that is fast, lightweight, and keyboard-driven.
 
-This version is a modern refactor of the original **ytree** by Werner Bregulla, incorporating features from XTree&trade; and ZTreeWin, using modern C standards (C99/POSIX), and integrating robust libraries like `libarchive`.
+It began from Ytree v2.10 but now continues as a separate Unix-like XTreeGold tribute, using contemporary POSIX/C99 code and libraries such as `libarchive`.
 
 If no command line arguments are provided, the current directory will be logged.
 


### PR DESCRIPTION
## Summary
- rewrite project-facing docs so YtreeNova is described as its own XTreeGold-style Unix-like line rather than as a modernized Ytree version
- keep Ytree as lineage/history only in README, FAQ, changelog, roadmap, audit, authors, architecture, workflow, and manpage-derived usage text
- regenerate `docs/USAGE.md` from `etc/ytnova.1.md`

## Why
Several docs still reflected the old "enhance and modernize Ytree" framing even though YtreeNova is now positioned as a separate tribute line with different goals and portability expectations.

## Validation
- `make docs`
- `make build/ytnova.1`
