### PR TITLE
test(tui): synchronize internal viewer returns

### DIFF
--- a/.agent/handoffs/task-99.current.md
+++ b/.agent/handoffs/task-99.current.md
@@ -353,3 +353,21 @@ Validation: focused normal-panel transition matrix passed, then `python3 scripts
 - Synthetic and real-home startup waits, target navigation, and tag progression: **addressed** through shared semantic action/state predicates.
 - Direct waiting/navigation baseline rows in both reproducers: **addressed** — absent after authoritative regeneration.
 - Validation: `python3 -m py_compile tests/repro_same_volume_home_mkdir_bug.py tests/repro_real_home_same_volume_split_bug.py`; resilience guard passed (6); `git diff --check` passed. Manual real-home execution is deliberately unrun because it mutates the caller HOME workflow; CI validates repository tests.
+
+## Next active family — internal viewer return completion
+
+**Selected defect family:** the two `tests/test_viewer_return_ui.py` waits share the same viewer subprocess-return/redraw completion boundary.
+
+### Inventory and closure criteria
+
+- Both internal viewer return tests: **in progress** — replace elapsed waits with return-to-full-UI fixture/state predicates.
+- `tests/tui_harness.py` and viewer runtime: **intentionally unchanged pending focused red evidence** — reuse existing semantic waiting primitives.
+- All other remaining rows: **deferred** — distinct prompt, archive-volume, refresh, layout, or retained-harness boundaries.
+- Baseline and roadmap: **pending** — update only after this family is reconciled; Task 99/99.2 remain In Progress.
+
+### Internal viewer return reconciliation
+
+- Both internal viewer startup waits: **addressed** — fixture identities establish readiness before entering file/archive mode.
+- Viewer runtime and harness: **intentionally unchanged** — focused return contracts passed without runtime evidence.
+- Baseline: **addressed** — both rows absent after regeneration.
+- Validation: focused viewer return tests and resilience guard passed; `git diff --check` passed.

--- a/tests/contract_resilience_baseline.json
+++ b/tests/contract_resilience_baseline.json
@@ -26304,20 +26304,9 @@
     },
     {
       "disposition": "out_of_scope",
-      "evidence": "time.sleep(0.8)",
-      "id": "direct-time-sleep:tests/test_viewer_return_ui.py:73:e37eaf549f4067e7",
-      "line": 73,
-      "owner": "waiting and navigation remediation",
-      "path": "tests/test_viewer_return_ui.py",
-      "pattern_id": "direct-time-sleep",
-      "reason": "Direct timing waits require event-driven synchronization redesign.",
-      "symbol": "test_internal_viewer_return_restores_full_ui_frame"
-    },
-    {
-      "disposition": "out_of_scope",
       "evidence": "assert \"next page/file\" not in footer, footer",
-      "id": "exact-prose-assertion:tests/test_viewer_return_ui.py:121:0a8f4ed8bc7affd2",
-      "line": 121,
+      "id": "exact-prose-assertion:tests/test_viewer_return_ui.py:120:1911144641e5004e",
+      "line": 120,
       "owner": "geometry and presentation remediation",
       "path": "tests/test_viewer_return_ui.py",
       "pattern_id": "exact-prose-assertion",
@@ -26327,8 +26316,8 @@
     {
       "disposition": "out_of_scope",
       "evidence": "assert \"next page\" in footer and \"next file\" in footer, footer",
-      "id": "exact-prose-assertion:tests/test_viewer_return_ui.py:122:110d5cb6fd785351",
-      "line": 122,
+      "id": "exact-prose-assertion:tests/test_viewer_return_ui.py:121:fda81471310c1701",
+      "line": 121,
       "owner": "geometry and presentation remediation",
       "path": "tests/test_viewer_return_ui.py",
       "pattern_id": "exact-prose-assertion",
@@ -26338,24 +26327,13 @@
     {
       "disposition": "out_of_scope",
       "evidence": "assert \"next hit\" in footer and \"prev hit\" in footer, footer",
-      "id": "exact-prose-assertion:tests/test_viewer_return_ui.py:123:68b00b10094f7328",
-      "line": 123,
+      "id": "exact-prose-assertion:tests/test_viewer_return_ui.py:122:c95e5b6af9f2cd80",
+      "line": 122,
       "owner": "geometry and presentation remediation",
       "path": "tests/test_viewer_return_ui.py",
       "pattern_id": "exact-prose-assertion",
       "reason": "Editable presentation prose requires a durable behavioural replacement.",
       "symbol": "test_internal_tagged_viewer_separates_file_and_hit_navigation"
-    },
-    {
-      "disposition": "out_of_scope",
-      "evidence": "time.sleep(0.8)",
-      "id": "direct-time-sleep:tests/test_viewer_return_ui.py:142:c4f907aa6939ef3c",
-      "line": 142,
-      "owner": "waiting and navigation remediation",
-      "path": "tests/test_viewer_return_ui.py",
-      "pattern_id": "direct-time-sleep",
-      "reason": "Direct timing waits require event-driven synchronization redesign.",
-      "symbol": "test_internal_viewer_return_in_archive_mode_restores_full_ui_frame"
     },
     {
       "disposition": "out_of_scope",

--- a/tests/test_viewer_return_ui.py
+++ b/tests/test_viewer_return_ui.py
@@ -1,4 +1,3 @@
-import time
 import tarfile
 import shutil
 
@@ -70,7 +69,7 @@ def test_internal_viewer_return_restores_full_ui_frame(tmp_path, ytnova_binary):
     (root / "alpha.txt").write_text("alpha", encoding="utf-8")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
+    assert tui.wait_for_text("alpha.txt", timeout=2.0), _screen_text(tui)
 
     try:
         tui.send_keystroke(Keys.ENTER, wait=0.5)
@@ -139,7 +138,7 @@ def test_internal_viewer_return_in_archive_mode_restores_full_ui_frame(
     _create_archive(root, "archive.tar")
 
     tui = YtreeNovaTUI(executable=ytnova_binary, cwd=str(root))
-    time.sleep(0.8)
+    assert tui.wait_for_text("archive.tar", timeout=2.0), _screen_text(tui)
 
     try:
         tui.send_keystroke(Keys.ENTER, wait=0.4)


### PR DESCRIPTION
## Summary
- Wait for viewer fixtures before internal return workflows.
- Reconcile viewer-return waiting contracts in the baseline.

## Validation
- `pytest -q tests/test_viewer_return_ui.py::test_internal_viewer_return_restores_full_ui_frame tests/test_viewer_return_ui.py::test_internal_viewer_return_in_archive_mode_restores_full_ui_frame tests/test_contract_resilience_guard.py`
- `git diff --check`