### PR TITLE
docs(ci): codify security gate merge evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,10 @@
-> Thank you for your contribution.
-> A brief plain-language summary of this PR is appreciated.
+## Summary
+
+## Validation
+- `make`
+- focused `pytest ...`
+- `make qa-unsafe-apis` (required when this PR triggers `.github/workflows/full-qa.yml` or changes safety-sensitive behavior)
+- `make qa-fileops-integrity` (required when file/archive mutation flows change)
 
 <!--
 Large PRs are difficult to review and carry more regression risk.

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -39,7 +39,7 @@ The project uses seven QA layers with increasing depth and cost:
 
 | Layer | Command | What it checks | When to run |
 |---|---|---|---|
-| CI Gate | `git push` (automatic) | Draft-PR baseline confidence checks (`qa-code-quality` + `qa-fileops-integrity`, path-filtered `qa-split-panel-gates` for split-touching changes, coverage pytest gate, fuzz gate) | Every push to `main` and every PR update targeting `main` (automatic) |
+| CI Gate | `git push` (automatic) | Draft-PR baseline confidence checks (`qa-code-quality` + `qa-fileops-integrity`, path-filtered `qa-split-panel-gates` for split-touching changes, docs gate for docs-touching changes, coverage pytest gate, fuzz gate) | Every push to `main` and every PR update targeting `main` (automatic) |
 | PR Full QA CI (required) | `.github/workflows/full-qa.yml` (`make qa-all`) | clang-tidy, cppcheck, scan-build, Valgrind smoke (`--version`), full `pytest`, unsafe API guard, dead-history comment guard, gitleaks, module-boundary guard, ai-config guard, fuzz guard | Must be green before merge to `main` |
 | Fileops Integrity Gate | `make qa-fileops-integrity` | Deterministic file/archive mutation integrity + security regression checks (copy/move/delete/rename/archive rewrite, cancel/failure safeguards, shell/tempfile hardening contracts) | Before merge and when touching file/archive mutation flows |
 | Sanitizer QA | `make qa-sanitize` | Main ytnova build + `pytest` under AddressSanitizer/UndefinedBehaviorSanitizer | Before release, after memory/UB-sensitive changes, or when triaging suspicious crashes |
@@ -52,6 +52,7 @@ The project uses seven QA layers with increasing depth and cost:
 - **Local QA** (`make qa-all`) is optional for faster local confidence and maintainer-requested deep preflight; avoid running it on every iteration by default.
 - **Fileops Integrity Gate** (`make qa-fileops-integrity`) is the dedicated regression wall for mutation integrity/security contracts; run it before merge and whenever file/archive mutation code or prompts change.
 - **Split Panel Regression Gate** (`make qa-split-panel-gates`) is the path-filtered regression wall for split-panel invariants, transition handoff, and split-authority source guards; split-touching PRs must satisfy it before merge.
+- **Non-trivial PRs** are the PRs that trigger `.github/workflows/full-qa.yml` (`src/**`, `include/**`, `tests/**`, `scripts/**`, `Makefile`, `.github/workflows/**`). They must carry explicit security evidence in PR validation notes (`make qa-unsafe-apis`, plus `make qa-fileops-integrity` when file/archive mutation flows change) and must not merge until the required security/full-QA checks are green.
 - **Deep Audit** (`make qa-valgrind-full`) is on-demand. It drives a scripted interactive ytnova session under Valgrind and takes ~2-3 minutes. Run it:
   - Before tagging a release
   - After changes to memory management, allocation, or cleanup paths
@@ -89,8 +90,8 @@ Scope is strict: QA/check/test organization and efficiency only. Non-QA workflow
 | Tier | Owner | Trigger | Required checks | Non-overlap default intent |
 |---|---|---|---|---|
 | Tier A (local fast iteration) | Developer | During implementation before first push and between risky edits | `make`; targeted pytest for touched scope; targeted guards (`qa-unsafe-apis`, `qa-fileops-integrity`) when relevant | Keep iteration fast; avoid full-suite duplication unless local risk demands it |
-| Tier B (PR baseline CI) | CI + PR author | Every push while the PR is active | `ci-baseline` (`qa-code-quality` + `qa-fileops-integrity` + `qa-pytest-coverage` + `qa-fuzz`) plus path-filtered `qa-split-panel-gates` on split-touching PRs | Provide baseline branch-protection signal (includes coverage by design); do not duplicate Tier C full local gate content |
-| Tier C (pre-merge full gate) | CI + PR author | Before merge to `main` (or earlier only when explicitly requested) | Green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent); optional local `make qa-all-log` evidence when maintainer-requested; plus explicit `qa-fileops-integrity` evidence when mutation workflows changed | Use CI as canonical full-gate signal; avoid duplicate local full-gate reruns during routine iteration |
+| Tier B (PR baseline CI) | CI + PR author | Every push while the PR is active | `ci-baseline` (`qa-code-quality` + `qa-fileops-integrity` + `qa-pytest-coverage` + `qa-fuzz`) plus path-filtered `Docs gate` on docs-touching PRs and `qa-split-panel-gates` on split-touching PRs | Provide baseline branch-protection signal (includes coverage by design); do not duplicate Tier C full local gate content |
+| Tier C (pre-merge full gate) | CI + PR author | Before merge to `main` (or earlier only when explicitly requested) | Green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent); explicit `make qa-unsafe-apis` evidence for full-QA-triggering PRs; optional local `make qa-all-log` evidence when maintainer-requested; plus explicit `qa-fileops-integrity` evidence when mutation workflows changed | Use CI as canonical full-gate signal; avoid duplicate local full-gate reruns during routine iteration |
 | Tier D (merge/release gate) | Maintainer + reviewer | Before merge and before release/tag cut | Branch-protection checks green; reviewer signoff; `qa-sanitize`; `qa-valgrind-full` for release-risk changes; `qa-valgrind-interactive` after major feature flows | Reserve deepest runtime checks for merge/release assurance to avoid slowing every draft iteration |
 
 ### branch-protection and PR State Criteria (Mandatory)
@@ -98,8 +99,14 @@ Scope is strict: QA/check/test organization and efficiency only. Non-QA workflow
 - **Open PR:** Branch exists and the PR is open. Red checks are acceptable while iterating. No review requests while checks are red unless the maintainer explicitly asks.
 - **Merge:** All required branch-protection checks are green, reviewer signoff is present, and Tier D evidence is attached for the current diff/risk.
 - Required branch-protection checks (sync with current workflows):
+  - `.github/workflows/ci.yml`: `Docs gate`
+  - `.github/workflows/full-qa.yml`: `Guard and code-quality gate`
   - `.github/workflows/ci.yml`: `Guard fuzz harness sync`
   - `.github/workflows/ci.yml`: `File mutation integrity gate`
+  - `.github/workflows/full-qa.yml`: `Static analyzer gate`
+  - `.github/workflows/full-qa.yml`: `Runtime and security gate`
+  - `.github/workflows/full-qa.yml`: `Full pytest gate`
+  - `.github/workflows/full-qa.yml`: `Sanitizer gate`
   - `.github/workflows/ci.yml`: `Full coverage baseline gate`
   - `.github/workflows/ci.yml`: `Fuzz baseline gate`
   - `.github/workflows/pr-conflict-assistant.yml`: `Up To Date With Main`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -144,9 +144,14 @@ Configure GitHub branch protection on `main`:
 1. Settings -> Branches -> Add branch protection rule for `main`.
 2. Enable `Require status checks to pass before merging`.
 3. Select required checks from GitHub Actions:
+   - `.github/workflows/ci.yml`: `Docs gate`.
+   - `.github/workflows/full-qa.yml`: `Guard and code-quality gate`.
    - `.github/workflows/ci.yml`: `Guard fuzz harness sync`.
    - `.github/workflows/ci.yml`: `File mutation integrity gate`.
-   - `.github/workflows/ci.yml`: `Split panel regression gate` for split-touching PRs.
+   - `.github/workflows/full-qa.yml`: `Static analyzer gate`.
+   - `.github/workflows/full-qa.yml`: `Runtime and security gate`.
+   - `.github/workflows/full-qa.yml`: `Full pytest gate`.
+   - `.github/workflows/full-qa.yml`: `Sanitizer gate`.
    - `.github/workflows/ci.yml`: `Full coverage baseline gate`.
    - `.github/workflows/ci.yml`: `Fuzz baseline gate`.
    - `.github/workflows/pr-conflict-assistant.yml`: `Up To Date With Main`.
@@ -211,6 +216,7 @@ Use **[AUDIT.md](AUDIT.md)** as the single source of truth.
 
 - During implementation, run focused checks first (`make` + targeted tests for touched scope).
 - Before merge to `main`, require green PR full-QA CI (`.github/workflows/full-qa.yml`, `make qa-all` equivalent). Local full audit loop is optional unless explicitly requested.
+- Treat any PR that triggers `.github/workflows/full-qa.yml` (`src/**`, `include/**`, `tests/**`, `scripts/**`, `Makefile`, `.github/workflows/**`) as non-trivial: include `make qa-unsafe-apis` in the validation evidence, and include `make qa-fileops-integrity` as well when file/archive mutation flows change.
 - Split-touching PRs must also pass the path-filtered `make qa-split-panel-gates` CI gate before merge.
 - Use the canonical tool order from `AUDIT.md`: `clang-tidy`, `cppcheck`, `scan-build`, `valgrind`, then `pytest` for regression verification.
 
@@ -225,7 +231,7 @@ Use **[AUDIT.md](AUDIT.md)** as the single source of truth.
 - GitHub baseline CI (`.github/workflows/ci.yml`) runs `make ci-baseline` on PRs to `main` and pushes to `main`.
 - GitHub split panel regression CI (`.github/workflows/ci.yml`) runs `make qa-split-panel-gates` on PRs that touch split-panel paths.
 - GitHub PR full QA CI (`.github/workflows/full-qa.yml`) runs `make qa-all` on PRs to `main` and is the required full pre-merge gate.
-- GitHub PR sanitizer gate in `.github/workflows/full-qa.yml` runs only on manual dispatch or when PR label `qa-sanitize` is present.
+- GitHub PR sanitizer gate in `.github/workflows/full-qa.yml` runs on the same full-QA-triggering PRs as the other pre-merge full-QA jobs.
 - GitHub nightly deep Valgrind CI (`.github/workflows/nightly-deep-valgrind.yml`) runs `make qa-valgrind-full` on schedule (and manual dispatch).
 
 Individual gates:
@@ -310,7 +316,7 @@ Contributions must preserve a secure-by-default codebase:
 - Default to fail-closed behavior on invalid or unexpected states.
 - Use least-privilege file/process handling; avoid broad permissions or escalation unless explicitly required.
 
-Security evidence is part of the required audit flow: include `make qa-unsafe-apis` results per **[AUDIT.md](AUDIT.md)**.
+Security evidence is part of the required audit flow: include `make qa-unsafe-apis` results for every non-trivial PR per **[AUDIT.md](AUDIT.md)**.
 If you change safety-sensitive behavior, update **[TRUST.md](TRUST.md)** so user-facing trust claims stay accurate.
 
 ## Source Comment Policy

--- a/docs/PR_GATE.md
+++ b/docs/PR_GATE.md
@@ -16,9 +16,11 @@ Use all four together. None of them is sufficient by itself.
 Before merging a PR into `main`, require all of the following:
 
 1. Baseline CI is green.
-2. `Up To Date With Main` is green.
-3. If size is `L` or `XL`, the PR body explains why it is large, why it is not split right now, and what could break. Provide this once, updating only if scope materially changes.
-4. At least one human maintainer approves.
+2. PR full QA is green, including the required `Guard and code-quality gate`, `Runtime and security gate`, `Static analyzer gate`, `Full pytest gate`, and `Sanitizer gate`.
+3. `Up To Date With Main` is green.
+4. Any non-trivial PR (the same source/test/script/Makefile/workflow changes that trigger `.github/workflows/full-qa.yml`) includes explicit security validation evidence in the PR body: `make qa-unsafe-apis`, plus `make qa-fileops-integrity` when file/archive mutation flows change.
+5. If size is `L` or `XL`, the PR body explains why it is large, why it is not split right now, and what could break. Provide this once, updating only if scope materially changes.
+6. At least one human maintainer approves.
 
 ## AI-First Review Contract
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1275,7 +1275,7 @@ Ordering policy (for all editors, including AI editors):
 *   **Goal:** Add explicit QA and merge-gate enforcement that audits the current codebase for security risks and blocks new or reintroduced security findings.
 *   **Scope:** shell-command construction and escaping boundaries, archive path trust policy, tempfile lifecycle, and unsafe API usage.
 *   **Acceptance Criteria:** Security baseline audit evidence exists, recurring security checks are mandatory in `qa-all`/PR evidence, and merge is blocked on unresolved blocker/high security findings.
-*   - [~] **Status:** In Progress.
+*   - [x] **Status:** Complete.
 
 #### **Task 51.1: Baseline Security Debt Audit and Classification**
 *   **Goal:** Run and document a focused baseline audit of current security risk classes already in scope for Phase 0.
@@ -1322,7 +1322,7 @@ Ordering policy (for all editors, including AI editors):
 #### **Task 51.3: Security Regression Gate in CI + Merge Workflow**
 *   **Goal:** Make security verification non-optional in routine change flow.
 *   **Mechanism:** Require security gate evidence for non-trivial PRs and keep merge blocked until gates pass.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Complete.
 
 ### **Task 52: Add Security Fuzzing Harness for High-Risk Input Paths**
 *   **Goal:** Add fuzzing coverage (for example libFuzzer) for archive parsing and shell-command construction paths to detect malformed-input crashes and security-critical edge cases early.

--- a/tests/test_security_gate_contract.py
+++ b/tests/test_security_gate_contract.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+
+REQUIRED_BRANCH_PROTECTION_CHECKS = (
+    "Docs gate",
+    "Guard and code-quality gate",
+    "Guard fuzz harness sync",
+    "File mutation integrity gate",
+    "Static analyzer gate",
+    "Runtime and security gate",
+    "Full pytest gate",
+    "Sanitizer gate",
+    "Full coverage baseline gate",
+    "Fuzz baseline gate",
+    "Up To Date With Main",
+)
+
+
+def _read(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_full_qa_workflow_retains_runtime_and_security_gate_contract() -> None:
+    source = _read(".github/workflows/full-qa.yml")
+
+    assert "runtime-and-security:" in source
+    assert "name: Runtime and security gate" in source
+    assert "make qa-valgrind" in source
+    assert 'make qa-fuzz FUZZ_CC="ccache clang"' in source
+    assert "make qa-gitleaks" in source
+    assert "name: qa-runtime-security-log" in source
+
+
+def test_docs_list_current_required_checks_for_merge_policy() -> None:
+    for path in ("docs/AUDIT.md", "docs/CONTRIBUTING.md"):
+        source = _read(path)
+        for check_name in REQUIRED_BRANCH_PROTECTION_CHECKS:
+            assert check_name in source, f"{path} missing required check {check_name}"
+
+
+def test_pr_gate_and_template_require_security_validation_evidence() -> None:
+    pr_gate = _read("docs/PR_GATE.md")
+    template = _read(".github/pull_request_template.md")
+
+    assert "non-trivial PR" in pr_gate
+    assert ".github/workflows/full-qa.yml" in pr_gate
+    assert "Runtime and security gate" in pr_gate
+    assert "make qa-unsafe-apis" in pr_gate
+    assert "make qa-fileops-integrity" in pr_gate
+
+    assert "## Validation" in template
+    assert "make qa-unsafe-apis" in template
+    assert "make qa-fileops-integrity" in template
+    assert ".github/workflows/full-qa.yml" in template


### PR DESCRIPTION
## Summary
- define non-trivial PR security evidence across `docs/AUDIT.md`, `docs/CONTRIBUTING.md` and `docs/PR_GATE.md`
- sync the documented required checks with the live `main` branch-protection gates, including `Runtime and security gate`
- add a focused contract test so the security merge-policy wording stays aligned with the workflows

## Validation
- Red proof: `gh api repos/robkam/ytreenova/branches/main/protection --jq '{required_status_checks: .required_status_checks.contexts}'` showed `Runtime and security gate` was already a live required check while the repo docs/template still omitted that security merge requirement.
- `source .venv/bin/activate && pytest -q tests/test_security_gate_contract.py`
