### PR TITLE
test(guard): preserve semantic wait classifications

### DIFF
--- a/.agent/handoffs/task-99.current.md
+++ b/.agent/handoffs/task-99.current.md
@@ -454,3 +454,40 @@ Validation: focused normal-panel transition matrix passed, then `python3 scripts
 - Green: `python3 scripts/check_test_contract_resilience.py --write-baseline && source .venv/bin/activate && pytest -q tests/reproduce_sort_bug.py::test_sort_help_missing_options tests/test_ui_layout.py::test_ui_layout_dynamic_resizing tests/test_contract_resilience_guard.py` — 8 passed; selected rows absent.
 - Green: `git diff --check`.
 - Deliberately unrun: local full QA and C build; this batch changes Python PTY synchronization, a generated inventory, and roadmap status only. Required PR full-QA CI remains the merge gate.
+
+## Next active family — semantic scan and canonical event-wait contracts
+
+**Selected defect family:** four remaining detector matches do not encode brittle interaction timing: the preview and stats loops scan an already captured screen, while the two `wait_for_condition` implementations are the canonical event-driven PTY/control predicates explicitly permitted by Task 99.2. They share the baseline-classification boundary and require retained durable reasons rather than artificial rewrites.
+
+### In-scope inventory and closure criteria
+
+- `tests/test_f7_preview.py::test_f7_file_name_clipping_at_boundaries`: **in progress** — classify its bounded scan of an already captured screen as a presentation-scanning concern, not polling. Do not alter the preview geometry assertions in this family.
+- `tests/test_stats_panel.py::_stats_strip_bounds`: **in progress** — classify its bounded string-search loop as deterministic snapshot parsing, not synchronization. Do not alter the stats presentation assertions in this family.
+- `tests/tui_harness.py::YtreeNovaTUI.wait_for_condition`: **in progress** — retain with a specific reason: it is the shared event-driven PTY-output predicate with deadline diagnostics, not a test-specific retry or sleep.
+- `tests/ytnova_control.py::YtreeNovaController.wait_for_condition`: **in progress** — retain with the corresponding control-session event predicate reason.
+- `tests/contract_resilience_baseline.json`: **pending** — retain/reassign the four matches with accurate durable reasons so they no longer represent unreconciled waiting/navigation work.
+- `docs/ROADMAP.md`: **intentionally unchanged unless an in-progress status clarification is necessary** — Task 99 and Task 99.2 must remain In Progress.
+- Help scroll, archive-volume, and refresh-race rows: **deferred** — modal-scroll, volume-lifecycle, and concurrent-deletion predicates are distinct runtime/action families.
+
+**Closure:** the four candidates have explicit accurate retained/reassigned dispositions; no direct time wait or action-count navigation is normalized as exempt; the resilience guard validates the registry; all inventory items are reconciled.
+
+**Inventory extension:** `scripts/check_test_contract_resilience.py` currently regenerates every match from pattern defaults, so per-row retained classifications cannot survive `--write-baseline`. `tests/test_contract_resilience_guard.py` is added to this family to prove exact reviewed exceptions survive generation. A narrow exact-match override registry is required; a broad detector suppression is excluded because it would conceal future genuine waits.
+
+### Closure reconciliation — semantic scan and canonical event-wait contracts
+
+- `tests/test_f7_preview.py::test_f7_file_name_clipping_at_boundaries`: **addressed by reclassification** — its bounded post-capture scan is now owned by geometry/presentation; it is not waiting or navigation.
+- `tests/test_stats_panel.py::_stats_strip_bounds`: **addressed by reclassification** — its bounded string search parses one snapshot and is now owned by geometry/presentation.
+- `tests/tui_harness.py::YtreeNovaTUI.wait_for_condition`: **retained with a durable reason** — it is the canonical event-driven PTY predicate with deadline diagnostics, not a time delay or test-specific retry.
+- `tests/ytnova_control.py::YtreeNovaController.wait_for_condition`: **retained with a durable reason** — it is the corresponding canonical control-session event predicate.
+- `scripts/check_test_contract_resilience.py::REVIEWED_EXCEPTIONS`: **addressed** — a narrow exact-match registry preserves reviewed classifications through baseline regeneration; it is not a broad detector suppression.
+- `tests/test_contract_resilience_guard.py::test_reviewed_semantic_wait_exceptions_survive_baseline_generation`: **addressed** — proves the presentation-scan reassignment and retained canonical wait disposition survive generation.
+- `tests/contract_resilience_baseline.json`: **addressed** — regenerated; only 4 waiting/navigation rows remain, belonging to help-scroll, archive-volume lifecycle, and refresh-race families.
+- `docs/ROADMAP.md`: **intentionally unchanged** — the existing in-progress wording remains accurate; no Task 99.2 completion claim is justified.
+- Help scroll, archive-volume, and refresh-race rows: **deferred** — modal-scroll, volume-lifecycle, and concurrent-deletion state predicates remain distinct coherent families.
+
+### Validation
+
+- Red: a manual baseline classification edit was lost by `--write-baseline`, proving the generator needed an exact reviewed-exception mechanism rather than a hand-edited registry.
+- Green: `python3 scripts/check_test_contract_resilience.py --write-baseline && source .venv/bin/activate && pytest -q tests/test_contract_resilience_guard.py` — 7 passed; reviewed classifications survived regeneration.
+- Green: `git diff --check`.
+- Deliberately unrun: local full QA and C build; this batch changes the Python baseline generator, its guard, generated registry, and recovery handoff. Required PR full-QA CI remains the merge gate.

--- a/scripts/check_test_contract_resilience.py
+++ b/scripts/check_test_contract_resilience.py
@@ -71,6 +71,45 @@ DEFAULT_DISPOSITIONS = {
     ),
 }
 
+REVIEWED_EXCEPTIONS = {
+    (
+        "tests/test_f7_preview.py",
+        "test_f7_file_name_clipping_at_boundaries",
+        "polling-or-retry-loop",
+    ): (
+        "out_of_scope",
+        "geometry and presentation remediation",
+        "Bounded scan parses one captured preview snapshot; it performs no waiting, retry, or user navigation.",
+    ),
+    (
+        "tests/test_stats_panel.py",
+        "_stats_strip_bounds",
+        "polling-or-retry-loop",
+    ): (
+        "out_of_scope",
+        "geometry and presentation remediation",
+        "Bounded string search parses one captured stats snapshot; it performs no waiting, retry, or user navigation.",
+    ),
+    (
+        "tests/tui_harness.py",
+        "wait_for_condition",
+        "polling-or-retry-loop",
+    ): (
+        "retained",
+        "waiting and navigation remediation",
+        "Canonical event-driven PTY-output predicate: waits for observable state with a deadline and diagnostic, never an elapsed test delay or fixed action count.",
+    ),
+    (
+        "tests/ytnova_control.py",
+        "wait_for_condition",
+        "polling-or-retry-loop",
+    ): (
+        "retained",
+        "waiting and navigation remediation",
+        "Canonical control-session event predicate: waits for observable state with a deadline and diagnostic, never an elapsed test delay or fixed action count.",
+    ),
+}
+
 
 class PatternVisitor(ast.NodeVisitor):
     def __init__(self, path: str, lines: list[str]) -> None:
@@ -260,7 +299,11 @@ def scan(root: Path) -> list[Match]:
 
 
 def _baseline_row(match: Match) -> dict[str, object]:
+    disposition = "out_of_scope"
     owner, reason = DEFAULT_DISPOSITIONS[match.pattern_id]
+    exception = REVIEWED_EXCEPTIONS.get((match.path, match.symbol, match.pattern_id))
+    if exception:
+        disposition, owner, reason = exception
     return {
         "id": match.identity,
         "pattern_id": match.pattern_id,
@@ -268,7 +311,7 @@ def _baseline_row(match: Match) -> dict[str, object]:
         "symbol": match.symbol,
         "line": match.line,
         "evidence": match.evidence,
-        "disposition": "out_of_scope",
+        "disposition": disposition,
         "reason": reason,
         "owner": owner,
     }

--- a/tests/contract_resilience_baseline.json
+++ b/tests/contract_resilience_baseline.json
@@ -16371,6 +16371,17 @@
     },
     {
       "disposition": "out_of_scope",
+      "evidence": "assert preview[\"owner\"] == \"geometry and presentation remediation\"",
+      "id": "exact-prose-assertion:tests/test_contract_resilience_guard.py:127:1be290ae8680d43d",
+      "line": 127,
+      "owner": "geometry and presentation remediation",
+      "path": "tests/test_contract_resilience_guard.py",
+      "pattern_id": "exact-prose-assertion",
+      "reason": "Editable presentation prose requires a durable behavioural replacement.",
+      "symbol": "test_reviewed_semantic_wait_exceptions_survive_baseline_generation"
+    },
+    {
+      "disposition": "out_of_scope",
       "evidence": "rc = int(lines[0].split(\"=\", 1)[1])",
       "id": "screen-slice-or-grid:tests/test_core.py:41:4d239ad224cfd1b0",
       "line": 41,
@@ -18255,10 +18266,10 @@
       "evidence": "for y in range(BORDER_MIN_Y, BORDER_MAX_Y + 1):",
       "id": "polling-or-retry-loop:tests/test_f7_preview.py:309:a5332c737ec8d8b5",
       "line": 309,
-      "owner": "waiting and navigation remediation",
+      "owner": "geometry and presentation remediation",
       "path": "tests/test_f7_preview.py",
       "pattern_id": "polling-or-retry-loop",
-      "reason": "Polling and retry mechanisms belong to the semantic waiting boundary.",
+      "reason": "Bounded scan parses one captured preview snapshot; it performs no waiting, retry, or user navigation.",
       "symbol": "test_f7_file_name_clipping_at_boundaries"
     },
     {
@@ -22490,10 +22501,10 @@
       "evidence": "while True:",
       "id": "polling-or-retry-loop:tests/test_stats_panel.py:99:19cea9fe2560a7c8",
       "line": 99,
-      "owner": "waiting and navigation remediation",
+      "owner": "geometry and presentation remediation",
       "path": "tests/test_stats_panel.py",
       "pattern_id": "polling-or-retry-loop",
-      "reason": "Polling and retry mechanisms belong to the semantic waiting boundary.",
+      "reason": "Bounded string search parses one captured stats snapshot; it performs no waiting, retry, or user navigation.",
       "symbol": "_stats_strip_bounds"
     },
     {
@@ -26292,25 +26303,25 @@
       "symbol": "test_wsl_notify_preserves_explicit_milestone_message"
     },
     {
-      "disposition": "out_of_scope",
+      "disposition": "retained",
       "evidence": "while True:",
       "id": "polling-or-retry-loop:tests/tui_harness.py:91:a458abea0ac708e9",
       "line": 91,
       "owner": "waiting and navigation remediation",
       "path": "tests/tui_harness.py",
       "pattern_id": "polling-or-retry-loop",
-      "reason": "Polling and retry mechanisms belong to the semantic waiting boundary.",
+      "reason": "Canonical event-driven PTY-output predicate: waits for observable state with a deadline and diagnostic, never an elapsed test delay or fixed action count.",
       "symbol": "wait_for_condition"
     },
     {
-      "disposition": "out_of_scope",
+      "disposition": "retained",
       "evidence": "while True:",
       "id": "polling-or-retry-loop:tests/ytnova_control.py:75:6f96abecfa3bc840",
       "line": 75,
       "owner": "waiting and navigation remediation",
       "path": "tests/ytnova_control.py",
       "pattern_id": "polling-or-retry-loop",
-      "reason": "Polling and retry mechanisms belong to the semantic waiting boundary.",
+      "reason": "Canonical control-session event predicate: waits for observable state with a deadline and diagnostic, never an elapsed test delay or fixed action count.",
       "symbol": "wait_for_condition"
     }
   ],

--- a/tests/test_contract_resilience_guard.py
+++ b/tests/test_contract_resilience_guard.py
@@ -102,3 +102,27 @@ def test_baseline_is_json_object() -> None:
     document = json.loads(baseline.read_text(encoding="utf-8"))
 
     assert document["schema_version"] == guard.SCHEMA_VERSION
+
+
+def test_reviewed_semantic_wait_exceptions_survive_baseline_generation() -> None:
+    preview = guard._baseline_row(
+        guard.Match(
+            "polling-or-retry-loop",
+            "tests/test_f7_preview.py",
+            "test_f7_file_name_clipping_at_boundaries",
+            309,
+            "for y in range(BORDER_MIN_Y, BORDER_MAX_Y + 1):",
+        )
+    )
+    harness = guard._baseline_row(
+        guard.Match(
+            "polling-or-retry-loop",
+            "tests/tui_harness.py",
+            "wait_for_condition",
+            91,
+            "while True:",
+        )
+    )
+
+    assert preview["owner"] == "geometry and presentation remediation"
+    assert harness["disposition"] == "retained"


### PR DESCRIPTION
Preserves exact reviewed classifications for canonical event predicates and snapshot scans when regenerating the resilience baseline.

## Validation
- Red: manual reviewed classifications were overwritten by baseline regeneration.
- `python3 scripts/check_test_contract_resilience.py --write-baseline && source .venv/bin/activate && pytest -q tests/test_contract_resilience_guard.py`
- `git diff --check`