### PR TITLE
test(tui): synchronize same volume reproducers

### DIFF
--- a/.agent/handoffs/task-99.current.md
+++ b/.agent/handoffs/task-99.current.md
@@ -335,3 +335,21 @@ This relay owns the complete Test Contract Resilience Remediation mission. Task 
 - Baseline: **addressed** — normal selected rows are absent; remaining Task 99.2 rows belong to other recorded families.
 
 Validation: focused normal-panel transition matrix passed, then `python3 scripts/check_test_contract_resilience.py --write-baseline && source .venv/bin/activate && pytest -q tests/test_contract_resilience_guard.py` passed (6). `git diff --check` passed. Full local QA deliberately unrun; PR full-QA CI is the merge gate.
+
+## Next active family — same-volume manual reproducer navigation
+
+**Selected defect family:** the five highest-count remaining rows are the real-home and synthetic same-volume mkdir/split reproducers. They share a manual compatibility action/state path and require an observed-tag progression predicate rather than filename-only selection.
+
+### Inventory and closure criteria
+
+- `tests/repro_real_home_same_volume_split_bug.py::main`: **in progress** — replace its startup delay and fixed navigation by observed real-home selection/volume identity.
+- `tests/repro_same_volume_home_mkdir_bug.py::_run_sequence_a`, `_run_sequence_b`, and `main`: **in progress** — model synthetic tag progression with observable state before replacing navigation and retry mechanics.
+- Existing fixture identity and action driver helpers: **in progress** — reuse or extend only after observing the exact tag progression.
+- Archive-volume release, help, preview, refresh, viewer, layout, and harness rows: **deferred** — separate state/validation boundaries.
+- Baseline and roadmap: **pending** — only update after this family reconciles; Task 99/99.2 stay In Progress.
+
+### Same-volume reproducer reconciliation
+
+- Synthetic and real-home startup waits, target navigation, and tag progression: **addressed** through shared semantic action/state predicates.
+- Direct waiting/navigation baseline rows in both reproducers: **addressed** — absent after authoritative regeneration.
+- Validation: `python3 -m py_compile tests/repro_same_volume_home_mkdir_bug.py tests/repro_real_home_same_volume_split_bug.py`; resilience guard passed (6); `git diff --check` passed. Manual real-home execution is deliberately unrun because it mutates the caller HOME workflow; CI validates repository tests.

--- a/tests/contract_resilience_baseline.json
+++ b/tests/contract_resilience_baseline.json
@@ -135,28 +135,6 @@
     },
     {
       "disposition": "out_of_scope",
-      "evidence": "time.sleep(0.9)",
-      "id": "direct-time-sleep:tests/repro_real_home_same_volume_split_bug.py:96:fc0565ed503eef27",
-      "line": 96,
-      "owner": "waiting and navigation remediation",
-      "path": "tests/repro_real_home_same_volume_split_bug.py",
-      "pattern_id": "direct-time-sleep",
-      "reason": "Direct timing waits require event-driven synchronization redesign.",
-      "symbol": "main"
-    },
-    {
-      "disposition": "out_of_scope",
-      "evidence": "for _ in range(3):",
-      "id": "fixed-navigation-loop:tests/repro_real_home_same_volume_split_bug.py:120:b01be612be51de0e",
-      "line": 120,
-      "owner": "waiting and navigation remediation",
-      "path": "tests/repro_real_home_same_volume_split_bug.py",
-      "pattern_id": "fixed-navigation-loop",
-      "reason": "Fixed key-count navigation must be replaced with target-identity navigation.",
-      "symbol": "main"
-    },
-    {
-      "disposition": "out_of_scope",
       "evidence": "candidate = lines[idx][split_x:] if split_x is not None else lines[idx]",
       "id": "screen-slice-or-grid:tests/repro_same_volume_home_mkdir_bug.py:34:b9831f7c2ed963cb",
       "line": 34,
@@ -165,39 +143,6 @@
       "pattern_id": "screen-slice-or-grid",
       "reason": "Screen-grid assertions require semantic visual-state replacement.",
       "symbol": "_stats_current_dir_contains"
-    },
-    {
-      "disposition": "out_of_scope",
-      "evidence": "for _ in range(3):",
-      "id": "fixed-navigation-loop:tests/repro_same_volume_home_mkdir_bug.py:69:49e8a1edce5a954d",
-      "line": 69,
-      "owner": "waiting and navigation remediation",
-      "path": "tests/repro_same_volume_home_mkdir_bug.py",
-      "pattern_id": "fixed-navigation-loop",
-      "reason": "Fixed key-count navigation must be replaced with target-identity navigation.",
-      "symbol": "_run_sequence_a"
-    },
-    {
-      "disposition": "out_of_scope",
-      "evidence": "while not _stats_current_dir_contains(tui.get_screen_dump(), \"cmd\"):",
-      "id": "polling-or-retry-loop:tests/repro_same_volume_home_mkdir_bug.py:116:6b5086ff3efb1e03",
-      "line": 116,
-      "owner": "waiting and navigation remediation",
-      "path": "tests/repro_same_volume_home_mkdir_bug.py",
-      "pattern_id": "polling-or-retry-loop",
-      "reason": "Polling and retry mechanisms belong to the semantic waiting boundary.",
-      "symbol": "_run_sequence_b"
-    },
-    {
-      "disposition": "out_of_scope",
-      "evidence": "time.sleep(0.9)",
-      "id": "direct-time-sleep:tests/repro_same_volume_home_mkdir_bug.py:195:efac50dbb6911b91",
-      "line": 195,
-      "owner": "waiting and navigation remediation",
-      "path": "tests/repro_same_volume_home_mkdir_bug.py",
-      "pattern_id": "direct-time-sleep",
-      "reason": "Direct timing waits require event-driven synchronization redesign.",
-      "symbol": "main"
     },
     {
       "disposition": "out_of_scope",

--- a/tests/repro_real_home_same_volume_split_bug.py
+++ b/tests/repro_real_home_same_volume_split_bug.py
@@ -18,13 +18,13 @@ Exit codes:
 import os
 import re
 import shutil
-import time
 from pathlib import Path
 
 from helpers_stats import detect_stats_split_x as _detect_stats_split_x
 from helpers_ui import footer_text as _footer_text
 from helpers_ui import line_marks_file_as_tagged as _line_marks_file_as_tagged
 from helpers_ui import screen_text as _screen_text
+from helpers_ui import drive_action_until
 from tui_harness import YtreeNovaTUI
 from ytnova_keys import Keys
 
@@ -67,13 +67,11 @@ def _discover_track_names(screen):
 
 
 def _goto_marker(tui, marker, steps=300):
-    attempts = 0
-    while not _stats_current_dir_contains(tui.get_screen_dump(), marker):
-        if attempts >= steps:
-            return False
-        tui.send_keystroke(Keys.DOWN, wait=0.08)
-        attempts += 1
-    return True
+    return bool(drive_action_until(
+        tui, Keys.DOWN,
+        lambda lines: lines if _stats_current_dir_contains(lines, marker) else False,
+        max_actions=steps,
+    ))
 
 
 def main():
@@ -93,7 +91,9 @@ def main():
         home / "ytnova" / "src" / "cmd" / mkdir_name,
     ]
     tui = YtreeNovaTUI(executable=exe, cwd=str(home), env_extra={"HOME": str(home)})
-    time.sleep(0.9)
+    if not tui.wait_for_text(home.name, timeout=2.0):
+        print("SETUP_FAIL: HOME tree did not render")
+        return 2
     try:
         if not _goto_marker(tui, "ytnova"):
             print("SETUP_FAIL: ytnova dir not found in HOME listing")
@@ -117,8 +117,15 @@ def main():
             print(_screen_text(tui))
             return 2
 
-        for _ in range(3):
-            tui.send_keystroke("t", wait=0.2)
+        tagged = drive_action_until(
+            tui, "t" + Keys.DOWN,
+            lambda lines: lines if sum("*" in line.split(".c")[0] for line in lines if ".c" in line) >= 3 else False,
+            max_actions=3,
+        )
+        if not tagged:
+            print("SETUP_FAIL: could not tag three src files")
+            print(_screen_text(tui))
+            return 2
 
         before = _screen_text(tui)
         tracked = {}

--- a/tests/repro_same_volume_home_mkdir_bug.py
+++ b/tests/repro_same_volume_home_mkdir_bug.py
@@ -10,13 +10,13 @@ Exit codes:
 
 import os
 import sys
-import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from helpers_stats import detect_stats_split_x as _detect_stats_split_x
 from helpers_ui import footer_text as _footer_text
 from helpers_ui import screen_text as _screen_text
+from helpers_ui import drive_action_until
 from tui_harness import YtreeNovaTUI
 from ytnova_keys import Keys
 
@@ -38,21 +38,21 @@ def _stats_current_dir_contains(lines, marker):
 
 
 def _navigate_to_src_cmd_file_mode(tui):
-    attempts = 0
-    while not _stats_current_dir_contains(tui.get_screen_dump(), "src"):
-        if attempts >= 80:
-            return False, f"SETUP_FAIL: could not focus src\n{_screen_text(tui)}"
-        tui.send_keystroke(Keys.DOWN, wait=0.12)
-        attempts += 1
+    if not drive_action_until(
+        tui, Keys.DOWN,
+        lambda lines: lines if _stats_current_dir_contains(lines, "src") else False,
+        max_actions=128,
+    ):
+        return False, f"SETUP_FAIL: could not focus src\n{_screen_text(tui)}"
 
     tui.send_keystroke(Keys.RIGHT, wait=0.25)
 
-    attempts = 0
-    while not _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
-        if attempts >= 80:
-            return False, f"SETUP_FAIL: could not focus src/cmd\n{_screen_text(tui)}"
-        tui.send_keystroke(Keys.DOWN, wait=0.12)
-        attempts += 1
+    if not drive_action_until(
+        tui, Keys.DOWN,
+        lambda lines: lines if _stats_current_dir_contains(lines, "cmd") else False,
+        max_actions=128,
+    ):
+        return False, f"SETUP_FAIL: could not focus src/cmd\n{_screen_text(tui)}"
 
     tui.send_keystroke(Keys.RIGHT, wait=0.2)
     tui.send_keystroke(Keys.ENTER, wait=0.45)
@@ -66,9 +66,13 @@ def _run_sequence_a(tui):
     if not ok:
         return 2, err, _screen_text(tui)
 
-    for _ in range(3):
-        tui.send_keystroke("t", wait=0.2)
-        tui.send_keystroke(Keys.DOWN, wait=0.2)
+    tagged = drive_action_until(
+        tui, "t" + Keys.DOWN,
+        lambda lines: lines if sum("*" in line.split(".c")[0] for line in lines if ".c" in line) >= 3 else False,
+        max_actions=3,
+    )
+    if not tagged:
+        return 2, "SETUP_FAIL: could not tag three src files", _screen_text(tui)
 
     # Original manual sequence: f8 tab enter home m 00
     tui.send_keystroke(Keys.F8, wait=0.4)
@@ -112,22 +116,21 @@ def _run_sequence_b(tui, home):
         return 2, "SETUP_FAIL: variant B did not reach file mode", _screen_text(tui)
     if "src_file_0.c" not in _screen_text(tui):
         tui.send_keystroke(Keys.ESC, wait=0.25)
-        attempts = 0
-        while not _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
-            if attempts >= 40:
-                break
-            tui.send_keystroke(Keys.UP, wait=0.12)
-            attempts += 1
-        attempts = 0
-        while not _stats_current_dir_contains(tui.get_screen_dump(), "cmd"):
-            if attempts >= 120:
-                return (
-                    2,
-                    "SETUP_FAIL: variant B could not re-focus src/cmd",
-                    _screen_text(tui),
-                )
-            tui.send_keystroke(Keys.DOWN, wait=0.12)
-            attempts += 1
+        selected = drive_action_until(
+            tui, Keys.UP,
+            lambda lines: lines if _stats_current_dir_contains(lines, "cmd") else False,
+            max_actions=40,
+        ) or drive_action_until(
+            tui, Keys.DOWN,
+            lambda lines: lines if _stats_current_dir_contains(lines, "cmd") else False,
+            max_actions=120,
+        )
+        if not selected:
+            return (
+                2,
+                "SETUP_FAIL: variant B could not re-focus src/cmd",
+                _screen_text(tui),
+            )
         tui.send_keystroke(Keys.ENTER, wait=0.45)
         if "src_file_0.c" not in _screen_text(tui):
             return 2, "SETUP_FAIL: variant B did not enter src/cmd file mode", _screen_text(tui)
@@ -192,7 +195,9 @@ def main():
             ("B", lambda t: _run_sequence_b(t, home)),
         ):
             tui = YtreeNovaTUI(executable=exe, cwd=str(repo), env_extra={"HOME": str(home)})
-            time.sleep(0.9)
+            if not tui.wait_for_text("src", timeout=2.0):
+                print("SETUP_FAIL: fixture tree did not render")
+                return 2
             try:
                 code, msg, screen = runner(tui)
                 print(msg)


### PR DESCRIPTION
## Summary
- Drive same-volume reproducer navigation by observable tree and tag state.
- Replace startup delays and retry loops with semantic predicates.

## Validation
- `python3 -m py_compile tests/repro_same_volume_home_mkdir_bug.py tests/repro_real_home_same_volume_split_bug.py`
- `pytest -q tests/test_contract_resilience_guard.py`
- `git diff --check`