### PR TITLE
chore(repo): rename starter theme and refresh script deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ YtreeNova logs filesystem hierarchies into memory, so you can work across whole 
 
 ## Background
 
-YtreeNova is a separate Unix-like XTreeGold tribute project with Ytree v2.10 lineage. It began from Werner Bregulla's Ytree codebase in October 2025 and now has its own name, command (`ytnova`), repository, and release history.
+YtreeNova is a Unix-like XTreeGold tribute project with Ytree v2.10 lineage. It began from Werner Bregulla's Ytree codebase in October 2025 and now has its own name, command (`ytnova`), repository, and release history.
 
 It remains in the [XTree](https://www.xtreefanpage.org/lowres/x10dirja.htm)/Ytree family of full-tree logging and tagging file managers: scan a hierarchy first, then navigate, filter, tag, view, and operate across the logged set as a whole. YtreeNova focuses on feature completeness for Unix power users, with split-screen work, integrated preview/autoview, archive-as-directory operations, and contemporary POSIX-oriented internals rather than old-system portability.
 

--- a/etc/ytnova.conf
+++ b/etc/ytnova.conf
@@ -112,7 +112,7 @@ TAGGEDVIEWER=internal
 # Edit semantic roles and file-type palette rules there.
 # Built-in starter themes (leave one uncommented):
 THEME=quiet-blue
-# THEME=orthodox-blue
+# THEME=norton-blue
 # THEME=bash-black
 
 [VIEWER]

--- a/etc/ytnova.themes
+++ b/etc/ytnova.themes
@@ -14,7 +14,7 @@
 # first matching selector wins. Omitted backgrounds inherit from the active
 # filename/window background.
 
-[theme orthodox-blue]
+[theme norton-blue]
 background = blue
 static_text = white
 dynamic_text = +white

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -6,7 +6,7 @@
 #
 annotated-types==0.7.0
     # via pydantic
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
 cffi==2.1.0
     # via cryptography
@@ -16,14 +16,14 @@ cryptography==49.0.0
     # via google-auth
 google-ai-generativelanguage==0.6.15
     # via google-generativeai
-google-api-core[grpc]==2.31.0
+google-api-core[grpc]==2.32.0
     # via
     #   google-ai-generativelanguage
     #   google-api-python-client
     #   google-generativeai
 google-api-python-client==2.198.0
     # via google-generativeai
-google-auth==2.56.0
+google-auth==2.56.2
     # via
     #   google-ai-generativelanguage
     #   google-api-core
@@ -99,7 +99,7 @@ requests==2.34.2
     # via google-api-core
 temporalio==1.30.0
     # via -r scripts/requirements.in
-tqdm==4.68.4
+tqdm==4.69.0
     # via google-generativeai
 types-protobuf==7.34.1.20260518
     # via temporalio

--- a/src/core/default_profile_template.h
+++ b/src/core/default_profile_template.h
@@ -114,7 +114,7 @@ static const char default_profile_template[] =
     "# Edit semantic roles and file-type palette rules there.\n"
     "# Built-in starter themes (leave one uncommented):\n"
     "THEME=quiet-blue\n"
-    "# THEME=orthodox-blue\n"
+    "# THEME=norton-blue\n"
     "# THEME=bash-black\n"
     "\n"
     "[VIEWER]\n"

--- a/src/core/default_theme_catalog.h
+++ b/src/core/default_theme_catalog.h
@@ -15,7 +15,7 @@ static const char default_theme_catalog[] =
     "# first matching selector wins. Omitted backgrounds inherit from the active\n"
     "# filename/window background.\n"
     "\n"
-    "[theme orthodox-blue]\n"
+    "[theme norton-blue]\n"
     "background = blue\n"
     "static_text = white\n"
     "dynamic_text = +white\n"


### PR DESCRIPTION
## Summary
- clarify the README background wording
- rename the bundled `orthodox-blue` starter theme to `norton-blue`
- keep generated built-in theme/config headers in sync with that rename
- refresh pinned script dependency versions in `scripts/requirements.txt`

## Impact
- docs describe YtreeNova more directly
- starter theme naming is consistent in config/theme sources and generated built-ins
- script dependencies pick up the reviewed version bumps already present in the lockfile

## Validation
- `make qa-code-quality`