### PR TITLE
feat(viewer): separate tagged hit navigation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -554,7 +554,7 @@ Ordering policy (for all editors, including AI editors):
 *   Footer keybinding hints and F1 help in internal `^V` mode explicitly show file-nav keys and hit-nav keys.
 *   `^S` remains the tagged-list search/filter action outside viewer mode and is documented distinctly.
 *   Add focused regression coverage for key behavior and help discoverability in this mode.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Complete.
 
 ### **Task 23: Replace `Write` with an Explicit `Output` / Hardcopy Flow**
 *   **Goal:** Make file-output and hardcopy behavior immediately understandable by repurposing `O` as an explicit `Output` action.

--- a/etc/help/f1.de.md
+++ b/etc/help/f1.de.md
@@ -79,6 +79,7 @@ Gehe mit `Left` zurück hierher oder mit `Esc` aus der Hilfe.
 - [Shared Commands](topic:shared-commands)
 - [Showall](topic:showall)
 - [Tagged](topic:tagged)
+- [Markierungsanzeige](topic:tagged-viewer)
 - [Theming](topic:theming)
 - [Vi Keys](topic:vi-keys)
 - [Volume](topic:volume-menu)
@@ -220,6 +221,25 @@ Baue eine Menge auf, arbeite damit, verenge sie weiter und leere oder invertiere
 * **View tagged**: Die markierten Dateien nacheinander öffnen.
 * **Search tagged**: Nur die markierten Dateien durchsuchen und Nicht-Treffer wieder entmarkieren.
 * **Archive**: Zuerst die markierte Menge archivieren. Wenn nichts markiert ist, fällt Archivieren auf die aktuelle Auswahl zurück.
+
+## topic:tagged-viewer
+```ytnova-help-meta
+title: Markierungsanzeige
+contexts: viewer.tagged
+```
+### Contextual F1
+`Markierte anzeigen` öffnet die markierten Suchergebnisse in der internen Anzeige.
+Mit `n` und `p` wechseln Sie zur nächsten oder vorherigen markierten Datei.
+`Leertaste`, `BildAb`, und `BildAuf` bewegen nur seitenweise in der aktuellen Datei.
+Nach `C-s` für die Suche in der Markierung wechselt `/` zum nächsten und `?` zum vorherigen Treffer in der aktuellen Datei.
+Außerhalb dieser Anzeige bleibt `C-s` die Suchaktion für die Markierungsliste.
+Mit `TAGGEDVIEWER=external` übernimmt das konfigurierte Anzeigeprogramm Suche und Treffernavigation.
+
+### Long form
+#### Navigationsbereiche
+Die interne Anzeige trennt Dateinavigation von Treffernavigation, damit Blättern nie die Datei wechselt.
+
+Siehe [Markierungen](topic:tagged).
 
 ## topic:command-line-editing
 ```ytnova-help-meta

--- a/etc/help/f1.en.md
+++ b/etc/help/f1.en.md
@@ -79,6 +79,7 @@ Use `Left` to come back here or `Esc` to leave help.
 - [Shared Commands](topic:shared-commands)
 - [Showall](topic:showall)
 - [Tagged](topic:tagged)
+- [Tagged Viewer](topic:tagged-viewer)
 - [Theming](topic:theming)
 - [Vi Keys](topic:vi-keys)
 - [Volume](topic:volume-menu)
@@ -220,6 +221,25 @@ Build a set, act on it, narrow it, then clear or invert it.
 * **View tagged**: Open the tagged files one after another.
 * **Search tagged**: Search only the tagged files, then untag non-matches.
 * **Archive**: Archive the tagged set first. When nothing is tagged, archive falls back to the current selection.
+
+## topic:tagged-viewer
+```ytnova-help-meta
+title: Tagged Viewer
+contexts: viewer.tagged
+```
+### Contextual F1
+`View tagged` opens the tagged search results in the internal viewer.
+Use `n` and `p` to move to the next or previous tagged file.
+Use `Space`, `PgDn`, and `PgUp` only to move by pages in the current file.
+After `C-s` searches the tagged set, use `/` for the next hit and `?` for the previous hit in the current file.
+`C-s` remains the tagged-list search action outside this viewer.
+With `TAGGEDVIEWER=external`, the configured pager owns search and hit navigation.
+
+### Long form
+#### Navigation scopes
+The internal viewer separates file traversal from search-hit traversal so paging never changes files.
+
+See [Tagged](topic:tagged).
 
 ## topic:command-line-editing
 ```ytnova-help-meta

--- a/etc/help/man.de.md
+++ b/etc/help/man.de.md
@@ -154,6 +154,18 @@ Du baust einen Satz auf, arbeitest damit, verengst ihn und löschst oder inverti
 * **Search tagged**: Nur im getaggten Satz suchen und Nicht-Treffer enttaggen.
 * **Archive**: Vorrangig den getaggten Satz archivieren; ohne Tags fällt der Befehl auf die aktuelle Auswahl zurück.
 
+## topic:tagged-viewer
+```ytnova-help-meta
+title: Markierungsanzeige
+contexts: viewer.tagged
+```
+### Contextual F1
+Mit `n` und `p` wechseln Sie Dateien, mit Seitentasten und `Leertaste` blättern Sie in der aktuellen Datei, und mit `/` oder `?` wechseln Sie zwischen Treffern der Markierungssuche. `C-s` durchsucht außerhalb der Anzeige die Markierungsliste.
+
+### Long form
+#### Navigationsbereiche
+Die interne Markierungsanzeige trennt Datei-, Seiten- und Treffernavigation. Eine externe Markierungsanzeige überlässt Suche und Treffernavigation dem konfigurierten Pager.
+
 ## topic:command-line-editing
 ```ytnova-help-meta
 title: Command-line Editing

--- a/etc/help/man.en.md
+++ b/etc/help/man.en.md
@@ -148,9 +148,21 @@ You can build a set, act on it, narrow it, then clear or invert it.
 * **Invert Tags**: Flip the tag state inside the current visible scope.
 * **Filter**: Press `F`, then `Tab` to switch the current file-list scope between all rows and tagged-only rows without changing tag state.
 * **Copy tagged** and **Move tagged**: Send the whole tagged set to one destination.
-* **View tagged**: Open the tagged files one after another.
+* **View tagged**: Open the tagged files one after another. In the internal viewer, `n`/`p` change file, `Space`/page keys scroll only the current file, and `/`/`?` move between tagged-search hits in that file. `TAGGEDVIEWER=external` keeps pager-native search and hit navigation.
 * **Search tagged**: Search only the tagged files, then untag non-matches.
 * **Archive**: Archive the tagged set first. When nothing is tagged, archive falls back to the current selection.
+
+## topic:tagged-viewer
+```ytnova-help-meta
+title: Tagged Viewer
+contexts: viewer.tagged
+```
+### Contextual F1
+Use `n` and `p` for files, page keys and `Space` within the current file, and `/` or `?` for tagged-search hits. `C-s` searches the tagged list outside the viewer.
+
+### Long form
+#### Navigation scopes
+The internal tagged viewer keeps file, page, and search-hit navigation separate. An external tagged viewer leaves search and hit navigation to the configured pager.
 
 ## topic:command-line-editing
 ```ytnova-help-meta

--- a/etc/ytnova.conf
+++ b/etc/ytnova.conf
@@ -102,7 +102,7 @@ EDITOR=vim
 # PAGER=less -cen
 # TAGGEDVIEWER controls `^V` (View Tagged) mode:
 #   external = use PAGER (default, less-style behavior)
-#   internal = use YtreeNova internal tagged viewer (space/n/p handling in YtreeNova)
+#   internal = use YtreeNova tagged viewer (page, file, and search-hit navigation)
 TAGGEDVIEWER=internal
 
 # THEME checks ~/.config/ytnova/themes.conf first, then the home fallback

--- a/src/core/default_profile_template.h
+++ b/src/core/default_profile_template.h
@@ -104,7 +104,7 @@ static const char default_profile_template[] =
     "# PAGER=less -cen\n"
     "# TAGGEDVIEWER controls `^V` (View Tagged) mode:\n"
     "#   external = use PAGER (default, less-style behavior)\n"
-    "#   internal = use YtreeNova internal tagged viewer (space/n/p handling in YtreeNova)\n"
+    "#   internal = use YtreeNova tagged viewer (page, file, and search-hit navigation)\n"
     "TAGGEDVIEWER=internal\n"
     "\n"
     "# THEME checks ~/.config/ytnova/themes.conf first, then the home fallback\n"

--- a/src/core/generated_help_topics.h
+++ b/src/core/generated_help_topics.h
@@ -62,6 +62,7 @@ static const GeneratedHelpLink generated_help_links_en_intro[] = {
     {"Shared Commands", "shared-commands"},
     {"Showall", "showall"},
     {"Tagged", "tagged"},
+    {"Tagged Viewer", "tagged-viewer"},
     {"Theming", "theming"},
     {"Vi Keys", "vi-keys"},
     {"Volume", "volume-menu"},
@@ -119,6 +120,10 @@ static const GeneratedHelpLink generated_help_links_en_tagged[] = {
 static const GeneratedHelpLongFormSection generated_help_sections_en_tagged[] = {
     {"Tagged basics", "Tags are a working set. They are not a second clipboard and not a saved search.\nBuild a set, act on it, narrow it, then clear or invert it."},
     {"Common tagged flows", "* **Tag** and **Untag**: Add or remove the current row from the working set.\n* **Invert Tags**: Flip tag state inside the current visible scope.\n* **Filter**: Press `F`, then `Tab` to switch the current file-list scope between all rows and tagged-only rows without changing tag state.\n* **Copy tagged** and **Move tagged**: Send the whole tagged set to one destination.\n* **View tagged**: Open the tagged files one after another.\n* **Search tagged**: Search only the tagged files, then untag non-matches.\n* **Archive**: Archive the tagged set first. When nothing is tagged, archive falls back to the current selection."},
+};
+
+static const GeneratedHelpLongFormSection generated_help_sections_en_tagged_viewer[] = {
+    {"Navigation scopes", "The internal viewer separates file traversal from search-hit traversal so paging never changes files.\n\nSee [Tagged](topic:tagged)."},
 };
 
 static const GeneratedHelpLink generated_help_links_en_command_line_editing[] = {
@@ -492,7 +497,7 @@ static const GeneratedHelpTopic generated_help_topics_en[] = {
         "Contents",
         NULL,
         "Browse this index when you know the question but not the page.\nPress `Enter` or `Right` on a topic to open it.\nUse `Left` to come back here or `Esc` to leave help.",
-        36,
+        37,
         generated_help_links_en_intro,
         2,
         generated_help_sections_en_intro,
@@ -536,6 +541,16 @@ static const GeneratedHelpTopic generated_help_topics_en[] = {
         generated_help_links_en_tagged,
         2,
         generated_help_sections_en_tagged,
+    },
+    {
+        "tagged-viewer",
+        "Tagged Viewer",
+        "viewer.tagged",
+        "`View tagged` opens the tagged search results in the internal viewer.\nUse `n` and `p` to move to the next or previous tagged file.\nUse `Space`, `PgDn`, and `PgUp` only to move by pages in the current file.\nAfter `C-s` searches the tagged set, use `/` for the next hit and `?` for the previous hit in the current file.\n`C-s` remains the tagged-list search action outside this viewer.\nWith `TAGGEDVIEWER=external`, the configured pager owns search and hit navigation.",
+        0,
+        NULL,
+        1,
+        generated_help_sections_en_tagged_viewer,
     },
     {
         "command-line-editing",
@@ -879,7 +894,7 @@ static const GeneratedHelpTopic generated_help_topics_en[] = {
     },
 };
 
-static const size_t generated_help_topic_count_en = 39;
+static const size_t generated_help_topic_count_en = 40;
 
 static const GeneratedHelpLink generated_help_links_de_intro[] = {
     {"Applications", "applications-menu"},
@@ -915,6 +930,7 @@ static const GeneratedHelpLink generated_help_links_de_intro[] = {
     {"Shared Commands", "shared-commands"},
     {"Showall", "showall"},
     {"Tagged", "tagged"},
+    {"Markierungsanzeige", "tagged-viewer"},
     {"Theming", "theming"},
     {"Vi Keys", "vi-keys"},
     {"Volume", "volume-menu"},
@@ -972,6 +988,10 @@ static const GeneratedHelpLink generated_help_links_de_tagged[] = {
 static const GeneratedHelpLongFormSection generated_help_sections_de_tagged[] = {
     {"Grundlagen", "Markierungen sind eine Arbeitsmenge. Sie sind weder eine zweite Zwischenablage noch eine gespeicherte Suche.\nBaue eine Menge auf, arbeite damit, verenge sie weiter und leere oder invertiere sie danach."},
     {"Häufige Abläufe", "* **Tag** und **Untag**: Die aktuelle Zeile zur Arbeitsmenge hinzufügen oder daraus entfernen.\n* **Invert Tags**: Den Markierungszustand im aktuellen sichtbaren Bereich umkehren.\n* **Filter**: Mit `F` und danach `Tab` zwischen allen Zeilen und nur markierten Zeilen umschalten, ohne die Markierungen selbst zu ändern.\n* **Copy tagged** und **Move tagged**: Die ganze markierte Menge an ein Ziel schicken.\n* **View tagged**: Die markierten Dateien nacheinander öffnen.\n* **Search tagged**: Nur die markierten Dateien durchsuchen und Nicht-Treffer wieder entmarkieren.\n* **Archive**: Zuerst die markierte Menge archivieren. Wenn nichts markiert ist, fällt Archivieren auf die aktuelle Auswahl zurück."},
+};
+
+static const GeneratedHelpLongFormSection generated_help_sections_de_tagged_viewer[] = {
+    {"Navigationsbereiche", "Die interne Anzeige trennt Dateinavigation von Treffernavigation, damit Blättern nie die Datei wechselt.\n\nSiehe [Markierungen](topic:tagged)."},
 };
 
 static const GeneratedHelpLink generated_help_links_de_command_line_editing[] = {
@@ -1365,7 +1385,7 @@ static const GeneratedHelpTopic generated_help_topics_de[] = {
         "Inhalt",
         NULL,
         "Benutze diesen Index, wenn du die Frage kennst, aber nicht weißt, welche Seite sie beantwortet.\nDrücke auf einem Thema `Enter` oder `Right`, um es zu öffnen.\nGehe mit `Left` zurück hierher oder mit `Esc` aus der Hilfe.",
-        36,
+        37,
         generated_help_links_de_intro,
         2,
         generated_help_sections_de_intro,
@@ -1409,6 +1429,16 @@ static const GeneratedHelpTopic generated_help_topics_de[] = {
         generated_help_links_de_tagged,
         2,
         generated_help_sections_de_tagged,
+    },
+    {
+        "tagged-viewer",
+        "Markierungsanzeige",
+        "viewer.tagged",
+        "`Markierte anzeigen` öffnet die markierten Suchergebnisse in der internen Anzeige.\nMit `n` und `p` wechseln Sie zur nächsten oder vorherigen markierten Datei.\n`Leertaste`, `BildAb`, und `BildAuf` bewegen nur seitenweise in der aktuellen Datei.\nNach `C-s` für die Suche in der Markierung wechselt `/` zum nächsten und `?` zum vorherigen Treffer in der aktuellen Datei.\nAußerhalb dieser Anzeige bleibt `C-s` die Suchaktion für die Markierungsliste.\nMit `TAGGEDVIEWER=external` übernimmt das konfigurierte Anzeigeprogramm Suche und Treffernavigation.",
+        0,
+        NULL,
+        1,
+        generated_help_sections_de_tagged_viewer,
     },
     {
         "command-line-editing",
@@ -1752,11 +1782,11 @@ static const GeneratedHelpTopic generated_help_topics_de[] = {
     },
 };
 
-static const size_t generated_help_topic_count_de = 39;
+static const size_t generated_help_topic_count_de = 40;
 
 static const GeneratedHelpCatalog generated_help_catalogs[] = {
-    {"en", 39, generated_help_topics_en},
-    {"de", 39, generated_help_topics_de},
+    {"en", 40, generated_help_topics_en},
+    {"de", 40, generated_help_topics_de},
 };
 
 static const size_t generated_help_catalog_count = 2;

--- a/src/ui/tagged_view.c
+++ b/src/ui/tagged_view.c
@@ -19,19 +19,54 @@
 static const UICommandStripCommand tagged_view_message_commands[] = {
     {UI_COMMAND_LAYOUT_MNEMONIC, NP_("tagged-view.commands", "Quit"), "Q",
      NULL, "tagged-view.commands"},
-    {UI_COMMAND_LAYOUT_KEY_PREFIX, NP_("tagged-view.commands", "next page/file"),
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, NP_("tagged-view.commands", "next page"),
      "Space", "PgDn", "tagged-view.commands"},
     {UI_COMMAND_LAYOUT_KEY_PREFIX, NP_("tagged-view.commands", "prev page"),
-     "PgUp", NULL, "tagged-view.commands"}};
+     "PgUp", NULL, "tagged-view.commands"},
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, NP_("tagged-view.commands", "help"), "F1",
+     NULL, "tagged-view.commands"}};
 static const UICommandStripCommand tagged_view_prompt_commands[] = {
     {UI_COMMAND_LAYOUT_MNEMONIC, NP_("tagged-view.commands", "Next file"),
      "N", NULL, "tagged-view.commands"},
     {UI_COMMAND_LAYOUT_MNEMONIC, NP_("tagged-view.commands", "Prev file (wrap)"),
      "P", NULL, "tagged-view.commands"},
-    {UI_COMMAND_LAYOUT_KEY_PREFIX, NP_("tagged-view.commands", "line"), "Up",
-     "Down", "tagged-view.commands"},
-    {UI_COMMAND_LAYOUT_KEY_PREFIX, NP_("tagged-view.commands", "of line"),
-     "Home", "End", "tagged-view.commands"}};
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, NP_("tagged-view.commands", "next hit"), "/",
+     NULL, "tagged-view.commands"},
+    {UI_COMMAND_LAYOUT_KEY_PREFIX, NP_("tagged-view.commands", "prev hit"), "?",
+     NULL, "tagged-view.commands"}};
+
+static long FindTaggedViewHit(const char *path, const char *term,
+                              long current_line, int direction) {
+  FILE *fp;
+  char line[4096];
+  long line_number = 0;
+  long first_hit = -1;
+  long previous_hit = -1;
+  long last_hit = -1;
+
+  if (!path || !term || !*term)
+    return -1;
+  fp = fopen(path, "r");
+  if (!fp)
+    return -1;
+  while (fgets(line, sizeof(line), fp)) {
+    if (strcasestr(line, term)) {
+      if (first_hit < 0)
+        first_hit = line_number;
+      last_hit = line_number;
+      if (direction > 0 && line_number > current_line) {
+        fclose(fp);
+        return line_number;
+      }
+      if (direction < 0 && line_number < current_line)
+        previous_hit = line_number;
+    }
+    line_number++;
+  }
+  fclose(fp);
+  return direction > 0 ? first_hit :
+                         (previous_hit >= 0 ? previous_hit : last_hit);
+}
 
 static BOOL CopyBoundedStringChecked(char *dst, size_t dst_size,
                                      const char *src) {
@@ -219,6 +254,7 @@ static int RunTaggedViewLoop(ViewContext *ctx, char **view_paths,
   int ch;
   BOOL quit = FALSE;
   long line_offset = 0;
+  long current_hit_line = -1;
 
   if (!ctx || !view_paths || !display_paths || path_count <= 0)
     return -1;
@@ -262,11 +298,13 @@ static int RunTaggedViewLoop(ViewContext *ctx, char **view_paths,
     case 'N':
       current_idx = (current_idx + 1) % path_count;
       line_offset = 0;
+      current_hit_line = -1;
       break;
     case 'p':
     case 'P':
       current_idx = (current_idx + path_count - 1) % path_count;
       line_offset = 0;
+      current_hit_line = -1;
       break;
     case KEY_UP:
       if (line_offset > 0)
@@ -307,16 +345,30 @@ static int RunTaggedViewLoop(ViewContext *ctx, char **view_paths,
 
       RenderFilePreview(ctx, ctx->viewer.view, view_paths[current_idx],
                         &probe_offset, 0);
-      if (probe_offset == old_offset) {
-        if (current_idx < path_count - 1) {
-          current_idx++;
-          line_offset = 0;
-        }
-      } else {
+      if (probe_offset != old_offset) {
         line_offset = probe_offset;
       }
       break;
     }
+    case '/':
+    case '?': {
+      int direction = (ch == '/') ? 1 : -1;
+      long hit_line = FindTaggedViewHit(view_paths[current_idx],
+                                        ctx->global_search_term,
+                                        current_hit_line, direction);
+
+      if (hit_line >= 0) {
+        current_hit_line = hit_line;
+        line_offset = hit_line;
+      }
+      break;
+    }
+#ifdef KEY_F
+    case KEY_F(1):
+      (void)UI_ShowGeneratedContextHelp(ctx, "viewer.tagged", NULL, 0);
+      SetupTaggedViewWindow(ctx);
+      break;
+#endif
     case 'L' & 0x1f:
       clearok(stdscr, TRUE);
       break;

--- a/tests/test_help_source_schema.py
+++ b/tests/test_help_source_schema.py
@@ -18,6 +18,7 @@ RUNTIME_HELP_CONTEXT_SOURCES = (
     Path("src/ui/f2_picker.c"),
     Path("src/ui/interactions.c"),
     Path("src/ui/print_controller.c"),
+    Path("src/ui/tagged_view.c"),
     Path("src/ui/volume_menu.c"),
 )
 REQUIRED_TOPICS = {
@@ -150,7 +151,7 @@ def _help_label_override_map():
 
 def _runtime_help_contexts():
     contexts = set()
-    pattern = re.compile(r'"((?:main|overlay|prompt|dialog)\.[a-z0-9.-]+)"')
+    pattern = re.compile(r'"((?:main|overlay|prompt|dialog|viewer)\.[a-z0-9.-]+)"')
     for path in RUNTIME_HELP_CONTEXT_SOURCES:
         contexts.update(pattern.findall(path.read_text(encoding="utf-8")))
     return contexts

--- a/tests/test_viewer_return_ui.py
+++ b/tests/test_viewer_return_ui.py
@@ -82,6 +82,47 @@ def test_internal_viewer_return_restores_full_ui_frame(tmp_path, ytnova_binary):
         tui.quit()
 
 
+def test_internal_tagged_viewer_separates_file_and_hit_navigation(
+    tmp_path, ytnova_binary
+):
+    root = tmp_path / "internal_tagged_navigation"
+    root.mkdir()
+    (root / "first.txt").write_text(
+        "needle one\n" + ("padding\n" * 40) + "needle two\n", encoding="utf-8"
+    )
+    (root / "second.txt").write_text("needle three\n", encoding="utf-8")
+    (root / ".ytnova").write_text("[GLOBAL]\nTAGGEDVIEWER=internal\n", encoding="utf-8")
+
+    tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
+    try:
+        tui.wait_for_text("Path:")
+        tui.send_keystroke(Keys.ENTER)
+        tui.wait_for_text("file view")
+        tui.send_keystroke("T")
+        tui.send_keystroke(Keys.DOWN)
+        tui.send_keystroke("T")
+        tui.send_keystroke(Keys.CTRL_S)
+        tui.wait_for_text("SEARCH TAGGED:")
+        tui.send_keystroke("needle")
+        tui.send_keystroke(Keys.ENTER)
+        tui.wait_for_text("file view")
+        tui.send_keystroke(Keys.CTRL_V)
+        tui.wait_for_text("View tagged files")
+
+        footer = _footer_text(tui).lower()
+        assert "next page/file" not in footer, footer
+        assert "next page" in footer and "next file" in footer, footer
+        assert "next hit" in footer and "prev hit" in footer, footer
+
+        tui.send_keystroke("/")
+        tui.send_keystroke("/")
+        tui.wait_for_text("needle two")
+        tui.send_keystroke("?")
+        tui.wait_for_text("needle one")
+    finally:
+        tui.quit()
+
+
 def test_internal_viewer_return_in_archive_mode_restores_full_ui_frame(
     tmp_path, ytnova_binary
 ):


### PR DESCRIPTION
## Summary
- Separate tagged-file, page, and search-hit movement in the internal viewer.
- Keep external pager traversal pager-native and add contextual viewer help.

## Validation
- Red proof: `pytest -q tests/test_viewer_return_ui.py::test_internal_tagged_viewer_separates_file_and_hit_navigation` failed before the behavior change.
- `make -j"$(nproc)"`
- `pytest -q tests/test_viewer_return_ui.py tests/test_help_source_schema.py tests/test_help_generator.py`