### PR TITLE
test(contracts): preserve external interface assertions

### DIFF
--- a/.agent/handoffs/task-99.5.current.md
+++ b/.agent/handoffs/task-99.5.current.md
@@ -1,0 +1,35 @@
+# Classify and Preserve Justified External Contracts
+
+- Status: In Progress.
+- Acceptance target: external CLI/config/template contracts retain only published machine- or user-consumed exactness; security/static guards retain non-observable safeguards with explicit rationale; filesystem/archive tests preserve end-state integrity while replacing only brittle setup.
+- Completion objective: reconcile every Task 99.5 test family with stable contracts and focused evidence, then update the roadmap status.
+
+## In-scope inventory
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| `docs/ROADMAP.md` Task 99.5 and Task 99.1 disposition authority | pending | Source of truth and closure status. |
+| External contracts: `test_cli_version_flags.py`, `test_profile_template_sync.py`, `test_theme_catalog_sync.py`, `test_theme_config_paths.py`, `test_mcp_doctor.py`, `test_pre_push_guard.py`, `test_ci_repair_loop.py`, `test_install_shadow_guard.py` | pending | Preserve published CLI/config/generated/workflow interfaces; remove only incidental prose/whitespace coupling. |
+| Security/static contracts: `test_c_unsafe_apis_guard.py`, `test_security_gate_contract.py`, `test_security_tempfiles.py`, `test_security_shell_paths.py`, `test_fuzz_harness_sync_guard.py`, `test_appstate_contract_guard.py` | pending | Identify invariant and why safe runtime proof is unavailable for retained inspection. |
+| Filesystem/archive effects: `test_core.py`, `test_destination_prompt.py`, `test_archive_backend.py`, `test_archive_write_parity.py`, `test_fileops_integrity.py` | pending | Preserve end-state integrity; change only brittle setup. |
+| Referenced scripts/config/template/guard/runtime paths and focused tests | pending | Determined by family audits before edits. |
+
+## Family split
+
+One coherent testing-contract family shares a Python-test validation path. Parallel audits collect the complete inventory; implementation will batch all adjacent findings that do not require materially different runtime ownership or validation.
+
+## Validation plan
+
+Run `make clean && make`, then the smallest complete focused pytest set for every touched family with `source .venv/bin/activate`; PR full QA CI is deliberately unrun locally because the repository requires it as the merge gate.
+
+## Reconciliation for published contract batch
+
+- `test_cli_version_flags.py`, `test_mcp_doctor.py`, `test_pre_push_guard.py`, `test_install_shadow_guard.py`: addressed; remove incidental diagnostic wording while preserving return codes and effects.
+- `test_theme_catalog_sync.py`: addressed; retain stale-header rejection without private rendering spellings.
+- `test_profile_template_sync.py`: addressed; retain generated-source equality with explicit static-invariant rationale.
+- `test_destination_prompt.py`: addressed; replace fixed read delay with semantic screen transition.
+- `test_theme_config_paths.py`, `test_ci_repair_loop.py`: deferred; require a separate runtime/workflow test-design boundary to replace private source/narrative coupling safely.
+- Security/static contract family: deferred; distinct security-audit risk class requires complete static-invariant review.
+- Remaining filesystem/archive end-state family: intentionally unchanged; audit found no remaining brittle setup.
+
+Validation: `make -j2`; `source .venv/bin/activate && pytest -q tests/test_theme_catalog_sync.py tests/test_cli_version_flags.py tests/test_mcp_doctor.py tests/test_pre_push_guard.py tests/test_install_shadow_guard.py tests/test_profile_template_sync.py tests/test_destination_prompt.py` (27 passed). Deliberately unrun: full QA locally; PR CI supplies the required full gate.

--- a/tests/test_cli_version_flags.py
+++ b/tests/test_cli_version_flags.py
@@ -43,10 +43,6 @@ def test_init_creates_profile_only_if_missing(ytnova_binary, tmp_path):
     assert not legacy_commands.exists()
     assert not legacy_themes.exists()
     assert not legacy_applications.exists()
-    assert "Created profile:" in first.stdout
-    assert "Created commands:" in first.stdout
-    assert "Created themes:" in first.stdout
-    assert "Created applications:" in first.stdout
     created = profile.read_text(encoding="utf-8")
     assert "# YtreeNova Defaults" in created
     assert "[GLOBAL]" in created
@@ -83,7 +79,6 @@ def test_init_creates_profile_only_if_missing(ytnova_binary, tmp_path):
     assert commands.read_text(encoding="utf-8") == "COMMANDS SENTINEL\n"
     assert themes.read_text(encoding="utf-8") == "THEME SENTINEL\n"
     assert applications.read_text(encoding="utf-8") == "APPLICATIONS SENTINEL\n"
-    assert "already exists; not overwritten" in second.stdout
 
 def test_init_with_explicit_profile_path_preserves_target(ytnova_binary, tmp_path):
     home = tmp_path / "home"
@@ -100,10 +95,6 @@ def test_init_with_explicit_profile_path_preserves_target(ytnova_binary, tmp_pat
     assert themes.exists()
     assert applications.exists()
     assert not (home / ".config" / "ytnova" / "ytnova.conf").exists()
-    assert "Created profile:" in result.stdout
-    assert "Created commands:" in result.stdout
-    assert "Created themes:" in result.stdout
-    assert "Created applications:" in result.stdout
     profile_text = profile.read_text(encoding="utf-8")
     assert "THEME=quiet-blue" in profile_text
     assert "# THEME=bash-black" in profile_text
@@ -133,7 +124,3 @@ def test_init_falls_back_to_home_targets_when_xdg_dir_is_unavailable(
     assert commands.exists()
     assert themes.exists()
     assert applications.exists()
-    assert "Created profile:" in result.stdout
-    assert "Created commands:" in result.stdout
-    assert "Created themes:" in result.stdout
-    assert "Created applications:" in result.stdout

--- a/tests/test_destination_prompt.py
+++ b/tests/test_destination_prompt.py
@@ -43,7 +43,7 @@ def test_copy_name_to_destination_prompt_does_not_redraw_working_view(
         assert tui.wait_for_text("alpha.txt", timeout=2.0), _screen_text(
             tui.get_screen_dump()
         )
-        tui.send_keystroke(Keys.ENTER, wait=0.3)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER, timeout=1.0)
         assert tui.wait_for_text("alpha.txt", timeout=1.5), _screen_text(
             tui.get_screen_dump()
         )
@@ -81,7 +81,7 @@ def test_missing_destination_choice_highlights_default_answer(
         assert tui.wait_for_text("alpha.txt", timeout=2.0), _screen_text(
             tui.get_screen_dump()
         )
-        tui.send_keystroke(Keys.ENTER, wait=0.3)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER, timeout=1.0)
         assert tui.wait_for_text("alpha.txt", timeout=1.5), _screen_text(
             tui.get_screen_dump()
         )
@@ -153,7 +153,7 @@ def test_existing_destination_conflict_shows_size_time_comparison(
         assert tui.wait_for_text("alpha.txt", timeout=2.0), _screen_text(
             tui.get_screen_dump()
         )
-        tui.send_keystroke(Keys.ENTER, wait=0.3)
+        assert tui.send_and_wait_for_screen_change(Keys.ENTER, timeout=1.0)
         assert tui.wait_for_text("alpha.txt", timeout=1.5), _screen_text(
             tui.get_screen_dump()
         )

--- a/tests/test_install_shadow_guard.py
+++ b/tests/test_install_shadow_guard.py
@@ -29,9 +29,6 @@ def test_install_shadow_guard_blocks_shadow_binary_and_manpage(tmp_path):
     result = _run_shadow_check(Path.cwd(), tmp_path)
 
     assert result.returncode != 0
-    combined = result.stdout + result.stderr
-    assert "stale binary" in combined
-    assert "stale man" in combined
 
 
 def test_install_shadow_guard_can_be_overridden_explicitly(tmp_path):

--- a/tests/test_mcp_doctor.py
+++ b/tests/test_mcp_doctor.py
@@ -78,8 +78,6 @@ def test_mcp_doctor_fix_bootstraps_user_config(
 
     assert rc == 0
     assert home_config.exists()
-    assert "FIXED: bootstrapped" in output
-    assert "RESULT: OK" in output
 
 
 def test_mcp_doctor_without_fix_reports_missing_user_config(
@@ -97,8 +95,6 @@ def test_mcp_doctor_without_fix_reports_missing_user_config(
     output = capsys.readouterr().out
 
     assert rc == 1
-    assert "FAIL: missing config" in output
-    assert "run with --fix" in output
 
 
 def test_mcp_doctor_allows_home_path_personal_override_with_warning(
@@ -121,4 +117,3 @@ def test_mcp_doctor_allows_home_path_personal_override_with_warning(
     output = capsys.readouterr().out
 
     assert rc == 0
-    assert "WARN: serena config references a home path" in output

--- a/tests/test_pre_push_guard.py
+++ b/tests/test_pre_push_guard.py
@@ -35,7 +35,6 @@ def test_push_without_codebase_changes_skips_local_gate(
     output = capsys.readouterr().out
 
     assert rc == 0
-    assert "skipping local quality gate" in output.lower()
 
 
 def test_failed_remote_head_blocks_fix_on_fix_push(
@@ -59,8 +58,6 @@ def test_failed_remote_head_blocks_fix_on_fix_push(
     output = capsys.readouterr().out
 
     assert rc == 1
-    assert "remote branch head has failing GitHub CI" in output
-    assert "must be rewritten from the last green state" in output
 
 
 def test_rewritten_branch_after_failed_remote_head_can_proceed(
@@ -87,7 +84,6 @@ def test_rewritten_branch_after_failed_remote_head_can_proceed(
 
     assert rc == 0
     assert calls == ["qa-code-quality"]
-    assert "Checks passed. Proceeding with push." in output
 
 
 def test_force_mode_still_respects_failed_remote_head_block(
@@ -108,4 +104,3 @@ def test_force_mode_still_respects_failed_remote_head_block(
     output = capsys.readouterr().out
 
     assert rc == 1
-    assert "failing GitHub CI" in output

--- a/tests/test_profile_template_sync.py
+++ b/tests/test_profile_template_sync.py
@@ -85,7 +85,10 @@ def test_default_profile_template_header_matches_packaged_config():
         encoding="utf-8"
     )
 
-    assert header_source == _render_profile_header(conf_source)
+    assert header_source == _render_profile_header(conf_source), (
+        "Generated profile header must match its canonical packaged source; runtime "
+        "cannot reveal pre-build source/generated drift."
+    )
 
 
 def test_default_commands_catalog_header_matches_packaged_commands():
@@ -94,7 +97,10 @@ def test_default_commands_catalog_header_matches_packaged_commands():
         encoding="utf-8"
     )
 
-    assert header_source == _render_commands_header(commands_source)
+    assert header_source == _render_commands_header(commands_source), (
+        "Generated commands header must match its canonical packaged source; runtime "
+        "cannot reveal pre-build source/generated drift."
+    )
 
 
 def test_default_command_presets_catalog_header_matches_packaged_presets():
@@ -103,4 +109,7 @@ def test_default_command_presets_catalog_header_matches_packaged_presets():
         encoding="utf-8"
     )
 
-    assert header_source == _render_command_presets_header(source_dir)
+    assert header_source == _render_command_presets_header(source_dir), (
+        "Generated command presets header must match canonical packaged sources; runtime "
+        "cannot reveal pre-build source/generated drift."
+    )

--- a/tests/test_theme_catalog_sync.py
+++ b/tests/test_theme_catalog_sync.py
@@ -32,21 +32,4 @@ def test_theme_catalog_drift_checker_rejects_stale_header(tmp_path):
     )
 
     assert result.returncode != 0
-    assert "drift" in (result.stdout + result.stderr).lower()
 
-
-def test_main_border_window_uses_content_background_role():
-    theme_source = _read("etc/ytnova.themes")
-    contrast_theme = theme_source.replace(
-        "box_lines = cyan", "box_lines = white on magenta", 1
-    ).replace("box_lines = grey", "box_lines = black on cyan", 1)
-    init_source = _read("src/core/init.c")
-    display_source = _read("src/ui/display.c")
-
-    assert "box_lines = white on magenta" in contrast_theme
-    assert "box_lines = black on cyan" in contrast_theme
-    assert (
-        "CoreInitWbkgdSet(ctx, ctx->ctx_border_window,\n"
-        "                     COLOR_PAIR(UI_ROLE_DYNAMIC_TEXT));"
-    ) in init_source
-    assert "wattron(ctx->ctx_border_window, COLOR_PAIR(UI_ROLE_BOX_LINES) | A_ALTCHARSET);" in display_source


### PR DESCRIPTION
## Summary

Preserve published external outcomes while removing incidental diagnostic and private-rendering coupling.

## Validation

- `make -j2`
- `source .venv/bin/activate && pytest -q tests/test_theme_catalog_sync.py tests/test_cli_version_flags.py tests/test_mcp_doctor.py tests/test_pre_push_guard.py tests/test_install_shadow_guard.py tests/test_profile_template_sync.py tests/test_destination_prompt.py`