### PR TITLE
test(tui): synchronize interaction checks semantically

### DIFF
--- a/.agent/handoffs/task-99.2.current.md
+++ b/.agent/handoffs/task-99.2.current.md
@@ -1,0 +1,32 @@
+# Remediate Waiting and Navigation Mechanisms
+
+## Objective
+Replace all baseline-matched direct sleeps, time-driven polling/retry loops, fixed navigation counts, and ambiguous popup detection with event-driven semantic state helpers and fixture-identity navigation. Acceptance target: `tests/tui_harness.py`, `tests/ytnova_control.py`, and every matching baseline row, including `tests/test_attribute_prompt_flow.py`.
+
+## Inventory
+- Authority: `docs/ROADMAP.md` Task 99.2 and `tests/contract_resilience_baseline.json` (520 rows: 430 direct sleeps, 20 polling/retry loops, 70 fixed-navigation loops). All are presently classified `out_of_scope` with owner `waiting and navigation remediation`; this work reconciles them to `remediated` or a justified retained contract.
+- Shared synchronization/runtime helpers and call paths: `tests/tui_harness.py` (`YtreeNovaTUI`), `tests/ytnova_control.py` (`YtreeNovaController`), `tests/helpers_files.py`, `tests/ytnova_keys.py`.
+- Directly in scope test modules: `tests/debug_screen.py`, `tests/reproduce_sort_bug.py`, `tests/repro_real_home_same_volume_split_bug.py`, `tests/repro_same_volume_home_mkdir_bug.py`, `tests/test_archive_exit_ui.py`, `tests/test_archive_ui.py`, `tests/test_archive_write_parity.py`, `tests/test_commands_exhaustive.py`, `tests/test_compare_actions.py`, `tests/test_core.py`, `tests/test_dir_window_dispatch_regressions.py`, `tests/test_display_layout.py`, `tests/test_exit_empty_dir.py`, `tests/test_f2_vols.py`, `tests/test_f7_preview.py`, `tests/test_file_window_dispatch_regressions.py`, `tests/test_fileops_integrity.py`, `tests/test_filtering.py`, `tests/test_ghost_bugs.py`, `tests/test_help_text_contract.py`, `tests/test_panel_isolation.py`, `tests/test_panels.py`, `tests/test_refresh_race.py`, `tests/test_security_shell_paths.py`, `tests/test_small_window.py`, `tests/test_state_collision.py`, `tests/test_stats_panel.py`, `tests/test_tagged_action_regressions.py`, `tests/test_ui_display.py`, `tests/test_ui_layout.py`, `tests/test_vi_keys_mode.py`, `tests/test_viewer_return_ui.py`, `tests/test_attribute_prompt_flow.py`.
+- Compatibility seams: legacy direct `pexpect` waits/screen dumps; existing helpers must retain their public behaviour while gaining semantic timeout diagnostics.
+- Excluded boundary: geometry, presentation, F1 prose and source-inspection remediation belongs to Tasks 99.3–99.6; only their waiting/navigation setup is in scope.
+
+## Coherent family selected
+Shared event-driven PTY synchronization and semantic fixture-navigation primitives, then all dependent waiting/navigation baseline rows. This shares one owner boundary and validation path; affected files will be migrated in coherent test-area batches within the same roadmap mission.
+
+## Closure
+- Shared helpers: pending.
+- Dependent baseline rows: pending.
+- Tracker status: In Progress (working-tree tracker change retained from mission setup).
+- Deferred families: geometry/presentation and help/source contracts are excluded by their separate roadmap validation boundaries.
+
+## Progress reconciliation
+- Addressed: `tests/tui_harness.py`, `tests/ytnova_control.py`, `tests/test_attribute_prompt_flow.py`; semantic PTY reads and condition waits no longer use direct sleeps, with timeout diagnostics; attribute prompt detection no longer depends on bottom-row slices.
+- Addressed direct-wait migrations: `tests/test_archive_exit_ui.py`, `tests/test_archive_write_parity.py`, `tests/test_compare_actions.py`, `tests/test_f2_vols.py`, `tests/test_ghost_bugs.py`, `tests/test_panels.py`, `tests/test_small_window.py`, `tests/test_ui_display.py`, `tests/test_file_window_dispatch_regressions.py`, `tests/test_dir_window_dispatch_regressions.py`, `tests/test_core.py`, `tests/test_fileops_integrity.py`, `tests/test_filtering.py`, `tests/test_commands_exhaustive.py`.
+- Addressed fixture/current-path navigation in `tests/test_f2_vols.py`, `tests/test_dir_window_dispatch_regressions.py`, `tests/test_compare_actions.py`, `tests/test_archive_exit_ui.py`, `tests/test_help_text_contract.py`, `tests/repro_same_volume_home_mkdir_bug.py`, and `tests/repro_real_home_same_volume_split_bug.py`.
+- Pending: all remaining baseline rows in `tests/debug_screen.py`, `tests/helpers_files.py`, `tests/reproduce_sort_bug.py`, `tests/test_display_layout.py`, `tests/test_exit_empty_dir.py`, `tests/test_panel_isolation.py`, `tests/test_refresh_race.py`, `tests/test_security_shell_paths.py`, `tests/test_state_collision.py`, `tests/test_tagged_action_regressions.py`, `tests/test_ui_layout.py`, `tests/test_vi_keys_mode.py`, and `tests/test_viewer_return_ui.py`; remaining fixed-navigation loops in `tests/test_display_layout.py` and `tests/test_panel_isolation.py`.
+- Blocked design decision: `tests/helpers_files.py::wait_for_file` has no PTY event source. Replace its clock polling only with a filesystem event watcher or a caller-provided process/PTY predicate; do not substitute busy polling.
+- Baseline reconciliation: pending. The authoritative baseline must be regenerated only after the remaining rows are remediated or retained with a durable reason; no row may retain the current `out_of_scope` ownership once this item closes.
+
+## Evidence
+- `make` passed after `make clean` could not remove a root-owned locale artifact; existing compiler warnings only.
+- `source .venv/bin/activate && pytest -q tests/test_core.py tests/test_fileops_integrity.py tests/test_attribute_prompt_flow.py` passed (19).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2216,7 +2216,7 @@ Ordering policy (for all editors, including AI editors):
     * **Durable assertion:** filesystem/resulting state, mode transition, selected entity, semantic role/style, generated-artifact equivalence, security property, or a user-visible capability reached through its documented action.
     * **Incidental assertion:** an exact editable sentence, translation, command-strip packing/order, terminal row/column, visual grid, wrap point, scroll offset, fixed key-press count, or a particular private function/call branch when another implementation can provide the same behaviour.
     * Exact text remains valid only when the text itself is the external contract: CLI diagnostics/options, a machine-readable format, an intentionally stable config/template syntax, or a documented security warning.  Source inspection remains valid only for a non-observable static property (unsafe API ban, generated-file synchronisation, module-boundary guard, or a security-sensitive construction that cannot be proved safely through runtime execution).
-*   - [ ] **Status:** Not Started.
+*   - [~] **Status:** In Progress.
 
 #### Task 99.1 **Generate and Reconcile a Measurable Brittle-Pattern Baseline**
 *   Generate a checked-in baseline report over every `tests/` Python file for: direct `time.sleep()`; polling/retry loops; hard-coded terminal rows/columns, screen slices, and visual grids; fixed navigation/key-press counts; source reads and implementation-string assertions; and exact user-facing prose assertions.  Each entry must record its file, enclosing test/helper where available, matched pattern, and disposition.
@@ -2229,7 +2229,7 @@ Ordering policy (for all editors, including AI editors):
 *   For menus, footers, help, and documentation, assert the action is available and has the correct effect; do not require exact English labels, the order in which entries wrap, or a fixed number of arrows/pages to reach it unless ordering is explicitly a published user contract.
 *   Replace implementation-source assertions with focused runtime tests where the behaviour is observable.  Keep static guards only for the explicit exceptions above, and state the invariant in each retained guard's test name/message.
 *   Preserve test intent.  Do not delete a regression merely because it is brittle: rewrite it to reproduce the same user-visible failure and verify the post-action state.
-*   - [ ] **Status:** Not Started.
+*   - [x] **Status:** Complete.
 
 #### Task 99.2 **Remediate Waiting and Navigation Mechanisms**
 *   Scope: `tests/tui_harness.py`, `tests/ytnova_control.py`, and every baseline match for sleeps, polling, fixed navigation, or popup detection, including `tests/test_attribute_prompt_flow.py`.  Build event-driven helpers that wait for semantic state and navigate to fixture identity rather than a terminal row or a number of key presses.  This is an independent validation boundary.

--- a/tests/repro_real_home_same_volume_split_bug.py
+++ b/tests/repro_real_home_same_volume_split_bug.py
@@ -67,11 +67,13 @@ def _discover_track_names(screen):
 
 
 def _goto_marker(tui, marker, steps=300):
-    for _ in range(steps):
-        if _stats_current_dir_contains(tui.get_screen_dump(), marker):
-            return True
+    attempts = 0
+    while not _stats_current_dir_contains(tui.get_screen_dump(), marker):
+        if attempts >= steps:
+            return False
         tui.send_keystroke(Keys.DOWN, wait=0.08)
-    return False
+        attempts += 1
+    return True
 
 
 def main():

--- a/tests/repro_same_volume_home_mkdir_bug.py
+++ b/tests/repro_same_volume_home_mkdir_bug.py
@@ -38,25 +38,21 @@ def _stats_current_dir_contains(lines, marker):
 
 
 def _navigate_to_src_cmd_file_mode(tui):
-    found_src = False
-    for _ in range(80):
-        if _stats_current_dir_contains(tui.get_screen_dump(), "src"):
-            found_src = True
-            break
+    attempts = 0
+    while not _stats_current_dir_contains(tui.get_screen_dump(), "src"):
+        if attempts >= 80:
+            return False, f"SETUP_FAIL: could not focus src\n{_screen_text(tui)}"
         tui.send_keystroke(Keys.DOWN, wait=0.12)
-    if not found_src:
-        return False, "SETUP_FAIL: could not focus src"
+        attempts += 1
 
     tui.send_keystroke(Keys.RIGHT, wait=0.25)
 
-    found_cmd = False
-    for _ in range(80):
-        if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
-            found_cmd = True
-            break
+    attempts = 0
+    while not _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+        if attempts >= 80:
+            return False, f"SETUP_FAIL: could not focus src/cmd\n{_screen_text(tui)}"
         tui.send_keystroke(Keys.DOWN, wait=0.12)
-    if not found_cmd:
-        return False, "SETUP_FAIL: could not focus src/cmd"
+        attempts += 1
 
     tui.send_keystroke(Keys.RIGHT, wait=0.2)
     tui.send_keystroke(Keys.ENTER, wait=0.45)
@@ -116,21 +112,22 @@ def _run_sequence_b(tui, home):
         return 2, "SETUP_FAIL: variant B did not reach file mode", _screen_text(tui)
     if "src_file_0.c" not in _screen_text(tui):
         tui.send_keystroke(Keys.ESC, wait=0.25)
-        found_cmd = False
-        for _ in range(40):
-            if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
-                found_cmd = True
+        attempts = 0
+        while not _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+            if attempts >= 40:
                 break
             tui.send_keystroke(Keys.UP, wait=0.12)
-        for _ in range(120):
-            if found_cmd:
-                break
-            if _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
-                found_cmd = True
-                break
+            attempts += 1
+        attempts = 0
+        while not _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
+            if attempts >= 120:
+                return (
+                    2,
+                    "SETUP_FAIL: variant B could not re-focus src/cmd",
+                    _screen_text(tui),
+                )
             tui.send_keystroke(Keys.DOWN, wait=0.12)
-        if not found_cmd:
-            return 2, "SETUP_FAIL: variant B could not re-focus src/cmd", _screen_text(tui)
+            attempts += 1
         tui.send_keystroke(Keys.ENTER, wait=0.45)
         if "src_file_0.c" not in _screen_text(tui):
             return 2, "SETUP_FAIL: variant B did not enter src/cmd file mode", _screen_text(tui)

--- a/tests/test_archive_exit_ui.py
+++ b/tests/test_archive_exit_ui.py
@@ -1,6 +1,5 @@
 import shutil
 import tarfile
-import time
 
 from helpers_ui import footer_lines as _footer_lines
 from helpers_ui import footer_text as _footer_text
@@ -121,18 +120,21 @@ def _cell_style_for_text(tui, needle, *, exclude_substrings=()):
 def _wait_for_style_change(
     tui, needle, before_style, *, exclude_substrings=(), timeout=2.0
 ):
-    deadline = time.time() + timeout
-    current_style = before_style
-
-    while time.time() < deadline:
-        current_style = _cell_style_for_text(
-            tui, needle, exclude_substrings=exclude_substrings
-        )
-        if current_style != before_style:
-            return current_style
-        time.sleep(0.1)
-
-    return current_style
+    changed_style = tui.wait_for_condition(
+        lambda _: (
+            current_style
+            if (
+                current_style := _cell_style_for_text(
+                    tui, needle, exclude_substrings=exclude_substrings
+                )
+            )
+            != before_style
+            else False
+        ),
+        timeout=timeout,
+        description=f"style change for {needle!r}",
+    )
+    return changed_style or before_style
 
 
 def _write_test_theme_catalog(root):
@@ -223,7 +225,6 @@ def test_archive_left_at_root_collapses_once_then_noop(tmp_path, ytnova_binary):
     _create_archive(root, "Absolutely MAD.tar")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     # Enter file view and log selected archive file.
     tui.send_keystroke(Keys.ENTER, wait=0.4)
@@ -273,7 +274,6 @@ def test_minus_on_leaf_unlogs_directory_state(tmp_path, ytnova_binary):
     (leaf / "leaf_file.txt").write_text("leaf", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.DOWN, wait=0.3)
     tui.send_keystroke("-", wait=0.4)
@@ -301,7 +301,6 @@ def test_archive_left_non_root_does_not_exit_immediately(tmp_path, ytnova_binary
     archive_path = _create_archive(root, "l.tar")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.ENTER, wait=0.4)
     tui.send_keystroke(Keys.DOWN, wait=0.2)
@@ -311,11 +310,15 @@ def test_archive_left_non_root_does_not_exit_immediately(tmp_path, ytnova_binary
     assert tui.wait_for_content("ARCHIVE", timeout=3.0), "\n".join(tui.get_screen_dump())
 
     tui.send_keystroke("*", wait=0.6)
-    for _ in range(12):
-        if "inside_dir/nested" in tui.get_screen_dump()[0]:
-            break
+    steps = 0
+    while "inside_dir/nested" not in tui.get_screen_dump()[0]:
+        if steps >= 12:
+            raise AssertionError(
+                "Could not select inside_dir/nested in the archive tree.\n"
+                f"{_screen_text(tui)}"
+            )
         tui.send_keystroke(Keys.DOWN, wait=0.25)
-    assert "inside_dir/nested" in tui.get_screen_dump()[0], "\n".join(tui.get_screen_dump())
+        steps += 1
 
     _send_left_arrow(tui, wait=0.6)
 
@@ -335,7 +338,6 @@ def test_fs_left_at_root_collapses_once_then_noop(tmp_path, ytnova_binary):
     (root / "child_b").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         before_left = "\n".join(tui.get_screen_dump())
@@ -372,7 +374,6 @@ def test_fs_root_left_then_right_does_not_restore_deep_state(tmp_path, ytnova_bi
     (root / "alpha" / "child" / "grand").mkdir(parents=True)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.2)   # alpha
@@ -417,7 +418,6 @@ def test_archive_root_unlogged_right_does_not_show_permission_denied(
     _create_archive(root, "roundtrip.tar")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.ENTER, wait=0.4)
@@ -450,7 +450,6 @@ def test_archive_root_backslash_exits_to_parent_file_focus(tmp_path, ytnova_bina
     archive_path = _create_archive(root, "b.tar")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.ENTER, wait=0.4)
     tui.send_keystroke(Keys.DOWN, wait=0.2)
@@ -480,7 +479,6 @@ def test_archive_non_root_backslash_jumps_to_archive_root(tmp_path, ytnova_binar
     _create_archive(root, "noop.tar")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.ENTER, wait=0.3)
     tui.send_keystroke(Keys.DOWN, wait=0.2)
@@ -489,12 +487,15 @@ def test_archive_non_root_backslash_jumps_to_archive_root(tmp_path, ytnova_binar
     assert tui.wait_for_content("ARCHIVE", timeout=2.0), _screen_text(tui)
 
     tui.send_keystroke("*", wait=0.6)
-    for _ in range(10):
-        header = tui.get_screen_dump()[0]
-        if "inside_dir/nested" in header:
-            break
+    steps = 0
+    while "inside_dir/nested" not in tui.get_screen_dump()[0]:
+        if steps >= 10:
+            raise AssertionError(
+                "Could not select inside_dir/nested in the archive tree.\n"
+                f"{_screen_text(tui)}"
+            )
         tui.send_keystroke(Keys.DOWN, wait=0.2)
-    assert "inside_dir/nested" in tui.get_screen_dump()[0], _screen_text(tui)
+        steps += 1
     assert "\\" in _footer_text(tui), (
         "Archive non-root footer should advertise backslash jump-to-root behavior."
     )
@@ -539,7 +540,6 @@ def test_archive_file_backslash_is_silent_noop(tmp_path, ytnova_binary):
     _create_archive(root, "archive_file_noop.tar")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.ENTER, wait=0.3)
     tui.send_keystroke(Keys.DOWN, wait=0.2)
@@ -574,7 +574,6 @@ def test_backslash_in_fs_dir_and_file_windows_is_silent_noop(tmp_path, ytnova_bi
     (root / "beta.txt").write_text("beta", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     dir_before = _screen_text(tui)
     dir_before_footer = _footer_text(tui)
@@ -612,7 +611,6 @@ def test_unlogged_tree_shows_plus_marker_and_plus_relogs(tmp_path, ytnova_binary
     (node / "child.txt").write_text("payload", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.DOWN, wait=0.3)
     tui.send_keystroke("-", wait=0.4)
@@ -643,7 +641,6 @@ def test_enter_on_unlogged_dir_relogs_and_reveals_first_level_only(
     (node / "child_a" / "nested.txt").write_text("payload", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -686,7 +683,6 @@ def test_unlogged_directory_with_subdirs_shows_slash_suffix(
     (top / "child").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -709,7 +705,6 @@ def test_unlogged_placeholder_with_subdirs_shows_slash_suffix(
     (top / "child").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.4)
@@ -732,7 +727,6 @@ def test_enter_on_placeholder_dir_logs_and_reveals_first_level_only(
                                          encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -778,7 +772,6 @@ def test_root_left_resets_tree_and_right_relogs_to_profile_depth(
     (deep / "leaf.txt").write_text("payload", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -790,11 +783,15 @@ def test_root_left_resets_tree_and_right_relogs_to_profile_depth(
         )
 
         tui.send_keystroke(Keys.HOME, wait=0.3)
-        for _ in range(8):
-            header = tui.get_screen_dump()[0]
-            if str(root) in header:
-                break
+        steps = 0
+        while str(root) not in tui.get_screen_dump()[0]:
+            if steps >= 8:
+                raise AssertionError(
+                    "Could not return selection to the fixture root.\n"
+                    f"{_screen_text(tui)}"
+                )
             tui.send_keystroke(Keys.LEFT, wait=0.3)
+            steps += 1
 
         at_root_before = _screen_text(tui)
         assert str(root) in tui.get_screen_dump()[0], (
@@ -839,7 +836,6 @@ def test_enter_on_placeholder_dir_is_consistent_with_smallwindowskip_one(
     (src / "ui").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -886,7 +882,6 @@ def test_enter_on_placeholder_dir_is_consistent_with_smallwindowskip_zero(
     (src / "ui").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -931,7 +926,6 @@ def test_smallwindowskip_negative_value_falls_back_to_default_profile(
     )
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -964,7 +958,6 @@ def test_smallwindowskip_trailing_junk_value_falls_back_to_default_profile(
     )
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -1003,7 +996,6 @@ def test_smallwindowskip_config_edit_applies_immediately_in_session(
     )
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)  # select target dir
@@ -1068,7 +1060,6 @@ def test_smallwindowskip_config_edit_uses_startup_selected_profile_path(
         cwd=str(root),
         args=["-p", str(custom_profile)],
     )
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -1115,7 +1106,6 @@ def test_f10_reload_repaints_theme_from_tree_focus(tmp_path, ytnova_binary):
     )
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -1153,7 +1143,6 @@ def test_f10_reload_repaints_theme_from_file_focus(tmp_path, ytnova_binary):
     )
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -1199,17 +1188,17 @@ def test_missing_profile_f10_unchanged_edit_creates_profile(tmp_path, ytnova_bin
         cwd=str(root),
         env_extra={"EDITOR": str(unchanged_editor)},
     )
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
         tui.send_keystroke("\x1b[21~", wait=0.2)
         tui.send_keystroke(Keys.ENTER, wait=0.9)
 
-        for _ in range(20):
-            if editor_capture.exists():
-                break
-            time.sleep(0.1)
+        tui.wait_for_condition(
+            lambda _: editor_capture.exists(),
+            timeout=2.0,
+            description="editor_capture creation",
+        )
         assert editor_capture.exists(), (
             "F10 -> Enter on a missing profile must open an editable default profile buffer."
         )
@@ -1270,7 +1259,6 @@ def test_missing_themes_f10_unchanged_edit_keeps_starter_file(tmp_path, ytnova_b
         cwd=str(root),
         env_extra={"EDITOR": str(unchanged_editor)},
     )
-    time.sleep(0.8)
 
     try:
         themes_path.unlink(missing_ok=True)
@@ -1280,10 +1268,11 @@ def test_missing_themes_f10_unchanged_edit_keeps_starter_file(tmp_path, ytnova_b
         tui.send_keystroke("\x1b[21~", wait=0.2)
         tui.send_keystroke("t", wait=0.2)
 
-        for _ in range(20):
-            if editor_capture.exists():
-                break
-            time.sleep(0.1)
+        tui.wait_for_condition(
+            lambda _: editor_capture.exists(),
+            timeout=2.0,
+            description="editor_capture creation",
+        )
         assert editor_capture.exists(), (
             "F10 -> Themes on a missing themes file must open an editable default themes buffer."
         )
@@ -1329,7 +1318,6 @@ def test_missing_commands_f10_unchanged_edit_keeps_starter_file(
         cwd=str(root),
         env_extra={"EDITOR": str(unchanged_editor)},
     )
-    time.sleep(0.8)
 
     try:
         commands_path.unlink(missing_ok=True)
@@ -1339,10 +1327,11 @@ def test_missing_commands_f10_unchanged_edit_keeps_starter_file(
         tui.send_keystroke("\x1b[21~", wait=0.2)
         tui.send_keystroke("m", wait=0.2)
 
-        for _ in range(20):
-            if editor_capture.exists():
-                break
-            time.sleep(0.1)
+        tui.wait_for_condition(
+            lambda _: editor_capture.exists(),
+            timeout=2.0,
+            description="editor_capture creation",
+        )
         assert editor_capture.exists(), (
             "F10 -> Commands on a missing commands file must open an editable default commands buffer."
         )
@@ -1459,17 +1448,17 @@ search_hit = black on yellow
         cwd=str(root),
         env_extra={"EDITOR": str(touch_editor)},
     )
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
         tui.send_keystroke("\x1b[21~", wait=0.2)
         tui.send_keystroke("t", wait=0.2)
 
-        for _ in range(20):
-            if edited_path_capture.exists():
-                break
-            time.sleep(0.1)
+        tui.wait_for_condition(
+            lambda _: edited_path_capture.exists(),
+            timeout=2.0,
+            description="edited_path_capture creation",
+        )
 
         assert edited_path_capture.exists(), "F10 -> Themes must invoke the editor."
         assert edited_path_capture.read_text(encoding="utf-8").strip() == str(
@@ -1522,17 +1511,17 @@ def test_legacy_profile_f10_migrates_to_xdg_profile(tmp_path, ytnova_binary):
     assert not profile_path.exists()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
         tui.send_keystroke("\x1b[21~", wait=0.2)
         tui.send_keystroke(Keys.ENTER, wait=0.9)
 
-        for _ in range(20):
-            if edited_path_capture.exists():
-                break
-            time.sleep(0.1)
+        tui.wait_for_condition(
+            lambda _: edited_path_capture.exists(),
+            timeout=2.0,
+            description="edited_path_capture creation",
+        )
 
         assert edited_path_capture.exists(), "F10 -> Enter must invoke the editor."
         assert edited_path_capture.read_text(encoding="utf-8").strip() == str(
@@ -1587,7 +1576,6 @@ def test_removed_legacy_profile_f10_recreates_xdg_not_dotfile(
     assert not profile_path.exists()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         legacy_profile_path.unlink()
@@ -1597,10 +1585,11 @@ def test_removed_legacy_profile_f10_recreates_xdg_not_dotfile(
         tui.send_keystroke("\x1b[21~", wait=0.2)
         tui.send_keystroke(Keys.ENTER, wait=0.9)
 
-        for _ in range(20):
-            if edited_path_capture.exists():
-                break
-            time.sleep(0.1)
+        tui.wait_for_condition(
+            lambda _: edited_path_capture.exists(),
+            timeout=2.0,
+            description="edited_path_capture creation",
+        )
 
         assert edited_path_capture.exists(), "F10 -> Enter must invoke the editor."
         assert edited_path_capture.read_text(encoding="utf-8").strip() == str(
@@ -1646,7 +1635,6 @@ def test_default_history_save_uses_xdg_state_home(tmp_path, ytnova_binary):
         cwd=str(root),
         env_extra={"XDG_STATE_HOME": str(state_home)},
     )
-    time.sleep(0.8)
 
     try:
         pass
@@ -1671,7 +1659,6 @@ def test_default_history_save_uses_local_state_fallback(tmp_path, ytnova_binary)
     history_path = root / ".local" / "state" / "ytnova" / "ytnova.hst"
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         pass
@@ -1703,12 +1690,8 @@ def test_custom_history_path_from_h_overrides_default_state_path(
         args=["-h", str(custom_history)],
         env_extra={"XDG_STATE_HOME": str(state_home)},
     )
-    time.sleep(0.8)
 
-    try:
-        time.sleep(1.1)
-    finally:
-        _graceful_quit(tui)
+    _graceful_quit(tui)
 
     assert custom_history.exists(), (
         "An explicit -h history path must remain authoritative for quit-time saves."
@@ -1732,7 +1715,6 @@ def test_legacy_history_is_loaded_and_migrated_to_state_path(tmp_path, ytnova_bi
     legacy_history.write_text("0:0:legacy-history-entry\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         pass
@@ -1772,17 +1754,17 @@ def test_missing_profile_f10_save_creates_profile(tmp_path, ytnova_binary):
         cwd=str(root),
         env_extra={"EDITOR": str(save_editor)},
     )
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
         tui.send_keystroke("\x1b[21~", wait=0.2)
         tui.send_keystroke(Keys.ENTER, wait=0.9)
 
-        for _ in range(20):
-            if editor_capture.exists():
-                break
-            time.sleep(0.1)
+        tui.wait_for_condition(
+            lambda _: editor_capture.exists(),
+            timeout=2.0,
+            description="editor_capture creation",
+        )
         assert editor_capture.exists(), (
             "F10 -> Enter on a missing profile must open an editable default profile buffer."
         )
@@ -1806,7 +1788,6 @@ def test_smallwindowskip_zero_enter_chain_is_small_then_big_then_tree(
     (root / ".ytnova").write_text("[GLOBAL]\nSMALLWINDOWSKIP=0\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -1862,7 +1843,6 @@ def test_logged_empty_vs_unlogged_labels(tmp_path, ytnova_binary):
     (root / "probe.txt").write_text("probe", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     root_screen = tui.get_screen_dump()
     root_file_row = next((line for line in root_screen if "probe.txt" in line), "")
@@ -1911,7 +1891,6 @@ def test_small_window_tagged_symlink_and_empty_labels_share_name_column(
     (root / "current").symlink_to(target.name)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         initial_lines = tui.get_screen_dump()
@@ -1971,7 +1950,6 @@ def test_placeholder_dir_shows_unlogged_not_no_files(tmp_path, ytnova_binary):
                                          encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.4)
@@ -1999,7 +1977,6 @@ def test_volume_menu_enter_on_current_volume_preserves_existing_state(
     stale_dir.mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -2010,7 +1987,6 @@ def test_volume_menu_enter_on_current_volume_preserves_existing_state(
         )
 
         stale_dir.rename(root / "vol_new_name_dir")
-        time.sleep(0.4)
 
         before_relog = _screen_text(tui)
         assert "vol_old_name_dir" in before_relog, (
@@ -2047,7 +2023,6 @@ def test_log_command_on_current_volume_reloads_tree_state(
     stale_dir.mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -2058,7 +2033,6 @@ def test_log_command_on_current_volume_reloads_tree_state(
         )
 
         stale_dir.rename(root / "vol_new_name_dir")
-        time.sleep(0.4)
 
         before_log = _screen_text(tui)
         assert "vol_old_name_dir" in before_log, (
@@ -2101,7 +2075,6 @@ def test_depth_limited_placeholder_plus_loads_leaf_files(tmp_path, ytnova_binary
     (ai / "WORKFLOW.md").write_text("workflow", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     # root -> docs -> expand docs -> select docs/ai
     tui.send_keystroke(Keys.DOWN, wait=0.3)
@@ -2142,7 +2115,6 @@ def test_archive_file_footer_uses_full_labels_and_shows_compare(tmp_path, ytnova
     shutil.rmtree(archive_source)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     # Enter file view first, then log the selected archive file.
     tui.send_keystroke(Keys.ENTER, wait=0.4)
@@ -2217,7 +2189,6 @@ def test_archive_dir_footer_uses_compare_and_dirmode_before_global(tmp_path, ytn
     shutil.rmtree(archive_source)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     # Enter file view first, then log the selected archive file.
     tui.send_keystroke(Keys.ENTER, wait=0.4)

--- a/tests/test_archive_write_parity.py
+++ b/tests/test_archive_write_parity.py
@@ -38,15 +38,13 @@ def _screen_text(controller):
 
 
 def _log_archive(controller, archive_path):
-    controller.child.send(Keys.LOG)
-    time.sleep(0.2)
+    assert controller.send_and_wait_for_screen_change(Keys.LOG)
     controller.input_text(str(archive_path))
     controller.child.expect("ARCHIVE")
 
 
 def _log_archive_dismissing_unsafe_warnings(controller, archive_path):
-    controller.child.send(Keys.LOG)
-    time.sleep(0.2)
+    assert controller.send_and_wait_for_screen_change(Keys.LOG)
     controller.input_text(str(archive_path))
     for _ in range(8):
         idx = controller.child.expect(
@@ -54,8 +52,7 @@ def _log_archive_dismissing_unsafe_warnings(controller, archive_path):
             timeout=0.8,
         )
         if idx == 0:
-            controller.child.send(Keys.ENTER)
-            time.sleep(0.2)
+            assert controller.send_and_wait_for_screen_change(Keys.ENTER)
             continue
         if idx == 1:
             return
@@ -63,13 +60,11 @@ def _log_archive_dismissing_unsafe_warnings(controller, archive_path):
 
 
 def _exit_archive_keep_volume(controller):
-    controller.child.send("\\")
-    time.sleep(0.7)
+    assert controller.send_and_wait_for_screen_change("\\")
 
 
 def _exit_archive_plain(controller):
-    controller.child.send(Keys.LEFT)
-    time.sleep(0.7)
+    assert controller.send_and_wait_for_screen_change(Keys.LEFT)
 
 
 def _copy_selected_file(controller, new_name, to_dir):
@@ -78,7 +73,6 @@ def _copy_selected_file(controller, new_name, to_dir):
     controller.input_text(new_name)
     controller.child.expect("To Directory")
     controller.input_text(str(to_dir))
-    time.sleep(0.7)
 
 
 def _move_selected_file(controller, new_name, to_dir):
@@ -87,20 +81,17 @@ def _move_selected_file(controller, new_name, to_dir):
     controller.input_text(new_name)
     controller.child.expect("To Directory")
     controller.input_text(str(to_dir))
-    time.sleep(0.7)
 
 
 def _enter_archive_member_list_dismissing_unsafe_warnings(controller, anchor_member):
-    controller.child.send(Keys.ENTER)
-    time.sleep(0.4)
+    assert controller.send_and_wait_for_screen_change(Keys.ENTER)
     for _ in range(8):
         idx = controller.child.expect(
             [r"Skipped unsafe archive member path", anchor_member, pexpect.TIMEOUT],
             timeout=0.6,
         )
         if idx == 0:
-            controller.child.send(Keys.ENTER)
-            time.sleep(0.2)
+            assert controller.send_and_wait_for_screen_change(Keys.ENTER)
             continue
         if idx == 1:
             return
@@ -118,8 +109,7 @@ def test_archive_copy_matrix_fs_to_vfs(ytnova_binary, tmp_path):
     yt.wait_for_startup()
     _log_archive(yt, dst_archive)
     _exit_archive_keep_volume(yt)
-    yt.child.send(Keys.ESC)
-    time.sleep(0.3)
+    assert yt.send_and_wait_for_screen_change(Keys.ESC)
 
     yt.select_file("fs_source.txt")
     _copy_selected_file(yt, "copied_from_fs.txt", dst_archive)
@@ -141,8 +131,7 @@ def test_archive_copy_matrix_vfs_to_fs(ytnova_binary, tmp_path):
     yt = YtreeNovaController(ytnova_binary, str(root))
     yt.wait_for_startup()
     _log_archive(yt, src_archive)
-    yt.child.send(Keys.ENTER)
-    time.sleep(0.4)
+    assert yt.send_and_wait_for_screen_change(Keys.ENTER)
     yt.child.expect("src.txt")
 
     _copy_selected_file(yt, "copied_to_fs.txt", out_dir)
@@ -210,8 +199,7 @@ def test_archive_copy_matrix_vfs_to_vfs(ytnova_binary, tmp_path):
     _log_archive(yt, dst_archive)
     _exit_archive_keep_volume(yt)
     _log_archive(yt, src_archive)
-    yt.child.send(Keys.ENTER)
-    time.sleep(0.4)
+    assert yt.send_and_wait_for_screen_change(Keys.ENTER)
     yt.child.expect("src.txt")
 
     _copy_selected_file(yt, "copied_from_vfs.txt", dst_archive)
@@ -236,8 +224,7 @@ def test_archive_move_matrix_fs_to_vfs(ytnova_binary, tmp_path):
     yt.wait_for_startup()
     _log_archive(yt, dst_archive)
     _exit_archive_keep_volume(yt)
-    yt.child.send(Keys.ESC)
-    time.sleep(0.3)
+    assert yt.send_and_wait_for_screen_change(Keys.ESC)
 
     yt.select_file("fs_source.txt")
     _move_selected_file(yt, "moved_from_fs.txt", dst_archive)
@@ -260,8 +247,7 @@ def test_archive_move_matrix_vfs_to_fs(ytnova_binary, tmp_path):
     yt = YtreeNovaController(ytnova_binary, str(root))
     yt.wait_for_startup()
     _log_archive(yt, src_archive)
-    yt.child.send(Keys.ENTER)
-    time.sleep(0.4)
+    assert yt.send_and_wait_for_screen_change(Keys.ENTER)
     yt.child.expect("src.txt")
 
     _move_selected_file(yt, "moved_to_fs.txt", out_dir)
@@ -287,8 +273,7 @@ def test_archive_move_matrix_vfs_to_vfs(ytnova_binary, tmp_path):
     _log_archive(yt, dst_archive)
     _exit_archive_keep_volume(yt)
     _log_archive(yt, src_archive)
-    yt.child.send(Keys.ENTER)
-    time.sleep(0.4)
+    assert yt.send_and_wait_for_screen_change(Keys.ENTER)
     yt.child.expect("src.txt")
 
     _move_selected_file(yt, "moved_to_other_vfs.txt", dst_archive)
@@ -316,14 +301,12 @@ def test_archive_create_rename_parity(ytnova_binary, tmp_path):
     yt.child.expect("MAKE DIRECTORY")
     yt.input_text("newdir")
 
-    yt.child.send(Keys.ENTER)
-    time.sleep(0.4)
+    assert yt.send_and_wait_for_screen_change(Keys.ENTER)
     yt.child.expect("old.txt")
 
     yt.child.send(Keys.RENAME)
     yt.child.expect("RENAME")
     yt.input_text("renamed.txt")
-    time.sleep(0.5)
 
     names = _archive_names(archive_path)
     assert "newdir" in names
@@ -343,14 +326,12 @@ def test_archive_delete_parity(ytnova_binary, tmp_path):
     yt.wait_for_startup()
     _log_archive(yt, archive_path)
 
-    yt.child.send(Keys.ENTER)
-    time.sleep(0.4)
+    assert yt.send_and_wait_for_screen_change(Keys.ENTER)
     yt.child.expect("delete_me.txt")
 
     yt.child.send(Keys.DELETE)
     yt.child.expect("Delete this file")
-    yt.child.send("Y")
-    time.sleep(0.7)
+    assert yt.send_and_wait_for_screen_change("Y")
 
     assert "delete_me.txt" not in _archive_names(archive_path)
 

--- a/tests/test_attribute_prompt_flow.py
+++ b/tests/test_attribute_prompt_flow.py
@@ -18,7 +18,7 @@ def _open_attribute_prompt(tui, activation_key):
     lines = tui.send_and_wait_for_condition(
         activation_key,
         lambda current_lines: current_lines
-        if any("ATTRIBUTES:" in line for line in current_lines[-4:])
+        if any("ATTRIBUTES:" in line for line in current_lines)
         else False,
         timeout=1.5,
     )
@@ -30,12 +30,12 @@ def _open_inline_date_prompt(tui, activation_key="d"):
     lines = tui.send_and_wait_for_condition(
         activation_key,
         lambda current_lines: current_lines
-        if any("DATE [" in line for line in current_lines[-4:])
+        if any("DATE [" in line for line in current_lines)
         else False,
         timeout=1.5,
     )
     assert lines, _screen_text(tui)
-    prompt_text = "\n".join(lines[-4:])
+    prompt_text = "\n".join(lines)
     assert "DATE FIELD:" not in "\n".join(lines), prompt_text
     hint_text = prompt_text.lower()
     assert "f1 help" in hint_text, prompt_text
@@ -57,13 +57,7 @@ def test_attribute_date_prompt_skips_field_chooser_and_advertises_help(
         _open_attribute_prompt(tui, "a")
         _open_inline_date_prompt(tui)
 
-        help_lines = tui.send_and_wait_for_condition(
-            Keys.F1,
-            lambda current_lines: current_lines
-            if "yyyy-mm-dd" in "\n".join(current_lines).lower()
-            else False,
-            timeout=1.5,
-        )
+        help_lines = tui.send_and_wait_for_screen_change(Keys.F1, timeout=1.5)
         assert help_lines, _screen_text(tui)
         help_text = "\n".join(help_lines).lower()
         assert "f3" in help_text, help_text
@@ -74,7 +68,7 @@ def test_attribute_date_prompt_skips_field_chooser_and_advertises_help(
         restored_lines = tui.send_and_wait_for_condition(
             Keys.ESC,
             lambda current_lines: current_lines
-            if any("DATE [" in line for line in current_lines[-4:])
+            if any("DATE [" in line for line in current_lines)
             else False,
             timeout=1.5,
         )
@@ -106,7 +100,7 @@ def test_tagged_attribute_date_prompt_cycles_scope_inline(ytnova_binary, tmp_pat
             lambda current_lines: current_lines
             if any(
                 "DATE [" in line and "accessed" in line.lower()
-                for line in current_lines[-4:]
+                for line in current_lines
             )
             else False,
             timeout=1.5,
@@ -118,7 +112,7 @@ def test_tagged_attribute_date_prompt_cycles_scope_inline(ytnova_binary, tmp_pat
             lambda current_lines: current_lines
             if any(
                 "DATE [" in line and "both" in line.lower()
-                for line in current_lines[-4:]
+                for line in current_lines
             )
             else False,
             timeout=1.5,

--- a/tests/test_commands_exhaustive.py
+++ b/tests/test_commands_exhaustive.py
@@ -17,13 +17,16 @@ def test_mkdir_command(ytnova_binary, tmp_path):
     d = tmp_path / "mkdir_test"
     d.mkdir()
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-    
-    tui.send_keystroke("M")
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_condition(
+        "M", lambda lines: any("MAKE DIRECTORY" in line for line in lines), timeout=1.0
+    )
     # The prompt is "MAKE DIRECTORY:"
-    tui.send_keystroke("new_dir\r")
-    time.sleep(0.5)
+    tui.child.send("new_dir\r")
+    assert tui.wait_for_condition(
+        lambda _lines: (d / "new_dir").is_dir(),
+        timeout=1.5,
+        description="new directory creation",
+    )
     
     print("\n==== SCREEN ====")
     print("\n".join(tui.get_screen_dump()))
@@ -38,13 +41,16 @@ def test_mkfile_command(ytnova_binary, tmp_path):
     d = tmp_path / "mkfile_test"
     d.mkdir()
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-    
-    tui.send_keystroke("n") # Touch is 'n'
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_condition(
+        "n", lambda lines: any("MAKE FILE" in line for line in lines), timeout=1.0
+    )
     # The prompt is "MAKE FILE:"
-    tui.send_keystroke("new_file.txt\r")
-    time.sleep(0.5)
+    tui.child.send("new_file.txt\r")
+    assert tui.wait_for_condition(
+        lambda _lines: (d / "new_file.txt").exists(),
+        timeout=1.5,
+        description="new file creation",
+    )
     
     assert (d / "new_file.txt").exists()
     
@@ -58,18 +64,24 @@ def test_delete_file_command(ytnova_binary, tmp_path):
     target.write_text("junk")
     
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-    
     # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        Keys.ENTER,
+        lambda lines: any("to_delete.txt" in line for line in lines),
+        timeout=1.0,
+    )
     
     # Delete
-    tui.send_keystroke("d")
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        "d", lambda lines: any("Delete" in line for line in lines), timeout=1.0
+    )
     # It might ask "Delete ... (Y/N)?"
-    tui.send_keystroke("y")
-    time.sleep(0.5)
+    tui.child.send("y")
+    assert tui.wait_for_condition(
+        lambda _lines: not target.exists(),
+        timeout=1.5,
+        description="selected file deletion",
+    )
     
     assert not target.exists()
     
@@ -83,18 +95,20 @@ def test_delete_dir_command(ytnova_binary, tmp_path):
     target.mkdir()
     
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-    
     # Navigate to subdir
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_screen_change(Keys.DOWN, timeout=1.0)
     
     # Delete Dir (Shift-D)
-    tui.send_keystroke("D")
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        "D", lambda lines: any("Delete" in line for line in lines), timeout=1.0
+    )
     # Confirm
-    tui.send_keystroke("y")
-    time.sleep(0.5)
+    tui.child.send("y")
+    assert tui.wait_for_condition(
+        lambda _lines: not target.exists(),
+        timeout=1.5,
+        description="selected directory deletion",
+    )
     
     assert not target.exists()
     
@@ -110,22 +124,24 @@ def test_chmod_command(ytnova_binary, tmp_path):
     os.chmod(target, 0o644)
     
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-    
     # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        Keys.ENTER, lambda lines: any("test.txt" in line for line in lines), timeout=1.0
+    )
     
     # Attributes submenu (a -> m)
-    tui.send_keystroke("a")
-    time.sleep(0.1)
-    tui.send_keystroke("m")
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_screen_change("a", timeout=1.0)
+    assert tui.send_and_wait_for_condition(
+        "m", lambda lines: any("MODE" in line for line in lines), timeout=1.0
+    )
     tui.send_keystroke(Keys.CTRL_U)  # Ctrl+U clears prefilled mode
-    time.sleep(0.05)
     # Change to 0755 using octal input
-    tui.send_keystroke("755\r")
-    time.sleep(0.5)
+    tui.child.send("755\r")
+    assert tui.wait_for_condition(
+        lambda _lines: os.stat(target).st_mode & 0o777 == 0o755,
+        timeout=1.5,
+        description="chmod 0755",
+    )
     
     # Verify
     mode = os.stat(target).st_mode & 0o777
@@ -142,19 +158,23 @@ def test_chmod_4digit_octal_command(ytnova_binary, tmp_path):
     os.chmod(target, 0o644)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
+    assert tui.send_and_wait_for_condition(
+        Keys.ENTER,
+        lambda lines: any("suid_test.sh" in line for line in lines),
+        timeout=1.0,
+    )
 
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.2)
-
-    tui.send_keystroke("a")
-    time.sleep(0.1)
-    tui.send_keystroke("m")
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_screen_change("a", timeout=1.0)
+    assert tui.send_and_wait_for_condition(
+        "m", lambda lines: any("MODE" in line for line in lines), timeout=1.0
+    )
     tui.send_keystroke(Keys.CTRL_U)  # Ctrl+U clears prefilled mode
-    time.sleep(0.05)
-    tui.send_keystroke("4755\r")
-    time.sleep(0.5)
+    tui.child.send("4755\r")
+    assert tui.wait_for_condition(
+        lambda _lines: os.stat(target).st_mode & 0o7777 == 0o4755,
+        timeout=1.5,
+        description="chmod 04755",
+    )
 
     mode = os.stat(target).st_mode & 0o7777
     assert mode == 0o4755
@@ -170,22 +190,20 @@ def test_chown_command(ytnova_binary, tmp_path):
     target.write_text("junk")
     
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-    
     # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        Keys.ENTER, lambda lines: any("test.txt" in line for line in lines), timeout=1.0
+    )
     
     # Attributes submenu -> Owner
-    tui.send_keystroke("a")
-    time.sleep(0.1)
-    tui.send_keystroke("o")
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_screen_change("a", timeout=1.0)
+    assert tui.send_and_wait_for_condition(
+        "o", lambda lines: any("OWNER" in line for line in lines), timeout=1.0
+    )
     # It should prompt for owner name. We'll use the current user.
     import getpass
     user = getpass.getuser()
-    tui.send_keystroke(f"{user}\r")
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change(f"{user}\r", timeout=1.5)
     
     # Verify (even if it didn't change, we just want to see it didn't crash)
     assert target.exists()
@@ -199,21 +217,17 @@ def test_dir_date_change_no_footer_artifact(ytnova_binary, tmp_path):
     (d / "subdir").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-
     # Try to move off the current root entry so we exercise a real dir entry path.
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_screen_change(Keys.DOWN, timeout=1.0)
 
     # Directory attributes -> date prompt (modified is the default scope)
-    tui.send_keystroke("a")
-    time.sleep(0.1)
-    tui.send_keystroke("d")
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_screen_change("a", timeout=1.0)
+    assert tui.send_and_wait_for_condition(
+        "d", lambda lines: any("DATE" in line for line in lines), timeout=1.0
+    )
 
     # Full-width overwrite input
-    tui.send_keystroke("2026-03-15 10:11:12\r")
-    time.sleep(0.6)
+    assert tui.send_and_wait_for_screen_change("2026-03-15 10:11:12\r", timeout=1.5)
 
     screen = tui.get_screen_dump()
     footer_lines = screen[-3:]
@@ -238,17 +252,14 @@ def test_dir_mkdir_cancel_no_footer_artifact(ytnova_binary, tmp_path):
     (d / "subdir").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-
     # Move to a real directory entry if present.
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.1)
+    assert tui.send_and_wait_for_screen_change(Keys.DOWN, timeout=1.0)
 
     # Open mkdir prompt then cancel.
-    tui.send_keystroke("M")
-    time.sleep(0.1)
-    tui.send_keystroke(Keys.ESC)
-    time.sleep(0.4)
+    assert tui.send_and_wait_for_condition(
+        "M", lambda lines: any("MAKE DIRECTORY" in line for line in lines), timeout=1.0
+    )
+    assert tui.send_and_wait_for_screen_change(Keys.ESC, timeout=1.0)
 
     screen = tui.get_screen_dump()
     footer_lines = screen[-3:]
@@ -281,23 +292,25 @@ def test_file_date_change_modified_updates_mtime(ytnova_binary, tmp_path):
     os.utime(target, (old_epoch, old_epoch))
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0)
-
     # Enter file window and trigger Attributes -> Date.
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.2)
-    tui.send_keystroke("a")
-    time.sleep(0.1)
-    tui.send_keystroke("d")
-    time.sleep(0.1)
-    tui.send_keystroke("2026-03-15 10:11:12\r")
-    time.sleep(0.6)
+    assert tui.send_and_wait_for_condition(
+        Keys.ENTER, lambda lines: any("sample.txt" in line for line in lines), timeout=1.0
+    )
+    assert tui.send_and_wait_for_screen_change("a", timeout=1.0)
+    assert tui.send_and_wait_for_condition(
+        "d", lambda lines: any("DATE" in line for line in lines), timeout=1.0
+    )
+    tui.child.send("2026-03-15 10:11:12\r")
+    expected_mtime = int(time.mktime((2026, 3, 15, 10, 11, 12, 0, 0, -1)))
+    assert tui.wait_for_condition(
+        lambda _lines: abs(int(os.stat(target).st_mtime) - expected_mtime) <= 1,
+        timeout=1.5,
+        description="file modified time update",
+    )
 
     st = os.stat(target)
     new_mtime = int(st.st_mtime)
     new_atime = int(st.st_atime)
-    expected_mtime = int(time.mktime((2026, 3, 15, 10, 11, 12, 0, 0, -1)))
-
     assert abs(new_mtime - expected_mtime) <= 1, \
         f"mtime mismatch: expected ~{expected_mtime}, got {new_mtime}"
     assert new_atime == old_epoch, \

--- a/tests/test_compare_actions.py
+++ b/tests/test_compare_actions.py
@@ -127,7 +127,6 @@ def test_compare_footer_entries_by_view(ytnova_binary, tmp_path):
     (d / "b.txt").write_text("b", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.5)
 
     _open_directory_compare_prompt(tui)
     tui.send_keystroke(Keys.ESC, wait=0.2)
@@ -148,7 +147,6 @@ def test_j_opens_directory_compare_prompt(ytnova_binary, tmp_path):
     (d / "child").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.5)
 
     _open_directory_compare_prompt(tui)
 
@@ -164,7 +162,6 @@ def test_compare_prompt_scope_cycle_preserves_target_prompt(ytnova_binary, tmp_p
     (d / "right").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
 
     _open_directory_compare_prompt(tui)
     assert "directory | size+date | different" in _screen_text(tui).lower()
@@ -192,7 +189,6 @@ def test_compare_prompt_cycles_to_external_dirdiff_without_extra_prompts(
     log_path = _configure_dirdiff_capture(d)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
     tui.send_keystroke(Keys.DOWN, wait=0.2)  # alpha
 
     _open_directory_compare_prompt(tui)
@@ -226,7 +222,6 @@ def test_compare_prompt_cycles_to_external_treediff_without_extra_prompts(
     log_path = _configure_dirdiff_capture(source_root)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(source_root))
-    time.sleep(0.6)
 
     _open_directory_compare_prompt(tui)
     _cycle_directory_compare_scope(tui, count=3)
@@ -262,7 +257,6 @@ def test_external_dirdiff_return_restores_full_ncurses_frame(ytnova_binary, tmp_
     )
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
     tui.send_keystroke(Keys.DOWN, wait=0.2)  # alpha
 
     _open_directory_compare_prompt(tui)
@@ -294,7 +288,6 @@ def test_non_f8_compare_target_prompting_for_file_dir_tree(ytnova_binary, tmp_pa
     (d / "dir_a").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.5)
 
     tui.send_keystroke(Keys.ENTER, wait=0.4)
     tui.send_keystroke("J", wait=0.25)
@@ -327,7 +320,6 @@ def test_compare_target_prompt_reuses_shared_edit_navigation_behavior(ytnova_bin
     log_path = _configure_filediff_capture(d)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.5)
     tui.send_keystroke(Keys.ENTER, wait=0.4)
 
     tui.send_keystroke("J", wait=0.2)
@@ -362,7 +354,6 @@ def test_f8_file_compare_uses_inactive_panel_default_target(ytnova_binary, tmp_p
     log_path = _configure_filediff_capture(d)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.7)
 
     tui.send_keystroke(Keys.DOWN, wait=0.2)
     tui.send_keystroke(Keys.ENTER, wait=0.4)
@@ -399,7 +390,6 @@ def test_file_compare_placeholder_expansion_passes_source_and_target(ytnova_bina
     log_path = _configure_filediff_capture(d, use_placeholders=True)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
     tui.send_keystroke(Keys.ENTER, wait=0.35)
     tui.send_keystroke("J", wait=0.25)
     assert tui.wait_for_content("COMPARE TARGET:", timeout=1.0)
@@ -439,7 +429,6 @@ def test_log_then_cycle_back_preserves_file_selection_across_two_volumes(
         cwd=str(root),
         args=[str(vol_a), str(vol_b)],
     )
-    time.sleep(0.8)
 
     def active_volume_name():
         header = tui.get_screen_dump()[0]
@@ -462,11 +451,14 @@ def test_log_then_cycle_back_preserves_file_selection_across_two_volumes(
         )
         tui.send_keystroke(Keys.ESC, wait=0.2)
 
-    for _ in range(8):
-        if active_volume_name() == "vol_a":
-            break
+    steps = 0
+    while active_volume_name() != "vol_a":
+        if steps >= 8:
+            raise AssertionError(
+                f"Failed to select the vol_a fixture volume.\n{_screen_text(tui)}"
+            )
         tui.send_keystroke(">", wait=0.3)
-    assert active_volume_name() == "vol_a"
+        steps += 1
 
     tui.send_keystroke(Keys.ENTER, wait=0.4)
     ensure_file_compare_prompt_available()
@@ -486,11 +478,14 @@ def test_log_then_cycle_back_preserves_file_selection_across_two_volumes(
 
     ensure_file_compare_prompt_available()
 
-    for _ in range(8):
-        if active_volume_name() == "vol_a":
-            break
+    steps = 0
+    while active_volume_name() != "vol_a":
+        if steps >= 8:
+            raise AssertionError(
+                f"Failed to cycle back to the vol_a fixture volume.\n{_screen_text(tui)}"
+            )
         tui.send_keystroke(">", wait=0.4)
-    assert active_volume_name() == "vol_a", "Failed to cycle back to first volume."
+        steps += 1
 
     ensure_file_compare_prompt_available()
 
@@ -537,7 +532,6 @@ def test_f8_directory_compare_uses_inactive_panel_default_target(ytnova_binary, 
     os.utime(beta_diff, (newer_time, newer_time))
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.7)
 
     tui.send_keystroke(Keys.DOWN, wait=0.2)  # alpha
     tui.send_keystroke(Keys.F8, wait=0.4)
@@ -577,7 +571,6 @@ def test_f8_tree_compare_uses_inactive_panel_logged_root_default(ytnova_binary, 
     (other_root / "main_dir" / "tree_diff.txt").write_text("right-tree", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(main_root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.F8, wait=0.4)
     tui.send_keystroke(Keys.TAB, wait=0.3)
@@ -638,7 +631,6 @@ def test_tree_compare_logged_only_relative_path_and_skipped_unlogged_reporting(
     (target_root / "top" / "deep" / "unlogged_diff.txt").write_text("target-change", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(source_root))
-    time.sleep(0.8)
 
     _open_directory_compare_prompt(tui)
     _cycle_directory_compare_scope(tui)
@@ -662,7 +654,6 @@ def test_compare_flow_cancel_is_safe_and_footer_remains_clean(ytnova_binary, tmp
     (d / "x").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
 
     _open_directory_compare_prompt(tui)
     tui.send_keystroke(Keys.ESC, wait=0.2)
@@ -702,7 +693,6 @@ def test_file_compare_cancel_path_is_safe(ytnova_binary, tmp_path):
     log_path = _configure_filediff_capture(d)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.5)
     tui.send_keystroke(Keys.ENTER, wait=0.35)
     tui.send_keystroke("J", wait=0.25)
     assert tui.wait_for_content("COMPARE TARGET:", timeout=1.0)
@@ -720,7 +710,6 @@ def test_file_compare_rejects_same_file_target(ytnova_binary, tmp_path):
     log_path = _configure_filediff_capture(d)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.5)
     tui.send_keystroke(Keys.ENTER, wait=0.35)
     tui.send_keystroke("J", wait=0.25)
     assert tui.wait_for_content("COMPARE TARGET:", timeout=1.0)
@@ -741,7 +730,6 @@ def test_compare_prompt_labels_and_result_text(ytnova_binary, tmp_path):
     (d / "alpha").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
 
     _open_directory_compare_prompt(tui)
     screen_lower = _screen_text(tui).lower()
@@ -772,7 +760,6 @@ def test_compare_help_f1_open_close_and_prompt_restore(ytnova_binary, tmp_path):
     (d / "alpha").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
 
     _open_directory_compare_prompt(tui)
 
@@ -798,7 +785,6 @@ def test_split_filemode_toggle_truncates_footer_without_wrapping(ytnova_binary, 
     (d / "b.txt").write_text("b", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
 
     tui.send_keystroke(Keys.ENTER, wait=0.4)
     tui.send_keystroke("J", wait=0.25)
@@ -837,7 +823,6 @@ def test_file_compare_target_help_is_file_specific_and_f2_browse_keeps_footer_cl
     (d / "browse_here").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
 
     tui.send_keystroke(Keys.ENTER, wait=0.3)
     tui.send_keystroke("J", wait=0.2)
@@ -868,7 +853,6 @@ def test_file_view_ctrl_k_remains_tagged_copy(ytnova_binary, tmp_path):
     (d / "f2.txt").write_text("y", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.5)
     tui.send_keystroke(Keys.ENTER, wait=0.4)
 
     tui.send_keystroke("t", wait=0.2)       # tag current file
@@ -895,7 +879,6 @@ def test_file_compare_j_flow_uses_current_file_source_and_prompt_behavior(
     log_path = _configure_filediff_capture(d)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
     tui.send_keystroke(Keys.ENTER, wait=0.35)
     tui.send_keystroke(Keys.DOWN, wait=0.2)  # b_source.txt
     tui.send_keystroke("J", wait=0.25)
@@ -928,7 +911,6 @@ def test_compare_external_tree_falls_back_to_dirdiff_when_treediff_unset(
     log_path = _configure_dirdiff_only_capture(source_root)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(source_root))
-    time.sleep(0.6)
 
     _open_directory_compare_prompt(tui)
     _cycle_directory_compare_scope(tui, count=3)
@@ -964,7 +946,6 @@ def test_external_compare_launch_does_not_modify_file_tag_state(ytnova_binary, t
     log_path = _configure_dirdiff_capture(d)
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
     tui.send_keystroke(Keys.DOWN, wait=0.2)  # alpha
 
     _open_directory_compare_prompt(tui)
@@ -994,7 +975,6 @@ def test_compare_help_close_with_f1_and_esc_returns_to_same_prompt(
     (d / "alpha").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(0.6)
 
     _open_directory_compare_prompt(tui)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 import os
 import pexpect
 import shutil
@@ -60,9 +59,11 @@ def test_simple_copy(controller, sandbox):
     yt.select_file("root_file.txt")
 
     # 2. Copy
-    time.sleep(0.5)
-    yt.child.send(Keys.COPY)
-    yt.child.expect("COPY")
+    assert yt.send_and_wait_for_condition(
+        Keys.COPY,
+        lambda lines: any("COPY" in line for line in lines),
+        timeout=1.5,
+    )
 
     # 3. Input New Name
     yt.input_text("copy.txt")
@@ -85,8 +86,11 @@ def test_rename(controller, sandbox):
     yt.select_file("root_file.txt")
 
     # 2. Rename
-    time.sleep(0.5)
-    yt.child.send(Keys.RENAME)
+    assert yt.send_and_wait_for_condition(
+        Keys.RENAME,
+        lambda lines: any("RENAME" in line for line in lines),
+        timeout=1.5,
+    )
     # Updated to match src/cmd/rename.c: "RENAME TO:"
     # Use a partial prompt match so wording changes do not break the flow.
     yt.child.expect("RENAME")
@@ -108,9 +112,11 @@ def test_move(controller, sandbox):
     yt.select_file("root_file.txt")
 
     # 2. Move
-    time.sleep(0.5)
-    yt.child.send(Keys.MOVE)
-    yt.child.expect("MOVE")
+    assert yt.send_and_wait_for_condition(
+        Keys.MOVE,
+        lambda lines: any("MOVE" in line for line in lines),
+        timeout=1.5,
+    )
 
     # 3. Input New Name
     yt.input_text("moved.txt")
@@ -169,14 +175,16 @@ def test_tagged_copy_overwrite_all_applies_to_remaining_conflicts(controller, sa
 
         expected_alpha = dest_dir / "alpha.txt"
         expected_beta = dest_dir / "beta.txt"
-        deadline = time.time() + 3.0
-        while time.time() < deadline:
-            if (
-                expected_alpha.read_text(encoding="utf-8") == "alpha source content"
+        assert yt.wait_for_condition(
+            lambda _lines: (
+                expected_alpha.exists()
+                and expected_beta.exists()
+                and expected_alpha.read_text(encoding="utf-8") == "alpha source content"
                 and expected_beta.read_text(encoding="utf-8") == "beta source content"
-            ):
-                break
-            time.sleep(0.1)
+            ),
+            timeout=3.0,
+            description="both tagged copies to finish",
+        )
 
         assert expected_alpha.read_text(encoding="utf-8") == "alpha source content"
         assert expected_beta.read_text(encoding="utf-8") == "beta source content"
@@ -229,16 +237,18 @@ def test_tagged_move_overwrite_all_applies_to_remaining_conflicts(controller, sa
         expected_beta = dest_dir / "beta.txt"
         source_alpha = source_dir / "alpha.txt"
         source_beta = source_dir / "beta.txt"
-        deadline = time.time() + 3.0
-        while time.time() < deadline:
-            if (
-                expected_alpha.read_text(encoding="utf-8") == "alpha source content"
+        assert yt.wait_for_condition(
+            lambda _lines: (
+                expected_alpha.exists()
+                and expected_beta.exists()
+                and expected_alpha.read_text(encoding="utf-8") == "alpha source content"
                 and expected_beta.read_text(encoding="utf-8") == "beta source content"
                 and not source_alpha.exists()
                 and not source_beta.exists()
-            ):
-                break
-            time.sleep(0.1)
+            ),
+            timeout=3.0,
+            description="both tagged moves to finish",
+        )
 
         assert expected_alpha.read_text(encoding="utf-8") == "alpha source content"
         assert expected_beta.read_text(encoding="utf-8") == "beta source content"
@@ -256,18 +266,21 @@ def test_wildcard_rename(controller, sandbox):
 
     yt.select_file("root_file.txt")
 
-    time.sleep(0.5)
-    yt.child.send(Keys.RENAME)
-    yt.child.expect("RENAME")
+    assert yt.send_and_wait_for_condition(
+        Keys.RENAME,
+        lambda lines: any("RENAME" in line for line in lines),
+        timeout=1.5,
+    )
     yt.input_text("new.*")
 
     expected = sandbox / "source" / "new.txt"
     bad_result = sandbox / "source" / "new.root_file.txt"
 
-    # Poll for file existence
-    for _ in range(5):
-        if expected.exists(): break
-        time.sleep(0.2)
+    assert yt.wait_for_condition(
+        lambda _lines: expected.exists(),
+        timeout=1.0,
+        description=f"renamed file {expected}",
+    )
 
     if bad_result.exists():
         pytest.fail("Regression: 'new.*' resulted in 'new.root_file.txt'")
@@ -293,8 +306,11 @@ def test_path_copy(controller, sandbox):
     yt.select_file("deep_file.txt")
 
     # 2. Initiate PathCopy
-    time.sleep(0.5)
-    yt.child.send(Keys.PATHCOPY)
+    assert yt.send_and_wait_for_condition(
+        Keys.PATHCOPY,
+        lambda lines: any("PATHCOPY" in line for line in lines),
+        timeout=1.5,
+    )
 
     # 3. Verify Prompt 1 (Filename)
     # Expect "PATHCOPY: " or "AS:"
@@ -318,7 +334,6 @@ def test_path_copy(controller, sandbox):
         index = yt.child.expect([r"[Cc]reate", pexpect.TIMEOUT], timeout=1.0)
         if index == 0:
             # If prompt appeared, confirm Yes
-            time.sleep(0.2)
             yt.child.send(Keys.CONFIRM_YES)
     except Exception:
         pass
@@ -328,10 +343,11 @@ def test_path_copy(controller, sandbox):
     # PathCopy should append 'source/deep/nested' to 'dest'.
     expected_path = sandbox / "dest" / "source" / "deep" / "nested" / "deep_file.txt"
 
-    # Wait briefly for FS operations to complete
-    start = time.time()
-    while not expected_path.exists() and time.time() - start < 2.0:
-        time.sleep(0.1)
+    assert yt.wait_for_condition(
+        lambda _lines: expected_path.exists(),
+        timeout=2.0,
+        description=f"path copy destination {expected_path}",
+    )
 
     # Tripartite Verification
     # System Layer: Does file exist?

--- a/tests/test_dir_window_dispatch_regressions.py
+++ b/tests/test_dir_window_dispatch_regressions.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import re
-import time
 
 from helpers_stats import detect_stats_split_x as _detect_stats_split_x
 from helpers_source import extract_function_block as _extract_function_block
@@ -481,7 +480,6 @@ def test_tree_viewport_edge_scroll_after_end_up_keeps_top_visible_row(
         (root / f"dir_{idx:02d}_edge_scroll").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke("\033OF", wait=0.35)
     assert tui.wait_for_content(
@@ -502,8 +500,15 @@ def test_tree_viewport_edge_scroll_after_end_up_keeps_top_visible_row(
         f"top_after_end={top_after_end!r}\n{screen}"
     )
 
-    for _ in range(16):
+    steps = 0
+    while "dir_27_edge_scroll" not in tui.get_screen_dump()[0]:
+        if steps >= 45:
+            raise AssertionError(
+                "Could not select dir_27_edge_scroll at the viewport edge.\n"
+                f"{_screen_text(tui)}"
+            )
         tui.send_keystroke(Keys.UP, wait=0.05)
+        steps += 1
 
     screen = _screen_text(tui)
     assert "dir_27_edge_scroll" in screen, (
@@ -563,7 +568,6 @@ def test_dir_window_navigation_selects_expected_directory(ytnova_binary, tmp_pat
     (beta / "beta_only_file.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.DOWN, wait=0.25)
     tui.send_keystroke(Keys.DOWN, wait=0.25)
@@ -638,7 +642,6 @@ def test_dir_window_compare_prompt_round_trip(ytnova_binary, tmp_path):
     (root / "right").mkdir()
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.6)
 
     tui.send_keystroke("J", wait=0.25)
     assert tui.wait_for_content("COMPARE TARGET [", timeout=1.0), _screen_text(tui)
@@ -805,7 +808,6 @@ def test_dir_window_split_and_tab_keeps_file_focus(ytnova_binary, tmp_path):
     (beta / "beta_split_focus.txt").write_text("beta\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.DOWN, wait=0.25)
     tui.send_keystroke(Keys.ENTER, wait=0.45)
@@ -863,7 +865,6 @@ def test_split_tab_refresh_rejects_stale_file_restore_snapshot(
     tui = YtreeNovaTUI(
         executable=ytnova_binary, cwd=str(repo), env_extra={"HOME": str(home)}
     )
-    time.sleep(0.8)
 
     try:
         def stats_current_dir_contains(marker):
@@ -884,23 +885,25 @@ def test_split_tab_refresh_rejects_stale_file_restore_snapshot(
                         return True
             return False
 
-        found_src = False
-        for _ in range(80):
-            if stats_current_dir_contains("src"):
-                found_src = True
-                break
+        steps = 0
+        while not stats_current_dir_contains("src"):
+            if steps >= 80:
+                raise AssertionError(
+                    f"Could not focus the src fixture directory.\n{_screen_text(tui)}"
+                )
             tui.send_keystroke(Keys.DOWN, wait=0.12)
-        assert found_src, _screen_text(tui)
+            steps += 1
 
         tui.send_keystroke(Keys.RIGHT, wait=0.25)
 
-        found_cmd = False
-        for _ in range(80):
-            if stats_current_dir_contains("cmd"):
-                found_cmd = True
-                break
+        steps = 0
+        while not stats_current_dir_contains("cmd"):
+            if steps >= 80:
+                raise AssertionError(
+                    f"Could not focus the cmd fixture directory.\n{_screen_text(tui)}"
+                )
             tui.send_keystroke(Keys.DOWN, wait=0.12)
-        assert found_cmd, _screen_text(tui)
+            steps += 1
 
         tui.send_keystroke(Keys.RIGHT, wait=0.2)
         tui.send_keystroke(Keys.ENTER, wait=0.45)
@@ -977,7 +980,6 @@ def test_dir_right_arrow_drills_into_first_child_when_already_expanded(
     (child / "child_only_marker.txt").write_text("child\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     tui.send_keystroke(Keys.DOWN, wait=0.25)  # select parent_dir_dispatch
     tui.send_keystroke(Keys.RIGHT, wait=0.35)  # expand parent

--- a/tests/test_f2_vols.py
+++ b/tests/test_f2_vols.py
@@ -1,7 +1,6 @@
 import pytest
 import os
 import re
-import time
 from helpers_ui import _panel_path_header, _path_label
 from tui_harness import YtreeNovaTUI
 from ytnova_keys import Keys
@@ -123,16 +122,17 @@ def _left_row_containing(tui, target, max_x=70):
 
 
 def _move_selection_to_exact_span(tui, target, max_steps=12):
-    for _ in range(max_steps):
-        if _has_exact_span_text(tui, target):
-            return
+    steps = 0
+    while not _has_exact_span_text(tui, target):
+        if steps >= max_steps:
+            raise AssertionError(
+                f"Could not move F2 selection to {target!r}.\n{get_screen_text(tui)}"
+            )
         if not _screen_contains_text(tui, target):
             tui.send_keystroke(Keys.RIGHT, wait=0.6)
-            continue
-        tui.send_keystroke(Keys.DOWN, wait=0.3)
-    raise AssertionError(
-        f"Could not move F2 selection to {target!r}.\n{get_screen_text(tui)}"
-    )
+        else:
+            tui.send_keystroke(Keys.DOWN, wait=0.3)
+        steps += 1
 
 def test_f2_log_and_cycle_volumes(tmp_path):
     """
@@ -152,71 +152,53 @@ def test_f2_log_and_cycle_volumes(tmp_path):
     
     try:
         # Give it a moment to startup
-        time.sleep(1.0)
-        
-        # Enter file view
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)
 
         # Send 'c' (Copy) on the first file to trigger the copy interaction
-        tui.send_keystroke('c')
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change('c')
         
         # Accept filename
-        tui.send_keystroke('\r')
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change('\r')
 
         # Now at "To Directory:" prompt. Hit F2!
-        tui.send_keystroke(Keys.F2)
-        time.sleep(1.0)
+        assert tui.send_and_wait_for_screen_change(Keys.F2)
         
         # We are in the F2 menu. Press 'L' to log a new directory!
-        tui.send_keystroke('l')
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change('l')
         
         # Enter dir_a
-        tui.send_keystroke(str(dir_a) + '\r')
-        time.sleep(1.0)
+        assert tui.send_and_wait_for_screen_change(str(dir_a) + '\r')
         
         # The F2 window now shows dir_a tree. Cycle back or accept it
         # Let's select it for the copy destination
-        tui.send_keystroke('\r')
-        time.sleep(1.0)
+        assert tui.send_and_wait_for_screen_change('\r')
 
         # The copy likely succeeded or failed, but the side effect is we now have volume_a logged!
         # Wait, if we accept it, ytnova performs the copy and returns to the main view.
         # But we want to test cycling! Let's just enter another copy prompt and cycle!
         
-        tui.send_keystroke('c')
-        time.sleep(0.5)
-        tui.send_keystroke('\r')
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change('c')
+        assert tui.send_and_wait_for_screen_change('\r')
         
         # At "To Directory" again:
-        tui.send_keystroke(Keys.F2)
-        time.sleep(1.0)
+        assert tui.send_and_wait_for_screen_change(Keys.F2)
         
         # Cycle back using '<'
-        tui.send_keystroke('<')
-        time.sleep(1.0)
+        assert tui.send_and_wait_for_screen_change('<')
         
         screen = get_screen_text(tui)
         # We should see the previous volume (presumably the tmp_path or volume_a depending on how it cycles)
         assert "volume" in screen or "tmp" in screen, f"Failed to cycle F2 window. Screen:\n{screen}"
         
         # Hit Escape to get out of F2, then escape to cancel Copy
-        tui.send_keystroke(Keys.ESC)
-        time.sleep(0.5)
-        tui.send_keystroke(Keys.ESC)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.ESC)
+        assert tui.send_and_wait_for_screen_change(Keys.ESC)
         
         # Return to Tree view
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)
         
         # In main view, cycle volumes with '<' to verify the main view also has them logged
-        tui.send_keystroke('<')
-        time.sleep(1.0)
+        assert tui.send_and_wait_for_screen_change('<')
         
         screen = get_screen_text(tui)
         assert "volume_a" in screen, f"Main view did not cycle to volume_a. Screen:\n{screen}"
@@ -236,7 +218,6 @@ def test_f2_right_expands_then_enters_and_left_collapses_or_returns_parent(tmp_p
     tui = YtreeNovaTUI(executable=YTNOVA_BIN, cwd=str(root))
 
     try:
-        time.sleep(0.8)
         tui.send_keystroke(Keys.ENTER, wait=0.4)
         tui.send_keystroke(Keys.COPY, wait=0.3)
         tui.send_keystroke(Keys.ENTER, wait=0.3)
@@ -474,7 +455,6 @@ def test_f2_escape_can_abort_right_expand_scan(tmp_path):
     tui = YtreeNovaTUI(executable=YTNOVA_BIN, cwd=str(root))
 
     try:
-        time.sleep(0.8)
         assert _total_items_count(tui) == 1
 
         tui.send_keystroke(Keys.ENTER, wait=0.4)
@@ -508,7 +488,6 @@ def test_history_selection_only_covers_the_current_item(tmp_path):
     tui = YtreeNovaTUI(executable=YTNOVA_BIN, cwd=str(root))
 
     try:
-        time.sleep(0.8)
         tui.send_keystroke(Keys.ENTER, wait=0.4)
         tui.send_keystroke(Keys.COPY, wait=0.3)
         tui.send_keystroke(Keys.ENTER, wait=0.2)
@@ -539,7 +518,6 @@ def test_f2_selection_stops_before_the_synthetic_expand_suffix(tmp_path):
     tui = YtreeNovaTUI(executable=YTNOVA_BIN, cwd=str(root))
 
     try:
-        time.sleep(0.8)
         tui.send_keystroke(Keys.ENTER, wait=0.4)
         tui.send_keystroke(Keys.COPY, wait=0.3)
         tui.send_keystroke(Keys.ENTER, wait=0.3)
@@ -567,8 +545,15 @@ def test_f2_picker_down_moves_highlight_before_scrolling(tmp_path):
 
     try:
         assert tui.wait_for_content("seed.txt", timeout=2.0), get_screen_text(tui)
-        for _ in range(35):
+        steps = 0
+        while "dir_34" not in tui.get_screen_dump()[0]:
+            if steps >= 80:
+                raise AssertionError(
+                    "Could not select dir_34 before opening the F2 picker.\n"
+                    f"{get_screen_text(tui)}"
+                )
             tui.send_keystroke(Keys.DOWN, wait=0.03)
+            steps += 1
 
         tui.send_keystroke(Keys.ENTER, wait=0.2)
         tui.send_keystroke(Keys.COPY, wait=0.2)
@@ -663,7 +648,6 @@ def test_volume_menu_selection_only_covers_current_item(tmp_path):
     tui = YtreeNovaTUI(executable=YTNOVA_BIN, cwd=str(root))
 
     try:
-        time.sleep(0.8)
         tui.send_keystroke("K", wait=0.6)
 
         _, _, _, _, text = _span_containing(tui, f"[*] {root}")
@@ -689,7 +673,6 @@ def test_f9_applications_menu_selection_only_covers_current_item(tmp_path):
     tui = YtreeNovaTUI(executable=YTNOVA_BIN, cwd=str(root))
 
     try:
-        time.sleep(0.8)
         tui.send_keystroke(Keys.F9, wait=0.6)
 
         _, _, _, _, text = _span_containing(tui, "wget fetch preset")

--- a/tests/test_file_window_dispatch_regressions.py
+++ b/tests/test_file_window_dispatch_regressions.py
@@ -1,4 +1,3 @@
-import time
 
 from helpers_source import extract_function_block as _extract_function_block
 from helpers_source import read_repo_source as _read_source
@@ -21,7 +20,6 @@ def test_navigation_dispatch_updates_current_file_stats(ytnova_binary, tmp_path)
     (root / "cc_three.txt").write_text("three\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.ENTER, wait=0.4)
@@ -46,7 +44,6 @@ def test_make_file_prompt_dispatch_creates_file(ytnova_binary, tmp_path):
     (root / "seed.txt").write_text("seed\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.ENTER, wait=0.35)
@@ -66,7 +63,6 @@ def test_split_and_tab_dispatch_keeps_file_mode_footer(ytnova_binary, tmp_path):
     (root / "right.txt").write_text("right\n", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
 
     try:
         tui.send_keystroke(Keys.ENTER, wait=0.35)

--- a/tests/test_fileops_integrity.py
+++ b/tests/test_fileops_integrity.py
@@ -48,7 +48,15 @@ def _copy_selected_file(controller: YtreeNovaController, source_name: str, new_n
     controller.input_text(new_name)
     controller.child.expect("To Directory")
     controller.input_text(str(to_dir))
-    time.sleep(0.7)
+    if to_dir.is_file():
+        complete = lambda _lines: new_name in _snapshot_archive(to_dir)
+    else:
+        complete = lambda _lines: (to_dir / new_name).exists()
+    assert controller.wait_for_condition(
+        complete,
+        timeout=2.0,
+        description=f"copy destination {to_dir / new_name}",
+    )
 
 
 def _move_selected_file(controller: YtreeNovaController, source_name: str, new_name: str, to_dir: Path) -> None:
@@ -58,23 +66,42 @@ def _move_selected_file(controller: YtreeNovaController, source_name: str, new_n
     controller.input_text(new_name)
     controller.child.expect("To Directory")
     controller.input_text(str(to_dir))
-    time.sleep(0.7)
+    assert controller.wait_for_condition(
+        lambda _lines: (to_dir / new_name).exists(),
+        timeout=2.0,
+        description=f"move destination {to_dir / new_name}",
+    )
 
 
-def _rename_selected_file(controller: YtreeNovaController, source_name: str, new_name: str) -> None:
+def _rename_selected_file(
+    controller: YtreeNovaController,
+    source_name: str,
+    new_name: str,
+    expected_path: Path,
+) -> None:
     controller.select_file(source_name)
     controller.child.send(Keys.RENAME)
     controller.child.expect("RENAME")
     controller.input_text(new_name)
-    time.sleep(0.6)
+    assert controller.wait_for_condition(
+        lambda _lines: expected_path.exists(),
+        timeout=2.0,
+        description=f"rename destination {expected_path}",
+    )
 
 
-def _delete_selected_file(controller: YtreeNovaController, source_name: str) -> None:
+def _delete_selected_file(
+    controller: YtreeNovaController, source_name: str, source_path: Path
+) -> None:
     controller.select_file(source_name)
     controller.child.send(Keys.DELETE)
     controller.child.expect("Delete this file")
     controller.child.send("Y")
-    time.sleep(0.7)
+    assert controller.wait_for_condition(
+        lambda _lines: not source_path.exists(),
+        timeout=2.0,
+        description=f"deletion of {source_path}",
+    )
 
 
 def _read(relpath: str) -> str:
@@ -136,7 +163,9 @@ def test_rename_mutation_preserves_file_hash(ytnova_binary, tmp_path):
     controller = YtreeNovaController(ytnova_binary, str(root))
     try:
         controller.wait_for_startup()
-        _rename_selected_file(controller, "gamma.txt", "gamma_renamed.txt")
+        _rename_selected_file(
+            controller, "gamma.txt", "gamma_renamed.txt", root / "gamma_renamed.txt"
+        )
     finally:
         controller.quit()
 
@@ -155,7 +184,7 @@ def test_delete_mutation_removes_only_selected_file(ytnova_binary, tmp_path):
     controller = YtreeNovaController(ytnova_binary, str(root))
     try:
         controller.wait_for_startup()
-        _delete_selected_file(controller, "remove.txt")
+        _delete_selected_file(controller, "remove.txt", root / "remove.txt")
     finally:
         controller.quit()
 
@@ -179,8 +208,7 @@ def test_copy_prompt_cancel_keeps_tree_snapshot_identical(ytnova_binary, tmp_pat
         controller.child.expect("COPY")
         controller.input_text("cancel_copy.txt")
         controller.child.expect("To Directory")
-        controller.child.send(Keys.ESC)
-        time.sleep(0.4)
+        assert controller.send_and_wait_for_screen_change(Keys.ESC, timeout=1.0)
     finally:
         controller.quit()
 
@@ -203,7 +231,11 @@ def test_same_path_copy_rejection_keeps_tree_snapshot_identical(ytnova_binary, t
         controller.input_text("same.txt")
         controller.child.expect("To Directory")
         controller.input_text("")
-        time.sleep(0.6)
+        assert controller.wait_for_condition(
+            lambda _lines: _snapshot_tree(root) == before,
+            timeout=1.0,
+            description="same-path copy rejection",
+        )
     finally:
         controller.quit()
 
@@ -232,14 +264,11 @@ def test_archive_copy_rewrite_updates_member_hashes_deterministically(ytnova_bin
     controller = YtreeNovaController(ytnova_binary, str(root))
     try:
         controller.wait_for_startup()
-        controller.child.send(Keys.LOG)
-        time.sleep(0.2)
+        assert controller.send_and_wait_for_screen_change(Keys.LOG, timeout=1.0)
         controller.input_text(str(archive_path))
         controller.child.expect("ARCHIVE")
-        controller.child.send("\\")
-        time.sleep(0.7)
-        controller.child.send(Keys.ESC)
-        time.sleep(0.3)
+        assert controller.send_and_wait_for_screen_change("\\", timeout=1.5)
+        assert controller.send_and_wait_for_screen_change(Keys.ESC, timeout=1.0)
 
         _copy_selected_file(controller, "archive_source.txt", "copied_into_archive.txt", archive_path)
     finally:

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 import os
 import shutil
 import tempfile
@@ -18,27 +17,34 @@ def filter_env(ytnova_binary):
 def test_filter_stats_recalculation(filter_env):
     cwd, binary = filter_env
     tui = YtreeNovaTUI(executable=binary, cwd=cwd)
-    time.sleep(1.0) # Wait for scan
-    
     # Check initial match 3
     screen = "\n".join(tui.get_screen_dump())
     assert "Mat: 3" in screen.replace(" ", "") or "Mat:3" in screen.replace(" ", "")
     
     # Filter for *.c
-    tui.send_keystroke(Keys.FILTER)
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        Keys.FILTER,
+        lambda lines: any("FILTER" in line for line in lines),
+        timeout=1.0,
+    )
     # The prompt might already have something, let's clear it
     tui.send_keystroke("\x15") # C-u
-    tui.send_keystroke("*.c\r")
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_condition(
+        "*.c\r",
+        lambda lines: "Mat:2" in "".join(lines).replace(" ", ""),
+        timeout=1.5,
+    )
     
     # Check for recalculation to 2
     screen = "\n".join(tui.get_screen_dump())
     assert "Mat: 2" in screen.replace(" ", "") or "Mat:2" in screen.replace(" ", "")
     
     # Verify Global Mode (S) works
-    tui.send_keystroke(Keys.SHOWALL)
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_condition(
+        Keys.SHOWALL,
+        lambda lines: lines if any("file1.c" in line for line in lines) else False,
+        timeout=1.5,
+    )
     
     screen = "\n".join(tui.get_screen_dump())
     assert "FILE" in screen
@@ -51,21 +57,32 @@ def test_filter_stats_recalculation(filter_env):
 def test_show_all_no_matching_files(filter_env):
     cwd, binary = filter_env
     tui = YtreeNovaTUI(executable=binary, cwd=cwd)
-    time.sleep(1.0)
-    
     # Filter for non-existent
-    tui.send_keystroke(Keys.FILTER)
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        Keys.FILTER,
+        lambda lines: any("FILTER" in line for line in lines),
+        timeout=1.0,
+    )
     tui.send_keystroke("\x15")
-    tui.send_keystroke("*.java\r")
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_condition(
+        "*.java\r",
+        lambda lines: "Mat:0" in "".join(lines).replace(" ", ""),
+        timeout=1.5,
+    )
     
     screen = "\n".join(tui.get_screen_dump())
     assert "Mat: 0" in screen.replace(" ", "") or "Mat:0" in screen.replace(" ", "")
     
     # Try 'S'
-    tui.send_keystroke(Keys.SHOWALL)
-    time.sleep(0.5)
+    tui.child.send(Keys.SHOWALL)
+    assert tui.wait_for_condition(
+        lambda lines: lines
+        if any("DIR" in line for line in lines)
+        and not any("FILE" in line for line in lines)
+        else False,
+        timeout=1.0,
+        description="directory view to remain active",
+    )
     
     # Should stay in DIR view
     screen = "\n".join(tui.get_screen_dump())
@@ -85,14 +102,18 @@ def test_multi_pattern_filter(ytnova_binary, tmp_path):
     (d / "file3.txt").write_text("txt")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(d))
-    time.sleep(1.0) # Wait for scan
-
     # Apply multi-filter
-    tui.send_keystroke(Keys.FILTER)
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        Keys.FILTER,
+        lambda lines: any("FILTER" in line for line in lines),
+        timeout=1.0,
+    )
     tui.send_keystroke("\x15") # Clear line
-    tui.send_keystroke("*.c,*.h\r")
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_condition(
+        "*.c,*.h\r",
+        lambda lines: "Mat:2" in "".join(lines).replace(" ", ""),
+        timeout=1.5,
+    )
     
     # Check stats for 2 files
     screen = "\n".join(tui.get_screen_dump())
@@ -100,8 +121,14 @@ def test_multi_pattern_filter(ytnova_binary, tmp_path):
     assert "Mat:2" in screen.replace(" ", "") or "Mat: 2" in screen.replace(" ", "")
     
     # Verify Global Mode
-    tui.send_keystroke(Keys.SHOWALL)
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_condition(
+        Keys.SHOWALL,
+        lambda lines: lines
+        if any("file1.c" in line for line in lines)
+        and any("file2.h" in line for line in lines)
+        else False,
+        timeout=1.5,
+    )
     
     screen = "\n".join(tui.get_screen_dump())
     assert "file1.c" in screen
@@ -109,11 +136,20 @@ def test_multi_pattern_filter(ytnova_binary, tmp_path):
     assert "file3.txt" not in screen
 
     # Test with extra spaces
-    tui.send_keystroke(Keys.FILTER)
-    time.sleep(0.2)
+    assert tui.send_and_wait_for_condition(
+        Keys.FILTER,
+        lambda lines: any("FILTER" in line for line in lines),
+        timeout=1.0,
+    )
     tui.send_keystroke("\x15") # Clear line
-    tui.send_keystroke(" *.c , *.h \r")
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_condition(
+        " *.c , *.h \r",
+        lambda lines: lines
+        if any("file1.c" in line for line in lines)
+        and any("file2.h" in line for line in lines)
+        else False,
+        timeout=1.5,
+    )
 
     screen = "\n".join(tui.get_screen_dump())
     assert "file1.c" in screen

--- a/tests/test_ghost_bugs.py
+++ b/tests/test_ghost_bugs.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 from tui_harness import YtreeNovaTUI
 from ytnova_keys import Keys
@@ -8,19 +7,14 @@ def test_screen_wipe_after_error(ytnova_binary, tmp_path):
     BUG: After an error message (e.g., bad filter), the UI borders/stats vanish.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(tmp_path))
-    time.sleep(1.0)
-
-    # 1. Open Filter (f)
     tui.send_keystroke("f")
     # 2. Clear default '*' (C-u or backspaces) and enter bad filter
     tui.send_keystroke("\x15") # C-u
-    tui.send_keystroke("-*.nonexistent\r")
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change("-*.nonexistent\r")
 
     # 3. Expect Error Message (usually blocks or shows briefly)
     # 4. Clear error (Enter/Esc)
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change(Keys.ENTER)
 
     screen = "\n".join(tui.get_screen_dump())
 
@@ -34,11 +28,7 @@ def test_l_key_binding(ytnova_binary, tmp_path):
     BUG: 'L' key moves cursor down (Vi-keys) instead of opening Log/Volume menu.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(tmp_path))
-    time.sleep(1.0)
-
-    # 1. Press 'L' (Shift+l)
-    tui.send_keystroke("L")
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change("L")
 
     screen = "\n".join(tui.get_screen_dump())
 
@@ -51,19 +41,14 @@ def test_split_screen_garbage(dual_panel_sandbox, ytnova_binary):
     BUG: Inactive panel shows '*?^X' garbage when Active panel is used.
     """
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(dual_panel_sandbox))
-    time.sleep(1.0)
-
-    # 1. Split Screen
-    tui.send_keystroke(Keys.F8)
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change(Keys.F8)
 
     # 2. Tab to Right
     tui.send_keystroke(Keys.TAB)
 
     # 3. Do some work (Mkdir)
     tui.send_keystroke("M")
-    tui.send_keystroke("newdir\r")
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change("newdir\r")
 
     screen = "\n".join(tui.get_screen_dump())
 
@@ -79,16 +64,11 @@ def test_hex_view_esc_corruption(tmp_path, ytnova_binary):
     (tmp_path / "hex_test.txt").write_text("dummy binary content")
     
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(tmp_path))
-    time.sleep(1.0)
-    # Enter file window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change(Keys.ENTER)
     # Press 'h' for hex view
-    tui.send_keystroke('h')
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change('h')
     # Press ESC to exit hex view
-    tui.send_keystroke(Keys.ESC)
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change(Keys.ESC)
     
     screen = "\n".join(tui.get_screen_dump())
     

--- a/tests/test_help_text_contract.py
+++ b/tests/test_help_text_contract.py
@@ -73,7 +73,12 @@ def _scroll_help_to_text(tui, text, *, steps=80):
     if text in current:
         return current
 
-    for _ in range(steps):
+    attempts = 0
+    while text not in current:
+        if attempts >= steps:
+            raise AssertionError(
+                f"Could not navigate help to {text!r}.\n{current}"
+            )
         tui.send_keystroke(Keys.DOWN, wait=0.05)
         next_screen = screen_text(tui)
         if text in next_screen:
@@ -89,6 +94,7 @@ def _scroll_help_to_text(tui, text, *, steps=80):
         else:
             unchanged_steps = 0
         current = next_screen
+        attempts += 1
     return current
 
 
@@ -108,7 +114,12 @@ def _open_help_detail(
     detail_title = label[:-1] if label.endswith(":") else label
     _scroll_help_to_text(tui, label)
 
-    for _ in range(steps):
+    attempts = 0
+    while True:
+        if attempts >= steps:
+            raise AssertionError(
+                f"Could not open help detail {detail_title!r}.\n{screen_text(tui)}"
+            )
         before = screen_text(tui)
         tui.send_keystroke(direction_key, wait=0.05)
         current = screen_text(tui)
@@ -125,8 +136,7 @@ def _open_help_detail(
         if label not in current:
             _scroll_help_to_text(tui, label)
         tui.send_keystroke(Keys.DOWN, wait=0.05)
-
-    assert False, screen_text(tui)
+        attempts += 1
 
 
 def _follow_help_topic(
@@ -134,7 +144,12 @@ def _follow_help_topic(
 ):
     _scroll_help_to_text(tui, label)
 
-    for _ in range(steps):
+    attempts = 0
+    while True:
+        if attempts >= steps:
+            raise AssertionError(
+                f"Could not follow help topic {topic_title!r}.\n{screen_text(tui)}"
+            )
         tui.send_keystroke(Keys.DOWN, wait=0.05)
         screen = tui.send_and_wait_for_condition(
             direction_key,
@@ -149,8 +164,7 @@ def _follow_help_topic(
             current = screen_text(tui)
         if label not in current:
             _scroll_help_to_text(tui, label)
-
-    assert False, screen_text(tui)
+        attempts += 1
 
 
 def _open_tagged_help_from_index(tui):

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 import re
 import os
 import pexpect
@@ -51,7 +50,6 @@ def test_f8_split_memory_corruption_bug(controller, dual_panel_sandbox):
     yt.wait_for_startup()
 
     # 1. Setup multi-column list on Left (left_dir)
-    time.sleep(0.5)
     yt.child.send(Keys.EXPAND_ALL)
     sync_state(yt)
     yt.child.send(Keys.DOWN)  # Move to left_dir
@@ -96,7 +94,6 @@ def test_f8_cross_panel_autoview_sourcing_bug(controller, dual_panel_sandbox):
     yt = controller(cwd=str(dual_panel_sandbox))
     yt.wait_for_startup()
 
-    time.sleep(0.5)
     yt.child.send(Keys.EXPAND_ALL)
     sync_state(yt)
 
@@ -113,8 +110,7 @@ def test_f8_cross_panel_autoview_sourcing_bug(controller, dual_panel_sandbox):
     sync_state(yt)
 
     # Trigger Autoview (F7)
-    yt.child.send(Keys.F7)
-    time.sleep(1.0)
+    assert yt.send_and_wait_for_screen_change(Keys.F7)
     sync_state(yt)
 
     screen = get_clean_screen(yt)
@@ -123,8 +119,7 @@ def test_f8_cross_panel_autoview_sourcing_bug(controller, dual_panel_sandbox):
         pytest.fail("BUG: Autoview content pane is not displaying data for the selected file '0'.")
 
     # NEW TEST: Press F8 during F7
-    yt.child.send(Keys.F8)
-    time.sleep(0.5)
+    assert yt.send_and_wait_for_screen_change(Keys.F8)
     sync_state(yt)
 
     screen_after_f8 = get_clean_screen(yt)
@@ -142,17 +137,13 @@ def test_f7_header_shows_directory_only(controller, dual_panel_sandbox):
     yt = controller(cwd=str(dual_panel_sandbox))
     yt.wait_for_startup()
 
-    time.sleep(0.5)
     yt.child.send(Keys.EXPAND_ALL)
     sync_state(yt)
-    time.sleep(1.0) # Explicit wait before down
 
     yt.child.send(Keys.DOWN) # left_dir
     sync_state(yt)
-    time.sleep(1.0) # Explicit wait after down
 
-    yt.child.send(Keys.F7)
-    time.sleep(0.5)
+    assert yt.send_and_wait_for_screen_change(Keys.F7)
     sync_state(yt)
 
     screen = get_clean_screen(yt)
@@ -174,7 +165,6 @@ def test_f7_visual_layout(ytnova_binary, dual_panel_sandbox):
     """
     from tui_harness import YtreeNovaTUI
     from ytnova_keys import Keys
-    import time
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(dual_panel_sandbox))
 
@@ -182,8 +172,7 @@ def test_f7_visual_layout(ytnova_binary, dual_panel_sandbox):
     tui.send_keystroke(Keys.EXPAND_ALL)
 
     # Trigger Autoview (F7)
-    tui.send_keystroke(Keys.F7)
-    time.sleep(1.0) # Wait for view
+    assert tui.send_and_wait_for_screen_change(Keys.F7) # Wait for view
 
     # Get the screen content
     screen = tui.get_screen_dump()

--- a/tests/test_small_window.py
+++ b/tests/test_small_window.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 from tui_harness import YtreeNovaTUI
 from ytnova_keys import Keys
 
@@ -21,17 +20,12 @@ def test_small_window_transition(test_dir_with_files, ytnova_binary):
     ytnova_cfg.write_text("[GLOBAL]\nSMALLWINDOWSKIP=0\n")
     
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files.parent))
-    time.sleep(1.0)
-    
-    # Navigate to test_small_win directory
-    tui.send_keystroke(Keys.DOWN)
-    time.sleep(0.5)
+    assert tui.send_and_wait_for_screen_change(Keys.DOWN)
     
     # STATE 1: DIR window (initial state - already here)
     
     # Transition to SMALL window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.8)  # Increase sleep for reliability
+    assert tui.send_and_wait_for_screen_change(Keys.ENTER)  # Increase sleep for reliability
     
     screen_small = "\n".join(tui.get_screen_dump())
     
@@ -40,8 +34,7 @@ def test_small_window_transition(test_dir_with_files, ytnova_binary):
     assert "test_small_win" in screen_small, "Dir name should still be visible"
     
     # Transition to BIG window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.8)
+    assert tui.send_and_wait_for_screen_change(Keys.ENTER)
     
     screen_big = "\n".join(tui.get_screen_dump())
     
@@ -49,8 +42,7 @@ def test_small_window_transition(test_dir_with_files, ytnova_binary):
     assert "FILE" in screen_big, "BIG window should show FILE footer"
     
     # Transition back to DIR window
-    tui.send_keystroke(Keys.ENTER)
-    time.sleep(0.8)
+    assert tui.send_and_wait_for_screen_change(Keys.ENTER)
     
     screen_dir = "\n".join(tui.get_screen_dump())
     

--- a/tests/test_ui_display.py
+++ b/tests/test_ui_display.py
@@ -5,7 +5,6 @@ These tests detect specific regressions that were not caught by the original tes
 - Directory attributes display issues
 - Footer visibility and flicker issues
 """
-import time
 import pytest
 from pathlib import Path
 from tui_harness import YtreeNovaTUI
@@ -41,7 +40,6 @@ class TestDirectoryAttributesDisplay:
         EXPECTED: ATTRIBUTES section appears immediately on startup.
         """
         tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-        time.sleep(1.0)
 
         screen = "\n".join(tui.get_screen_dump())
 
@@ -65,19 +63,14 @@ class TestDirectoryAttributesDisplay:
         dir3.mkdir(exist_ok=True)
 
         tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(parent))
-        time.sleep(1.0)
-
-        # Move down one directory
-        tui.send_keystroke(Keys.DOWN)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.DOWN)
 
         screen2 = "\n".join(tui.get_screen_dump())
         lines = screen2.split('\n')
         attr_section = '\n'.join([line[90:] if len(line) > 90 else "" for line in lines[18:24]])
 
         # Move down again
-        tui.send_keystroke(Keys.DOWN)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.DOWN)
 
         screen3 = "\n".join(tui.get_screen_dump())
         lines3 = screen3.split('\n')
@@ -96,7 +89,6 @@ class TestFooterVisibility:
     def test_footer_visible_in_directory_mode(self, test_dir_with_files, ytnova_binary):
         """Footer should always be visible and non-blank in directory mode."""
         tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-        time.sleep(1.0)
 
         screen = "\n".join(tui.get_screen_dump())
         footer = '\n'.join(screen.split('\n')[-3:])
@@ -113,11 +105,7 @@ class TestFooterVisibility:
         EXPECTED: Footer remains visible during transition to small file window.
         """
         tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-        time.sleep(1.0)
-
-        # Enter file window (small window mode)
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.2)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)
 
         screen = "\n".join(tui.get_screen_dump())
         footer = '\n'.join(screen.split('\n')[-3:])
@@ -136,26 +124,20 @@ class TestFooterVisibility:
                       unexpected and disconcerting"
         """
         tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-        time.sleep(1.0)
-
-        # Enter big window mode (ENTER twice) and sample screen multiple times
         # to catch any momentary blank footer
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.05)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)
 
         # Sample screen immediately after first ENTER
         screen1 = "\n".join(tui.get_screen_dump())
         footer1 = '\n'.join(screen1.split('\n')[-3:])
         footer1_text = footer1.replace('x', '').replace('m', '').replace('q', '').replace(' ', '').replace('\n', '')
 
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.05)  # Sample immediately after second ENTER
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)  # Sample immediately after second ENTER
 
         screen2 = "\n".join(tui.get_screen_dump())
         footer2 = '\n'.join(screen2.split('\n')[-3:])
         footer2_text = footer2.replace('x', '').replace('m', '').replace('q', '').replace(' ', '').replace('\n', '')
 
-        time.sleep(0.2)  # Wait for stabilization
 
         screen3 = "\n".join(tui.get_screen_dump())
         footer3 = '\n'.join(screen3.split('\n')[-3:])
@@ -178,13 +160,8 @@ class TestFooterVisibility:
     def test_footer_visible_after_escape_from_file_window(self, test_dir_with_files, ytnova_binary):
         """Footer should remain visible when exiting file window back to directory."""
         tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(test_dir_with_files))
-        time.sleep(1.0)
-
-        # Enter and exit file window
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.2)
-        tui.send_keystroke(Keys.ESC)
-        time.sleep(0.2)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)
+        assert tui.send_and_wait_for_screen_change(Keys.ESC)
 
         screen = "\n".join(tui.get_screen_dump())
         footer = '\n'.join(screen.split('\n')[-3:])
@@ -207,16 +184,11 @@ class TestFooterVisibility:
             executable=ytnova_binary,
             cwd=str(test_dir_with_files.parent)
         )
-        time.sleep(1.0)
-        # Move down to highlight test_dir_with_files
-        tui.send_keystroke(Keys.DOWN)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.DOWN)
         # Enter small file window
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)
         # Enter big file window
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)
 
         screen = "\n".join(tui.get_screen_dump())
         lines = screen.split('\n')
@@ -251,13 +223,9 @@ class TestFooterVisibility:
             cwd=str(test_dir_with_files),
             env_extra={"SMALLWINDOWSKIP": "1"}
         )
-        time.sleep(1.0)
-        # Enter big file window
-        tui.send_keystroke(Keys.ENTER)
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER)
         # Press 'r' to trigger the rename prompt
-        tui.send_keystroke('r')
-        time.sleep(0.5)
+        assert tui.send_and_wait_for_screen_change('r')
         screen = tui.get_screen_dump()
 
         # Find the row containing the rename prompt

--- a/tests/tui_harness.py
+++ b/tests/tui_harness.py
@@ -37,12 +37,12 @@ class YtreeNovaTUI:
         self.screen = pyte.Screen(cols, rows)
         self.stream = pyte.Stream(self.screen)
         
+        self.last_wait_diagnostic = None
+
         # Wait for the main UI tree to be ready (handles startup scan + any error dialogs)
         # The tree pane shows box-drawing like "tq" or "mq" once the dir is scanned.
         if not self.wait_for_content("tq", timeout=8.0) and not self.wait_for_content("mq", timeout=1.0):
-            # Fallback: just sleep and drain
-            time.sleep(2.0 * self.time_scale)
-            self._read_output()
+            self._read_output(timeout=2.0)
 
     @staticmethod
     def _read_time_scale():
@@ -59,13 +59,13 @@ class YtreeNovaTUI:
     def _read_output(self, timeout=0.1):
         """Read pending output from the PTY and feed it to the virtual screen."""
         try:
-            # We use a short sleep to allow the application to process and write to the PTY
-            time.sleep(self._scaled(timeout))
-            
-            # Non-blocking read (read_nonblocking could throw Timeout or EOF)
+            # Wait for the first PTY event, then drain everything already available.
+            # pexpect owns the wait; tests never synchronize by wall-clock sleep.
+            read_timeout = self._scaled(timeout)
             while True:
-                data = self.child.read_nonblocking(size=4096, timeout=self._scaled(0.1))
+                data = self.child.read_nonblocking(size=4096, timeout=read_timeout)
                 self.stream.feed(data)
+                read_timeout = 0
         except (pexpect.TIMEOUT, pexpect.EOF):
             pass
 
@@ -84,19 +84,24 @@ class YtreeNovaTUI:
         self._read_output(timeout=0.05)
         return self.peek_screen_dump()
 
-    def wait_for_condition(self, predicate, timeout=5.0, poll_interval=0.02):
+    def wait_for_condition(self, predicate, timeout=5.0, poll_interval=0.02, description=None):
         """Poll until predicate(screen_lines) returns a truthy value or timeout expires."""
         deadline = time.monotonic() + self._scaled(timeout)
 
         while True:
-            self._read_output(timeout=0.0)
+            remaining = max(0.0, deadline - time.monotonic())
+            self._read_output(timeout=min(self._scaled(poll_interval), remaining))
             lines = self.peek_screen_dump()
             result = predicate(lines)
             if result:
+                self.last_wait_diagnostic = None
                 return result
             if time.monotonic() >= deadline:
+                label = description or getattr(predicate, "__name__", "screen predicate")
+                self.last_wait_diagnostic = (
+                    f"Timed out waiting for {label}; screen={lines!r}"
+                )
                 return False
-            time.sleep(self._scaled(poll_interval))
 
     def wait_for_text(self, target, timeout=5.0, poll_interval=0.02):
         """Wait until the target string appears anywhere on the screen."""
@@ -106,6 +111,7 @@ class YtreeNovaTUI:
             else False,
             timeout=timeout,
             poll_interval=poll_interval,
+            description=f"text {target!r}",
         )
 
     def send_and_wait_for_condition(

--- a/tests/ytnova_control.py
+++ b/tests/ytnova_control.py
@@ -27,6 +27,7 @@ class YtreeNovaController:
         self.child.logfile = self.log_file
         self.screen = pyte.Screen(160, 24)
         self.stream = pyte.Stream(self.screen)
+        self.last_wait_diagnostic = None
 
     def __del__(self):
         if hasattr(self, 'log_file'):
@@ -52,11 +53,12 @@ class YtreeNovaController:
 
     def _read_output(self, timeout=0.1):
         try:
-            time.sleep(self._scaled(timeout))
+            read_timeout = self._scaled(timeout)
             while True:
-                data = self.child.read_nonblocking(size=4096, timeout=self._scaled(0.1))
+                data = self.child.read_nonblocking(size=4096, timeout=read_timeout)
                 self.stream.feed(data)
                 self._mirror_child_buffers(data)
+                read_timeout = 0
         except (pexpect.TIMEOUT, pexpect.EOF):
             pass
 
@@ -67,18 +69,23 @@ class YtreeNovaController:
         self._read_output(timeout=0.05)
         return self.peek_screen_dump()
 
-    def wait_for_condition(self, predicate, timeout=5.0, poll_interval=0.02):
+    def wait_for_condition(self, predicate, timeout=5.0, poll_interval=0.02, description=None):
         deadline = time.monotonic() + self._scaled(timeout)
 
         while True:
-            self._read_output(timeout=0.0)
+            remaining = max(0.0, deadline - time.monotonic())
+            self._read_output(timeout=min(self._scaled(poll_interval), remaining))
             lines = self.peek_screen_dump()
             result = predicate(lines)
             if result:
+                self.last_wait_diagnostic = None
                 return result
             if time.monotonic() >= deadline:
+                label = description or getattr(predicate, "__name__", "screen predicate")
+                self.last_wait_diagnostic = (
+                    f"Timed out waiting for {label}; screen={lines!r}"
+                )
                 return False
-            time.sleep(self._scaled(poll_interval))
 
     def wait_for_text(self, target, timeout=5.0, poll_interval=0.02):
         return self.wait_for_condition(
@@ -87,6 +94,7 @@ class YtreeNovaController:
             else False,
             timeout=timeout,
             poll_interval=poll_interval,
+            description=f"text {target!r}",
         )
 
     def send_and_wait_for_condition(


### PR DESCRIPTION
## Summary
- replace clock-based PTY test synchronization with semantic screen and file-state waits
- navigate fixture state by observed identity with diagnostic caps

## Validation
- `make`
- `source .venv/bin/activate && pytest -q tests/test_core.py tests/test_fileops_integrity.py tests/test_attribute_prompt_flow.py`