### PR TITLE
fix(ui): preserve tree anchors without file context

### DIFF
--- a/src/ui/panel_anchor.c
+++ b/src/ui/panel_anchor.c
@@ -76,9 +76,6 @@ BOOL CapturePanelAnchorPath(const YtreeNovaPanel *panel, const struct Volume *vo
   assert(!panel->vol || panel->vol == vol);
   if (panel->vol != vol)
     return FALSE;
-  assert(panel->saved_focus != FOCUS_FILE ||
-         panel->file_selection_dir_path[0] != '\0');
-
   if (panel->saved_focus == FOCUS_FILE) {
     if (panel->file_selection_dir_path[0]) {
       (void)snprintf(out_path, out_path_size, "%s",

--- a/tests/test_panel_anchor_contract.py
+++ b/tests/test_panel_anchor_contract.py
@@ -1,0 +1,14 @@
+"""Regression coverage for panel anchor capture invariants."""
+
+from pathlib import Path
+
+
+def test_capture_panel_anchor_falls_back_when_file_context_is_unavailable():
+    source = Path("src/ui/panel_anchor.c").read_text()
+    start = source.index("BOOL CapturePanelAnchorPath")
+    end = source.index("void CapturePanelViewportSnapshot", start)
+    capture = source[start:end]
+
+    assert "panel->saved_focus == FOCUS_FILE" in capture
+    assert "if (panel->file_selection_dir_path[0])" in capture
+    assert "panel->saved_focus != FOCUS_FILE" not in capture


### PR DESCRIPTION
## Summary
- fall back to the visible tree selection when a file-focused panel has no saved file directory
- cover the fallback contract to prevent DEBUG startup aborts

## Validation
- Red: `source .venv/bin/activate && pytest -q tests/test_panel_anchor_contract.py`
- `make -j4 DEBUG=1`
- `source .venv/bin/activate && pytest -q tests/test_panel_anchor_contract.py tests/test_stats_panel.py::test_lowercase_l_key_triggers_log`