### PR TITLE
feat(help): add modal explainer navigation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -828,7 +828,7 @@ Ordering policy (for all editors, including AI editors):
 *   `Enter` (and optionally `Right`) follows, `Left` backs out one page, `Esc` closes from anywhere, and `Up`/`Down`/`PgUp`/`PgDn`/`Home`/`End` continue to serve page navigation/reading.
 *   Theme support for linked text and linked-target emphasis is defined in the theme catalog path, not as one-off `[COLORS]` or `ytnova.conf` knobs.
 *   Add focused regression coverage for link focus, follow, back, and close behavior.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Completed.
 
 #### **Task 43.2: Keep Progress Indicators from Clobbering Footer/Prompt/F1 Guidance**
 *   **Goal:** Preserve footer, prompt, and `F1` help ownership while long-running operations update progress/spinner state.

--- a/include/ytnova_ui.h
+++ b/include/ytnova_ui.h
@@ -237,6 +237,8 @@ typedef struct {
 typedef struct {
   const UICommandStripCommand *commands;
   size_t command_count;
+  size_t link_command_count;
+  size_t active_command_index;
   int (*key_handler)(ViewContext *, int, void *);
   void *key_data;
 } UIHelpPopupFooterSpec;
@@ -244,6 +246,9 @@ extern int UI_CommandStripVisualLength(const UICommandStripCommand *commands,
                                        size_t command_count);
 extern int UI_FormatCommandStripEntryText(const UICommandStripCommand *command,
                                           char *buf, size_t buf_size);
+extern int UI_RenderCommandStripEntry(WINDOW *win, int y, int x,
+                                      const UICommandStripCommand *command,
+                                      int ncolor, int hcolor);
 extern void UI_RenderCommandStrip(WINDOW *win, int y, int x,
                                   const UICommandStripCommand *commands,
                                   size_t command_count, int ncolor,

--- a/src/ui/display_utils.c
+++ b/src/ui/display_utils.c
@@ -1226,6 +1226,34 @@ static void CommandStripRenderCommandFull(WINDOW *win, int y, int *x, int max_x,
   }
 }
 
+int UI_RenderCommandStripEntry(WINDOW *win, int y, int x,
+                               const UICommandStripCommand *command,
+                               int ncolor, int hcolor) {
+  int max_x;
+  int normal_attr;
+  int key_attr;
+
+  if (win == NULL || command == NULL || x < 0 || y < 0)
+    return x;
+
+  max_x = getmaxx(win);
+  if (max_x <= 0 || x >= max_x)
+    return x;
+
+#ifdef COLOR_SUPPORT
+  normal_attr = COLOR_PAIR(ncolor);
+  key_attr = UIKeybindAttrForBase(hcolor, ncolor);
+#else
+  normal_attr = A_NORMAL;
+  key_attr = A_BOLD;
+#endif
+
+  CommandStripRenderCommandFull(win, y, &x, max_x, command, normal_attr,
+                                key_attr);
+  wattrset(win, 0);
+  return x;
+}
+
 void UI_RenderCommandStrip(WINDOW *win, int y, int x,
                            const UICommandStripCommand *commands,
                            size_t command_count, int ncolor, int hcolor) {

--- a/src/ui/help_popup.c
+++ b/src/ui/help_popup.c
@@ -23,6 +23,43 @@ static int HelpPopupFooterWidth(const UICommandStripCommand *commands,
   return UI_CommandStripVisualLength(commands, command_count);
 }
 
+static void RenderHelpPopupFooter(
+    WINDOW *win, int y, int start_x, const UICommandStripCommand *commands,
+    size_t command_count, const UIHelpPopupFooterSpec *footer_spec) {
+  size_t i;
+  int x = start_x;
+
+  if (win == NULL || commands == NULL)
+    return;
+
+  if (footer_spec == NULL || footer_spec->link_command_count == 0 ||
+      footer_spec->active_command_index >= footer_spec->link_command_count) {
+    UI_RenderCommandStrip(win, y, x, commands, command_count, UI_ROLE_HELP,
+                          UI_ROLE_KEYBIND);
+    return;
+  }
+
+  for (i = 0; i < command_count; ++i) {
+    int normal_role = UI_ROLE_HELP;
+    int key_role = UI_ROLE_KEYBIND;
+
+    if (i > 0) {
+      PrintSpecialString(win, y, x, "  ", UI_ROLE_HELP);
+      x += 2;
+    }
+
+    if (i < footer_spec->link_command_count) {
+      normal_role = i == footer_spec->active_command_index
+                        ? UI_ROLE_HELP_LINK_SELECTION
+                        : UI_ROLE_HELP_LINK;
+      key_role = normal_role;
+    }
+
+    x = UI_RenderCommandStripEntry(win, y, x, &commands[i], normal_role,
+                                   key_role);
+  }
+}
+
 static int HelpPopupRowWidth(const UIHelpPopupRow *row) {
   int width = 0;
 
@@ -196,19 +233,23 @@ static int ShowHelpPopupInternal(ViewContext *ctx, const char *title,
     for (i = 0; i < visible_rows && scroll_offset + i < (int)row_count; ++i)
       RenderHelpPopupRow(win, 2 + i, content_width, &rows[scroll_offset + i]);
 
-    UI_RenderCommandStrip(win, height - 2,
+    RenderHelpPopupFooter(win, height - 2,
                           MAXIMUM(2, (width - footer_width) / 2),
                           effective_footer_commands, effective_footer_count,
-                          UI_ROLE_HELP, UI_ROLE_KEYBIND);
+                          footer_spec);
     wrefresh(win);
 
     ch = WGetch(ctx, win);
     if (ch == ERR)
       continue;
 
-    if (footer_spec != NULL && footer_spec->key_handler != NULL &&
-        footer_spec->key_handler(ctx, ch, footer_spec->key_data)) {
-      break;
+    if (footer_spec != NULL && footer_spec->key_handler != NULL) {
+      int handled = footer_spec->key_handler(ctx, ch, footer_spec->key_data);
+
+      if (handled > 0)
+        break;
+      if (handled < 0)
+        continue;
     }
 
     if (ch == KEY_F(1) || ch == ESC || ch == CR || ch == LF)

--- a/src/ui/runtime_help.c
+++ b/src/ui/runtime_help.c
@@ -10,14 +10,20 @@
 #include <ctype.h>
 #include <string.h>
 
-#define GENERATED_HELP_MAX_FOOTER_COMMANDS 8
+#define GENERATED_HELP_MAX_FOOTER_COMMANDS 10
+#define GENERATED_HELP_MAX_HISTORY 2
+#define GENERATED_HELP_NO_SELECTION ((size_t)-1)
 #define GENERATED_HELP_MAX_ROWS 16
 #define GENERATED_HELP_MAX_TEXT_LINES 8
 #define GENERATED_HELP_MAX_TEXT_WIDTH 256
 
 typedef struct {
   const GeneratedHelpTopic *topic;
+  size_t history_count;
   const char *next_topic_id;
+  size_t link_command_count;
+  size_t active_link_index;
+  BOOL back_requested;
   UICommandStripCommand footer_commands[GENERATED_HELP_MAX_FOOTER_COMMANDS];
   char footer_keys[GENERATED_HELP_MAX_FOOTER_COMMANDS][2];
   UIHelpPopupRow rows[GENERATED_HELP_MAX_ROWS];
@@ -114,15 +120,17 @@ static char PickFooterMnemonic(const char *label, const char used_keys[],
 
 static size_t BuildFooterCommands(RuntimeHelpPopupState *state) {
   char used_keys[GENERATED_HELP_MAX_FOOTER_COMMANDS];
+  size_t reserved_tail;
   size_t command_count = 0;
   size_t i;
 
   if (state == NULL || state->topic == NULL)
     return 0;
 
+  reserved_tail = state->history_count > 0 ? 2 : 1;
   memset(used_keys, 0, sizeof(used_keys));
   for (i = 0; i < state->topic->explainer_link_count &&
-              command_count + 1 < GENERATED_HELP_MAX_FOOTER_COMMANDS;
+              command_count + reserved_tail < GENERATED_HELP_MAX_FOOTER_COMMANDS;
        ++i) {
     char key =
         PickFooterMnemonic(state->topic->explainer_links[i].label, used_keys,
@@ -136,6 +144,18 @@ static size_t BuildFooterCommands(RuntimeHelpPopupState *state) {
         state->topic->explainer_links[i].label;
     state->footer_commands[command_count].primary_key =
         state->footer_keys[command_count];
+    state->footer_commands[command_count].secondary_key = NULL;
+    command_count++;
+  }
+
+  state->link_command_count = command_count;
+  state->active_link_index =
+      command_count > 0 ? 0 : GENERATED_HELP_NO_SELECTION;
+
+  if (state->history_count > 0) {
+    state->footer_commands[command_count].layout = UI_COMMAND_LAYOUT_KEY_PREFIX;
+    state->footer_commands[command_count].label = "back";
+    state->footer_commands[command_count].primary_key = "Left";
     state->footer_commands[command_count].secondary_key = NULL;
     command_count++;
   }
@@ -204,12 +224,33 @@ static int HandleGeneratedHelpFooterKey(ViewContext *ctx, int ch,
   if (state == NULL || state->topic == NULL)
     return 0;
 
+  if (ch == KEY_LEFT) {
+    if (state->history_count > 0) {
+      state->back_requested = TRUE;
+      return 1;
+    }
+    return 0;
+  }
+
+  if (ch == KEY_RIGHT || ch == CR || ch == LF) {
+    if (state->link_command_count == 0)
+      return 0;
+    if (state->history_count >= GENERATED_HELP_MAX_HISTORY)
+      return -1;
+
+    state->next_topic_id =
+        state->topic->explainer_links[state->active_link_index]
+            .target_topic_id;
+    return 1;
+  }
+
   key = islower(ch) ? toupper(ch) : ch;
-  for (i = 0; i < state->topic->explainer_link_count &&
-              i < state->footer_command_count;
-       ++i) {
+  for (i = 0; i < state->link_command_count; ++i) {
     if (state->footer_commands[i].primary_key != NULL &&
         state->footer_commands[i].primary_key[0] == key) {
+      if (state->history_count >= GENERATED_HELP_MAX_HISTORY)
+        return -1;
+      state->active_link_index = i;
       state->next_topic_id = state->topic->explainer_links[i].target_topic_id;
       return 1;
     }
@@ -221,6 +262,8 @@ static int HandleGeneratedHelpFooterKey(ViewContext *ctx, int ch,
 int UI_ShowGeneratedContextHelp(ViewContext *ctx, const char *context_id,
                                 const UIHelpPopupRow *prefix_rows,
                                 size_t prefix_row_count) {
+  const GeneratedHelpTopic *history[GENERATED_HELP_MAX_HISTORY];
+  size_t history_count = 0;
   const GeneratedHelpTopic *topic;
 
   if (ctx == NULL || context_id == NULL || context_id[0] == '\0')
@@ -233,24 +276,43 @@ int UI_ShowGeneratedContextHelp(ViewContext *ctx, const char *context_id,
   while (topic != NULL) {
     RuntimeHelpPopupState state;
     UIHelpPopupFooterSpec footer_spec;
+    const GeneratedHelpTopic *next_topic;
 
     memset(&state, 0, sizeof(state));
     state.topic = topic;
+    state.history_count = history_count;
     state.footer_command_count = BuildFooterCommands(&state);
     state.row_count = BuildTextRows(&state, prefix_rows, prefix_row_count);
     if (state.row_count == 0)
       return -1;
 
+    memset(&footer_spec, 0, sizeof(footer_spec));
     footer_spec.commands = state.footer_commands;
     footer_spec.command_count = state.footer_command_count;
+    footer_spec.link_command_count = state.link_command_count;
+    footer_spec.active_command_index = state.active_link_index;
     footer_spec.key_handler = HandleGeneratedHelpFooterKey;
     footer_spec.key_data = &state;
 
     (void)UI_ShowHelpPopupWithFooter(ctx, topic->title, state.rows,
                                      state.row_count, &footer_spec);
+
+    if (state.back_requested) {
+      if (history_count == 0)
+        break;
+      topic = history[history_count - 1];
+      history_count--;
+      continue;
+    }
+
     if (state.next_topic_id == NULL)
       break;
-    topic = FindGeneratedTopicById(state.next_topic_id);
+    next_topic = FindGeneratedTopicById(state.next_topic_id);
+    if (next_topic == NULL)
+      break;
+    if (history_count < GENERATED_HELP_MAX_HISTORY)
+      history[history_count++] = topic;
+    topic = next_topic;
   }
 
   return 0;

--- a/tests/test_help_text_contract.py
+++ b/tests/test_help_text_contract.py
@@ -218,6 +218,36 @@ def test_showall_help_links_to_global_help_via_generated_footer_navigation(tmp_p
         assert "single-volume aggregated file view" in showall_help, showall_help
         assert "Press `Esc` to return to the previously selected directory." in showall_help, showall_help
 
+        navigation_help_screen = tui.send_and_wait_for_condition(
+            Keys.ENTER,
+            lambda lines: lines if any("Navigation" in line for line in lines) else False,
+            timeout=1.5,
+        )
+        assert navigation_help_screen, screen_text(tui)
+        navigation_help = "\n".join(navigation_help_screen)
+        assert "Arrow keys, paging keys, `Home`, `End`, and `Enter`" in navigation_help
+
+        showall_again = tui.send_and_wait_for_condition(
+            Keys.LEFT,
+            lambda lines: lines if any("Showall Help" in line for line in lines) else False,
+            timeout=1.5,
+        )
+        assert showall_again, screen_text(tui)
+
+        navigation_again = tui.send_and_wait_for_condition(
+            Keys.RIGHT,
+            lambda lines: lines if any("Navigation" in line for line in lines) else False,
+            timeout=1.5,
+        )
+        assert navigation_again, screen_text(tui)
+
+        showall_again = tui.send_and_wait_for_condition(
+            Keys.LEFT,
+            lambda lines: lines if any("Showall Help" in line for line in lines) else False,
+            timeout=1.5,
+        )
+        assert showall_again, screen_text(tui)
+
         global_help_screen = tui.send_and_wait_for_condition(
             "g",
             lambda lines: lines if any("Global Help" in line for line in lines) else False,
@@ -227,6 +257,16 @@ def test_showall_help_links_to_global_help_via_generated_footer_navigation(tmp_p
         global_help = "\n".join(global_help_screen)
         assert "multi-volume aggregated file view" in global_help, global_help
         assert "different logged volume root" in global_help, global_help
+
+        showall_again = tui.send_and_wait_for_condition(
+            Keys.LEFT,
+            lambda lines: lines if any("Showall Help" in line for line in lines) else False,
+            timeout=1.5,
+        )
+        assert showall_again, screen_text(tui)
+
+        tui.send_keystroke(Keys.ESC, wait=0.2)
+        assert tui.wait_for_content("alpha.txt", timeout=1.0), screen_text(tui)
     finally:
         tui.quit()
 

--- a/tests/test_modal_color_taxonomy.py
+++ b/tests/test_modal_color_taxonomy.py
@@ -22,13 +22,19 @@ def test_shared_help_popup_uses_help_palette():
         help_source,
         "static int ShowHelpPopupInternal(ViewContext *ctx, const char *title,",
     )
+    footer_block = _extract_function_block(
+        help_source,
+        "static void RenderHelpPopupFooter(",
+    )
 
     assert "WbkgdSet(ctx, win, COLOR_PAIR(UI_ROLE_HELP));" in popup_block
     assert "wattron(win, COLOR_PAIR(UI_ROLE_BOX_LINES));" in popup_block
     assert "wattroff(win, COLOR_PAIR(UI_ROLE_BOX_LINES));" in popup_block
-    assert "UI_RenderCommandStrip(win, height - 2," in popup_block
-    assert "UI_ROLE_HELP," in popup_block
-    assert "UI_ROLE_KEYBIND" in popup_block
+    assert "RenderHelpPopupFooter(win, height - 2," in popup_block
+    assert "UI_RenderCommandStrip(win, y, x, commands, command_count, UI_ROLE_HELP," in footer_block
+    assert "UI_ROLE_KEYBIND" in footer_block
+    assert "UI_ROLE_HELP_LINK" in footer_block
+    assert "UI_ROLE_HELP_LINK_SELECTION" in footer_block
     assert "COLOR_PAIR(UI_ROLE_WARNING)" not in popup_block
     assert "COLOR_PAIR(UI_ROLE_ERROR)" not in popup_block
 


### PR DESCRIPTION
## Summary
- add selected-link rendering for generated contextual help popups
- let modal F1 explainers follow with Enter/Right, backtrack with Left, and stay bounded to shallow history
- add focused regression coverage and close the roadmap item status line

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_help_text_contract.py::test_showall_help_links_to_global_help_via_generated_footer_navigation`
- `make clean && make`
- `source .venv/bin/activate && pytest -q tests/test_help_text_contract.py tests/test_help_generator.py tests/test_help_source_schema.py`