### PR TITLE
fix(ui): keep integrated help command rows alive

### DIFF
--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -1444,6 +1444,8 @@ int UI_ShowIntegratedHelp(ViewContext *ctx, const DirEntry *dir_entry) {
   size_t row_count = 0;
   const char *title;
   ViewFocus active_focus;
+  ResolvedFooterCommand resolved[32];
+  UICommandStripCommand commands[32];
 
   if (ctx == NULL)
     return -1;
@@ -1463,8 +1465,6 @@ int UI_ShowIntegratedHelp(ViewContext *ctx, const DirEntry *dir_entry) {
   }
 
   if (active_focus == FOCUS_TREE) {
-    ResolvedFooterCommand resolved[32];
-    UICommandStripCommand commands[32];
     const HelpCommandStrip *nav_strip = &dir_help_nav_builtin[0];
     const FooterCommandSpec *specs;
     const char *line0_signpost;
@@ -1480,8 +1480,6 @@ int UI_ShowIntegratedHelp(ViewContext *ctx, const DirEntry *dir_entry) {
                                          line1_signpost, commands, spec_count);
     row_count = AppendPopupStripRow(rows, row_count, nav_strip);
   } else {
-    ResolvedFooterCommand resolved[32];
-    UICommandStripCommand commands[32];
     const HelpCommandStrip *nav_strip;
     const FooterCommandSpec *specs;
     const char *line0_signpost;

--- a/tests/test_help_text_contract.py
+++ b/tests/test_help_text_contract.py
@@ -184,6 +184,27 @@ def test_main_f1_help_tracks_directory_file_preview_and_split_contexts(tmp_path)
         tui.quit()
 
 
+def test_integrated_help_directory_and_file_modes_do_not_crash(tmp_path):
+    root = _root_with_file(tmp_path, "integrated_help_scope_lifetime")
+    tui = _spawn_help_tui(root)
+
+    try:
+        assert tui.wait_for_content("alpha.txt", timeout=1.5), screen_text(tui)
+
+        help_screen = _wait_for_help(tui, "Directory Help")
+        assert "compare" in help_screen.lower(), help_screen
+
+        tui.send_keystroke(Keys.ESC)
+        assert tui.wait_for_content("alpha.txt", timeout=1.0), screen_text(tui)
+
+        tui.send_keystroke(Keys.ENTER)
+        assert tui.wait_for_content("beta.txt", timeout=1.5), screen_text(tui)
+        help_screen = _wait_for_help(tui, "File Help")
+        assert "pathcopy" in help_screen.lower(), help_screen
+    finally:
+        tui.quit()
+
+
 def test_picker_dialog_f1_help_covers_volume_and_applications(tmp_path):
     root = _root_with_file(tmp_path, "integrated_help_picker_dialogs")
     tui = _spawn_help_tui(root)


### PR DESCRIPTION
## Summary
- keep integrated help popup command data alive for the full popup render path
- add a regression test that opens integrated help in both directory and file modes under ASan

## Root cause
`UI_ShowIntegratedHelp()` built popup rows from block-scoped `ResolvedFooterCommand` and `UICommandStripCommand` arrays, then passed row pointers into `UI_ShowHelpPopup()`. The help popup measured those rows after the block scope ended, triggering AddressSanitizer `stack-use-after-scope` failures.

## Impact
- pressing `F1` in integrated directory help no longer crashes
- pressing `F1` in integrated file help no longer crashes
- the regression is now covered by a focused TUI test

## Validation
- `source .venv/bin/activate && make clean && make DEBUG=1 && pytest -q tests/test_help_text_contract.py::test_integrated_help_directory_and_file_modes_do_not_crash tests/test_help_text_contract.py::test_main_f1_help_tracks_directory_file_preview_and_split_contexts`